### PR TITLE
Add Forsakens patches

### DIFF
--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+					
+						<!-- There is only one type of Forsaken arrow, no subcategory for variants required -->
+
+						<!--==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_ForsakensArrows</defName>
+							<label>forsakens arrows</label>
+							<ammoTypes>
+								<Ammo_ForsakensArrows>Projectile_ForsakensArrows</Ammo_ForsakensArrows>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<!--==================== Ammo ========================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+							<defName>Ammo_ForsakensArrows</defName>
+							<label>forsakens arrow</label>
+							<description>Heavy arrow designed to be fired from a forsaken bow.</description>
+							<graphicData>
+								<texPath>ThirdParty/Forsakens/FAmmoArrow</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<Mass>0.115</Mass>
+								<MarketValue>0.66</MarketValue>
+								<Flammability>0</Flammability>
+							</statBases>
+							<ammoClass>ForsakenArrow</ammoClass>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, BaseGreatArrowProjectile) -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+							<defName>Projectile_ForsakensArrows</defName>
+							<label>forsakens arrow</label>
+							<graphicData>
+								<texPath>Weapons/FArrow</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>7</damageAmountBase>
+								<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
+								<armorPenetrationSharp>2</armorPenetrationSharp>
+								<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
+								<!-- 25 arrows per resource -->
+								<preExplosionSpawnThingDef>Ammo_ForsakensArrows</preExplosionSpawnThingDef>
+							</projectile>
+						</ThingDef>
+
+						<!-- ==================== Recipes ========================== -->
+
+						<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+							<defName>MakeAmmo_ForsakensArrows</defName>
+							<label>make forsakens arrows x10</label>
+							<description>Craft 10 forsakens arrows.</description>
+							<jobString>Making forsaken arrows.</jobString>
+							<workAmount>400</workAmount>
+							<ingredients>
+								<!-- Stats manually specified due to alien nature of ammo -->
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>4</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_ForsakensArrows>10</Ammo_ForsakensArrows>
+							</products>
+						</RecipeDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ProjReskin.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Custom ammoset and projectile definitions for Forsaken ranged weapons, allowing them to use existing generic CE charged ammo while firing mod-unique projectiles -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<!-- ========== 8x35mm Charged cartridge for Forsaken Sniping Rifle ========== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_8x35mmCharged_ForsakenSniper</defName>
+							<label>8x35mm Charged</label>
+							<ammoTypes>
+								<Ammo_8x35mmCharged>Bullet_8x35mmCharged_ForsakenSniper</Ammo_8x35mmCharged>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+							<defName>Bullet_8x35mmCharged_ForsakenSniper</defName>
+							<label>8x35mm Charged bullet</label>
+							<graphicData>
+								<texPath>Weapons/SnipPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>19</damageAmountBase>
+								<secondaryDamage>
+									<li>
+										<def>Bomb_Secondary</def>
+										<amount>6</amount>
+									</li>
+								</secondaryDamage>
+								<armorPenetrationSharp>14</armorPenetrationSharp>
+								<armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<!-- ========== 12 Gauge Charged shotgun cartridge for Forsaken ShotGun ========== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_12GaugeCharged_ForsakenShotGun</defName>
+							<label>12 Gauge Charged</label>
+							<ammoTypes>
+								<Ammo_12GaugeCharged>Bullet_12GaugeCharged_ForsakenShotGun</Ammo_12GaugeCharged>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeChargedBullet">
+							<defName>Bullet_12GaugeCharged_ForsakenShotGun</defName>
+							<label>charge shot pellet</label>
+							<graphicData>
+								<texPath>Weapons/ShotPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<!-- Original mod implemented the shotgun blast as a slug  -->
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>15</damageAmountBase>
+								<secondaryDamage>
+									<li>
+										<def>Bomb_Secondary</def>
+										<amount>5</amount>
+									</li>
+								</secondaryDamage>
+								<armorPenetrationSharp>8</armorPenetrationSharp>      
+								<armorPenetrationBlunt>32.4</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<!-- ========== 5x35mm Charged cartridge for Forsaken Assault Rifle ========== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_5x35mmCharged_ForsakenAR</defName>
+							<label>5x35mm Charged</label>
+							<ammoTypes>
+								<Ammo_5x35mmCharged>Bullet_5x35mmCharged_ForsakenAR</Ammo_5x35mmCharged>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+						
+						<!-- Workaround for conditionally-patched projectiles: use an existing abstract class from the generic ammo library (In this case, Base8x35mmChargedBullet) -->
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+							<defName>Bullet_5x35mmCharged_ForsakenAR</defName>
+							<label>5x35mm Charged bullet</label>
+							<graphicData>
+								<texPath>Weapons/SmolPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bullet</damageDef>
+								<damageAmountBase>11</damageAmountBase>
+								<speed>200</speed>
+								<secondaryDamage>
+									<li>
+										<def>Bomb_Secondary</def>
+										<amount>2</amount>
+									</li>
+								</secondaryDamage>
+								<armorPenetrationSharp>30</armorPenetrationSharp>
+								<armorPenetrationBlunt>40</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Forsaken Hood and Cloak ========== -->
+				
+				<!-- Note: Forsaken fabric apparel are only craftable from Synthread -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Forsaken_Hood"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Forsaken_Cloak"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Forsaken_Hood" or
+						defName="Forsaken_Cloak"
+					]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<!-- Equvalent to vanilla Synthread duster at normal quality -->
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="Forsaken_Hood" or
+						defName="Forsaken_Cloak"
+					]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<!-- Equvalent to vanilla Synthread duster at normal quality -->
+						<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken Helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="TForsakenH"]/statBases</xpath>
+					<value>
+						<!-- Slightly larger item bulk than vanilla Power armor helmet, to account for horns on Forsaken helmet -->
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="TForsakenH"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<!-- Equvalent to vanilla Power armor helmet at normal quality -->
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="TForsakenH"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<!-- Equvalent to vanilla Power armor helmet at normal quality -->
+						<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken Armor ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="TForsakenA"]/statBases</xpath>
+					<value>
+						<Bulk>100</Bulk>
+						<WornBulk>15</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="TForsakenA"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryBulk>10</CarryBulk>
+						<CarryWeight>80</CarryWeight>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="TForsakenA"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<!-- Equvalent to vanilla Power armor at normal quality -->
+						<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="TForsakenA"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<!-- Equvalent to vanilla Power armor at normal quality -->
+						<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_BodyDefs_Forsaken_Body.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_BodyDefs_Forsaken_Body.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- Add HeadAttackTool to head of Forsaken body, as it is missing from the original mod -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Forsaken"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+					<value>
+						<li>HeadAttackTool</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Drugs.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Drugs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ========== Patch item bulk ========== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="Razor" or
+					defName="Vitaminf"
+				]/statBases</xpath>
+				<value>
+					<!-- Equivalent to vanilla pill drugs -->
+					<Bulk>0.01</Bulk>
+				</value>
+			</li>
+			
+			<!-- ========== Patch item mass ========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="Razor" or
+					defName="Vitaminf"
+				]/statBases/Mass</xpath>
+				<value>
+					<!-- Equivalent to vanilla pill drugs -->
+					<Mass>0.005</Mass>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_PawnKinds_Forsaken.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_PawnKinds_Forsaken.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Reduce meals and medicine carried by all pawns ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[
+						@Name="ForsakenBase" or
+						defName="ForsakenSniper" or
+						defName="ForsakenSlasher"
+					]/invNutrition</xpath>
+					<value>
+						<invNutrition>1</invNutrition>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[
+					defName="ForsakenSlasher" or
+					defName="ForsakenGunner" or
+					defName="KingOfTheLostOnes"
+				]/inventoryOptions/subOptionsChooseOne</xpath>
+					<value>
+						<subOptionsChooseOne>
+							<li>
+								<thingDef>Silver</thingDef>
+								<countRange>
+									<min>180</min>
+									<max>400</max>
+								</countRange>
+							</li>
+							<li>
+								<thingDef>MedicineIndustrial</thingDef>
+								<countRange>
+									<min>1</min>
+									<max>1</max>
+								</countRange>
+							</li>
+						</subOptionsChooseOne>
+					</value>
+				</li>
+
+				<!-- ========== Remove smokepop belt ========== -->
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/PawnKindDef[
+					defName="ForsakenGunner" or
+					defName="KingOfTheLostOnes" or
+					defName="Town_GuardF" or
+					defName="Town_TraderF"
+				]/apparelTags/li[.="BeltDefensePop"]</xpath>
+				</li>
+
+				<!-- ========== Forsaken faction pawns should spawn backpacks, allowing them to carry their inventory ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[
+						defName="Town_GuardF" or
+						defName="VillagerF" or
+						defName="Town_TraderF"
+					]</xpath>
+					<value>
+						<apparelRequired>
+							<li>Apparel_Backpack</li>
+						</apparelRequired>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[
+						defName="ForsakenSniper" or
+						defName="ForsakenSlasher" or
+						defName="ForsakenGunner" or
+						defName="KingOfTheLostOnes"
+					]/apparelRequired</xpath>
+					<value>
+						<li>Apparel_Backpack</li>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken faction pawns should spawn with ammo appropriate to their primary weapon ========== -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[
+						defName="ForsakenSniper" or
+						defName="ForsakenSlasher" or
+						defName="ForsakenGunner" or
+						defName="KingOfTheLostOnes" or
+						defName="Town_GuardF" or
+						defName="VillagerF" or
+						defName="Town_TraderF"
+				]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>6</min>
+								<max>8</max>
+							</primaryMagazineCount>
+						</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_PawnKinds_Forsaken.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_PawnKinds_Forsaken.xml
@@ -38,7 +38,7 @@
 							<li>
 								<thingDef>MedicineIndustrial</thingDef>
 								<countRange>
-									<min>1</min>
+									<min>0</min>
 									<max>1</max>
 								</countRange>
 							</li>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Race_Forsaken.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Race_Forsaken.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Forsaken"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Forsaken"]/statBases</xpath>
+					<value>
+						<AimingAccuracy>1</AimingAccuracy>
+						<MeleeCritChance>1</MeleeCritChance>
+						<MeleeParryChance>1</MeleeParryChance>
+						<ReloadSpeed>1</ReloadSpeed>
+						<Suppressability>1</Suppressability>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Forsaken"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<linkedBodyPartsGroup>LeftHandClawsGroup</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<linkedBodyPartsGroup>RightHandClawsGroup</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>4.49</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<success>Always</success>
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Forsaken"][not(comp)]</xpath>
+					<value>
+						<comps />
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Forsaken"]/comps</xpath>
+					<value>
+						<li>
+							<compClass>CombatExtended.CompPawnGizmo</compClass>
+						</li>
+						<li Class="CombatExtended.CompProperties_Suppressable" />
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Race_Nightling.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Race_Nightling.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="NightlingF"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="NightlingF"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.91</MeleeDodgeChance>
+						<MeleeCritChance>1.8</MeleeCritChance>
+						<MeleeParryChance>0.09</MeleeParryChance>
+						<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+						<ArmorRating_Blunt>5</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="NightlingF"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>16</power>
+								<cooldownTime>1.5</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.900</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.075</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>16</power>
+								<cooldownTime>1.5</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.900</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.075</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>razorfangs</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>23</power>
+								<cooldownTime>1.46</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<chanceFactor>2</chanceFactor>
+								<armorPenetrationSharp>0.8</armorPenetrationSharp>
+								<armorPenetrationBlunt>5.063</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>3.2</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>1.225</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Scenario.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Scenario.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ScenarioDef[defName="ForsakenCrashlanded"]/scenario/parts</xpath>
+					<value>
+						<li Class="ScenPart_StartingThing_Defined">
+							<def>StartingThing_Defined</def>
+							<thingDef>Ammo_ForsakensArrows</thingDef>
+							<count>500</count>
+						</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons.xml
@@ -1,0 +1,561 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Forsaken Sniping Rifle ========== -->
+
+				<!-- (CE implementation based on Accuracy International AWM sniper rifle from RN Weapons, chambered for 8x35mm Charged cartridge) -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>ForsakenSniper</defName>
+					<statBases>
+						<Mass>7.18</Mass>
+						<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>3.50</SightsEfficiency>
+						<ShotSpread>0.01</ShotSpread>
+						<SwayFactor>1.61</SwayFactor>
+						<Bulk>15.60</Bulk>
+						<WorkToMake>50500</WorkToMake>
+					</statBases>
+					<costList>
+						<!-- from original mod -->
+						<Steel>300</Steel>
+						<Plasteel>75</Plasteel>
+						<ComponentIndustrial>12</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_8x35mmCharged_ForsakenSniper</defaultProjectile>
+						<warmupTime>2.55</warmupTime>
+						<range>86</range>
+						<soundCast>Shot_SniperRifle</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>12</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_8x35mmCharged_ForsakenSniper</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>ForsakenSniper</li>
+					</weaponTags>
+
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
+
+				<!-- ========== Forsaken ShotGun ========== -->
+
+				<!-- (CE implementation based on UTS-15 shotgun from RN Weapons, chambered for 12 Gauge Charged shotgun cartridge) -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>ForsakenShotGun</defName>
+					<statBases>
+						<Mass>3.10</Mass>
+						<RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.14</ShotSpread>
+						<SwayFactor>1.03</SwayFactor>
+						<Bulk>7.20</Bulk>
+						<WorkToMake>54500</WorkToMake>
+					</statBases>
+					<costList>
+						<!-- from original mod -->
+						<Steel>350</Steel>
+						<Plasteel>120</Plasteel>
+						<ComponentIndustrial>20</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12GaugeCharged_ForsakenShotGun</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>16</range>
+						<soundCast>Shot_Shotgun</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>14</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<!-- Reduced magazine size -->
+						<magazineSize>6</magazineSize>
+						<reloadTime>4.25</reloadTime>
+						<ammoSet>AmmoSet_12GaugeCharged_ForsakenShotGun</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>ForsakenGun</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== Forsaken Assault Rifle ========== -->
+
+				<!-- (CE implementation based on M16A1 assault rifle from RN Weapons, chambered for 5x35mm Charged cartridge) -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>ForsakenAR</defName>
+					<statBases>
+						<Mass>2.89</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.00</SightsEfficiency>
+						<ShotSpread>0.07</ShotSpread>
+						<SwayFactor>1.29</SwayFactor>
+						<Bulk>10.03</Bulk>
+						<WorkToMake>60500</WorkToMake>
+					</statBases>
+					<costList>
+						<!-- from original mod -->
+						<Steel>500</Steel>
+						<Plasteel>100</Plasteel>
+						<ComponentIndustrial>10</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.63</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_5x35mmCharged_ForsakenAR</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>59</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+						<soundCast>Shot_ChargeRifle</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>1</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_5x35mmCharged_ForsakenAR</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<weaponTags>
+						<li>ForsakenGun</li>
+					</weaponTags>
+				</li>			
+
+				<!-- == Shared patches for firearm melee tools == -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="ForsakenSniper" or
+						defName="ForsakenShotGun" or
+						defName="ForsakenAR"
+					]</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				
+				<!-- ========== Forsaken Long Blade ========== -->
+
+				<!-- (CE implementation based on CE Melee Wraithblade) -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ForsakenLongBlade"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<chanceFactor>0.33</chanceFactor>
+								<cooldownTime>1.52</cooldownTime>
+								<armorPenetrationBlunt>0.500</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>1</cooldownTime>
+								<armorPenetrationBlunt>11.250</armorPenetrationBlunt>
+								<armorPenetrationSharp>90</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>23</power>
+								<cooldownTime>0.5</cooldownTime>
+								<armorPenetrationBlunt>25</armorPenetrationBlunt>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenLongBlade"]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<MeleeCounterParryBonus>1.6</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenLongBlade"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>4</MeleeCritChance>
+							<MeleeParryChance>1.2</MeleeParryChance>
+							<MeleeDodgeChance>0.4</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken Combat Blade ========== -->
+
+				<!-- (CE implementation based on vanilla CE knife with armor penetration of CE Melee Wraithblade) -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ForsakenCombatBlade"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>blade</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1.18</cooldownTime>
+								<armorPenetrationBlunt>25</armorPenetrationBlunt>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>1.26</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>11.250</armorPenetrationBlunt>
+								<armorPenetrationSharp>90</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenCombatBlade"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenCombatBlade"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.5</MeleeCritChance>
+							<MeleeParryChance>0.15</MeleeParryChance>
+							<MeleeDodgeChance>0.05</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken Battle Axe ========== -->
+
+				<!-- (CE implementation based on Vanilla Weapons Expanded Battle Axe) -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ForsakenBattle"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>48</power>
+								<cooldownTime>3.4</cooldownTime>
+								<chanceFactor>1.165</chanceFactor>
+								<armorPenetrationBlunt>10.4</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.8</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>41</power>
+								<cooldownTime>1.8</cooldownTime>
+								<chanceFactor>1.165</chanceFactor>
+								<armorPenetrationBlunt>2.3</armorPenetrationBlunt>
+								<armorPenetrationSharp>2.2</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenBattle"]/statBases</xpath>
+					<value>
+						<Bulk>13</Bulk>
+						<MeleeCounterParryBonus>1.08</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenBattle"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.2</MeleeCritChance>
+							<MeleeParryChance>1.45</MeleeParryChance>
+							<MeleeDodgeChance>0.6</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>				
+
+				<!-- ========== Forsaken Bulk Sword ========== -->
+
+				<!-- (Weaker than vanilla CE longsword, but low cooldown time) -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ForsakenBulksword"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>0.5</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>0.5</cooldownTime>
+								<chanceFactor>0.60</chanceFactor>
+								<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.6</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>0.5</cooldownTime>
+								<chanceFactor>0.30</chanceFactor>
+								<armorPenetrationBlunt>2.592</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.58</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenBulksword"]/statBases</xpath>
+					<value>
+						<!-- Slightly bulkier than vanilla CE longsword -->
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenBulksword"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.63</MeleeCritChance>
+							<MeleeParryChance>0.75</MeleeParryChance>
+							<MeleeDodgeChance>0.4</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>	
+				</li>
+
+				<!-- ========== Forsaken Spear ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="FSpear"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>shaft</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>1.35</cooldownTime>
+								<chanceFactor>0.15</chanceFactor>
+								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>shaft</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>1.78</cooldownTime>
+								<chanceFactor>0.05</chanceFactor>
+								<armorPenetrationBlunt>1</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>1.19</cooldownTime>
+								<chanceFactor>1.00</chanceFactor>
+								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="FSpear"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<MeleeCounterParryBonus>1.68</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="FSpear"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.17</MeleeCritChance>
+							<MeleeParryChance>1.45</MeleeParryChance>
+							<MeleeDodgeChance>0.9</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- ========== Forsaken Bow ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>FBow</defName>
+					<statBases>
+						<SightsEfficiency>0.6</SightsEfficiency>
+						<ShotSpread>1</ShotSpread>
+						<SwayFactor>2</SwayFactor>
+						<Bulk>4.00</Bulk>
+						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+					</statBases>
+					<costList>
+						<Steel>180</Steel>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Projectile_ForsakensArrows</defaultProjectile>
+						<warmupTime>1.2</warmupTime>
+						<range>32</range>
+						<soundCast>Bow_Large</soundCast>
+					</Properties>
+					<AmmoUser>
+						<ammoSet>AmmoSet_ForsakensArrows</ammoSet>
+					</AmmoUser>
+					<FireModes />
+					<researchPrerequisite>RecurveBow</researchPrerequisite>
+					<AllowWithRunAndGun>true</AllowWithRunAndGun>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="FBow"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>1.6</cooldownTime>
+								<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons_BlackHydra.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons_BlackHydra.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Forsakens</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- NOTE: Black Hydra is currently disabled for CE, as the original mod incorrectly uses a thingDef rather than ThingDef, which is incompatible with CE patching -->
+				
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/thingDef[defName="ForsakenHydra"]</xpath>
+				</li>
+
+				<!-- ========== Forsaken Black Hydra ========== -->
+
+				<!-- (CE implementation based on BFG 9000 from CP DOOM mod, with infinite ammo as per item description in original Forsakens mod) -->
+
+				<!-- TEMPORARILY DISABLED 
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>ForsakenHydra</defName>
+					<statBases>
+						<Mass>10.00</Mass>
+						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.00</SightsEfficiency>
+						<ShotSpread>0.01</ShotSpread>
+						<SwayFactor>0.88</SwayFactor>
+						<Bulk>13.00</Bulk>
+						<WorkToMake>72500</WorkToMake>
+					</statBases>
+					<costList>
+						<Silver>100</Silver>
+						<Plasteel>100</Plasteel>
+						<ComponentSpacer>6</ComponentSpacer>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_HydraBlast</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+						<range>62</range>
+						<soundCast>ChargeLance_Fire</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<onlyManualCast>false</onlyManualCast>
+						<muzzleFlashScale>1</muzzleFlashScale>
+						<stopBurstWithoutLos>false</stopBurstWithoutLos>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+					</Properties>
+
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>ForsakenGun</li>
+					</weaponTags>
+					
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ForsakenHydra"]</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>2.44</cooldownTime>
+								<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>-->
+
+				<!-- Patch Hydra Blast projectile to be CE compatible, with armor penetration and blast damage stats similar to vanilla CE M6 HEAT rockets
+				
+				Note that the lightning strike effect has been removed, as the Forsaken.Linking Class required is incompatible with CombatExtended.AmmoDef -->
+				
+
+				<!-- TEMPORARILY DISABLED 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Bullet_HydraBlast"]</xpath>
+					<value>
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+							<defName>Bullet_HydraBlast</defName>
+							<label>Hydra Blast</label>
+							<graphicData>
+								<texPath>Weapons/BigPulse</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>HydraBlast</damageDef>
+								<damageAmountBase>141</damageAmountBase>
+								<armorPenetrationSharp>76</armorPenetrationSharp>
+								<armorPenetrationBlunt>42.273</armorPenetrationBlunt>
+								<speed>75</speed>
+								<explosionRadius>3</explosionRadius>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>1</preExplosionSpawnChance>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>-->
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

* Add compatibility patches for Forsakens, as part of the FastTrack merger
* Add conditionally-patched mod-unique ammo and projectiles:
  * Forsaken arrow (stats identical to Steel Great Arrows, ammo textures implemented in CE ThirdParty folder, projectile texture directly referenced from original mod)
  * Reskinned projectile variants of 8x35mm Charged cartridge, 12 Gauge Charged shotgun cartridge and 5x35mm Charged cartridge ammo, allowing Forsaken weapons to use generic CE Charged ammo while firing their own projectiles

## References

- Contributes towards #10

## Reasoning

* Added `HeadAttackTool` to Forsaken race, to address @N7Huntsman's concerns regarding weird AI behaviour if pawns become armless
* Apparel sharp and blunt AP stats balanced to latest CE standards
  * Forsaken fabric apparel are only craftable from Synthread, so stats are based on a normal quality vanilla apparel made from Synthread
  * Forsaken armor comparable to vanilla CE power armor
* Drug mass and bulk comparable to vanilla CE drugs
* All Forsaken pawn inventory comes with 6~8 magazines for their weapon, as they only spawn with firearms
* Nightling animal stats based on a mix of Wargs and AnimalCollabProj Dire Wolves
* Forsaken weapon stats based on various other vanilla CE or third-party mod patch stats
  * See comments in xml file for specific justifications
  * Bladed melee weapon sharp/blunt AP balanced relative to similar weapons from CE Melee
  * Black Hydra weapon currently disabled for CE, as original mod had it defined with thingDef instead of ThingDef, which is incompatible with CE's PatchOperationMakeGunCECompatible

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
