### PR TITLE
Change ArmorPenetration to ArmorPenetration_Blunt for Heavy Charge Blaster, Charge Lance, Inferno Cannon and Minigun's melee attack with the barrel 

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -842,7 +842,7 @@
             <li>Blunt</li>
           </capacities>
           <power>10</power>
-          <cooldownTime>1.9</cooldownTime>
+          <cooldownTime>2.44</cooldownTime>
           <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
         </li>
@@ -1158,7 +1158,7 @@
             <li>Blunt</li>
           </capacities>
           <power>10</power>
-          <cooldownTime>1.9</cooldownTime>
+          <cooldownTime>2.44</cooldownTime>
           <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
@@ -1225,7 +1225,7 @@
             <li>Blunt</li>
           </capacities>
           <power>10</power>
-          <cooldownTime>1.9</cooldownTime>
+          <cooldownTime>2.44</cooldownTime>
           <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
@@ -1289,7 +1289,7 @@
             <li>Blunt</li>
           </capacities>
           <power>10</power>
-          <cooldownTime>1.9</cooldownTime>
+          <cooldownTime>2.44</cooldownTime>
           <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -843,7 +843,7 @@
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
-          <armorPenetration>0.118</armorPenetration>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
         </li>
       </tools>
@@ -1159,7 +1159,7 @@
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
-          <armorPenetration>0.118</armorPenetration>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
       </tools>
@@ -1226,7 +1226,7 @@
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
-          <armorPenetration>0.118</armorPenetration>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
       </tools>
@@ -1290,7 +1290,7 @@
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
-          <armorPenetration>0.118</armorPenetration>
+          <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
       </tools>


### PR DESCRIPTION
Changing the CE 1.0 ArmorPenetration to ArmorPenetrationBlunt using as a reference the Gun_Triple_Rocket and Gun_Doomsday_Rocket ArmorPenetration_Blunt values for their respective barrels.

## Additions

- ArmorPenetrationBlunt value of 3.5 for the Heavy Charge Blaster, Charge Lance, Inferno Cannon and Minigun's melee attack with the barrel. Inspired by Gun_Triple_Rocket and Gun_Doomsday used values for Core Patch.

## Changes

- MeleeCooldown of 2.44 to match the reference values.

## References

- Same file.

## Reasoning

The lack of current armorpenetration syntax make red errors pop up due to incompatibility.

## Alternatives

- Implement in Line 74 along with Gun_Minigun and Gun_TripleRocketLauncher patchoperationreplace.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)