### PR TITLE
Mpt1.1 fixes

### DIFF
--- a/Patches/More Practical Traits/TraitDefs/Traits_MPT.xml
+++ b/Patches/More Practical Traits/TraitDefs/Traits_MPT.xml
@@ -16,14 +16,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="VanyaTA01mhgg"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="VanyaTA01mhgg"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -33,6 +33,15 @@
 				<xpath>Defs/TraitDef[defName="VanyaTB01tzz"]/degreeDatas/li/statFactors</xpath>
 				<value>
 					<SmokeSensitivity>0.95</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<!--Delicate-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="VanyaTC01rrwg"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>17.4</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -60,8 +69,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="VanyaTS01by"]/degreeDatas/li/statFactors</xpath>
 				<value>
-					<CarryWeight>1.5</CarryWeight>
-					<CarryBulk>1.5</CarryBulk>
+					<CarryWeight>1.1</CarryWeight>
+					<CarryBulk>1.1</CarryBulk>
 				</value>
 			</li>
 			
@@ -91,8 +100,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA03nwj"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>7.5</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
+					<CarryWeight>3</CarryWeight>
+					<CarryBulk>3</CarryBulk>
 				</value>
 			</li>
 			
@@ -101,8 +110,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA04kg"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>12.5</CarryWeight>
-					<CarryBulk>12.5</CarryBulk>
+					<CarryWeight>5</CarryWeight>
+					<CarryBulk>5</CarryBulk>
 				</value>
 			</li>
 			
@@ -123,8 +132,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA08tj"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>7.5</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
+					<CarryWeight>3</CarryWeight>
+					<CarryBulk>3</CarryBulk>
 				</value>
 			</li>
 			
@@ -133,8 +142,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA09dkj"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>7.5</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
+					<CarryWeight>3</CarryWeight>
+					<CarryBulk>3</CarryBulk>
 				</value>
 			</li>
 			
@@ -156,25 +165,30 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB02tb"]/degreeDatas/li/label</xpath>
+				<value>
+					<label>&lt;color=#33ff00&gt;Valiant&lt;/color&gt;</label>
+				</value>
+			</li>
+			
 			<!--Strong-->
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA15qz"]/degreeDatas/li/statFactors</xpath>
 				<value>
-					<CarryWeight>2</CarryWeight>
-					<CarryBulk>1.5</CarryBulk>
+					<CarryWeight>1.2</CarryWeight>
+					<CarryBulk>1.2</CarryBulk>
 				</value>
 			</li>
 			
-			<!--Earnest-->
-			
-			<!--Tailor-->
+			<!--Craftsman-->
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA17cf"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>7.5</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
+					<CarryWeight>3</CarryWeight>
+					<CarryBulk>3</CarryBulk>
 				</value>
 			</li>
 			
@@ -183,8 +197,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA18fmg"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>7.5</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
+					<CarryWeight>3</CarryWeight>
+					<CarryBulk>3</CarryBulk>
 				</value>
 			</li>
 			
@@ -193,8 +207,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTA19zg"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>25</CarryWeight>
-					<CarryBulk>25</CarryBulk>
+					<CarryWeight>4</CarryWeight>
+					<CarryBulk>4</CarryBulk>
 				</value>
 			</li>
 			
@@ -217,20 +231,90 @@
 				</value>
 			</li>
 			
+			<!--Assassin-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB22ck"]/degreeDatas/li/statOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>0.4</MeleeDodgeChance>
+					<MeleeCritChance>0.05</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTB22ck"]/degreeDatas/li/statFactors</xpath>
+				<value>
+					<MeleeCritChance>1.3</MeleeCritChance>
+				</value>
+			</li>
+			
+			<!--Executioner-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB23gzs"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTB23gzs"]/degreeDatas/li/statFactors</xpath>
+				<value>
+					<MeleeParryChance>1.3</MeleeParryChance>
+					<CarryBulk>1.1</CarryBulk>
+					<CarryWeight>1.1</CarryWeight>
+				</value>
+			</li>
+			
+			<!--Martial Arts-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTB25wx"]/degreeDatas/li/statOffsets</xpath>
+				<value>
+					<UnarmedDamage>5</UnarmedDamage>
+				</value>
+			</li>
+			
+			<!--New Type-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTC17xrl"]/degreeDatas/li/statFactors</xpath>
+				<value>
+					<AimingAccuracy>1.225</AimingAccuracy>
+				</value>
+			</li>
+			
 			<!--Impregnable defense-->
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/TraitDef[defName="VanyaTA01mhgg"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<xpath>Defs/TraitDef[defName="PTB02tb"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					<ArmorRating_Sharp>3.2</ArmorRating_Sharp>
 					<Suppressability>-0.25</Suppressability>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/TraitDef[defName="VanyaTA01mhgg"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
+				<xpath>Defs/TraitDef[defName="PTB02tb"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>4.8</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!--Clone-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB27qhr"]/degreeDatas/li/statOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
+					<AimingAccuracy>0.4</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB27qhr"]/degreeDatas/li/statOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>0.7</MeleeDodgeChance>
 				</value>
 			</li>
 			
@@ -258,8 +342,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTC02wjj"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>25</CarryWeight>
-					<CarryBulk>25</CarryBulk>
+					<CarryWeight>10</CarryWeight>
+					<CarryBulk>10</CarryBulk>
 				</value>
 			</li>
 			
@@ -297,6 +381,16 @@
 				<xpath>Defs/TraitDef[defName="PTC11bdbq"]/degreeDatas/li/statOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-0.50</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<!--Arms Dealer-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTB27qhr"]/degreeDatas/li/statOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
+					<AimingAccuracy>0.25</AimingAccuracy>
 				</value>
 			</li>
 			
@@ -358,12 +452,19 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTF01hy"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>7.2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
 			<!--Warrior of the sun-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTF02tyqs"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					<Suppressability>-0.25</Suppressability>
 				</value>
 			</li>
@@ -371,7 +472,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTF02tyqs"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>15</ArmorRating_Blunt>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -395,7 +496,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTF03mrqw"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10.8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>7.2</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -404,7 +505,7 @@
 				<value>
 					<MeleeCritChance>0.03</MeleeCritChance>
 					<MeleeParryChance>0.0375</MeleeParryChance>
-					<UnarmedDamage>3</UnarmedDamage>
+					<UnarmedDamage>20</UnarmedDamage>
 					<Suppressability>-0.25</Suppressability>
 				</value>
 			</li>
@@ -414,7 +515,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTF04skjs"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8.4</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -433,19 +534,44 @@
 				</value>
 			</li>
 			
+			<!--Punisher-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTC13cjz"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>5.6</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTC13cjz"]/degreeDatas/li/statOffsets</xpath>
+				<value>
+					<Suppressability>-0.25</Suppressability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTC13cjz"]/degreeDatas/li/statFactors</xpath>
+				<value>
+					<MeleeCritChance>1.05</MeleeCritChance>
+					<MeleeParryChance>1.15</MeleeParryChance>
+					<AimingAccuracy>1.175</AimingAccuracy>
+				</value>
+			</li>
+			
 			<!--Diligent fighter-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS01yz"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>9</ArmorRating_Sharp>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS01yz"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>19.8</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -464,7 +590,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS02ss"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14.4</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/More Practical Traits/TraitDefs/Traits_MPT.xml
+++ b/Patches/More Practical Traits/TraitDefs/Traits_MPT.xml
@@ -54,20 +54,21 @@
 				</value>
 			</li>
 			
+			
 			<!--Bear-->
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/TraitDef[defName="VanyaTE01gsdzf"]/degreeDatas/li/statOffsets</xpath>
+				<xpath>Defs/TraitDef[defName="VanyaTS01by"]/degreeDatas/li/statFactors</xpath>
 				<value>
-					<SmokeSensitivity>-0.275</SmokeSensitivity>
+					<CarryWeight>1.5</CarryWeight>
+					<CarryBulk>1.5</CarryBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/TraitDef[defName="VanyaTC03fwgz"]/degreeDatas/li/statFactors</xpath>
+				<xpath>Defs/TraitDef[defName="VanyaTS01by"]/degreeDatas/li/statOffsets</xpath>
 				<value>
-					<CarryWeight>1.5</CarryWeight>
-					<CarryBulk>1.5</CarryBulk>
+					<SmokeSensitivity>-0.275</SmokeSensitivity>
 				</value>
 			</li>
 			
@@ -200,10 +201,10 @@
 			<!--Hunter-->
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/TraitDef[defName="PTA24lr"]/degreeDatas/li/statOffsets/ShootingAccuracyPawn</xpath>
+				<xpath>Defs/TraitDef[defName="PTA24lr"]/degreeDatas/li/statFactors/ShootingAccuracyPawn</xpath>
 				<value>
-					<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
-					<AimingAccuracy>0.15</AimingAccuracy>
+					<ShootingAccuracyPawn>1.20</ShootingAccuracyPawn>
+					<AimingAccuracy>1.10</AimingAccuracy>
 				</value>
 			</li>
 			
@@ -300,13 +301,6 @@
 			</li>
 			
 			<!--Yandere-->
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/TraitDef[defName="PTD01bj"]/degreeDatas/li/statOffsets/MeleeDodgeChance</xpath>
-				<value>
-					<MeleeDodgeChance>0.4</MeleeDodgeChance>
-				</value>
-			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/TraitDef[defName="PTD01bj"]/degreeDatas/li/statFactors</xpath>
@@ -415,19 +409,43 @@
 				</value>
 			</li>
 			
+			<!--Swordmaster of Squin-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="PTF04skjs"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTF04skjs"]/degreeDatas/li/statOffsets</xpath>
+				<value>
+					<Suppressability>-0.25</Suppressability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName="PTF04skjs"]/degreeDatas/li/statFactors</xpath>
+				<value>
+					<MeleeCritChance>1.05</MeleeCritChance>
+					<MeleeParryChance>1.15</MeleeParryChance>
+				</value>
+			</li>
+			
 			<!--Diligent fighter-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS01yz"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10.8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>9</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS01yz"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>21</ArmorRating_Blunt>
+					<ArmorRating_Blunt>19.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -465,8 +483,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/TraitDef[defName="PTS04zrzz"]/degreeDatas/li/statOffsets/ShootingAccuracyPawn</xpath>
 				<value>
-					<ShootingAccuracyPawn>-0.6</ShootingAccuracyPawn>
-					<AimingAccuracy>-0.3</AimingAccuracy>
+					<ShootingAccuracyPawn>-0.7</ShootingAccuracyPawn>
+					<AimingAccuracy>-0.35</AimingAccuracy>
 				</value>
 			</li>
 			


### PR DESCRIPTION
## Additions

Added CE specific stats to new traits from 1.1 version.

## Changes

Armor stats have been adjusted so that equivalent 100% protection from vanilla is equal to a steel vest.

Traits that previously provided carry capacity added 1/2 of that stat as a flat buff to bulk/weight capacities. This has been reduced to 1/5 of the bonus carry capacity in order to make them less seriously impactful in terms of loadouts.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded