### PR TITLE
Gatling turret no longer goes boom when destroyed

### DIFF
--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
@@ -60,6 +60,10 @@
 
         <!-- == Remove stuff == -->
         <li Class="PatchOperationRemove">
+          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+        </li>
+
+        <li Class="PatchOperationRemove">
           <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
         </li>
 


### PR DESCRIPTION
## Changes

- Removed ` CompProperties_Explosive ` from the Gatling turret

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested
