### PR TITLE
Update to Recon armour mass

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -424,7 +424,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/statBases/Mass</xpath>
+		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/statBases/Mass</xpath>
 		<value>
 			<Mass>40</Mass>
 		</value>


### PR DESCRIPTION
Mass of recon armor fixed. Previously there were 2 lines 'replacing' the mass of regular power armor.

## Testing

Check tests you have performed:
- [x ] Compiles without warnings
- [x ] Game runs without errors
- [x ] (For compatibility patches) ...with and without patched mod loaded
- [x ] Playtested a colony (specify how long)
