### PR TITLE
Increased grenade launcher reload time.

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -27,7 +27,7 @@
       <WoodLog>10</WoodLog>
     </costList>	
     <weaponTags>
-      <li>GunHeavy</li>
+      	  <li>GunHeavy</li>
 	  <li>GrenadeSmoke</li>
 	  <li>GrenadeEMP</li>		  
     </weaponTags>
@@ -51,7 +51,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
-        <reloadTime>0.85</reloadTime>
+        <reloadTime>1.6</reloadTime>
         <ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">


### PR DESCRIPTION
Currently, the break action grenade launcher fires awfully fast in comparison to the Milkor, given that it's single fire and lacks an ejector.