### PR TITLE
Fixes certain Ni'hal pawntypes not spawning with ammo

### DIFF
--- a/Patches/Nihal/PawnKinds_NiHal.xml
+++ b/Patches/Nihal/PawnKinds_NiHal.xml
@@ -41,6 +41,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/PawnKindDef[defName="NihalPeasant"]/weaponMoney</xpath>
 				<value>
@@ -81,6 +82,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalRefugee"]</xpath>
 				<value>
@@ -112,6 +114,41 @@
 				  </li>
 				</value>
 			</li>
+				
+ 
+   		   	<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/PawnKindDef[defName="NihalMilitia"]</xpath>
+				<value>
+				  <li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+					  <min>3</min>
+					  <max>5</max>
+					</primaryMagazineCount>
+					<shieldMoney>
+					  <min>500</min>
+					  <max>1400</max>
+					</shieldMoney>
+					<shieldTags>
+					  <li>OutlanderShield</li>
+					</shieldTags>
+					<shieldChance>0.25</shieldChance>
+					<sidearms>
+					  <li>
+						<generateChance>0.5</generateChance>
+						<sidearmMoney>
+						  <min>100</min>
+						  <max>300</max>
+						</sidearmMoney>
+						<weaponTags>
+						  <li>CE_Sidearm_Melee</li>
+						</weaponTags>
+					  </li>
+					</sidearms>
+				  </li>
+				</value>
+			</li>
+       
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalTownCouncilman"]</xpath>
 				<value>
@@ -151,7 +188,8 @@
 					  <max>800</max>
 					</weaponMoney>
 				</value>
-			</li>			
+			</li>	
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalSniper"]</xpath>
 				<value>
@@ -183,6 +221,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalSoldier"]</xpath>
 				<value>
@@ -214,6 +253,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalSlasher"]</xpath>
 				<value>
@@ -245,6 +285,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalGunner"]</xpath>
 				<value>
@@ -276,6 +317,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NihalGrenadier"]</xpath>
 				<value>
@@ -307,6 +349,7 @@
 				  </li>
 				</value>
 			</li>
+				
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="NiHalBoss"]</xpath>
 				<value>


### PR DESCRIPTION
Ni'hal Militia pawns spawn with ammo now
