### PR TITLE
add `new` keyword to GetBaseValueFor, to silence warning

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BodyPartDensity.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_BodyPartDensity.cs
@@ -8,7 +8,7 @@ namespace CombatExtended
     {
         protected abstract string UnitString { get; }
 
-        protected abstract float GetBaseValueFor(StatRequest req);
+        protected abstract new float GetBaseValueFor(StatRequest req);
 
         public override bool ShouldShowFor(StatRequest req)
         {


### PR DESCRIPTION
## Reasoning

`GetBaseValueFor` is inherited from `RimWorld.StatWorker`, and is overridden here.  As this override appears to be intentional, the `new` keyword is supposed to be used (generates a warning if it is not).
## Alternatives

Describe alternative implementations you have considered, e.g.
Change the name of `GetBaseValueFor`, which leaves access to the base class's version.
Not declare it abstract here, 
## Testing

Check tests you have performed:
- [❌] Compiles without warnings (1 fewer warning though)
- [✔] Game runs without errors
- [✔] Playtested a colony (minutes)
