### PR TITLE
Explicitly use ReferenceEquals instead of == when Reference check is …

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
@@ -70,7 +70,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 yield return code;
                 if (!patched)
                 {
-                    if (code.opcode == OpCodes.Isinst && code.operand == Stance_RunAndGun)
+		  if (code.opcode == OpCodes.Isinst && ReferenceEquals(code.operand, Stance_RunAndGun))
                     {
                         ready = true;
                     }

--- a/Source/CombatExtended/Harmony/Harmony-DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony-DamageWorker_AddInjury.cs
@@ -34,7 +34,7 @@ namespace CombatExtended.HarmonyCE
             var codes = instructions.ToList();
            
             // Find armor block
-            var armorBlockEnd = codes.FirstIndexOf(c => c.operand == typeof(ArmorUtility).GetMethod("GetPostArmorDamage", AccessTools.all));
+            var armorBlockEnd = codes.FirstIndexOf(c => ReferenceEquals(c.operand, typeof(ArmorUtility).GetMethod("GetPostArmorDamage", AccessTools.all)));
           
             int armorBlockStart = -1;
 

--- a/Source/CombatExtended/Harmony/Harmony-Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Fire.cs
@@ -28,7 +28,7 @@ namespace CombatExtended.HarmonyCE
                     code.operand = 300f;
                 }
 
-                if (code.operand == AccessTools.Field(typeof(RulePackDefOf), nameof(RulePackDefOf.DamageEvent_Fire)))
+                if (ReferenceEquals(code.operand, AccessTools.Field(typeof(RulePackDefOf), nameof(RulePackDefOf.DamageEvent_Fire))))
                 {
                     yield return new CodeInstruction(OpCodes.Ldloca, 0);
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Fire_DoFireDamage), nameof(ApplySizeMult)));
@@ -195,7 +195,7 @@ namespace CombatExtended.HarmonyCE
                     continue;
                 }
 
-                if (code.operand == AccessTools.Field(typeof(GenRadial), nameof(GenRadial.ManualRadialPattern)))
+                if (ReferenceEquals(code.operand, AccessTools.Field(typeof(GenRadial), nameof(GenRadial.ManualRadialPattern))))
                 {
                     codes.Add(new CodeInstruction(OpCodes.Ldarg_0));
                     codes.Add(passedRadPattern

--- a/Source/CombatExtended/Harmony/Harmony-PawnColumnWorkers.cs
+++ b/Source/CombatExtended/Harmony/Harmony-PawnColumnWorkers.cs
@@ -148,7 +148,7 @@ namespace CombatExtended.HarmonyCE
 
                 // Watch for calls to rect.y + 2f, we replace them with our num4 (see PawnColumnWorker_Loadout)
                 if (curCode.opcode == OpCodes.Call &&
-                    curCode.operand == typeof(Rect).GetMethod("get_y", AccessTools.all))
+                    ReferenceEquals(curCode.operand, typeof(Rect).GetMethod("get_y", AccessTools.all)))
                 {
                     if (passedFirstRectYCall && i + 1 < codes.Count && codes[i + 1].opcode == OpCodes.Ldc_R4 && codes[i + 1].operand.Equals(2f))
                     {

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -37,7 +37,7 @@ namespace CombatExtended.HarmonyCE
             get
             {
                 if (harmony == null)
-                    harmony = harmony = new Harmony("CombatExtended.HarmonyCE");
+                    harmony = new Harmony("CombatExtended.HarmonyCE");
                 return harmony;
             }
         }

--- a/Source/CombatExtended/Harmony/Harmony_ApparelGraphicRecordGetter.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ApparelGraphicRecordGetter.cs
@@ -40,7 +40,7 @@ namespace CombatExtended.HarmonyCE
                     code.opcode = OpCodes.Brtrue;   //OR try Brfalse
                 }
 
-                if (code.opcode == OpCodes.Ldsfld && code.operand == AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Overhead)))
+                if (code.opcode == OpCodes.Ldsfld && ReferenceEquals(code.operand, AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Overhead))))
                 {
                     write = true;
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Harmony_ApparelGraphicRecordGetter), nameof(IsHeadwear)));

--- a/Source/CombatExtended/Harmony/Harmony_AttackTargetFinder.cs
+++ b/Source/CombatExtended/Harmony/Harmony_AttackTargetFinder.cs
@@ -22,7 +22,7 @@ namespace CombatExtended.HarmonyCE
             var codes = instructions.ToList();
             for (int i = 0; i < instructions.Count(); i++)
             {
-                if (codes[i].opcode == OpCodes.Call && codes[i].operand == AccessTools.Method(typeof(VerbUtility), nameof(VerbUtility.IsEMP)))
+	      if (codes[i].opcode == OpCodes.Call && ReferenceEquals(codes[i].operand, AccessTools.Method(typeof(VerbUtility), nameof(VerbUtility.IsEMP))))
                 {
                     codes[i - 2].opcode = OpCodes.Nop;
                     codes[i - 1].opcode = OpCodes.Nop;

--- a/Source/CombatExtended/Harmony/Harmony_FireUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FireUtility.cs
@@ -23,7 +23,7 @@ namespace CombatExtended.HarmonyCE
 
                     write = false;
                 }
-                else if (code.opcode == OpCodes.Ldfld && code.operand == AccessTools.Field(typeof(ThingDef), nameof(ThingDef.category)))
+                else if (code.opcode == OpCodes.Ldfld && ReferenceEquals(code.operand, AccessTools.Field(typeof(ThingDef), nameof(ThingDef.category))))
                 {
                     write = true;
                 }

--- a/Source/CombatExtended/Harmony/Harmony_Hediff_Injury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Hediff_Injury.cs
@@ -26,9 +26,9 @@ namespace CombatExtended.HarmonyCE
                         // search for BodyPartRecord::coverageAbs
                         case 0:
                             if (instruction.opcode == OpCodes.Ldfld
-                                && instruction.operand == AccessTools.Field(
+                                && ReferenceEquals(instruction.operand, AccessTools.Field(
                                     typeof(BodyPartRecord),
-                                    nameof(BodyPartRecord.coverageAbs)))
+                                    nameof(BodyPartRecord.coverageAbs))))
                                 patchPhase = 1;
                             break;
                         // search for greater than check

--- a/Source/CombatExtended/Harmony/Harmony_PawnGraphicSet.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnGraphicSet.cs
@@ -30,7 +30,7 @@ namespace CombatExtended.HarmonyCE
                     code.opcode = OpCodes.Brtrue;
                 }
 
-                if (code.opcode == OpCodes.Ldsfld && code.operand == AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Overhead)))
+                if (code.opcode == OpCodes.Ldsfld && ReferenceEquals(code.operand, AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Overhead))))
                 {
                     write = true;
                     yield return new CodeInstruction(OpCodes.Callvirt, AccessTools.Method(typeof(Harmony_PawnGraphicSet), nameof(RenderSpecial)));

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -119,7 +119,7 @@ namespace CombatExtended.HarmonyCE
                     code.opcode = OpCodes.Brtrue;
                 }
 
-                if (state == WriteState.WritePostShell && code.opcode == OpCodes.Call && code.operand == AccessTools.Method(typeof(GenDraw), nameof(GenDraw.DrawMeshNowOrLater)))
+                if (state == WriteState.WritePostShell && code.opcode == OpCodes.Call && ReferenceEquals(code.operand, AccessTools.Method(typeof(GenDraw), nameof(GenDraw.DrawMeshNowOrLater))))
                 {
                     state = WriteState.None;
 
@@ -136,7 +136,7 @@ namespace CombatExtended.HarmonyCE
                 {
                     state = WriteState.WriteHead;
                 }
-                else if (code.opcode == OpCodes.Ldsfld && code.operand == AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Shell)))
+                else if (code.opcode == OpCodes.Ldsfld && ReferenceEquals(code.operand, AccessTools.Field(typeof(ApparelLayerDefOf), nameof(ApparelLayerDefOf.Shell))))
                 {
                     state = WriteState.WriteShell;
                     code.opcode = OpCodes.Callvirt;


### PR DESCRIPTION
## Reasoning
The `==` operator falls back to `ReferenceEquals` in cases where one operand does not implement a custom equality check.  In the case where one implements a custom equality check and the other does not, it still falls back to `ReferenceEquals`, but also issues a compiler warning.  Since the code is working as intended in these cases, using `ReferenceEquals`, we should make that explicit, as in the context of harmony patches, `ReferenceEquals` is the correct comparison.

## Testing

Check tests you have performed:
- [✔] Compiles without warnings (if using all my other patches too)
- [✔] Game runs without errors
- [✔] Playtested a colony (minutes)
