### PR TITLE
Fix remaining unused variable warnings.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -25,12 +25,12 @@ namespace CombatExtended
         #region Fields
 
         private static Texture2D
-            _arrowBottom = ContentFinder<Texture2D>.Get("UI/Icons/arrowBottom"),
-            _arrowDown = ContentFinder<Texture2D>.Get("UI/Icons/arrowDown"),
-            _arrowTop = ContentFinder<Texture2D>.Get("UI/Icons/arrowTop"),
-            _arrowUp = ContentFinder<Texture2D>.Get("UI/Icons/arrowUp"),
+            //_arrowBottom = ContentFinder<Texture2D>.Get("UI/Icons/arrowBottom"),
+            //_arrowDown = ContentFinder<Texture2D>.Get("UI/Icons/arrowDown"),
+            //_arrowTop = ContentFinder<Texture2D>.Get("UI/Icons/arrowTop"),
+            //_arrowUp = ContentFinder<Texture2D>.Get("UI/Icons/arrowUp"),
             _darkBackground = SolidColorMaterials.NewSolidColorTexture(0f, 0f, 0f, .2f),
-            _iconEdit = ContentFinder<Texture2D>.Get("UI/Icons/edit"),
+            //_iconEdit = ContentFinder<Texture2D>.Get("UI/Icons/edit"),
             _iconClear = ContentFinder<Texture2D>.Get("UI/Icons/clear"),
             _iconAmmo = ContentFinder<Texture2D>.Get("UI/Icons/ammo"),
             _iconRanged = ContentFinder<Texture2D>.Get("UI/Icons/ranged"),

--- a/Source/CombatExtended/CombatExtended/PatchOperationFindMod.cs
+++ b/Source/CombatExtended/CombatExtended/PatchOperationFindMod.cs
@@ -11,7 +11,7 @@ namespace CombatExtended
 {
     public class PatchOperationFindMod : PatchOperation
     {
-        private string modName;
+        protected string modName;
 
         protected override bool ApplyWorker(XmlDocument xml)
         {


### PR DESCRIPTION
## Reasoning

Just fixes the remaining unused variable warnings.
In `PatchOperationFindMod`, `modName` was `private`, but doesn't get set within the file, it gets set via reflection elsewhere, but the compiler issues a warning.
Easiest way to silence the warning is to change it to protected.

Check tests you have performed:
- [✔] Compiles without warnings (finally, if all the other patches are also applied)
- [✔] Game runs without errors
- [✔] Playtested a colony (minutes)
