### PR TITLE
VWE / VFE-Settlers Fixes

### DIFF
--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -37,15 +37,24 @@
         </li>
 
         <!-- == Weapon == -->
-        
         <li Class="PatchOperationAttributeSet">
           <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
         </li>
+        
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
+          
+          <value>
+            <thingCategories>
+              <li>WeaponsRanged</li>
+            </thingCategories>
+          </value>
+        </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/costStuffCount</xpath>
+          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/costStuffCount</xpath>
         </li>
 
         <li Class="PatchOperationRemove">

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -261,7 +261,7 @@
         <!-- === Throwing Knives === -->
         <!-- == Projectile == -->
         <li Class="PatchOperationReplace">
-          <xpath>Defs/ThingDef[defName="VWE_FlyingBlade"]/projectile</xpath>
+          <xpath>/Defs/ThingDef[defName="VWE_FlyingBlade"]/projectile</xpath>
 
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -279,8 +279,19 @@
         <!-- == Weapon == -->
         <li Class="PatchOperationAttributeSet">
           <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
+          
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
+        </li>
+        
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
+          
+          <value>
+            <thingCategories>
+              <li>WeaponsRanged</li>
+            </thingCategories>
+          </value>
         </li>
 
         <li Class="PatchOperationRemove">
@@ -288,7 +299,7 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/costStuffCount</xpath>
+          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/costStuffCount</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
@@ -339,6 +350,10 @@
             <soundCast>ThrowGrenade</soundCast>
              <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
           </Properties>
+          
+          <weaponTags>
+            <li>CE_OneHandedWeapon</li>
+          </weaponTags>
         </li>
 
         <li Class="PatchOperationReplace">

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -84,10 +84,20 @@
 
         <!-- == Weapon == -->
         <li Class="PatchOperationAttributeSet">
-          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
+          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
 
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
+        </li>
+        
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
+          
+          <value>
+            <thingCategories>
+              <li>WeaponsRanged</li>
+            </thingCategories>
+          </value>
         </li>
 
         <li Class="PatchOperationRemove">
@@ -178,7 +188,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]/tools</xpath>
+          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
## Changes
Fixes the missing ` thingCategories ` on the throwing rocks / knives from Vanilla Weapons Expanded and the Tomahawak from Settlers, can be stored now.
## Testing

- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested
