### PR TITLE
Cleanup unused variables

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -20,7 +20,7 @@ namespace CombatExtended
 
         #region Properties
 
-        private static readonly SimpleCurve dmgMultCurve = new SimpleCurve { new CurvePoint(0.5f, 0), new CurvePoint(1, 0.5f), new CurvePoint(2, 1) };    // Used to calculate the damage reduction from the penetration / armor ratio
+
         private static readonly StuffCategoryDef[] softStuffs = { StuffCategoryDefOf.Fabric, DefDatabase<StuffCategoryDef>.GetNamed("Leathery") };
 
         #endregion
@@ -44,7 +44,7 @@ namespace CombatExtended
             armorReduced = false;
 
             if (originalDinfo.Def.armorCategory == null
-                || (!(originalDinfo.Weapon?.projectile is ProjectilePropertiesCE projectile)
+                || (!(originalDinfo.Weapon?.projectile is ProjectilePropertiesCE)
                     && Verb_MeleeAttackCE.LastAttackVerb == null
                     && originalDinfo.Weapon == null
                     && originalDinfo.Instigator == null))

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -13,7 +13,6 @@ namespace CombatExtended
     public class CompAmmoResupplyOnWakeup : ThingComp
     {
         public HashSet<Building_TurretGunCE> nearbyTurrets = new HashSet<Building_TurretGunCE>();
-        bool initialized = false;
         const int turretsWithinDistanceSqr = 100;
         const int ticksBetweenChecks = 600;    //Divide by 60 for seconds
 
@@ -23,7 +22,7 @@ namespace CombatExtended
         //Only do something when ammo system is enabled
         public bool IsActive => Controller.settings.EnableAmmoSystem && (parent.TryGetComp<CompCanBeDormant>()?.Awake ?? true);
 
-        FieldInfo thingsField = typeof(LordJob_MechanoidDefendBase).GetField("things");
+        //FieldInfo thingsField = typeof(LordJob_MechanoidDefendBase).GetField("things");
         FieldInfo mechClusterDefeatedField = typeof(LordJob_MechanoidDefendBase).GetField("mechClusterDefeated");
         LordJob_MechanoidDefendBase parentLordJob => ((parent as Building)?.GetLord()?.LordJob as LordJob_MechanoidDefendBase);
         public bool ClusterAlive

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -56,7 +56,6 @@ namespace CombatExtended
 			if (DoReloadCheck(pawn, out gun, out ammo))
 			{
 				CompAmmoUser comp = gun.TryGetComp<CompAmmoUser>();
-				CompInventory compInventory = pawn.TryGetComp<CompInventory>();
 				// we relied on DoReloadCheck() to do error checking of many variables.
 				
 				if (!comp.TryUnload()) return null; // unload the weapon or stop trying if there was a problem.

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -303,7 +303,6 @@ namespace CombatExtended
                     }
                 }
 
-                Room room = RegionAndRoomQuery.RoomAtFast(pawn.Position, pawn.Map);
 
                 // Find weapon in inventory and try to switch if any ammo in inventory.
                 if (priority == WorkPriority.Weapon && !hasPrimary)

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -272,7 +272,7 @@ namespace CombatExtended
                 int count;
                 Pawn carriedBy;
                 bool doEquip = false;
-                LoadoutSlot prioritySlot = GetPrioritySlot(pawn, out priority, out closestThing, out count, out carriedBy);
+                GetPrioritySlot(pawn, out priority, out closestThing, out count, out carriedBy);
                 // moved logic to detect if should equip vs put in inventory here...
                 if (closestThing != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -23,7 +23,6 @@ namespace CombatExtended
         private const float _topPadding = 20f;
         private const float _standardLineHeight = 22f;
         private static readonly Color _highlightColor = new Color(0.5f, 0.5f, 0.5f, 1f);
-        private static readonly Color _thingLabelColor = new Color(0.9f, 0.9f, 0.9f, 1f);
         private Vector2 _scrollPosition = Vector2.zero;
 
         private float _scrollViewHeight;
@@ -410,7 +409,6 @@ namespace CombatExtended
             if (num > 0.005f)
             {
                 Rect rect = new Rect(0f, curY, width, _standardLineHeight);
-                BodyPartRecord bpr = new BodyPartRecord();
                 List<BodyPartRecord> bpList = SelPawnForGear.RaceProps.body.AllParts;
                 string text = "";
                 for (int i = 0; i < bpList.Count; i++)

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -77,7 +77,6 @@ namespace CombatExtended
         public float AccuracyFactor;
 
         #region FreeIntercept
-        private static List<IntVec3> checkedCells = new List<IntVec3>();
         #endregion
 
         #region Height

--- a/Source/CombatExtended/CombatExtended/SightUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SightUtility.cs
@@ -55,7 +55,6 @@ namespace CombatExtended
             // First endpoint
             var xEnd = Mathf.Round(x0);
             var yEnd = y0 + gradient * (xEnd - x0);
-            var xGap = 1 - (x0 + 0.5f).GetFractional();
             var xPixel1 = xEnd;
             var yPixel1 = Mathf.Floor(yEnd);
             if (isSteep)
@@ -78,7 +77,6 @@ namespace CombatExtended
             // Second endpoint
             xEnd = Mathf.Round(x1);
             yEnd = y1 + gradient * (xEnd - x1);
-            xGap = (x1 + 0.5f).GetFractional();
             var xPixel2 = xEnd;
             var yPixel2 = Mathf.Floor(yEnd);
             if (isSteep)

--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -48,7 +48,6 @@ namespace CombatExtended
         private CompChangeableProjectile compChangeable = null;
         public bool isReloading = false;
         private int ticksUntilAutoReload = 0;
-        private int lastSurroundingAmmoCheck = int.MinValue;
 
         #endregion
 

--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -110,7 +110,6 @@ namespace CombatExtended
                     }
                     else
                     {
-                        var transferedDensity = this.density / 2;
                         var newSmokeCloud = (Smoke)GenSpawn.Spawn(CE_ThingDefOf.Gas_BlackSmoke, freeCell, Map);
                         TransferDensityTo(newSmokeCloud, this.density / 2);
                     }

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-GraphicApparelDetour.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-GraphicApparelDetour.cs
@@ -12,7 +12,6 @@ namespace CombatExtended.HarmonyCE.Compatibility
     [HarmonyPatch]
     class GraphicApparelDetour_Disable
     {
-        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: ";
         static List<Assembly> target_asses = new List<Assembly>();
 
         static bool Prepare()

--- a/Source/CombatExtended/Harmony/Harmony-Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Fire.cs
@@ -185,7 +185,7 @@ namespace CombatExtended.HarmonyCE
             var delete = false;
             var passedRadPattern = false;
             var codes = new List<CodeInstruction>();
-            var getComponentMethodInfo = AccessTools.Method(typeof(Map), nameof(Map.GetComponent), new Type[] { }).MakeGenericMethod(typeof(WeatherTracker));
+
             foreach (var code in instructions)
             {
                 if (delete)

--- a/Source/CombatExtended/Harmony/Harmony-FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony-FloatMenuMakerMap.cs
@@ -20,7 +20,6 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch]
     static class FloatMenuMakerMap_PatchKnowledge
     {
-        static readonly string logPrefix = "Combat Extended :: " + typeof(FloatMenuMakerMap_PatchKnowledge).Name + " :: ";
 
         const string ClassNamePart = "DisplayClass5";   //1.0: "AddHumanLikeOrders" to target <AddHumanLikeOrders>c__AnonStoreyB
         const string MethodNamePart = "g__Equip";       //1.0: "m__" to target <>m__0()

--- a/Source/CombatExtended/Harmony/Harmony-JobDriverWait.cs
+++ b/Source/CombatExtended/Harmony/Harmony-JobDriverWait.cs
@@ -28,7 +28,7 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(JobDriver_Wait), "CheckForAutoAttack")]
     static class Harmony_JobDriverWait_CheckForAutoAttack
     {
-        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: " + typeof(Harmony_JobDriverWait_CheckForAutoAttack).Name + " :: ";
+
         //static MethodInfo Patched_ClosestThingTarget_Global = null;
 
         /// <summary>
@@ -72,7 +72,6 @@ namespace CombatExtended.HarmonyCE
             {
                 if (codes[i].opcode == OpCodes.Ldnull)
                 {
-                    CodeInstruction tmp = HarmonyBase.MakeLocalLoadInstruction(verbLocalIndex);
                     codes[i++] = HarmonyBase.MakeLocalLoadInstruction(verbLocalIndex);
                     codes.Insert(i, new CodeInstruction(OpCodes.Call, typeof(Harmony_JobDriverWait_CheckForAutoAttack).GetMethod("GetValidTargetPredicate", AccessTools.all)));
                     break;

--- a/Source/CombatExtended/Harmony/Harmony-JobGiver_UnloadYourInventory.cs
+++ b/Source/CombatExtended/Harmony/Harmony-JobGiver_UnloadYourInventory.cs
@@ -42,7 +42,6 @@ namespace CombatExtended.HarmonyCE
 
             Label branchFalse = il.DefineLabel(); // since the logic is gettin changed more than I thought, need a new label.
 
-            Label? branchTrue = null;
 
             int patchPhase = 0;
             foreach (CodeInstruction instruction in instructions)
@@ -58,7 +57,6 @@ namespace CombatExtended.HarmonyCE
                 // The first branch we find is the one to remember.  This is also the insertion point...
                 if (patchPhase == 0 && instruction.opcode.Equals(OpCodes.Brtrue_S))
                 {
-                    branchTrue = instruction.operand as Label?;
 
                     // If the inventory isn't set to unload mode, short circuit and jump to return null path...
                     yield return new CodeInstruction(OpCodes.Brfalse, branchFalse);

--- a/Source/CombatExtended/Harmony/Harmony-PawnColumnWorkers.cs
+++ b/Source/CombatExtended/Harmony/Harmony-PawnColumnWorkers.cs
@@ -17,7 +17,6 @@ namespace CombatExtended.HarmonyCE
      */
     static class PawnColumnWorkers_Resize
     {
-        static readonly string logPrefix = "Combat Extended :: " + typeof(PawnColumnWorkers_Resize).Name + " :: ";
 
         static readonly float orgMinWidth = 194f;
         static readonly float orgOptimalWidth = 251f;
@@ -88,7 +87,6 @@ namespace CombatExtended.HarmonyCE
      */
     static class PawnColumnWorkers_SwapButtons
     {
-        static readonly string logPrefix = "Combat Extended :: " + typeof(PawnColumnWorkers_SwapButtons).Name + " :: ";
 
         // NOTE: For the two strings below you can also change the translation string...
         private const string apparelString = "CE_Outfits"; // change this to change the word after "Edit" in the edit tooltip for outfits.

--- a/Source/CombatExtended/Harmony/Harmony-Pawn_HealthTracker.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Pawn_HealthTracker.cs
@@ -22,7 +22,7 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(Pawn_HealthTracker), "CheckForStateChange")]
     static class Harmony_Pawn_HealthTracker_CheckForStateChange
     {
-        static readonly string logPrefix = "Combat Extended :: " + typeof(Harmony_Pawn_HealthTracker_CheckForStateChange).Name + " :: ";
+
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {


### PR DESCRIPTION
## Reasoning
Managed to miss this commit with the previous cleanup, just removes the rest of the unused variables causing warnings.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (minutes)
