### PR TITLE
Compatibility patch for Rimworld Witcher Monster Hunt

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -179,7 +179,7 @@
 						<damageDef>Bomb</damageDef>
 						<damageAmountBase>40</damageAmountBase>
 						<soundExplode>MortarBomb_Explode</soundExplode>
-						<speed>16</speed>
+						<speed>14</speed>
 						<armorPenetrationSharp>5</armorPenetrationSharp>
 						<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -193,8 +193,8 @@
 					<comps>				
 						<li Class="CombatExtended.CompProperties_Fragments">
 							<fragments>
-							<Fragment_Small>18</Fragment_Small>
-							<Fragment_Large>5</Fragment_Large>
+							<Fragment_Small>14</Fragment_Small>
+							<Fragment_Large>4</Fragment_Large>
 							</fragments>
 						</li>
 					</comps>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animus_Vox.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animus_Vox.xml
@@ -20,10 +20,17 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_AnimusVox"]/statBases</xpath>
 				<value>
-					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					<MeleeDodgeChance>0.36</MeleeDodgeChance>
 					<MeleeCritChance>0.02</MeleeCritChance>
 					<MeleeParryChance>0.01</MeleeParryChance>
 				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_AnimusVox"]/race/wildness</xpath>
+		<value>
+			<wildness>0.4</wildness>
+		</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
@@ -46,7 +53,7 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationSharp>0.07</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.18</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -65,15 +72,15 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationSharp>0.07</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.18</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>9</power>
-							<cooldownTime>1.4</cooldownTime>
+							<power>11</power>
+							<cooldownTime>1.45</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -83,7 +90,7 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationSharp>0.15</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.4</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
@@ -17,11 +17,19 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_ArcticLion"]/race/wildness</xpath>
+		<value>
+			<wildness>0.85</wildness>
+		</value>
+			</li>
+
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_ArcticLion"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
-					<MeleeCritChance>0.3</MeleeCritChance>
+					<MeleeCritChance>0.34</MeleeCritChance>
 					<MeleeParryChance>0.14</MeleeParryChance>
 				</value>
 			</li>
@@ -35,8 +43,8 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>18</power>
-							<cooldownTime>0.9</cooldownTime>
+							<power>19</power>
+							<cooldownTime>0.8</cooldownTime>
 							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -46,16 +54,16 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.6</armorPenetrationSharp>
-							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.9</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right claw</label>
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>18</power>
-							<cooldownTime>0.9</cooldownTime>
+							<power>19</power>
+							<cooldownTime>0.8</cooldownTime>
 							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -65,14 +73,14 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.6</armorPenetrationSharp>
-							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.9</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>32</power>
+							<power>34</power>
 							<cooldownTime>1.5</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
@@ -49,7 +49,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>24</power>
+							<power>26</power>
 							<cooldownTime>1.68</cooldownTime>
 							<linkedBodyPartsGroup>AA_PincerAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -60,7 +60,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>24</power>
+							<power>26</power>
 							<cooldownTime>1.68</cooldownTime>
 							<linkedBodyPartsGroup>AA_PincerAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -70,7 +70,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>20</power>
+							<power>24</power>
 							<cooldownTime>1.8</cooldownTime>
 							<linkedBodyPartsGroup>AA_Sting</linkedBodyPartsGroup>
 							<armorPenetrationSharp>10</armorPenetrationSharp>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -49,7 +49,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>13</power>
+							<power>14</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -60,7 +60,7 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>13</power>
+							<power>14</power>
 							<cooldownTime>1.2</cooldownTime>
 							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationSharp>0.4</armorPenetrationSharp>
@@ -70,7 +70,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>20</power>
+							<power>23</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -161,7 +161,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>37</power>
+							<power>40</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
@@ -24,7 +24,7 @@
 				<value>
 					<statBases> <!-- Actually having to add statBases.... -->
 						<ArmorRating_Blunt>15</ArmorRating_Blunt>
-						<ArmorRating_Sharp>9</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.18</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Daggersnout.xml
@@ -23,8 +23,8 @@
 				<xpath>/Defs/ThingDef[defName="AA_Daggersnout"]</xpath>
 				<value>
 					<statBases> <!-- Actually having to add statBases.... -->
-						<ArmorRating_Blunt>9</ArmorRating_Blunt>
-						<ArmorRating_Sharp>15</ArmorRating_Sharp>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
+						<ArmorRating_Sharp>9</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.30</MeleeCritChance>
 						<MeleeParryChance>0.18</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
@@ -69,7 +69,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>20</power>
+							<power>23</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -159,7 +159,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>37</power>
+							<power>40</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -69,7 +69,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>18</power>
+							<power>22</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
@@ -159,7 +159,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>35</power>
+							<power>38</power>
 							<cooldownTime>1.85</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
@@ -69,7 +69,7 @@
 							<capacities>
 								<li>AA_ToxicSting</li>
 							</capacities>
-							<power>20</power>
+							<power>23</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
@@ -12,29 +12,28 @@
 				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>QuadrupedLow</bodyShape>
+						<bodyShape>Quadruped</bodyShape>
 					</li>
 				</value>
 			</li>
-				
+
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/PawnKindDef[defName="AA_MammothWorm"]/combatPower</xpath>
-				<value>
-					<combatPower>160</combatPower>
-				</value>
+		<xpath>/Defs/PawnKindDef[defName="AA_MammothWorm"]/combatPower</xpath>
+		<value>
+			<combatPower>230</combatPower>
+		</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
-			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -42,7 +41,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
-					<MeleeCritChance>0.75</MeleeCritChance>
+					<MeleeCritChance>0.8</MeleeCritChance>
 					<MeleeParryChance>0.23</MeleeParryChance>
 				</value>
 			</li>
@@ -57,7 +56,7 @@
 								<li>AA_SiegeBlunt</li>
 							</capacities>
 							<power>40</power>
-							<cooldownTime>3</cooldownTime>
+							<cooldownTime>2.38</cooldownTime>
 							<surpriseAttack>
 								<extraMeleeDamages>
 									<li>
@@ -66,17 +65,17 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>46</power>
-							<cooldownTime>3</cooldownTime>
+							<power>48</power>
+							<cooldownTime>2.68</cooldownTime>
 							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>6</armorPenetrationSharp>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>40</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
@@ -54,7 +54,7 @@
 							<power>36</power>
 							<cooldownTime>3.3</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>18</armorPenetrationBlunt>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
@@ -44,7 +44,7 @@
 							<power>28</power>
 							<cooldownTime>2.4</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>5.944</armorPenetrationBlunt>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
@@ -54,7 +54,7 @@
 							<power>36</power>
 							<cooldownTime>3.3</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+							<armorPenetrationBlunt>18</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
@@ -54,7 +54,7 @@
 							<power>36</power>
 							<cooldownTime>3.3</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>18.144</armorPenetrationBlunt>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
 							<chanceFactor>1</chanceFactor>
 						</li>
 					</tools>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
@@ -44,7 +44,7 @@
 							<power>28</power>
 							<cooldownTime>2.4</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>5.944</armorPenetrationBlunt>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
@@ -54,7 +54,7 @@
 							<power>36</power>
 							<cooldownTime>3.3</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationBlunt>15.144</armorPenetrationBlunt>
+							<armorPenetrationBlunt>18.144</armorPenetrationBlunt>
 							<chanceFactor>1</chanceFactor>
 						</li>
 					</tools>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -20,22 +20,22 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>3.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
-					<MeleeCritChance>0.3</MeleeCritChance>
+					<MeleeCritChance>0.34</MeleeCritChance>
 					<MeleeParryChance>0.4</MeleeParryChance>
 				</value>
 			</li>
 				
 					<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/MoveSpeed</xpath>
+		<xpath>Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.5</MoveSpeed>
 		</value>
@@ -50,8 +50,8 @@
 							<capacities>
 								<li>AA_Pierce</li>
 							</capacities>
-							<power>40</power>
-							<cooldownTime>1.9</cooldownTime>
+							<power>48</power>
+							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>AA_BladeAttackTool</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 							<surpriseAttack>
@@ -62,16 +62,16 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>12</armorPenetrationSharp>
-							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right blade</label>
 							<capacities>
 								<li>AA_Pierce</li>
 							</capacities>
-							<power>40</power>
-							<cooldownTime>1.9</cooldownTime>
+							<power>48</power>
+							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>AA_BladeAttackTool</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 							<surpriseAttack>
@@ -82,17 +82,17 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>12</armorPenetrationSharp>
-							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>28</power>
+							<power>30</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>AA_Mouth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationSharp>0.8</armorPenetrationSharp>
 							<armorPenetrationBlunt>3.750</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
@@ -17,13 +17,35 @@
 				</value>
 			</li>
 
+					<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_SandLion"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>7.25</MoveSpeed>
+		</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="AA_SandLion"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>2.1</baseHealthScale>
+					</value>
+				</li>
+
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_SandLion"]/statBases</xpath>
 				<value>
-					<MeleeDodgeChance>0.45</MeleeDodgeChance>
-					<MeleeCritChance>0.25</MeleeCritChance>
+					<MeleeDodgeChance>0.56</MeleeDodgeChance>
+					<MeleeCritChance>0.24</MeleeCritChance>
 					<MeleeParryChance>0.14</MeleeParryChance>
 				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AA_SandLion"]/race/wildness</xpath>
+		<value>
+			<wildness>0.85</wildness>
+		</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
@@ -36,7 +58,7 @@
 								<li>Scratch</li>
 							</capacities>
 							<power>15</power>
-							<cooldownTime>0.8</cooldownTime>
+							<cooldownTime>0.72</cooldownTime>
 							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -46,8 +68,8 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.6</armorPenetrationSharp>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right claw</label>
@@ -55,7 +77,7 @@
 								<li>Scratch</li>
 							</capacities>
 							<power>15</power>
-							<cooldownTime>0.8</cooldownTime>
+							<cooldownTime>0.72</cooldownTime>
 							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -65,15 +87,15 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationSharp>0.6</armorPenetrationSharp>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
 								<li>Bite</li>
 							</capacities>
-							<power>27</power>
-							<cooldownTime>1.4</cooldownTime>
+							<power>28</power>
+							<cooldownTime>1.28</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -98,17 +120,6 @@
 							<chanceFactor>0.2</chanceFactor>
 						</li>
 					</tools>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandLion"]/comps/li[gasType="AA_SandPuff"]</xpath>
-				<value>
-					<li Class="AlphaBehavioursAndEvents.CompProperties_GasProducer">
-						<gasType>AA_SandPuff</gasType>
-						<rate>0.7</rate>
-						<radius>3</radius>
-					</li>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Bodies_WMH-CE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Bodies_WMH-CE.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+		
+			<match Class="PatchOperationSequence">
+				<operations>
+					
+					<!-- SingleEyedHumanoid (Cyclops) -->
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="WMH_SingleEyedHumanoid"]//*[def="Torso" or def="Ribcage" or def="Sternum" or def="Pelvis" or def="Neck" or def="Head" or def="Skull" or def="Nose" or def="Jaw" or def="Shoulder" or def="Clavicle" or def="Arm" or def="Humerus" or def="Radius" or def="Hand" or def="Finger" or def="Waist" or def="Leg" or def="Femur" or def="Tibia" or def="Foot" or def="Toe"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+					<!-- JellyFish -->
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="WMH_JellyfishBody"]//*[def="WMH_JellyfishMainBody" or def="WMH_HydrogenSac" or def="AnimalJaw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+					<!-- WingedBird / Bird -->
+					
+					<li Class="PatchOperationConditional"> <!-- Start off by adding groups to things that don't have them, just in case author decides to add them at some point -->
+						<success>Always</success>
+						<xpath>/Defs/BodyDef[defName="WMH_Bird"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="Beak" or def="Leg" or def="Foot"]/groups</xpath>
+							<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="WMH_Bird"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="Beak" or def="Leg" or def="Foot"]</xpath>
+								<value>
+									<groups>
+									</groups>
+								</value>
+							</nomatch>
+					</li>
+					
+					<li Class="PatchOperationAdd"> <!-- Then add natural armor -->
+						<xpath>/Defs/BodyDef[defName="WMH_Bird"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="Beak" or def="Leg" or def="Foot"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+					<!-- WingedReptile / Reptile (Literal copy-paste of the above lines except instead of Beak it's AnimalJaw) -->
+					
+					<li Class="PatchOperationConditional"> <!-- Start off by adding groups to things that don't have them, just in case author decides to add them at some point -->
+						<success>Always</success>
+						<xpath>/Defs/BodyDef[defName="WMH_Reptile"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="AnimalJaw" or def="Leg" or def="Foot"]/groups</xpath>
+							<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="WMH_Reptile"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="AnimalJaw" or def="Leg" or def="Foot"]</xpath>
+								<value>
+									<groups>
+									</groups>
+								</value>
+							</nomatch>
+					</li>
+					
+					<li Class="PatchOperationAdd"> <!-- Then add natural armor -->
+						<xpath>/Defs/BodyDef[defName="WMH_Reptile"]//*[def="Body" or def="Tail" or def="Neck" or def="Head" or def="Skull" or def="AnimalJaw" or def="Leg" or def="Foot"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+					<!-- WMH_RockHumanoid -->
+					
+					<li Class="PatchOperationConditional"> <!-- Start off by adding groups to things that don't have them, just in case author decides to add them at some point -->
+						<success>Always</success>
+						<xpath>/Defs/BodyDef[defName="WMH_RockHumanoid"]//*[def="Torso" or def="WMH_RockHead" or def="WMH_RockArm" or def="WMH_RockLeg"]/groups</xpath>
+							<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="WMH_RockHumanoid"]//*[def="Torso" or def="WMH_RockHead" or def="WMH_RockArm" or def="WMH_RockLeg"]</xpath>
+								<value>
+									<groups>
+									</groups>
+								</value>
+							</nomatch>
+					</li>
+					
+					<li Class="PatchOperationAdd"> <!-- Then add natural armor -->
+						<xpath>/Defs/BodyDef[defName="WMH_RockHumanoid"]//*[def="Torso" or def="WMH_RockHead" or def="WMH_RockArm" or def="WMH_RockLeg"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Projectile_WH.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Projectile_WH.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_LeshyWave" or
+				defName="WMH_WyvernAcidSpit" or
+				defName="WMH_Rock" or
+				defName="WMH_WispProjectile"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.BulletCE</thingClass>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_WyvernAcidSpit" or
+				defName="WMH_Rock" or
+				defName="WMH_WispProjectile"
+				]/graphicData/graphicClass</xpath>
+				<value>
+					<graphicClass>Graphic_Single</graphicClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="WMH_Rock"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_LeshyWave"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>WMH_VeryToxicBite</damageDef>
+						<damageAmountBase>40</damageAmountBase>
+						<speed>28</speed>
+						<armorPenetrationSharp>10</armorPenetrationSharp>
+						<armorPenetrationBlunt>20.660</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_WyvernAcidSpit"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>WMH_AcidSpit</damageDef>
+						<damageAmountBase>40</damageAmountBase>
+						<speed>22</speed>
+						<armorPenetrationSharp>10</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_WyvernAcidSpit"]/graphicData/texPath</xpath>
+				<value>
+			<texPath>Things/Projectiles/WMH_AcidSpit/WMH_AcidSpitF</texPath>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_WispProjectile"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Flame</damageDef>
+						<damageAmountBase>6</damageAmountBase>
+						<speed>13</speed>
+						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_WispProjectile"]/graphicData/texPath</xpath>
+				<value>
+			<texPath>Things/Projectiles/WMH_WispProjectile/WMH_WispProjectile_b</texPath>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_Rock"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<explosionRadius>1.5</explosionRadius>
+						<damageDef>Bomb</damageDef>
+						<damageAmountBase>40</damageAmountBase>
+						<soundExplode>MortarBomb_Explode</soundExplode>
+						<speed>13</speed>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<armorPenetrationBlunt>25</armorPenetrationBlunt>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					</projectile>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WMH_Rock"]</xpath>
+				<value>
+					<comps>				
+						<li Class="CombatExtended.CompProperties_Fragments">
+							<fragments>
+							<Fragment_Small>14</Fragment_Small>
+							<Fragment_Large>5</Fragment_Large>
+							</fragments>
+						</li>
+					</comps>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_Rock"]/graphicData/texPath</xpath>
+				<value>
+			<texPath>Things/Projectiles/WMH_Boulder/WMH_BoulderA</texPath>
+				</value>
+			</li>
+						
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Basilisk"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					<MeleeCritChance>0.3</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.8</MoveSpeed>
+		</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/statBases</xpath>
+		<value>
+			<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>18</power>
+							<cooldownTime>0.65</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>18</power>
+							<cooldownTime>0.65</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>razor beak</label>
+				<capacities>
+					<li>WMH_VeryToxicBite</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>1.2</cooldownTime>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+				<chanceFactor>0.9</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>12</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4.55</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+				<surpriseAttack>
+					<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>25</amount>
+						</li>
+					</extraMeleeDamages>
+				</surpriseAttack>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.3</MeleeDodgeChance>
+					<MeleeCritChance>0.75</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>5</ArmorRating_Sharp>
+		</value>
+	</li>
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.4</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>fangs</label>
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>50</power>
+							<cooldownTime>1.25</cooldownTime>
+							<armorPenetrationSharp>12</armorPenetrationSharp>
+							<armorPenetrationBlunt>24</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>tentacles</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>22</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>Arms</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<chanceFactor>0.5</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_ChortCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_ChortCE.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Chort"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Chort"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.08</MeleeDodgeChance>
+			<MeleeCritChance>0.5</MeleeCritChance>
+			<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Chort"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>horn</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>45</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>horn</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Chewy</label>
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>19</power>
+							<cooldownTime>1.45</cooldownTime>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<chanceFactor>0.6</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.1</MeleeDodgeChance>
+					<MeleeCritChance>0.75</MeleeCritChance>
+			<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+
+                                 <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4</MoveSpeed>
+		</value>
+			</li>
+
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left fist</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>54</power>
+							<cooldownTime>2.9</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right fist</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>54</power>
+							<cooldownTime>2.9</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>teeth</label>
+				<capacities>
+					<li>BiteBlunt</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+				                                                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>30</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>15.55</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_DjinCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_DjinCE.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Djinn"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Djinn"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>0.25</AimingAccuracy>
+			<ShootingAccuracyPawn>0.25</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.8</MeleeDodgeChance>
+					<MeleeCritChance>0.01</MeleeCritChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Djinn"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>pseudopod</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>9</power>
+				<cooldownTime>1.88</cooldownTime>
+				<linkedBodyPartsGroup>WMH_Pseudopods</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					<MeleeCritChance>0.1</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+		</value>
+	</li>
+
+                                 <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.75</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>9</power>
+							<cooldownTime>0.5</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>9</power>
+							<cooldownTime>0.5</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>fangs</label>
+				<capacities>
+					<li>WMH_EkimmaraBite</li>
+				</capacities>
+							<power>23</power>
+							<cooldownTime>1.6</cooldownTime>
+							<armorPenetrationSharp>5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>13</power>
+							<cooldownTime>3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4.55</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FiendCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FiendCE.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Fiend"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Fiend"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.03</MeleeDodgeChance>
+					<MeleeCritChance>1</MeleeCritChance>
+			<MeleeParryChance>0.55</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Fiend"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>38</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>right claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>38</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>1.88</cooldownTime>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<chanceFactor>0.6</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>Horn</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>40</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Fleder"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+				<MeleeCritChance>0.36</MeleeCritChance>
+			               <MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+                                 <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>5.8</MoveSpeed>
+		</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Fleder"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>18</power>
+							<cooldownTime>1.02</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>18</power>
+							<cooldownTime>1.02</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>fangs</label>
+				<capacities>
+					<li>WMH_FlederBite</li>
+				</capacities>
+							<power>33</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>13</power>
+							<cooldownTime>3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4.55</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FogletCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FogletCE.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Fogler"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.35</MeleeDodgeChance>
+					<MeleeCritChance>0.1</MeleeCritChance>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+		</value>
+	</li>
+
+                                 <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.2</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Fogler"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left fist</label>
+				<capacities>
+					<li>WMH_InfectedClaws</li>
+				</capacities>
+							<power>9</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right fist</label>
+				<capacities>
+					<li>WMH_InfectedClaws</li>
+				</capacities>
+							<power>9</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>15</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+				                                                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				                                                <chanceFactor>0.7</chanceFactor>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>3</power>
+				<cooldownTime>1.6</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_GhoulCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_GhoulCE.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Ghoul"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Ghoul"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.12</MeleeDodgeChance>
+					<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
+
+					<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Ghoul"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Ghoul"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left fist</label>
+				<capacities>
+					<li>WMH_InfectedClaws</li>
+				</capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right fist</label>
+				<capacities>
+					<li>WMH_InfectedClaws</li>
+				</capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>4</power>
+							<cooldownTime>1.8</cooldownTime>
+							<armorPenetrationSharp>0.35</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				                                                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				                                                <chanceFactor>0.7</chanceFactor>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.6</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Golem"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.1</MeleeDodgeChance>
+					<MeleeCritChance>0.85</MeleeCritChance>
+			<MeleeParryChance>0.6</MeleeParryChance>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>34</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>17</ArmorRating_Sharp>
+		</value>
+	</li>
+
+                                <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>3</MoveSpeed>
+		</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Golem"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claws</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>44</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right claws</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>44</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>30</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_HymCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_HymCE.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Hym"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Hym"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.4</MeleeDodgeChance>
+					<MeleeCritChance>0.1</MeleeCritChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Hym"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left fist</label>
+				<capacities>
+					<li>WMH_HymPunch</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>2.2</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>40</armorPenetrationSharp>
+							<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right fist</label>
+				<capacities>
+					<li>WMH_HymPunch</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>2.2</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>40</armorPenetrationSharp>
+							<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>WMH_HymPunch</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>1.6</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>40</armorPenetrationSharp>
+							<armorPenetrationBlunt>60</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWorker"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWorker"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					<MeleeCritChance>0.07</MeleeCritChance>
+					<MeleeParryChance>0.08</MeleeParryChance>
+				</value>
+			</li>
+
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWorker"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWorker"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>4</power>
+							<cooldownTime>1.2</cooldownTime>
+				                                                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				                                                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				                                                <chanceFactor>0.1</chanceFactor>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                <label>mandibles</label>
+							<capacities>
+								<li>ToxicBite</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.65</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWarrior"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.5</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					<MeleeCritChance>0.2</MeleeCritChance>
+					<MeleeParryChance>0.25</MeleeParryChance>
+				</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>1.25</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>14</power>
+							<cooldownTime>1.65</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                               <label>mandibles</label>
+							<capacities>
+								<li>ToxicBite</li>
+							</capacities>
+							<power>24</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="WMH_KikimoreQueen"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.01</MeleeDodgeChance>
+					<MeleeCritChance>0.65</MeleeCritChance>
+					<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>3.5</MoveSpeed>
+		</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WMH_KikimoreQueen"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>25</power>
+							<cooldownTime>2</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>mandibles</label>
+							<capacities>
+								<li>WMH_ParalysingBite</li>
+							</capacities>
+							<power>50</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -94,14 +94,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>2</ArmorRating_Blunt>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>1.25</ArmorRating_Sharp>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
 	</li>
 
@@ -164,14 +164,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+			<ArmorRating_Blunt>16</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>6</ArmorRating_Sharp>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -23,6 +23,8 @@
 					<MeleeDodgeChance>0.18</MeleeDodgeChance>
 					<MeleeCritChance>0.07</MeleeCritChance>
 					<MeleeParryChance>0.08</MeleeParryChance>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 				</value>
 			</li>
 
@@ -85,23 +87,23 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases</xpath>
 				<value>
-					<MeleeDodgeChance>0.18</MeleeDodgeChance>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>0.25</MeleeParryChance>
+					<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					<MeleeCritChance>0.25</MeleeCritChance>
+					<MeleeParryChance>0.4</MeleeParryChance>
 				</value>
 			</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
 		</value>
 	</li>
 
@@ -149,7 +151,7 @@
 				<xpath>/Defs/ThingDef[defName="WMH_KikimoreQueen"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
-					<MeleeCritChance>0.65</MeleeCritChance>
+					<MeleeCritChance>0.7</MeleeCritChance>
 					<MeleeParryChance>0.3</MeleeParryChance>
 				</value>
 			</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_LeshyCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_LeshyCE.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Leshy"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+                                <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Leshy"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Leshy"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeParryChance>0.25</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Leshy"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>Horn</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>12</power>
+							<cooldownTime>0.85</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Horn</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+							<power>7</power>
+							<cooldownTime>0.85</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Left Claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>12</power>
+							<cooldownTime>0.85</cooldownTime>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right Claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>11</power>
+							<cooldownTime>1</cooldownTime>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>13</power>
+							<cooldownTime>2.67</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>6.55</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_NekkerCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_NekkerCE.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Nekker"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Nekker"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.22</MeleeDodgeChance>
+					<MeleeCritChance>0.01</MeleeCritChance>
+				</value>
+			</li>
+
+                                   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Nekker"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.2</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Nekker"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left fist</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right fist</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<capacities>
+					<li>Bite</li>
+				</capacities>
+							<power>4</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				                                                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				                                                <chanceFactor>0.7</chanceFactor>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.6</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Werewolf"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Werewolf"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.45</MeleeDodgeChance>
+					<MeleeCritChance>0.3</MeleeCritChance>
+				</value>
+			</li>
+
+                               <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Werewolf"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>7.6</MoveSpeed>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Werewolf"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>20</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>20</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<capacities>
+					<li>WMH_WerewolfBite</li>
+				</capacities>
+							<power>36</power>
+							<cooldownTime>1.85</cooldownTime>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				                                                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<chanceFactor>0.5</chanceFactor>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>11</power>
+				<cooldownTime>2</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>5</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WraithCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WraithCE.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Wraith"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Wraith"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.45</MeleeDodgeChance>
+					<MeleeCritChance>0.2</MeleeCritChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Wraith"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+				<label>left claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>20</power>
+							<cooldownTime>3.2</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>40</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>right claw</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>20</power>
+							<cooldownTime>3.2</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>40</armorPenetrationBlunt>
+						</li>
+				<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>3</power>
+				<cooldownTime>1.1</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="WMH_Wyvern"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases</xpath>
+				<value>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<MeleeDodgeChance>0.25</MeleeDodgeChance>
+					<MeleeCritChance>0.33</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+
+                               <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>5.25</MoveSpeed>
+		</value>
+			</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+		</value>
+	</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				<label>left claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>17</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>Right claws</label>
+				<capacities>
+					<li>Scratch</li>
+				</capacities>
+							<power>17</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>razor beak</label>
+				<capacities>
+					<li>WMH_VeryToxicBite</li>
+				</capacities>
+							<power>30</power>
+							<cooldownTime>1.33</cooldownTime>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<chanceFactor>0.8</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				<label>tail</label>
+				<capacities>
+					<li>WMH_VeryToxicBite</li>
+				</capacities>
+				<power>36</power>
+				<cooldownTime>1.45</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<armorPenetrationSharp>10</armorPenetrationSharp>
+				<armorPenetrationBlunt>10</armorPenetrationBlunt>
+				<chanceFactor>0.75</chanceFactor>
+				<surpriseAttack>
+					<extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>25</amount>
+						</li>
+					</extraMeleeDamages>
+				</surpriseAttack>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimWorld - Witcher Monster Hunt/WH_ProjectileShoot.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/WH_ProjectileShoot.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>RimWorld - Witcher Monster Hunt</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+				<!-- Wyvern -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="WMH_Wyvern"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>WMH_WyvernAcidSpit</defaultProjectile>
+											<warmupTime>1.5</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>1</minRange>
+											<range>30</range>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>0.5</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<!-- Leshy -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="WMH_Leshy"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>WMH_LeshyWave</defaultProjectile>
+											<warmupTime>1</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>50</range>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<!-- Wisp -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="WMH_Djinn"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>WMH_WispProjectile</defaultProjectile>
+											<warmupTime>0.3</warmupTime>
+											<burstShotCount>50</burstShotCount>
+											<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+											<minRange>1</minRange>
+											<range>36</range>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<!-- Cyclop -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="WMH_Cyclops"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>WMH_Rock</defaultProjectile>
+											<warmupTime>3</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>6</minRange>
+											<range>32</range>
+											<soundCast>WMH_RockThrow</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+											<commonality>0.4</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+				</operations>
+			</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
Compatibility Patch for Rimworld - Witcher Monster Hunt
## Changes

Monsters and projectile attacks made compatible and rebalanced for CE.

Additional balance pass for the alpha animal patch.

## References

## Reasoning

## Alternatives

## Testing

Check tests you have performed:
- [ x ] Compiles without warnings
- [ x ] Game runs without errors
- [ x ] (For compatibility patches) ...with and without patched mod loaded
- [ x ] Playtested a colony (specify how long)
