### PR TITLE
Save Our Ship 2 Patch Update

### DIFF
--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -7,8 +7,24 @@
     </mods>
 		<match Class="PatchOperationSequence">
 		<operations>
+			
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSurvivalBelt"]/statBases</xpath>
+		<value>
+			<Bulk>3</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	 </li>
+
 
 	<!--  EVA Helmet -->
+	 <li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+		</li>
 	   <li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
@@ -18,17 +34,81 @@
 	   <li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				<ArmorRating_Blunt>20</ArmorRating_Blunt>
 			</value>
 	   </li>
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/equippedStatOffsets</xpath>
 		<value>
+			<ToxicSensitivity>-0.50</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	   </li>
 			
+   <li Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/apparel/layers</xpath>
+    <value>
+      <li>OnHead</li>
+      <li>StrappedHead</li>
+      <li>MiddleHead</li>
+    </value>
+ </li>
+			
+				<!--  Heavy EVA Helmet -->
+
+	   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			</value>
+	   </li>
+	   <li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>36</ArmorRating_Blunt>
+			</value>
+	   </li>
+	   <li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/equippedStatOffsets</xpath>
+		<value>
+			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+		</value>
+	   </li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>2</WornBulk>
+					</value>
+		</li>
+			
+    <li Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/costList/Plasteel</xpath>
+    <value>
+      <Plasteel>50</Plasteel>
+      <DevilstrandCloth>20</DevilstrandCloth>
+    </value>
+   </li>
+			
+	<li Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/apparel/layers</xpath>
+    <value>
+      <li>OnHead</li>
+      <li>StrappedHead</li>
+      <li>MiddleHead</li>
+    </value>
+ </li>
+			
 	<!--  Heavy EVA Suit -->
+		<li Class="PatchOperationAdd">
+		      <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList</xpath>
+		      <value>
+			 <DevilstrandCloth>50</DevilstrandCloth>
+		      </value>
+		</li>
+			
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
@@ -40,6 +120,38 @@
 			<value>
 				<ArmorRating_Blunt>45</ArmorRating_Blunt>
 			</value>
+		</li>
+		<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases</xpath>
+			<value>
+				<Bulk>100</Bulk>
+				<WornBulk>15</WornBulk>
+				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<Flammability>0</Flammability>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>400</MaxHitPoints>
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/Mass</xpath>
+		<value>
+			<Mass>50</Mass>
+		</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryBulk>10</CarryBulk>
+			<CarryWeight>80</CarryWeight>
+			<ToxicSensitivity>-0.50</ToxicSensitivity>
+		</value>
 		</li>
 		</operations>
 		</match>

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -8,6 +8,7 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 			
+	<!--  Survival Belt -->
 	<li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSurvivalBelt"]/statBases</xpath>
 		<value>
@@ -15,6 +16,22 @@
 			<WornBulk>1</WornBulk>
 		</value>
 	 </li>
+
+	<!--  EVA Suit -->
+	 <li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBody"]/statBases</xpath>
+		<value>
+			<Bulk>6</Bulk>
+			<WornBulk>4</WornBulk>
+		</value>
+	 </li>
+
+	   <li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBody"]/equippedStatOffsets</xpath>
+		<value>
+                         <ToxicSensitivity>-0.50</ToxicSensitivity>
+		</value>
+	   </li>
 
 
 	<!--  EVA Helmet -->

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -108,6 +108,13 @@
 		</value>
 		</li>
 			
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>200</MaxHitPoints>
+		</value>
+		</li>
+			
 	<!--  Heavy EVA Suit -->
 		<li Class="PatchOperationAdd">
 		      <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList</xpath>

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -92,7 +92,7 @@
     </value>
    </li>
 			
-	<li Class="PatchOperationAdd">
+    <li Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/apparel/layers</xpath>
     <value>
       <li>OnHead</li>
@@ -100,6 +100,13 @@
       <li>MiddleHead</li>
     </value>
  </li>
+			
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0</Flammability>
+		</value>
+		</li>
 			
 	<!--  Heavy EVA Suit -->
 		<li Class="PatchOperationAdd">

--- a/Patches/Save Our Ship 2/PawnKindsDefs_SOS2.xml
+++ b/Patches/Save Our Ship 2/PawnKindsDefs_SOS2.xml
@@ -47,7 +47,7 @@
 		<value>
 		  <li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
-			  <min>1</min>
+			  <min>2</min>
 			  <max>2</max>
 			</primaryMagazineCount>
 		  </li>
@@ -69,8 +69,8 @@
 		<value>
 		  <li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
-			  <min>2</min>
-			  <max>3</max>
+			  <min>3</min>
+			  <max>4</max>
 			</primaryMagazineCount>
 		  </li>
 		</value>
@@ -92,7 +92,7 @@
 		  <li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
 			  <min>3</min>
-			  <max>4</max>
+			  <max>5</max>
 			</primaryMagazineCount>
         <sidearms>
           <li>

--- a/Patches/Save Our Ship 2/PawnKindsDefs_SOS2.xml
+++ b/Patches/Save Our Ship 2/PawnKindsDefs_SOS2.xml
@@ -5,17 +5,122 @@
     <mods>
 		<li>Save Our Ship 2</li>
     </mods>
-	<match Class="PatchOperationAddModExtension">
+		<match Class="PatchOperationSequence">
+			<operations>
+
+		<li Class="PatchOperationAddModExtension">
   	<xpath>Defs/PawnKindDef[defName="SpaceCannibal"]</xpath>
 		<value>
 		  <li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
 			  <min>3</min>
-			  <max>6</max>
+			  <max>4</max>
 			</primaryMagazineCount>
 		  </li>
 		</value>
-	</match>
-	</Operation>
-</Patch>
+			</li>
 
+
+                                  <li Class="PatchOperationReplace">
+                   <xpath>Defs/PawnKindDef[defName="SpaceCrew"]/apparelMoney</xpath>
+                              <value>
+                              <apparelMoney>
+                                         <min>400</min>
+                                         <max>800</max>
+                             </apparelMoney>
+                              </value>
+		</li>
+
+
+   <li Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="SpaceCrew"]/weaponMoney</xpath>
+    <value>
+      <weaponMoney>
+        <min>100</min>
+        <max>300</max>
+      </weaponMoney>
+    </value>
+			</li>
+
+		<li Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="SpaceCrew"]</xpath>
+		<value>
+		  <li Class="CombatExtended.LoadoutPropertiesExtension">
+			<primaryMagazineCount>
+			  <min>1</min>
+			  <max>2</max>
+			</primaryMagazineCount>
+		  </li>
+		</value>
+			</li>
+
+   <li Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="SpaceCrewMarine"]/weaponMoney</xpath>
+    <value>
+      <weaponMoney>
+        <min>500</min>
+        <max>900</max>
+      </weaponMoney>
+    </value>
+			</li>
+
+		<li Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="SpaceCrewMarine"]</xpath>
+		<value>
+		  <li Class="CombatExtended.LoadoutPropertiesExtension">
+			<primaryMagazineCount>
+			  <min>2</min>
+			  <max>3</max>
+			</primaryMagazineCount>
+		  </li>
+		</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="SpaceCrewMarineHeavy"]/weaponMoney</xpath>
+    <value>
+      <weaponMoney>
+        <min>600</min>
+        <max>1300</max>
+      </weaponMoney>
+    </value>
+			</li>
+
+		<li Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="SpaceCrewMarineHeavy"]</xpath>
+		<value>
+		  <li Class="CombatExtended.LoadoutPropertiesExtension">
+			<primaryMagazineCount>
+			  <min>3</min>
+			  <max>4</max>
+			</primaryMagazineCount>
+        <sidearms>
+          <li>
+            <sidearmMoney>
+              <min>400</min>
+              <max>800</max>
+            </sidearmMoney>
+            <weaponTags>
+              <li>CE_Sidearm_Melee</li>
+            </weaponTags>
+          </li>
+        </sidearms>
+		  </li>
+		</value>
+			</li>
+
+
+ <li Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="SpaceCrewMarineHeavy"]/combatPower</xpath>
+    <value>
+      <combatPower>280</combatPower>
+    </value>
+ </li>
+
+			</operations>		
+		</match>
+	</Operation>
+			  
+
+   
+  </Patch>


### PR DESCRIPTION
Standardized SOS2 apparel with its CE counterpart.
Added Ammo to SOS2 space crews.

## Testing

Check tests you have performed:
- [ x ] Compiles without warnings
- [ x ] Game runs without errors
- [ x ] (For compatibility patches) ...with and without patched mod loaded
- [ x ] Playtested a colony (specify how long)
