### PR TITLE
Pilum tags, fix GoJuice patch

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -116,10 +116,9 @@
 		<equippedAngleOffset>30</equippedAngleOffset>
 		<stackLimit>25</stackLimit>
 		<weaponTags>
-			<li>NeolithicRanged</li>
+      		<li>NeolithicRangedHeavy</li>
 			<li>CE_Pila</li>
 			<li>CE_OneHandedWeapon</li>
-			<li>CE_AI_Rifle</li>
 		</weaponTags>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Patches/Core/Drugs/Drugs.xml
+++ b/Patches/Core/Drugs/Drugs.xml
@@ -49,8 +49,8 @@
 
 	<!-- ========== Patch addictiveness ========== -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GoJuice"]/comps/li[@Class="CompProperties_Drug"]/minToleranceToAddict</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GoJuice"]/comps/li[@Class="CompProperties_Drug"]</xpath>
 		<value>
 			<minToleranceToAddict>0.05</minToleranceToAddict>
 		</value>


### PR DESCRIPTION
## Changes
- Add `NeolithicRangedHeavy` to Pila, since it currently lacks it and so doesn't spawn on tribal Heavy Archers.
- Change GoJuice patchop to account for RW change.