### PR TITLE
Tweak fire balance

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Things_Special.xml
+++ b/Patches/Core/ThingDefs_Misc/Things_Special.xml
@@ -11,11 +11,11 @@
     <xpath>Defs/ThingDef[defName="Fire"]</xpath>
     <value>
       <li Class="CombatExtended.FireSpreadExtension">
-        <baseSpreadTicks>15</baseSpreadTicks>                         <!-- Base number of ticks a fire must wait to spread to a new adjacent cell, before size and wind multipliers. -->
-        <minSpreadTicks>4</minSpreadTicks>                            <!-- Hard cap on spread rate, fire must always wait this number of ticks to spread even if multipliers would put it below this value. -->
-        <baseGrowthPerTick>0.00055</baseGrowthPerTick>                <!-- How quickly fire increases in size when it has something to burn. -->
-        <spreadFarBaseChance>0.02</spreadFarBaseChance>               <!-- Base chance of fire spawning a spark (sparks can set fire to objects up to 3 tiles away). This is affected by wind. -->
-        <fireSizeMultiplier>2.85</fireSizeMultiplier>                 <!-- Controls how strongly fire size affects its rate of spread. -->
+        <baseSpreadTicks>14</baseSpreadTicks>                         <!-- Base number of ticks a fire must wait to spread to a new adjacent cell, before size and wind multipliers. -->
+        <minSpreadTicks>5</minSpreadTicks>                            <!-- Hard cap on spread rate, fire must always wait this number of ticks to spread even if multipliers would put it below this value. -->
+        <baseGrowthPerTick>0.00050</baseGrowthPerTick>                <!-- How quickly fire increases in size when it has something to burn. -->
+        <spreadFarBaseChance>0.0175</spreadFarBaseChance>               <!-- Base chance of fire spawning a spark (sparks can set fire to objects up to 3 tiles away). This is affected by wind. -->
+        <fireSizeMultiplier>2.75</fireSizeMultiplier>                 <!-- Controls how strongly fire size affects its rate of spread. -->
         <windSpeedMultiplier>1.0</windSpeedMultiplier>                <!-- Controls how easily wind can push fire in its direction. -->
         <maxHumidity>180000</maxHumidity>                             <!-- Map humidity ranges between 0 and this value, with rain increasing it, and dry weather decreasing it. -->
         <humidityDecayPerTick>0.05</humidityDecayPerTick>             <!-- How much humidity is reduced per tick when it isn't raining. -->

--- a/Patches/Core/ThingDefs_Misc/Things_Special.xml
+++ b/Patches/Core/ThingDefs_Misc/Things_Special.xml
@@ -12,11 +12,11 @@
     <value>
       <li Class="CombatExtended.FireSpreadExtension">
         <baseSpreadTicks>14</baseSpreadTicks>                         <!-- Base number of ticks a fire must wait to spread to a new adjacent cell, before size and wind multipliers. -->
-        <minSpreadTicks>5</minSpreadTicks>                            <!-- Hard cap on spread rate, fire must always wait this number of ticks to spread even if multipliers would put it below this value. -->
+        <minSpreadTicks>8</minSpreadTicks>                            <!-- Hard cap on spread rate, fire must always wait this number of ticks to spread even if multipliers would put it below this value. -->
         <baseGrowthPerTick>0.00050</baseGrowthPerTick>                <!-- How quickly fire increases in size when it has something to burn. -->
         <spreadFarBaseChance>0.0175</spreadFarBaseChance>               <!-- Base chance of fire spawning a spark (sparks can set fire to objects up to 3 tiles away). This is affected by wind. -->
-        <fireSizeMultiplier>2.75</fireSizeMultiplier>                 <!-- Controls how strongly fire size affects its rate of spread. -->
-        <windSpeedMultiplier>1.0</windSpeedMultiplier>                <!-- Controls how easily wind can push fire in its direction. -->
+        <fireSizeMultiplier>2.50</fireSizeMultiplier>                 <!-- Controls how strongly fire size affects its rate of spread. -->
+        <windSpeedMultiplier>0.70</windSpeedMultiplier>                <!-- Controls how easily wind can push fire in its direction. -->
         <maxHumidity>180000</maxHumidity>                             <!-- Map humidity ranges between 0 and this value, with rain increasing it, and dry weather decreasing it. -->
         <humidityDecayPerTick>0.05</humidityDecayPerTick>             <!-- How much humidity is reduced per tick when it isn't raining. -->
         <humidityIncreaseMultiplier>3.0</humidityIncreaseMultiplier>  <!-- How quickly rain increases humidity, per tick. This value is multiplied by RainRate, which is always 1.0 for vanilla weathers (as of RW-1.1). -->


### PR DESCRIPTION
Adjusts some of the fire values, which should hopefully result in fires not spreading as aggressively in the rain, without significantly weakening brush fires in dry weather.