### PR TITLE
patch for Vegetable Garden new fabrics

### DIFF
--- a/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
+++ b/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>VGP Garden Fabrics</modName>
+			</li>
+				
+				<!-- LinenCloth -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Flaxcloth"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.013</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Flaxcloth"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.019</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Flaxcloth"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<!-- Hemp -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HempCloth"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.012</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HempCloth"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.023</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="HempCloth"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<!-- Wool Base-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.022</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<!-- Blended Wool -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.022</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
+					</value>
+				</li>
+		</operations>
+
+	</Operation>
+
+</Patch>

--- a/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
+++ b/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>VGP Garden Fabrics</li>
+    </mods>
+		<match Class="PatchOperationSequence">
 		<operations>
 
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>VGP Garden Fabrics</modName>
-			</li>
-				
 				<!-- LinenCloth -->
 
 				<li Class="PatchOperationReplace">
@@ -77,7 +77,6 @@
 					</value>
 				</li>
 		</operations>
-
+		</match>
 	</Operation>
-
 </Patch>

--- a/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
+++ b/Patches/VGP Garden Fabrics/VGP Garden Fabrics.xml
@@ -54,47 +54,24 @@
 					</value>
 				</li>
 
-				<!-- Wool Base-->
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Sharp</xpath>
-					<value>
-						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Blunt</xpath>
-					<value>
-						<StuffPower_Armor_Blunt>0.022</StuffPower_Armor_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_WoolBase"]/statBases/StuffPower_Armor_Heat</xpath>
-					<value>
-						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
-					</value>
-				</li>
-
 				<!-- Blended Wool -->
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.022</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases/StuffPower_Armor_Heat</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VG_BlendedWool"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
 					</value>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -122,6 +122,7 @@ Vanilla Vehicles Expanded	|
 Vanilla Weapons Expanded Quickdraw	|
 Vanilla-Friendly Animal Surgery	|
 Vanilla-Friendly Weapon Expansion	|
+VGP Fabrics
 Vulpine Race Pack	|
 Weapons+	|
 WWII Soviet Faction	|


### PR DESCRIPTION
VGP fabrics adds linen Cloth, Hemp and blended wools. Sharp, Blunt and Heat stats are too high and have to be tweaked to fit the new armor models

## Additions

Describe new functionality added by your code, e.g.
- just tweaking armor stats for these new fabrics

## Changes

Describe adjustments to existing features made in this merge, e.g.
- heat stat is the same as normal cloth
- linen is supposed to be 30% stronger than cotton fabric, so values were adjusted

## References

Links to the associated issues or other related pull requests, e.g.
- N/A

## Reasoning

Why did you choose to implement things this way, e.g.
- I like the VGP fabric mod, but the stats were way too high, close to hyperweave/synthread

## Alternatives

Describe alternative implementations you have considered, e.g.
- N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
