### PR TITLE
Updated 'Dragon's Descent' patch and added 'Insects have chitin' patch.

### DIFF
--- a/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
+++ b/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Hooray, more updating -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== DraconicAmbrosia (Draconic ambrosia) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DraconicAmbrosia"]/statBases</xpath>
+					<value>
+						<Bulk>0.2</Bulk>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
+++ b/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Hooray, more updating -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== DragonsBlood (Dragon's blood potion) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DragonsBlood"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+					</value>
+				</li>
+
+				<!-- ======== DragonsBloodHigh ======== -->
+				<!-- ====== stages ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/HediffDef[defName="DragonsBloodHigh"]/stages/li[1]</xpath>
+					<value>
+						<statOffsets>
+							<Suppressability>-0.25</Suppressability>
+						</statOffsets>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
@@ -7,92 +7,9 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- ==== Common dragon base ==== -->
-				<!-- === bodyShape === -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Birdlike</bodyShape>
-						</li>
-					</value>
-				</li>
-
-				<!-- === statBases === -->
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.13</MeleeDodgeChance>
-						<MeleeCritChance>1.75</MeleeCritChance>
-						<MeleeParryChance>0.54</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>40</ArmorRating_Blunt>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<!-- === baseHealthScale and manhunterOnTameFailChance === -->
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>10</baseHealthScale>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
-					<value>
-						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
-					</value>
-				</li>
-
-				<!-- === Verbs === -->
-				<li Class="PatchOperationReplace">
-					<xpath>
-						/Defs/ThingDef[
-							defName="Black_Dragon" or 
-							defName="Blue_Dragon" or 
-							defName="Green_Dragon" or
-							defName="Purple_Dragon" or 
-							defName="Red_Dragon" or 
-							defName="White_Dragon" or 
-							defName="Yellow_Dragon"]/verbs
-					</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
-								<burstShotCount>25</burstShotCount>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<warmupTime>5</warmupTime>
-								<range>25</range>
-								<minRange>2</minRange>
-								<soundCast>DragonBreathShot</soundCast>
-								<muzzleFlashScale>1</muzzleFlashScale>
-								<commonality>0.9</commonality>
-								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-								<targetParams>
-									<canTargetLocations>true</canTargetLocations>
-								</targetParams>
-								<recoilAmount>0.4</recoilAmount>
-							</li>
-						</verbs>
-					</value>
-				</li>
-
-				<!-- === Tools === -->
-				<!-- == Base Tools == -->
+				<!-- ======== Common Dragons ======== -->
+				<!-- ====== Tools ====== -->
+				<!-- ==== Base Tools ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>
 						/Defs/ThingDef[
@@ -185,8 +102,8 @@
 						</tools>
 					</value>
 				</li>
-				<!-- == Unique Tools == -->
-				<!-- = Black Dragon = -->
+				<!-- ==== Unique Tools ==== -->
+				<!-- == Black Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Black_Dragon"]/tools</xpath>
 					<value>
@@ -204,7 +121,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Blue Dragon = -->
+				<!-- == Blue Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Blue_Dragon"]/tools</xpath>
 					<value>
@@ -222,7 +139,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Green Dragon = -->
+				<!-- == Green Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Green_Dragon"]/tools</xpath>
 					<value>
@@ -240,7 +157,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Purple Dragon = -->
+				<!-- == Purple Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Purple_Dragon"]/tools</xpath>
 					<value>
@@ -284,7 +201,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Red Dragon = -->
+				<!-- == Red Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Red_Dragon"]/tools</xpath>
 					<value>
@@ -321,7 +238,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = White Dragon = -->
+				<!-- == White Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="White_Dragon"]/tools</xpath>
 					<value>
@@ -358,7 +275,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Yellow Dragon = -->
+				<!-- == Yellow Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Yellow_Dragon"]/tools</xpath>
 					<value>
@@ -403,29 +320,29 @@
 					</value>
 				</li>
 
-				<!-- === Wildness (descending order) === -->
-				<!-- == Black Dragon and Red Dragon == -->
+				<!-- ====== Wildness (descending order) ====== -->
+				<!-- ==== Black Dragon and Red Dragon ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Black_Dragon" or defName="Red_Dragon"]/race/wildness</xpath>
 					<value>
 						<wildness>0.99</wildness>
 					</value>
 				</li>
-				<!-- == Green Dragon ==-->
+				<!-- ==== Green Dragon ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Green_Dragon"]/race/wildness</xpath>
 					<value>
 						<wildness>0.97</wildness>
 					</value>
 				</li>
-				<!-- == Purple Dragon == -->
+				<!-- ==== Purple Dragon ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Purple_Dragon"]/race/wildness</xpath>
 					<value>
 						<wildness>0.94</wildness>
 					</value>
 				</li>
-				<!-- == Blue Dragon and White Dragon and Yellow Dragon == -->
+				<!-- ==== Blue Dragon and White Dragon and Yellow Dragon ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Blue_Dragon" or defName="White_Dragon" or defName="Yellow_Dragon"]/race/wildness</xpath>
 					<value>
@@ -435,5 +352,4 @@
 			</operations>
 		</match>
 	</Operation>
-
 </Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- I took 3 months off of RimWorld and I've forgotten how to do patches. Great. -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== BaseDragon (Dragon Base) ======== -->
+				<!-- ====== ModExtension ====== -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[@Name="BaseDragon"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Birdlike</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<!-- ======== DragonRaceBase (Common Dragon Base) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						<MeleeCritChance>1.75</MeleeCritChance>
+						<MeleeParryChance>0.54</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- ====== race (Race Properties) ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>10</baseHealthScale>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
+					<value>
+						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
+					</value>
+				</li>
+				<!-- ====== verbs (Because XPath dumb) ======== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]</xpath>
+					<value>
+						<verbs Inherit="false">
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
+								<burstShotCount>25</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<warmupTime>5</warmupTime>
+								<range>25</range>
+								<minRange>2</minRange>
+								<soundCast>DragonBreathShot</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>0.9</commonality>
+								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0.4</recoilAmount>
+							</li>
+						</verbs>
+					</value>
+				</li>
+
+				<!-- ======== RDragonRaceBase (Rare Dragon Base) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						<MeleeCritChance>1.96</MeleeCritChance>
+						<MeleeParryChance>0.64</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>19.2</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- ====== race (Race Properties) ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>12</baseHealthScale>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
+					<value>
+						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
+					</value>
+				</li>
+				<!-- ====== verbs (Because XPath dumb) ======== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]</xpath>
+					<value>
+						<verbs Inherit="false">
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
+								<burstShotCount>25</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<warmupTime>5</warmupTime>
+								<range>25</range>
+								<minRange>2</minRange>
+								<soundCast>DragonBreathShot</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>0.9</commonality>
+								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0.4</recoilAmount>
+							</li>
+						</verbs>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
@@ -1,99 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Dragon's Descent</li>
 		</mods>
-
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- ==== Rare Dragon Base ==== -->
-				<!-- === bodyShape === -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[@Name="RDragonRaceBase"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Birdlike</bodyShape>
-						</li>
-					</value>
-				</li>
-
-				<!-- === statBases === -->
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="RDragonRaceBase"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.13</MeleeDodgeChance>
-						<MeleeCritChance>1.96</MeleeCritChance>
-						<MeleeParryChance>0.64</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>48</ArmorRating_Blunt>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
-
-					<value>
-						<ArmorRating_Sharp>19.2</ArmorRating_Sharp>
-					</value>
-				</li>
-
-				<!-- === baseHealthScale and manhunterOnTameFailChance === -->
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/race/baseHealthScale</xpath>
-
-					<value>
-						<baseHealthScale>12</baseHealthScale>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
-
-					<value>
-						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
-					</value>
-				</li>
-
-				<!-- === Verbs === -->
-				<li Class="PatchOperationReplace">
-					<xpath> 
-						/Defs/ThingDef[ 
-							defName="Gold_Dragon" or 
-							defName="Silver_Dragon" or 
-							defName="Jade_Dragon" or 
-							defName="True_Dragon"]/verbs
-					</xpath>
-					<value>
-						<verbs>
-							<li Class="CombatExtended.VerbPropertiesCE">
-								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-								<hasStandardCommand>true</hasStandardCommand>
-								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
-								<burstShotCount>25</burstShotCount>
-								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-								<warmupTime>5</warmupTime>
-								<range>25</range>
-								<minRange>2</minRange>
-								<soundCast>DragonBreathShot</soundCast>
-								<muzzleFlashScale>1</muzzleFlashScale>
-								<commonality>0.9</commonality>
-								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-								<targetParams>
-									<canTargetLocations>true</canTargetLocations>
-								</targetParams>
-								<recoilAmount>0.4</recoilAmount>
-							</li>
-						</verbs>
-					</value>
-				</li>
-
-				<!-- === Tools === -->
-				<!-- == Base Tools -->
+				<!-- ======== Rare Dragons ======== -->
+				<!-- ====== Tools ====== -->
+				<!-- ==== Base Tools ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[
 							defName="Gold_Dragon" or 
@@ -180,8 +95,8 @@
 						</tools>
 					</value>
 				</li>
-				<!-- == Unique Tools == -->
-				<!-- = Gold Dragon = -->
+				<!-- ==== Unique Tools ==== -->
+				<!-- == Gold Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Gold_Dragon"]/tools</xpath>
 					<value>
@@ -218,7 +133,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Silver Dragon = -->
+				<!-- == Silver Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Silver_Dragon"]/tools</xpath>
 					<value>
@@ -255,7 +170,7 @@
 						</li>
 					</value>
 				</li>
-				<!-- = Jade Dragon = -->
+				<!-- == Jade Dragon == -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Jade_Dragon"]/tools</xpath>
 					<value>
@@ -292,9 +207,8 @@
 						</li>
 					</value>
 				</li>
-
-				<!-- === Wildness === -->
-				<!-- == Gold Dragon and Silver Dragon and Jade Dragon == -->
+				<!-- ====== Wildness ====== -->
+				<!-- ==== Gold Dragon and Silver Dragon and Jade Dragon ==== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Gold_Dragon" or defName="Silver_Dragon" or defName="Jade_Dragon"]/race/wildness</xpath>
 					<value>
@@ -302,14 +216,15 @@
 					</value>
 				</li>
 
-				<!-- ==== True Dragon ==== -->
-				<!-- === statBases === -->
+				<!-- ======== True Dragon ======== -->
+				<!-- ====== statBases ====== -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="True_Dragon"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.14</MeleeDodgeChance>
 						<MeleeCritChance>2.34</MeleeCritChance>
 						<MeleeParryChance>0.64</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
 					</value>
 				</li>
 
@@ -325,8 +240,7 @@
 						<ArmorRating_Sharp>23</ArmorRating_Sharp>
 					</value>
 				</li>
-
-				<!-- === Tools === -->
+				<!-- ====== Tools ====== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="True_Dragon"]/tools</xpath>
 					<value>
@@ -472,8 +386,7 @@
 						</tools>
 					</value>
 				</li>
-
-				<!-- === Wildness === -->
+				<!-- ====== Wildness ====== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="True_Dragon"]/race/wildness</xpath>
 					<value>
@@ -483,5 +396,4 @@
 			</operations>
 		</match>
 	</Operation>
-
 </Patch>

--- a/Patches/Insects have chitin/ThingDefs_Items/Chitin.xml
+++ b/Patches/Insects have chitin/ThingDefs_Items/Chitin.xml
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Finding the mod -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Insects have chitin</li>
+		</mods>
+		<!-- Once found, patching -->
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- InsectChitin -->
+				<!-- statBases. Armor values are based on the Alpha Animals patch. -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/SharpDamageMultiplier</xpath>
+					<value>
+						<SharpDamageMultiplier>0.6</SharpDamageMultiplier>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/statBases/BluntDamageMultiplier</xpath>
+					<value>
+						<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
+					</value>
+				</li>
+				<!-- StuffProps -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="InsectChitin"]/stuffProps/statFactors</xpath>
+					<value>
+						<MeleePenetrationFactor>0.6</MeleePenetrationFactor>
+						<Mass>0.2</Mass>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
- Made a patch for 'Insects have chitin'.

## Changes
- Updated the 'Dragon's Descent' patch to the latest version of 'Dragon's Descent'.

## Reasoning
- For the 'Insects have chitin' patch, I based it off the 'Alpha Animals' patch's chitin and Core patch's wood log. I used wood log because the chitin is categorized as 'Woody'.
- For updating the 'Dragon's Descent' patch, the latest version of the mod had changes which caused the patch to no longer work. The mod also added more items to the game.

## Testing
Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
