### PR TITLE
Added a null check to Harmony-GlobalControls.cs

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony-GlobalControls.cs
+++ b/Source/CombatExtended/Harmony/Harmony-GlobalControls.cs
@@ -16,7 +16,7 @@ namespace CombatExtended.HarmonyCE
         private static void Postfix(ref float curBaseY)
         {
             float offsetXFromOriginalMethod = UI.screenWidth - 200f;
-            Find.CurrentMap.GetComponent<WeatherTracker>().DoWindGUI(offsetXFromOriginalMethod + magicExtraOffset, ref curBaseY);
+            Find.CurrentMap?.GetComponent<WeatherTracker>().DoWindGUI(offsetXFromOriginalMethod + magicExtraOffset, ref curBaseY);
         }
     }
 }


### PR DESCRIPTION
## Additions
- Added a null check to `Harmony-GlobalControls.cs`.

## References
- Closes #89.

## Reasoning
- Abandoning your last colony means that there is no longer a `CurrentMap` (`CurrentMap` becomes null). Adding a null check fixes the referenced issue.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] Wind direction GUI does update.
- [x] The GUI no longer disappears after abandoning your last colony.
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
