### PR TITLE
Increase range of all psycasts 15%, increase smokepop psycast radius.

### DIFF
--- a/Royalty/Patches/AbilityDefs/Abilities.xml
+++ b/Royalty/Patches/AbilityDefs/Abilities.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Very Short Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="BerserkPulse"]/verbProperties/range</xpath>
+		<value>
+      		<range>17.25</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Short Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[
+		defName="Beckon" or
+		defName="Berserk" or	
+		defName="Invisibility" or	
+		defName="Flashstorm"					
+		]/verbProperties/range</xpath>
+		<value>
+      		<range>23</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Medium Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[
+			defName="Painblock" or
+			defName="Stun" or
+			defName="BlindingPulse" or
+			defName="EntropyDump" or
+			defName="VertigoPulse" or
+			defName="ChaosSkip" or
+			defName="Wallraise" or
+			defName="Smokepop" or
+			defName="Waterskip" or
+			defName="BulletShield"																						
+			]/verbProperties/range</xpath>
+		<value>
+      		<range>28</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Long Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[
+		defName="Skip" or
+		defName="Focus"	or
+		@Name="PsycastBase"						
+		]/verbProperties/range</xpath>
+		<value>
+      		<range>32</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Very Long Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Burden"]/verbProperties/range</xpath>
+		<value>
+      		<range>34.5</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Very Long Range Psycasts ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="ManhunterPulse"]/verbProperties/range</xpath>
+		<value>
+      		<range>40</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Increase Skip Destination Range ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Skip"]/comps/li[@Class="CompProperties_AbilityTeleport"]/range</xpath>
+		<value>
+      		<range>32</range>
+		</value>
+	</Operation>
+
+	<!-- ========== Increase Chaos Skip Range ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="ChaosSkip"]/comps/li[@Class="CompProperties_AbilityTeleport"]/randomRange</xpath>
+		<value>
+        	<randomRange>6.9~28</randomRange>
+		</value>
+	</Operation>
+
+	<!-- ========== Increase Mass Chaos Skip Range ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="ChaosSkip"]/comps/li[@Class="CompProperties_AbilityTeleport"]/randomRange</xpath>
+		<value>
+        	<randomRange>6.9~28</randomRange>
+		</value>
+	</Operation>
+
+	<!-- ========== Increase Smokepop Radius ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="Smokepop"]/comps/li[@Class="CompProperties_AbilitySmokepop"]/smokeRadius</xpath>
+		<value>
+        	<smokeRadius>4.0</smokeRadius>
+		</value>
+	</Operation>
+
+</Patch>
+

--- a/Royalty/Patches/AbilityDefs/Abilities.xml
+++ b/Royalty/Patches/AbilityDefs/Abilities.xml
@@ -66,7 +66,7 @@
 		</value>
 	</Operation>
 
-	<!-- ========== Very Long Range Psycasts ========== -->
+	<!-- ========== Extreme Range Psycasts ========== -->
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/AbilityDef[defName="ManhunterPulse"]/verbProperties/range</xpath>


### PR DESCRIPTION
- Increase the range of all Psycasts by 15%
- Increase from radius of Smokepop from 3.5 to 4.0

Close #125 