### PR TITLE
Initial Port of MVT Patch

### DIFF
--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Ammo_Shells.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Ammo_Shells.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>More Vanilla Turrets 1.1</modName>
+			</li>
+
+			<!-- ========== Define 81mm plasma mortar shell and unique ammoset for Devastator Mortar ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_81mmMortarShell_Plasma</defName>
+						<label>81mm mortar shells</label>
+						<ammoTypes>
+							<Shell_Plasma>Bullet_81mmMortarShell_Plasma</Shell_Plasma>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+						<defName>Shell_Plasma</defName>
+						<label>81mm mortar shell (Plasma)</label>
+						<graphicData>
+							<texPath>ThirdParty/More Vanilla Turrets/PlasmaMortarShell</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<statBases>
+							<MarketValue>237</MarketValue>
+							<Mass>6.5</Mass>
+							<Bulk>8.17</Bulk>
+						</statBases>
+						<ammoClass>Plasma</ammoClass>
+						<detonateProjectile>Bullet_81mmMortarShell_Plasma</detonateProjectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base81mmMortarShell">
+						<defName>Bullet_81mmMortarShell_Plasma</defName>
+						<label>81mm mortar shell (Plasma)</label>
+						<graphicData>
+							<texPath>ThirdParty/More Vanilla Turrets/PlasmaMortarProj</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>524</damageAmountBase>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<armorPenetrationBlunt>0</armorPenetrationBlunt>
+							<explosionRadius>5</explosionRadius>
+							<flyOverhead>true</flyOverhead>
+							<explosionChanceToStartFire>0.75</explosionChanceToStartFire>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							<explosionEffect>GiantExplosion</explosionEffect>
+							<soundExplode>Explosion_GiantBomb</soundExplode>
+						</projectile>
+					</ThingDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeShell_Plasma</defName>
+						<label>make 81mm Plasma mortar shells x5</label>
+						<description>Craft 5 81mm Plasma mortar shells.</description>
+						<jobString>Making 81mm Plasma mortar shells.</jobString>
+						<workAmount>49200</workAmount>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Plasteel</li>
+									</thingDefs>
+								</filter>
+								<count>120</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Plasteel</li>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Shell_Plasma>5</Shell_Plasma>
+						</products>
+					</RecipeDef>
+
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch> 

--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
@@ -20,10 +20,10 @@
 					<Bulk>18.54</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.25</recoilAmount>
+					<recoilAmount>1.08</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
 					<warmupTime>1.1</warmupTime>
 					<range>86</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -39,7 +39,7 @@
 				<AmmoUser>
 					<magazineSize>100</magazineSize>
 					<reloadTime>7.8</reloadTime>
-					<ammoSet>AmmoSet_50BMG</ammoSet>
+					<ammoSet>AmmoSet_303British</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -115,13 +115,13 @@
 					<Bulk>37.08</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>0.83</recoilAmount>
+					<recoilAmount>1.09</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
 					<warmupTime>1.1</warmupTime>
-					<range>86</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<range>54</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 					<burstShotCount>20</burstShotCount>
 					<soundCast>Shot_AssaultRifle</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
@@ -154,12 +154,12 @@
 					<Bulk>37.08</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>0.83</recoilAmount>
+					<recoilAmount>1.09</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
 					<warmupTime>1.1</warmupTime>
-					<range>126</range>
+					<range>54</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 					<burstShotCount>20</burstShotCount>
 					<soundCast>Shot_AssaultRifle</soundCast>
@@ -294,7 +294,7 @@
 				<defName>Gun_TurretPrecision</defName>
 				<statBases>
 					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-					<SightsEfficiency>1</SightsEfficiency>
+					<SightsEfficiency>1.2</SightsEfficiency>
 					<ShotSpread>0.01</ShotSpread>
 					<SwayFactor>1.32</SwayFactor>
 					<Bulk>28.72</Bulk>
@@ -303,7 +303,7 @@
 					<recoilAmount>1.80</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_25x137mmNATO_Sabot</defaultProjectile>
+					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
 					<warmupTime>1.4</warmupTime>
 					<range>89</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -317,14 +317,11 @@
 					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>100</magazineSize>
+					<magazineSize>25</magazineSize>
 					<reloadTime>7.8</reloadTime>
-					<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+					<ammoSet>AmmoSet_145x114mm</ammoSet>
 				</AmmoUser>
 				<FireModes>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>AimedShot</aiAimMode>
-					<aimedBurstShotCount>3</aimedBurstShotCount>
 				</FireModes>
 			</li>
 
@@ -501,7 +498,7 @@
 					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>400</magazineSize>
+					<magazineSize>375</magazineSize>
 					<reloadTime>7.8</reloadTime>
 					<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 				</AmmoUser>
@@ -548,7 +545,7 @@
 					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>100</magazineSize>
+					<magazineSize>375</magazineSize>
 					<reloadTime>7.8</reloadTime>
 					<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 				</AmmoUser>
@@ -606,9 +603,9 @@
 					<soundCast>ChargeLance_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>55</muzzleFlashScale>
-					<circularError>1</circularError>
+					<circularError>3</circularError>
 					<requireLineOfSight>false</requireLineOfSight>
-					<indirectFirePenalty>0.2</indirectFirePenalty>
+					<indirectFirePenalty>0.8</indirectFirePenalty>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>

--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
@@ -1,0 +1,741 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>More Vanilla Turrets 1.1</modName>
+			</li>
+
+			<!-- ========== Gun Complex ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_GunComplex</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.59</SwayFactor>
+					<Bulk>18.54</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.25</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>86</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>10</burstShotCount>
+					<soundCast>Shot_Minigun</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>18</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_50BMG</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GunComplex"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Rocket Complex ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_RocketComplex</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.23</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>2.16</SwayFactor>
+					<Bulk>14.71</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_83mmSMAW_HEAT</defaultProjectile>
+					<warmupTime>2.09</warmupTime>
+					<range>58</range>
+					<minRange>3</minRange>
+					<soundCast>InfernoCannon_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>30</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>8.6</reloadTime>
+					<ammoSet>AmmoSet_83mmSMAW</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RocketComplex"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>48</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Military Grade Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretMilitary</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.02</ShotSpread>
+					<SwayFactor>2.13</SwayFactor>
+					<Bulk>37.08</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.83</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>86</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>20</burstShotCount>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>200</magazineSize>
+					<reloadTime>15.6</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MilitaryTurretGun"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Manned Military Grade Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretMilitaryManned</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.02</ShotSpread>
+					<SwayFactor>2.13</SwayFactor>
+					<Bulk>37.08</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.83</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>126</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>20</burstShotCount>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>200</magazineSize>
+					<reloadTime>15.6</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>10</aimedBurstShotCount>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MilitaryTurretGunManned"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>86</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Shredder Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretShredder</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>2.02</SwayFactor>
+					<Bulk>10.66</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.34</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20</range>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<burstShotCount>4</burstShotCount>
+					<soundCast>Shot_Shotgun</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>18</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+					<requireLineOfSight>false</requireLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>4</aimedBurstShotCount>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ShredderTurretGun"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>20</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Manned Shredder Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretShredderManned</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>2.02</SwayFactor>
+					<Bulk>10.66</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.34</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20</range>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<burstShotCount>4</burstShotCount>
+					<soundCast>Shot_Shotgun</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>18</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+					<requireLineOfSight>false</requireLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>4.9</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>4</aimedBurstShotCount>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ShredderTurretGunManned"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>20</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Precision Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretPrecision</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.32</SwayFactor>
+					<Bulk>28.72</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.80</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_25x137mmNATO_Sabot</defaultProjectile>
+					<warmupTime>1.4</warmupTime>
+					<range>89</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>5</burstShotCount>
+					<soundCast>Shot_SniperRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>45</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PrecisionTurretGun"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>89</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Manned Precision Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TurretPrecisionManned</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.32</SwayFactor>
+					<Bulk>28.72</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.80</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_25x137mmNATO_Sabot</defaultProjectile>
+					<warmupTime>1.4</warmupTime>
+					<range>89</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>5</burstShotCount>
+					<soundCast>Shot_SniperRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>45</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PrecisionTurretGunManned"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>89</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Blast Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_BlastCharge</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>0.99</SwayFactor>
+					<Bulk>12.9</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.58</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>40</range>
+					<minRange>5</minRange>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>3</burstShotCount>
+					<soundCast>Mortar_LaunchA</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>20</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>48</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BlastTurretGun"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>40</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Manned Blast Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_BlastChargeManned</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>0.99</SwayFactor>
+					<Bulk>12.9</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.58</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>40</range>
+					<minRange>5</minRange>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>3</burstShotCount>
+					<soundCast>Mortar_LaunchA</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>20</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>48</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_40x53mmGrenade</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BlastTurretGunManned"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>40</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Vulcan Cannon ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_VulcanCannon</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.20</SwayFactor>
+					<Bulk>20.27</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.80</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_20x102mmNATO_Sabot</defaultProjectile>
+					<warmupTime>4.1</warmupTime>
+					<range>62</range>
+					<minRange>6</minRange>
+					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+					<burstShotCount>40</burstShotCount>
+					<soundCast>Shot_Minigun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>6</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>400</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>20</aimedBurstShotCount>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VulcanCannon"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>62</specialDisplayRadius>
+				</value>
+			</li>
+
+			<!-- ========== Manned Vulcan Cannon ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_VulcanCannonManned</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.20</SwayFactor>
+					<Bulk>20.27</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.80</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_20x102mmNATO_Sabot</defaultProjectile>
+					<warmupTime>4.1</warmupTime>
+					<range>62</range>
+					<minRange>4</minRange>
+					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+					<burstShotCount>40</burstShotCount>
+					<soundCast>Shot_Minigun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>6</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>20</aimedBurstShotCount>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>			
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VulcanCannonManned"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>62</specialDisplayRadius>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="VulcanCannon" or
+					defName="VulcanCannonManned"
+					]/passability</xpath>
+				<value>
+					<!-- Turrets must be passable to allow reloading -->
+					<passability>PassThroughOnly</passability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="VulcanCannon" or
+					defName="VulcanCannonManned"
+					]</xpath>
+				<value>
+					<!-- Workaround to replace passability=Impassable -->
+					<pathCost>200</pathCost>
+				</value>
+			</li>
+
+			<!-- ========== Devastator Mortar ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Artillery_DevastatorBomb</defName>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+					<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_81mmMortarShell_Plasma</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<minRange>20</minRange>
+					<range>500</range>
+					<burstShotCount>5</burstShotCount>
+					<soundCast>ChargeLance_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>55</muzzleFlashScale>
+					<circularError>1</circularError>
+					<requireLineOfSight>false</requireLineOfSight>
+					<indirectFirePenalty>0.2</indirectFirePenalty>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>25</magazineSize>
+					<reloadTime>5</reloadTime>
+					<ammoSet>AmmoSet_81mmMortarShell_Plasma</ammoSet>
+				</AmmoUser>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "Artillery_DevastatorBomb"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Charges">
+						<chargeSpeeds>
+							<li>30</li>
+							<li>50</li>
+							<li>70</li>
+							<li>90</li>
+						</chargeSpeeds>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Turret_DevastatorMortarBomb"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>15</turretBurstCooldownTime>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bullet_81mmMortarShell_Plasma"]/graphicData/texPath</xpath>
+				<value>
+					<texPath>Things/Building/Security/DevastatorShell</texPath>
+				</value>
+			</li>
+
+			<!--<li Class="PatchOperationAdd">
+				<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
+				<value>
+					<Shell_Plasma>Bullet_81mmMortarShell_Plasma</Shell_Plasma>
+				</value>
+			</li>-->
+
+			<!-- ========== Common to many or all Turrets ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="GunComplex" or
+					defName="RocketComplex" or
+					defName="MilitaryTurretGun" or
+					defName="MilitaryTurretGunManned" or
+					defName="ShredderTurretGun" or
+					defName="ShredderTurretGunManned" or
+					defName="PrecisionTurretGun" or
+					defName="PrecisionTurretGunManned" or
+					defName="BlastTurretGun" or
+					defName="BlastTurretGunManned" or
+					defName="VulcanCannon" or
+					defName="VulcanCannonManned" or
+					defName="Turret_DevastatorMortarBomb"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					defName="MilitaryTurretGun" or
+					defName="MilitaryTurretGunManned" or
+					defName="ShredderTurretGun" or
+					defName="ShredderTurretGunManned" or
+					defName="PrecisionTurretGun" or
+					defName="PrecisionTurretGunManned" or
+					defName="BlastTurretGun" or
+					defName="BlastTurretGunManned"
+				]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[
+					defName="GunComplex" or
+					defName="RocketComplex" or
+					defName="MilitaryTurretGun" or
+					defName="MilitaryTurretGunManned" or
+					defName="ShredderTurretGun" or
+					defName="ShredderTurretGunManned" or
+					defName="PrecisionTurretGun" or
+					defName="PrecisionTurretGunManned" or
+					defName="BlastTurretGun" or
+					defName="BlastTurretGunManned" or
+					defName="VulcanCannon" or
+					defName="VulcanCannonManned"
+				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="GunComplex" or
+					defName="RocketComplex" or
+					defName="MilitaryTurretGun" or
+					defName="MilitaryTurretGunManned" or
+					defName="ShredderTurretGun" or
+					defName="ShredderTurretGunManned" or
+					defName="PrecisionTurretGun" or
+					defName="PrecisionTurretGunManned" or
+					defName="BlastTurretGun" or
+					defName="BlastTurretGunManned" or
+					defName="VulcanCannon" or
+					defName="VulcanCannonManned"
+				]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ResearchProjectDef[defName="VulcanCannon"]/prerequisites/li[text()="MultibarrelWeapons"]</xpath>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch> 

--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
@@ -218,7 +218,7 @@
 					</targetParams>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>100</magazineSize>
+					<magazineSize>50</magazineSize>
 					<reloadTime>4.9</reloadTime>
 					<ammoSet>AmmoSet_12Gauge</ammoSet>
 				</AmmoUser>
@@ -268,7 +268,7 @@
 					</targetParams>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>100</magazineSize>
+					<magazineSize>50</magazineSize>
 					<reloadTime>4.9</reloadTime>
 					<ammoSet>AmmoSet_12Gauge</ammoSet>
 				</AmmoUser>
@@ -306,8 +306,6 @@
 					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
 					<warmupTime>1.4</warmupTime>
 					<range>89</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<burstShotCount>5</burstShotCount>
 					<soundCast>Shot_SniperRifle</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<targetParams>
@@ -322,6 +320,7 @@
 					<ammoSet>AmmoSet_145x114mm</ammoSet>
 				</AmmoUser>
 				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>				
 				</FireModes>
 			</li>
 
@@ -347,11 +346,9 @@
 					<recoilAmount>1.80</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_25x137mmNATO_Sabot</defaultProjectile>
+					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
 					<warmupTime>1.4</warmupTime>
 					<range>89</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<burstShotCount>5</burstShotCount>
 					<soundCast>Shot_SniperRifle</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<targetParams>
@@ -361,14 +358,12 @@
 					<recoilPattern>Mounted</recoilPattern>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>100</magazineSize>
+					<magazineSize>25</magazineSize>
 					<reloadTime>7.8</reloadTime>
-					<ammoSet>AmmoSet_25x137mmNATO</ammoSet>
+					<ammoSet>AmmoSet_145x114mm</ammoSet>
 				</AmmoUser>
 				<FireModes>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>AimedShot</aiAimMode>
-					<aimedBurstShotCount>3</aimedBurstShotCount>
 				</FireModes>
 			</li>
 
@@ -603,9 +598,9 @@
 					<soundCast>ChargeLance_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>55</muzzleFlashScale>
-					<circularError>3</circularError>
+					<circularError>1.2</circularError>
 					<requireLineOfSight>false</requireLineOfSight>
-					<indirectFirePenalty>0.8</indirectFirePenalty>
+					<indirectFirePenalty>0.3</indirectFirePenalty>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
 					</targetParams>
@@ -706,6 +701,10 @@
 					defName="VulcanCannon" or
 					defName="VulcanCannonManned"
 				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="GunComplex"]/thingCategories/li[text()="BuildingsSecurity"]</xpath>
 			</li>
 
 			<li Class="PatchOperationAdd">


### PR DESCRIPTION
# Additions 
This is a port of the in-progress patch for More Vanilla Turrets.

Changes from that PR:
- Vulcan Turret ammo up to 400 from 100 (10 bursts per reload, maybe needs to be higher)
- Military Grade Turret (auto and manned version) changed to use 7.62 NATO ammoset from previously used .50BMG ammoset. 
- Rocket Complex range up to 58 from 48.

# References
- From https://github.com/CombatExtendedRWMod/CombatExtended/pull/1165
