### PR TITLE
Added support for Genetic Rim+Genetic Rim Alpha Animal Patch 

### DIFF
--- a/Patches/Genetic Rim/Bodies/GeneticRim_CE_AlphaHybrids_Patch_Bodies.xml
+++ b/Patches/Genetic Rim/Bodies/GeneticRim_CE_AlphaHybrids_Patch_Bodies.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Alpha Animals Patch</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+
+					<!-- Beetlefleet -->
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_JellyfishBody"]//*[
+						def="AA_JellyfishMainBody" or 
+						def="AA_HydrogenSac"
+						]</xpath>
+						<value>
+							<groups/>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_JellyfishBody"]//*[
+						def="AA_JellyfishMainBody" or 
+						def="AA_HydrogenSac" or 
+						def="AA_JellyfishTentacle" or 
+						def="AnimalJaw"
+						]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+
+
+					<!-- Groundfallo -->
+					
+					<!-- Add Groups -->
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_QuadrupedAnimalWithPawsHornAndTail"]//*[
+						def="Body" or 
+						def="Neck" or 
+						customLabel="rear left leg" or 
+						customLabel="rear right leg" or 
+						customLabel="rear left hoof" or 
+						customLabel="rear right hoof"
+						]</xpath>
+						<value>
+							<groups/>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_QuadrupedAnimalWithPawsHornAndTail"]//*[
+						def="Body" or 
+						def="Neck" or 
+						def="Head" or 
+						def="Skull" or 
+						def="AnimalJaw" or 
+						def="Leg" or 
+						def="Paw" or
+						def="Hoof"
+						]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+
+
+					<!-- Night Thrumbo -->
+					
+					<!-- Add Groups -->
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_QuadrupedAnimalWithPawsHornAndTailThrumbo"]//*[
+						def="Body" or 
+						def="Neck" or 
+						customLabel="rear left leg" or 
+						customLabel="rear right leg" or 
+						customLabel="rear left paw" or 
+						customLabel="rear right paw"
+						]</xpath>
+						<value>
+							<groups/>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_QuadrupedAnimalWithPawsHornAndTailThrumbo"]//*[
+						def="Body" or 
+						def="Neck" or 
+						def="Head" or 
+						def="Skull" or 
+						def="AnimalJaw" or 
+						def="Leg" or 
+						def="Paw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+
+					
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/Bodies/GeneticRim_CE_Patch_Bodies.xml
+++ b/Patches/Genetic Rim/Bodies/GeneticRim_CE_Patch_Bodies.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+			<!-- ====== Adding custom bodytype for TurtleLike creatures ======= -->
+
+					<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+						<value>
+	<BodyDef>
+		<defName>GR_Arachnid</defName>
+		<label>arachnid body</label>
+		<corePart>
+			<def>Body</def>
+			<height>Middle</height>
+			<depth>Outside</depth>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+			<parts>
+				<li>
+					<def>AA_Thorax</def>
+					<coverage>0.10</coverage>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>Stomach</def>
+					<coverage>0.05</coverage>
+					<depth>Inside</depth>
+				</li>
+				<li>
+					<def>InsectHeart</def>
+					<coverage>0.03</coverage>
+					<depth>Inside</depth>
+				</li>
+				<li>
+					<def>Pronotum</def>
+					<coverage>0.08</coverage>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+					<height>Top</height>
+					<parts>
+						<li>
+							<def>InsectHead</def>
+							<coverage>0.65</coverage>
+							<groups>
+								<li>HeadAttackTool</li>
+				                                                               <li>CoveredByNaturalArmor</li>
+							</groups>
+							<parts>
+								<li>
+									<def>Brain</def>
+									<coverage>0.2</coverage>
+									<depth>Inside</depth>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>left first eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>left second eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>left third eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>left fourth eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>right first eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>right second eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>right third eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>Eye</def>
+									<customLabel>right fourth eye</customLabel>
+									<coverage>0.05</coverage>
+								</li>
+								<li>
+									<def>InsectNostril</def>
+									<coverage>0.1</coverage>
+								</li>
+								<li>
+									<def>AA_InsectMouth</def>
+									<coverage>0.05</coverage>
+									<groups>
+										<li>Mouth</li>
+									</groups>
+								</li>
+							</parts>
+						</li>
+					</parts>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>left first leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+					<groups>
+						<li>LegAttackTool</li>
+				                               <li>CoveredByNaturalArmor</li>
+					</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>right first leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+					<groups>
+						<li>LegAttackTool</li>
+				                               <li>CoveredByNaturalArmor</li>
+					</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>left second leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>right second leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>left third leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>right third leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>left fourth leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+				<li>
+					<def>InsectLeg</def>
+					<customLabel>right fourth leg</customLabel>
+					<coverage>0.06</coverage>
+					<height>Bottom</height>
+			<groups>
+				<li>CoveredByNaturalArmor</li>
+			</groups>
+				</li>
+			</parts>
+		</corePart>
+	</BodyDef>
+						</value>
+					</li>
+
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/race/body</xpath>
+						<value>
+							<body>GR_Arachnid</body>
+						</value>
+					</li>
+
+			
+					<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+						<value>
+							<BodyDef>
+								<defName>GR_TurtleLike</defName>
+								<label>turtle-like</label>
+									<corePart>
+									<def>AA_Shell</def>
+									<coverage>0.8</coverage>
+									<height>Middle</height>
+									<depth>Outside</depth>
+									<groups>
+										<li>CoveredByNaturalArmor</li>
+									</groups>
+									<parts>
+										<li>
+											<def>Plastron</def>
+											<coverage>0.06</coverage>
+											<height>Bottom</height>
+											<groups>
+												<li>CoveredByNaturalArmor</li>
+											</groups>
+										</li>
+										<li>
+											<def>Spine</def>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Stomach</def>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Heart</def>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Lung</def>
+											<customLabel>left lung</customLabel>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Lung</def>
+											<customLabel>right lung</customLabel>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Kidney</def>
+											<customLabel>left kidney</customLabel>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Kidney</def>
+											<customLabel>right kidney</customLabel>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Liver</def>
+											<coverage>0.03</coverage>
+											<depth>Inside</depth>
+										</li>
+										<li>
+											<def>Head</def>
+											<coverage>0.02</coverage>
+											<groups>
+												<li>HeadAttackTool</li>
+											</groups>
+											<parts>
+												<li>
+													<def>Brain</def>
+													<coverage>0.18</coverage>
+													<depth>Inside</depth>
+												</li>
+												<li>
+													<def>Eye</def>
+													<customLabel>left eye</customLabel>
+													<coverage>0.15</coverage>
+												</li>
+												<li>
+													<def>Eye</def>
+													<customLabel>right eye</customLabel>
+													<coverage>0.15</coverage>
+												</li>
+												<li>
+													<def>Nose</def>
+													<coverage>0.15</coverage>
+													</li>
+												<li>
+													<def>TurtleBeak</def>
+													<coverage>0.20</coverage>
+													<groups>
+												<li>TurtleBeakAttackTool</li>
+												</groups>
+												</li>
+											</parts>
+										</li>
+										<li>
+											<def>Leg</def>
+											<customLabel>front left leg</customLabel>
+											<coverage>0.01</coverage>
+											<height>Bottom</height>
+										</li>
+										<li>
+											<def>Leg</def>
+											<customLabel>front right leg</customLabel>
+											<coverage>0.01</coverage>
+											<height>Bottom</height>
+										</li>
+										<li>
+											<def>Leg</def>
+											<customLabel>rear left leg</customLabel>
+											<coverage>0.01</coverage>
+											<height>Bottom</height>
+										</li>
+										<li>
+											<def>Leg</def>
+											<customLabel>rear right leg</customLabel>
+											<coverage>0.01</coverage>
+											<height>Bottom</height>
+										</li>
+									</parts>
+									</corePart>
+							</BodyDef>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+						<value>
+							<BodyPartDef>
+								<defName>AA_Shell</defName>
+								<label>mineral shell</label>
+								<hitPoints>100</hitPoints>
+								<skinCovered>false</skinCovered>
+								<solid>true</solid>
+								<alive>false</alive>
+								<bleedRate>0</bleedRate>
+							</BodyPartDef>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/race/body</xpath>
+						<value>
+							<body>GR_TurtleLike</body>
+						</value>
+					</li>
+					
+					<!-- Horned Bird -->
+					
+					<!-- Add Groups -->
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_HornedBird"]//*[def="Body" or def="Neck" or def="Leg" or def="Tail"]</xpath>
+						<value>
+							<groups/>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="GR_HornedBird"]//*[def="Body" or def="Neck" or def="Head" or def="Skull" or def="Beak" or def="Leg" or def="Foot" or def="Tail"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+			
+					
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_AA_CE_Items_Resource_Stuff.xml.xml
+++ b/Patches/Genetic Rim/GeneticRim_AA_CE_Items_Resource_Stuff.xml.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Alpha Animals Patch</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+			<!--Boomthread -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.16</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Gas.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Gas.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Genetic Rim</li>
+		</mods>
+		
+		<match Class="PatchOperationSequence">
+			<success>Always</success>
+			<operations>
+		
+			<!-- Adding CE's gas attributes to certain creatures, except OcularGas since it has a particular AA effect -->
+			
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="GR_Gas_Ice" or
+					defName="GR_Poison_Gas" or
+					defName="GR_Hairballs" or
+					defName="GR_Poison_Cloud" or
+					defName="GR_InsectCloudMotes" or
+					defName="GR_Gas_Dust"
+					]</xpath>
+					<value>
+						<thingClass>CombatExtended.Smoke</thingClass>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Gas.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Gas.xml
@@ -14,9 +14,6 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="GR_Gas_Ice" or
 					defName="GR_Poison_Gas" or
-					defName="GR_Hairballs" or
-					defName="GR_Poison_Cloud" or
-					defName="GR_InsectCloudMotes" or
 					defName="GR_Gas_Dust"
 					]</xpath>
 					<value>

--- a/Patches/Genetic Rim/GeneticRim_CE_Hediffs_Local_Implants_Animals.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Hediffs_Local_Implants_Animals.xml
@@ -1,0 +1,466 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+        <li>Genetic Rim</li>
+        </mods>
+
+            <match Class="PatchOperationSequence">
+                <operations>
+
+	<!--=============== Animal Hybrid Implants ====================-->
+
+	<!--=============== Legs ====================-->
+
+	<!--========= Bear Leg ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_BearLeg"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: bear leg (tier 1)</label>
+                    <capacities>
+                        <li>Scratch</li>
+                    </capacities>
+                    <power>18</power>
+                    <cooldownTime>1.75</cooldownTime>
+                    <armorPenetrationSharp>1</armorPenetrationSharp>
+                    <armorPenetrationBlunt>4</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_BearLeg"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_BearLeg"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= lizard Leg ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_LizardLeg"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: lizard leg (tier 2)</label>
+                    <capacities>
+                        <li>Scratch</li>
+                    </capacities>
+                    <power>24</power>
+                    <cooldownTime>1.7</cooldownTime>
+                    <armorPenetrationSharp>1.5</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_LizardLeg"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_LizardLeg"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Thrumbo Leg ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboLeg"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: thrumbo leg (tier 3)</label>
+                    <capacities>
+                        <li>Scratch</li>
+                    </capacities>
+                    <power>34</power>
+                    <cooldownTime>1.85</cooldownTime>
+                    <armorPenetrationSharp>2.5</armorPenetrationSharp>
+                    <armorPenetrationBlunt>10</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboLeg"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboLeg"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+            </value>
+        </li>
+
+		<!--=============== Tails ====================-->
+
+	<!--========= Scyther Tail ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ScytherTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: scyther tail (tier 2)</label>
+                    <capacities>
+                        <li>Cut</li>
+                        <li>Stab</li>
+                    </capacities>
+                    <power>35</power>
+                    <cooldownTime>1.75</cooldownTime>
+                    <armorPenetrationSharp>2</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ScytherTail"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ScytherTail"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Mechanoid Tail ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: mechanoid tail (tier 3)</label>
+                    <capacities>
+                        <li>Cut</li>
+                    </capacities>
+                    <power>45</power>
+                    <cooldownTime>1.85</cooldownTime>
+                    <armorPenetrationSharp>4</armorPenetrationSharp>
+                    <armorPenetrationBlunt>12</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaTail"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaTail"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+            </value>
+        </li>
+
+		<!--=============== Eyes ====================-->
+
+	<!--========= Insectile Eye ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectileEye"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectileEye"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= ThrumboEye ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboEye"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboEye"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Ears ====================-->
+
+	<!--========= Moth Ear ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MothTympanalOrgan"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MothTympanalOrgan"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Mechanoid Ear ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaReceptors"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaReceptors"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Noses ====================-->
+
+	<!--========= Insect Pheromones ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectoidPheromones"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectoidPheromones"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Miniature Thrombo Horn ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MiniatureThrumboHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: miniature thrumbo horn (tier 3)</label>
+                    <capacities>
+							<li>Scratch</li>
+							<li>Stab</li>
+                    </capacities>
+                    <power>36</power>
+                    <cooldownTime>1.65</cooldownTime>
+                    <armorPenetrationSharp>2.5</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MiniatureThrumboHorn"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MiniatureThrumboHorn"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Jaws ====================-->
+
+	<!--========= Insect Mandibles ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectMandibles"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: insect mandibles (tier 2)</label>
+                    <capacities>
+							<li>Bite</li>
+                    </capacities>
+                    <power>24</power>
+                    <cooldownTime>1.6</cooldownTime>
+                    <armorPenetrationSharp>1.5</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectMandibles"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_InsectMandibles"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Thrumbo Jaws ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboJaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>animal Implant: bionic thrumbo jaws (tier 3)</label>
+                    <capacities>
+							<li>Bite</li>
+                    </capacities>
+                    <power>40</power>
+                    <cooldownTime>1.85</cooldownTime>
+                    <armorPenetrationSharp>3</armorPenetrationSharp>
+                    <armorPenetrationBlunt>8</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboJaws"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboJaws"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Spines ====================-->
+
+	<!--========= Muffalo Spine ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MuffaloSpine"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MuffaloSpine"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Crocodile Spine ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_CrocodileSpine"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_CrocodileSpine"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Mecha Spine ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaSpine"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaSpine"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Hearts ====================-->
+
+	<!--========= Chitinous Heart ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ChitinousHeart"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ChitinousHeart"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--========= Mecha Heart ============-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaHeart"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MechaHeart"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+            </value>
+        </li>
+
+		</operations>
+	</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Hediffs_Local_Implants_Humanoid.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Hediffs_Local_Implants_Humanoid.xml
@@ -1,0 +1,149 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+        <li>Genetic Rim</li>
+        </mods>
+
+            <match Class="PatchOperationSequence">
+                <operations>
+
+	<!--=============== Human Hybrid Implants ====================-->
+
+	<!--=============== Bear Claw ====================-->
+
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_BearClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>bear claws</label>
+                    <capacities>
+                        <li>Scratch</li>
+                    </capacities>
+                    <power>30</power>
+                    <cooldownTime>1.36</cooldownTime>
+                    <armorPenetrationSharp>1.8</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+	<!--=============== Digging Bear Claw ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_DiggingBearClaws"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>humanoid implant: digging bear claws</label>
+                    <capacities>
+                        <li>Scratch</li>
+                    </capacities>
+                    <power>21</power>
+                    <cooldownTime>1.65</cooldownTime>
+                    <armorPenetrationSharp>3</armorPenetrationSharp>
+                    <armorPenetrationBlunt>8</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+
+	<!--=============== Muffalo Skin ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MuffaloSkin"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_MuffaloSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+            </value>
+        </li>
+
+	<!--=============== Thrumbo Horn ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_HumanThrumboHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>humanoid implant: thrumbo horn</label>
+                    <capacities>
+                        <li>Cut</li>
+                        <li>Stab</li>
+                    </capacities>
+                    <power>40</power>
+                    <cooldownTime>1.5</cooldownTime>
+                    <armorPenetrationSharp>2.5</armorPenetrationSharp>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+	<!--=============== Thrumbo Skin ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboSkin"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>2</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_ThrumboSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>2</ArmorRating_Blunt>
+            </value>
+        </li>
+
+
+	<!--=============== Venomous Fangs ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_VenomousFangs"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+            <value>
+                <tools>
+                    <li Class="CombatExtended.ToolCE">
+                    <label>humanoid implant: venomous fangs</label>
+                    <capacities>
+                        <li>GR_VeryToxicBite</li>
+                    </capacities>
+                    <power>22</power>
+                    <cooldownTime>1.75</cooldownTime>
+                    <armorPenetrationSharp>1</armorPenetrationSharp>
+                    <armorPenetrationBlunt>2</armorPenetrationBlunt>
+                </li>
+                </tools>
+            </value>
+        </li>
+
+	<!--=============== Iguana Scales ====================-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_IguanaScales"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+            <value>
+                    <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/HediffDef[defName="GR_IguanaScales"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+            <value>
+                    <ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+            </value>
+        </li>
+
+
+		</operations>
+	</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Items_Resource_HybridAnimalProducts_Wools.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Items_Resource_HybridAnimalProducts_Wools.xml
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+        <li>Genetic Rim</li>
+        </mods>
+
+            <match Class="PatchOperationSequence">
+                <operations>
+
+
+			<!--Bearfallo Wool -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_BearffaloWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Hairball Wool -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_HairballWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Chickenfallo Wool -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ChickenffaloWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Muffalochicken Wool -->
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalochickenWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--Chickenspider Silk -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ChickenspiderSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ChickenspiderSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--Spidersnake Silk -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_SpidersnakeSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_SpidersnakeSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--Muffalopede Chitin -->
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalopedeChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalopedeChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.10</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--Mechanoid Wool -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalopedeChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalopedeChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.15</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--Muffalowolf Wool -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_MuffalowolfWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Wolffalo Wool -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_WolffaloWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Wolfsnake Skin -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_WolfsnakeSkin"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Thrumbear Wool -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_ThrumbearWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.14</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--Thrumfallo Wool -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_ThrumffaloWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_SniperFlechette" or
+				defName="GR_RazorProjectile" or
+				defName="GR_Laser" or
+				defName="GR_Disintegrator" or
+				defName="GR_StunBolt" or
+				defName="GR_PoisonBlast" or
+				defName="GR_HairballProjectile" or
+				defName="GR_GreatHairballProjectile" or
+				defName="GR_CryoBlast"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.BulletCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Proj_ThrownSac" or
+				defName="GR_IncendiaryMote" or
+				defName="GR_Warhead" or
+				defName="GR_PlasmaBurst" or
+				defName="GR_SmokeBomb"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				</value>
+			</li>
+			
+			<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
+			
+			<!-- =============== Now defining Projectiles in CE Procedure ============= -->
+						
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_SniperFlechette"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Bullet</damageDef>
+						<damageAmountBase>20</damageAmountBase>
+						<speed>200</speed>
+						<armorPenetrationSharp>10</armorPenetrationSharp>
+						<armorPenetrationBlunt>30</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_RazorProjectile"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Cut</damageDef>
+						<damageAmountBase>20</damageAmountBase>
+						<speed>64</speed>
+						<armorPenetrationSharp>4</armorPenetrationSharp>
+						<armorPenetrationBlunt>17</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Laser"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Flame</damageDef>
+						<damageAmountBase>13</damageAmountBase>
+						<speed>300</speed>
+			                                                <ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Disintegrator"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Flame</damageDef>
+						<damageAmountBase>1500</damageAmountBase>
+						<speed>300</speed>
+			                                                 <ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_StunBolt"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Stun</damageDef>
+						<damageAmountBase>20</damageAmountBase>
+						<speed>140</speed>
+						<armorPenetrationSharp>2.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>3</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_PoisonBlast"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>GR_ToxicExplosion</damageDef>
+						<damageAmountBase>26</damageAmountBase>
+						<speed>78</speed>
+						<armorPenetrationSharp>40</armorPenetrationSharp>
+						<armorPenetrationBlunt>40</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_HairballProjectile"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>GR_HairballProjectileDamage</damageDef>
+						<damageAmountBase>5</damageAmountBase>
+						<speed>18</speed>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_GreatHairballProjectile"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>GR_GreatHairballProjectileDamage</damageDef>
+						<damageAmountBase>14</damageAmountBase>
+						<speed>14</speed>
+						<armorPenetrationBlunt>0.85</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_CryoBlast"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Frostbite</damageDef>
+						<damageAmountBase>25</damageAmountBase>
+						<speed>48</speed>
+					</projectile>
+				</value>
+			</li>
+
+			
+						<!-- ======== Note: AA_ExplodingWeb wasn't used in any Race, so it wasn't included. If it gets added, just add a secondaryDamage to the corresponding projectile, with the Bomb damageDef ======== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Proj_ThrownSac"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>10</speed>
+						<damageDef>Bomb</damageDef>
+						<damageAmountBase>30</damageAmountBase>
+			                                                <explosionRadius >2.9</explosionRadius >
+			                                                 <explosionDelay>70</explosionDelay>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_SmokeBomb"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>18</speed>
+						<damageDef>Smoke</damageDef>
+						<damageAmountBase>1</damageAmountBase>
+			<explosionRadius >5.9</explosionRadius >
+			<explosionDelay>1</explosionDelay>
+			<postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+			<postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>
+			<postExplosionSpawnChance>1</postExplosionSpawnChance>
+					</projectile>
+				</value>
+			</li>
+
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_PlasmaBurst"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>31</speed>
+						<damageDef>Bomb</damageDef>
+						<damageAmountBase>45</damageAmountBase>
+			                                                <explosionRadius >4</explosionRadius >
+			                                                <explosionDelay>1</explosionDelay>
+					</projectile>
+				</value>
+			</li>
+
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_IncendiaryMote"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>17</speed>
+						<damageDef>Flame</damageDef>
+						<damageAmountBase>5</damageAmountBase>
+						<explosionRadius>1.1</explosionRadius>
+						<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+						<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
+						<ai_IsIncendiary>true</ai_IsIncendiary>
+						<soundExplode>Interact_Ignite</soundExplode>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Warhead"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>60</speed>
+						<damageDef>Bomb</damageDef>
+						<damageAmountBase>250</damageAmountBase>
+						<explosionRadius>8.9</explosionRadius>
+			<explosionChanceToStartFire>0.25</explosionChanceToStartFire>
+			<explosionDamageFalloff>true</explosionDamageFalloff>
+			<explosionEffect>GiantExplosion</explosionEffect>
+			<flyOverhead>False</flyOverhead>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundExplode>Explosion_GiantBomb</soundExplode>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+						<armorPenetrationSharp>100</armorPenetrationSharp>
+						<armorPenetrationBlunt>100</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>GR_Weapon_ThrownSac</defName>
+		<statBases>
+			<Mass>0.4</Mass>
+			<Bulk>0.7</Bulk>
+			<MarketValue>7.05</MarketValue>
+			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.65</SightsEfficiency>
+		</statBases>
+		<Properties>
+			<label>throw sac</label>
+			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<range>12</range>
+			<minRange>2.9</minRange>
+			<warmupTime>0.8</warmupTime>
+			<noiseRadius>4</noiseRadius>
+			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+			<soundCast>ThrowMolotovCocktail</soundCast>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<defaultProjectile>GR_Proj_ThrownSac</defaultProjectile>
+			<onlyManualCast>true</onlyManualCast>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+		</Properties>
+		<weaponTags>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+			</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles_AlphaAnimalPatch.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles_AlphaAnimalPatch.xml
@@ -57,13 +57,13 @@
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
-						<damageDef>Stun</damageDef>
+						<damageDef>Bomb</damageDef>
 						<damageAmountBase>12.5</damageAmountBase>
-						<speed>12</speed>
+                                 		<explosionRadius >0.9</explosionRadius >				<speed>12</speed>
 						<secondaryDamage>
 							<li>
-							  <def>Bomb</def>
-							  <amount>15</amount>
+							  <def>Stun</def>
+							  <amount>6</amount>
 							</li>
 						</secondaryDamage>
 					</projectile>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles_AlphaAnimalPatch.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles_AlphaAnimalPatch.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Alpha Animals Patch</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_Bullet_TinyVenomBarb" or
+				defName="AA_HugeQuill" or
+				defName="AA_ExplodingWeb"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.BulletCE</thingClass>
+				</value>
+			</li>
+			
+			<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
+			
+			<!-- =============== Now defining Projectiles in CE Procedure ============= -->
+						
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_Bullet_TinyVenomBarb"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>AA_ToxicSting</damageDef>
+						<damageAmountBase>2</damageAmountBase>
+						<speed>20</speed>
+						<armorPenetrationSharp>0.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_HugeQuill"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>AA_ToxicSting</damageDef>
+						<damageAmountBase>40</damageAmountBase>
+						<speed>16</speed>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<armorPenetrationBlunt>29.8</armorPenetrationBlunt>
+					</projectile>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_ExplodingWeb"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Stun</damageDef>
+						<damageAmountBase>12.5</damageAmountBase>
+						<speed>12</speed>
+						<secondaryDamage>
+							<li>
+							  <def>Bomb</def>
+							  <amount>15</amount>
+							</li>
+						</secondaryDamage>
+					</projectile>
+				</value>
+			</li>
+			
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_VerbShootCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_VerbShootCE.xml
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+				<!-- Syntax
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName=""]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+										...
+									</li>
+								</verbs>
+							</value>
+					</li>
+				-->
+
+				<!-- Archocentipede -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_Disintegrator</defaultProjectile>
+											<warmupTime>0.2</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>100</range>
+											<soundCast>GR_DisintegratorSound</soundCast>
+											<muzzleFlashScale>15</muzzleFlashScale>
+											<commonality>0.8</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+
+				            <li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_Proj_ThrownSac</defaultProjectile>
+											<warmupTime>2</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>3</minRange>
+											<range>20</range>
+											<soundCast>Pawn_BigInsect_Call</soundCast>
+											<muzzleFlashScale>2</muzzleFlashScale>
+											<commonality>0.75</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_HairballProjectile</defaultProjectile>
+											<warmupTime>1.35</warmupTime>
+											<burstShotCount>2</burstShotCount>
+											<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>30</range>
+											<soundCast>Bow_Recurve</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>0.6</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+
+					<!-- Mechas -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_PlasmaBurst</defaultProjectile>
+											<warmupTime>3</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+											<minRange>4</minRange>
+											<range>46</range>
+											<soundCast>Pawn_Mech_Centipede_Call</soundCast>
+											<muzzleFlashScale>2</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_IncendiaryMote</defaultProjectile>
+											<warmupTime>0.4</warmupTime>
+											<burstShotCount>2</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>20</range>
+											<soundCast>ThrowMolotovCocktail</soundCast>
+											<muzzleFlashScale>2</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_SniperFlechette</defaultProjectile>
+											<warmupTime>2.2</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>9</minRange>
+											<range>70</range>
+											<soundCast>Bow_Small</soundCast>
+											<muzzleFlashScale>9</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_Laser</defaultProjectile>
+											<warmupTime>1.6</warmupTime>
+											<burstShotCount>10</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>56</range>
+											<soundCast>GR_LaserSound</soundCast>
+											<muzzleFlashScale>9</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_SmokeBomb</defaultProjectile>
+											<warmupTime>4</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>4</minRange>
+											<range>55</range>
+											<soundCast>Pawn_Mech_Centipede_Call</soundCast>
+											<muzzleFlashScale>2</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<!-- Gallatross -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_StunBolt</defaultProjectile>
+											<warmupTime>1.25</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>8</range>
+											<soundCast>GR_Buzz</soundCast>
+											<muzzleFlashScale>9</muzzleFlashScale>
+											<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_PoisonBlast</defaultProjectile>
+											<warmupTime>2</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>62</range>
+											<soundCast>GR_PoisonBlast</soundCast>
+											<muzzleFlashScale>9</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>GR_CryoBlast</defaultProjectile>
+											<warmupTime>2</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>40</range>
+											<soundCast>GR_Liquid</soundCast>
+											<muzzleFlashScale>9</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+					
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>GR_Warhead</defaultProjectile>
+										<warmupTime>6</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+										<minRange>11</minRange>
+										<range>90</range>
+										<soundCast>Mortar_LaunchA</soundCast>
+										<muzzleFlashScale>15</muzzleFlashScale>
+										<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>GR_RazorProjectile</defaultProjectile>
+										<warmupTime>1.1</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+										<minRange>2</minRange>
+										<range>32</range>
+										<soundCast>Pawn_Melee_MechanoidSlash_HitPawn</soundCast>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_VerbShootCE_AlphaAnimalPatch.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_VerbShootCE_AlphaAnimalPatch.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Alpha Animals Patch</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+
+				<!-- Syntax
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName=""]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+										...
+									</li>
+								</verbs>
+							</value>
+					</li>
+				-->
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>AA_HugeQuill</defaultProjectile>
+											<warmupTime>2.4</warmupTime>
+											<burstShotCount>1</burstShotCount>
+											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>20</range>
+											<soundCast>AA_DartSound</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>0.8</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>AA_ExplodingWeb</defaultProjectile>
+											<warmupTime>2.5</warmupTime>
+											<burstShotCount>3</burstShotCount>
+											<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+											<minRange>1</minRange>
+											<range>16</range>
+											<soundCast>AA_Throw</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>0.8</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>AA_Bullet_TinyVenomBarb</defaultProjectile>
+											<warmupTime>1.8</warmupTime>
+											<burstShotCount>12</burstShotCount>
+											<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+											<minRange>2</minRange>
+											<range>14</range>
+											<soundCast>AA_DartSound</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>0.99</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Damage_CE/GeneticRim_CE_Patch_DamageDef.xml
+++ b/Patches/Genetic Rim/GeneticRim_Damage_CE/GeneticRim_CE_Patch_DamageDef.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+					
+					<!-- Buffing some Hediffs -->
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_LightToxicBite"]/additionalHediffs/li[hediff="ToxicBuildup"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.006</severityPerDamageDealt>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_VeryToxicBite"]/additionalHediffs/li[hediff="ToxicBuildup"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.033</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_HairballProjectileDamage"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.09</severityPerDamageDealt>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_GreatHairballProjectileDamage"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.09</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_ToxicExplosion"]/additionalHediffs/li[hediff="GR_ToxicDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.07</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_HairballExplosion"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.0002</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_PlagueBite"]/additionalHediffs/li[hediff="Plague"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.0125</severityPerDamageDealt>
+						</value>
+					</li>
+					
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Damage_CE/GeneticRim_CE_Patch_DamageDef_AlphaAnimalPatch.xml
+++ b/Patches/Genetic Rim/GeneticRim_Damage_CE/GeneticRim_CE_Patch_DamageDef_AlphaAnimalPatch.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+			<match Class="PatchOperationSequence">
+				<operations>
+					
+					<!-- Buffing some Hediffs -->
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_LightToxicBite"]/additionalHediffs/li[hediff="ToxicBuildup"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.005</severityPerDamageDealt>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_VeryToxicBite"]/additionalHediffs/li[hediff="ToxicBuildup"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.03</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_HairballProjectileDamage"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.09</severityPerDamageDealt>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_GreatHairballProjectileDamage"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.09</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_ToxicExplosion"]/additionalHediffs/li[hediff="GR_ToxicDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.07</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_HairballExplosion"]/additionalHediffs/li[hediff="GR_HairballDamage"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.0002</severityPerDamageDealt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="GR_PlagueBite"]/additionalHediffs/li[hediff="Plague"]/severityPerDamageDealt</xpath>
+						<value>
+							<severityPerDamageDealt>0.0125</severityPerDamageDealt>
+						</value>
+					</li>
+					
+				</operations>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_AberrationsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_AberrationsCE.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.01</MeleeDodgeChance>
+				<MeleeCritChance>0.23</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>22</power>
+							<cooldownTime>2.56</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Alpha_HybridCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Alpha_HybridCE.xml
@@ -1,0 +1,631 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>GeneticRim Alpha Animals Patch</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_BearBug"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.4</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>mandibles</label>
+							<capacities>
+								<li>AA_ParalysingBite</li>
+							</capacities>
+							<power>28</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Boomspider -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.65</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.65</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>
+				<MeleeCritChance>0.18</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left first leg</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>14</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right first leg</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>14</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>LegAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>AA_ToxicSting</li>
+							</capacities>
+							<power>23</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Chicken Cactus -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.3</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.3</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stings</label>
+							<capacities>
+					                                     <li>AA_ToxicSting</li>
+                                                                                                                </capacities>
+							<power>7</power>
+							<cooldownTime>1.2</cooldownTime>
+							<armorPenetrationSharp>0.35</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>Bite</label>
+							<capacities><li>Bite</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>AA_Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.12</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.12</MeleeDodgeChance>
+				<MeleeCritChance>0.24</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
+				<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.56</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>tentacles</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Arms</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Groundfallo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Groundfallo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>
+				<MeleeCritChance>0.4</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Groundfallo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>22</power>
+							<cooldownTime>2.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>22</power>
+							<cooldownTime>2.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+                                                                                                               <li>Scratch</li>
+					                               <li>Stab</li>
+                                                                                                               </capacities>
+							<power>25</power>
+							<cooldownTime>2.85</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Birdlizard -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>16</power>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>15</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.33</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+					                                                 <li>AA_ToxicSting</li>
+							</capacities>
+							<power>21</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>13</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.78</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.48</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>BiteBlunt</li></capacities>
+							<power>4</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.9</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.9</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.7</MeleeCritChance>
+				<MeleeParryChance>0.45</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				</value>
+			</li>
+
+		                 <li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5</baseHealthScale>
+					</value>
+		                </li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities><li>Cut</li><li>Stab</li></capacities>
+							<power>46</power>
+							<cooldownTime>2.0</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationSharp>8</armorPenetrationSharp>
+								<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>ToxicBite</li></capacities>
+							<power>36</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+		                                <surpriseAttack>
+					   <extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>25</amount>
+						</li>
+					</extraMeleeDamages>
+				</surpriseAttack>
+								<armorPenetrationSharp>3</armorPenetrationSharp>
+								<armorPenetrationBlunt>9</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>18</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+				                                                <chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>1</MeleeDodgeChance>
+				<MeleeCritChance>0.21</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				<ArmorRating_Blunt>2</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>AA_Pierce</li></capacities>
+							<power>26</power>
+							<cooldownTime>1.12</cooldownTime>
+							<linkedBodyPartsGroup>AA_BladeAttackTool</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+								<armorPenetrationSharp>7</armorPenetrationSharp>
+								<armorPenetrationBlunt>7</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>AA_Pierce</li></capacities>
+							<power>26</power>
+							<cooldownTime>1.12</cooldownTime>
+							<linkedBodyPartsGroup>AA_BladeAttackTool</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+								<armorPenetrationSharp>7</armorPenetrationSharp>
+								<armorPenetrationBlunt>7</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>AA_Mouth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+								<armorPenetrationSharp>2.5</armorPenetrationSharp>
+								<armorPenetrationBlunt>7</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ArchoCent_CE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ArchoCent_CE.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>3</AimingAccuracy>
+			                <ShootingAccuracyPawn>3</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.01</MeleeDodgeChance>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.25</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>180</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>42</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+				                                                <label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>100</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>200</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_BearhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_BearhybridsCE.xml
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.25</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>31</power>
+							<cooldownTime>2.1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>12</power>
+							<cooldownTime>2.22</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.12</MeleeDodgeChance>
+				<MeleeCritChance>0.07</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.48</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>15</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.48</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>15</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>16</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>13</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.6</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>5</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.07</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.68</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.68</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>30</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>18</power>
+							<cooldownTime>2.78</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>25</power>
+							<cooldownTime>1.6</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.55</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<MeleeCritChance>0.16</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>10</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.35</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>10</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li><li>Stab</li></capacities>
+							<power>20</power>
+							<cooldownTime>1.8</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+				<MeleeCritChance>0.23</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>14</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>14</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>25</power>
+							<cooldownTime>1.6</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_BoomalopehybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_BoomalopehybridsCE.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>18</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>10</power>
+							<cooldownTime>2.22</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.08</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>13</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.20</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.15</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>17</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.66</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.06</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.06</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.05</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomacat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomacat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.15</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomacat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>13</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CathybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CathybridsCE.xml
@@ -1,0 +1,408 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catbear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catbear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.11</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catbear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>7</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.14</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>7</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.14</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>15</power>
+							<cooldownTime>1.78</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.02</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>6</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.01</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catfallo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catfallo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.06</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catfallo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>10</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.17</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.01</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>2</power>
+							<cooldownTime>0.55</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.06</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>2</power>
+							<cooldownTime>0.55</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.06</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>4</power>
+							<cooldownTime>0.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.07</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>5</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.05</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.12</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>5</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.05</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.12</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>10</power>
+							<cooldownTime>1.55</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.18</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>	
+						
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ChickenhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ChickenhybridsCE.xml
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>10</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.12</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.12</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.33</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.35</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.04</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.39</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>2</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.04</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Cut</li></capacities>
+							<power>4</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>5</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_InsectoidhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_InsectoidhybridsCE.xml
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>0.27</MeleeParryChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Cut</li></capacities>
+							<power>40</power>
+							<cooldownTime>2.56</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.33</armorPenetrationSharp>
+							<armorPenetrationBlunt>18</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Stab</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.88</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.65</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.65</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.15</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Cut</li></capacities>
+							<power>19</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.8</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Stab</li></capacities>
+							<power>15</power>
+							<cooldownTime>2.1</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>4</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/comps/li[@Class="NewAnimalSubproducts.CompProperties_AnimalProduct"]</xpath>
+		<value>
+			<li Class="NewAnimalSubproducts.CompProperties_AnimalProduct">
+				<resourceDef>GR_Weapon_ThrownSac</resourceDef>
+				<gatheringIntervalDays>30</gatheringIntervalDays>
+				<resourceAmount>5</resourceAmount>
+				<customResourceString>SacGrowth</customResourceString>
+			</li>
+		</value>
+	</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.24</MeleeDodgeChance>
+				<MeleeCritChance>0.05</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.03</MeleeDodgeChance>
+				<MeleeCritChance>0.4</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Cut</li></capacities>
+							<power>24</power>
+							<cooldownTime>2.78</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.55</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.28</MeleeCritChance>
+				<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Cut</li></capacities>
+							<power>22</power>
+							<cooldownTime>1.68</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Stab</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.88</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.95</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.75</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.75</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.13</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Stab</li></capacities>
+							<power>11</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
@@ -1,0 +1,626 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.45</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>3</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>43</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>12</armorPenetrationSharp>
+							<armorPenetrationBlunt>32</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>25</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>16</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>14</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>2.6</AimingAccuracy>
+			                <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.65</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>1</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>0.55</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1.6</AimingAccuracy>
+			                <ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.36</MeleeDodgeChance>
+				<MeleeCritChance>0.4</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>25</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>2.1</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>13</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Stab</li><li>Cut</li></capacities>
+							<power>34</power>
+							<cooldownTime>1.7</cooldownTime>
+							<linkedBodyPartsGroup>AA_InsectMouth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>16</armorPenetrationSharp>
+							<armorPenetrationBlunt>16</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>4</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>32</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>0.8</AimingAccuracy>
+			                <ShootingAccuracyPawn>0.8</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				<MeleeCritChance>0.03</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>0.75</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>2</power>
+							<cooldownTime>0.55</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1.6</AimingAccuracy>
+			                <ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>58</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>23</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>2.5</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>15</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>28</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.75</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>48</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>6</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities><li>Cut</li></capacities>
+							<power>56</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>40</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>50</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases</xpath>
+				<value>
+				<AimingAccuracy>1</AimingAccuracy>
+			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+				<MeleeDodgeChance>0.75</MeleeDodgeChance>
+				<MeleeCritChance>0.25</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+
+		<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>15</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>28</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
@@ -239,9 +239,9 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities><li>Stab</li><li>Cut</li></capacities>
-							<power>34</power>
-							<cooldownTime>1.7</cooldownTime>
-							<linkedBodyPartsGroup>AA_InsectMouth</linkedBodyPartsGroup>
+							<power>35</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
 									<li>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MuffalohybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MuffalohybridsCE.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.38</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>28</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.12</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.33</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>27</power>
+							<cooldownTime>1.85</cooldownTime>
+					                                <chanceFactor>0.5</chanceFactor>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.6</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>Tusk</label>
+							<capacities><li>Bite</li></capacities>
+							<power>24</power>
+							<cooldownTime>2</cooldownTime>
+					                                <chanceFactor>0.5</chanceFactor>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ParagonCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ParagonCE.xml
@@ -1,0 +1,849 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.6</MeleeCritChance>
+				<MeleeParryChance>0.3</MeleeParryChance>
+			<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBear"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>4</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>30</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>27</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>30</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>27</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>46</power>
+							<cooldownTime>1.95</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>24</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>5</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>20</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Entelodont / Daeodon -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWildBoar"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWildBoar"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWildBoar"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Scratch</li>
+								<li>Stab</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>15</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>9</power>
+							<cooldownTime>1.55</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.88</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Gigantopithecus -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBoomalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBoomalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.04</MeleeDodgeChance>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>0.01</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaBoomalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>15</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaChicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaChicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.02</MeleeCritChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaChicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>5</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.18</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaEmu"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaEmu"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>7</MoveSpeed>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaEmu"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.92</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaEmu"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>13</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>10</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>18</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.55</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaMuffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaMuffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.01</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaMuffalo"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>4.6</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaMuffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>2.66</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaOstrich"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaOstrich"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>7</MoveSpeed>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaOstrich"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.75</MeleeDodgeChance>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaOstrich"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>15</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.55</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRhinoceros"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRhinoceros"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.06</MeleeDodgeChance>
+				<MeleeCritChance>0.75</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRhinoceros"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>4.6</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRhinoceros"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn (Blunt)</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>32</power>
+							<cooldownTime>2.3</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities><li>Stab</li><li>Scratch</li></capacities>
+							<power>43</power>
+							<cooldownTime>2.3</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>BiteBlunt</li></capacities>
+							<power>10</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWolfTimber"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWolfTimber"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>7.1</MoveSpeed>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWolfTimber"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaWolfTimber"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>30</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaHare"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaHare"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+				<MeleeCritChance>0.08</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaHare"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>BiteBlunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaIguana"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaIguana"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaIguana"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>4</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaIguana"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>9</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>9</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.88</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>4</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaPig"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaPig"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaPig"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.02</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaRat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>GR_PlagueBite</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.12</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>GR_PlagueBite</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.12</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_PlagueBite</li></capacities>
+							<power>5</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.34</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaTortoise"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaTortoise"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.03</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaTortoise"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaTortoise"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_AlphaTortoise"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>18</power>
+							<cooldownTime>3.6</cooldownTime>
+							<linkedBodyPartsGroup>TurtleBeakAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.48</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>12</power>
+							<cooldownTime>3.6</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ReptilehybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ReptilehybridsCE.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.05</MeleeDodgeChance>
+				<MeleeCritChance>0.43</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>0.3</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>17</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>17</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.3</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>30</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>21</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1.25</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>6</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Serpentine</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.33</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>21</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.07</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>claws</label>
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>4</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>4</power>
+							<cooldownTime>0.9</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.12</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>GR_LightToxicBite</li></capacities>
+							<power>1</power>
+							<cooldownTime>0.86</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.12</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.06</MeleeDodgeChance>
+				<MeleeCritChance>0.4</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.88</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>3.17</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Serpentine</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+				<MeleeCritChance>0.07</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>12</power>
+							<cooldownTime>1.6</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.3</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Sharp>0.12</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities>
+								<li>GR_VeryToxicBite</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities>
+								<li>GR_VeryToxicBite</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>3</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.88</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Serpentine</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<MeleeCritChance>0.25</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_RodenthybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_RodenthybridsCE.xml
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Molebear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Molebear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.18</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Molebear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>9</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>9</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.28</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.15</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>5</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>7</power>
+							<cooldownTime>1.56</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.25</MeleeDodgeChance>
+				<MeleeCritChance>0.02</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>3</power>
+							<cooldownTime>0.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.06</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.15</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Ratfallo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Ratfallo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.22</MeleeDodgeChance>
+				<MeleeCritChance>0.03</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Ratfallo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>5</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.18</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.35</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.18</MeleeDodgeChance>
+				<MeleeCritChance>0.15</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.2</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>8</power>
+							<cooldownTime>1.2</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>16</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.65</armorPenetrationSharp>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>3</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.23</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>16</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>16</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>34</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>4</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ThrumbohybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ThrumbohybridsCE.xml
@@ -1,0 +1,679 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.01</MeleeDodgeChance>
+				<MeleeCritChance>0.8</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>12</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>4.3</MoveSpeed>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>9</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.3</chanceFactor>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>Smash!</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>42</power>
+							<cooldownTime>2.43</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+					                                <chanceFactor>0.3</chanceFactor>
+							<armorPenetrationBlunt>45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>Smash!</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>42</power>
+							<cooldownTime>2.43</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+					                                <chanceFactor>0.3</chanceFactor>
+							<armorPenetrationBlunt>45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>BiteBlunt</li></capacities>
+							<power>24</power>
+							<cooldownTime>2.6</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					                                <chanceFactor>0.1</chanceFactor>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>25</power>
+							<cooldownTime>2.75</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.1</chanceFactor>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.06</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>12</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>7.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>19</power>
+							<cooldownTime>2.0</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Birdlike</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>6</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>36</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+		                                <surpriseAttack>
+					   <extraMeleeDamages>
+						<li>
+							<def>Stun</def>
+							<amount>25</amount>
+						</li>
+					</extraMeleeDamages>
+				</surpriseAttack>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>27</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>3</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.04</MeleeDodgeChance>
+				<MeleeCritChance>0.65</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>15</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>7.5</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>7.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left hoof</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right hoof</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>21</power>
+							<cooldownTime>2.33</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>2.33</cooldownTime>
+					                                <chanceFactor>0.2</chanceFactor>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.35</MeleeDodgeChance>
+				<MeleeCritChance>0.55</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
+			                <ArmorRating_Blunt>10</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>5</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>33</power>
+							<cooldownTime>1.35</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>7</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>17</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>17</power>
+							<cooldownTime>1.45</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7.2</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>31</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.44</MeleeDodgeChance>
+				<MeleeCritChance>0.56</MeleeCritChance>
+				<MeleeParryChance>0.25</MeleeParryChance>
+			                <ArmorRating_Blunt>10</ArmorRating_Blunt>
+			                <ArmorRating_Sharp>5</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5</baseHealthScale>
+					</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+								<li>Stab</li>
+							</capacities>
+							<power>31</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>7</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right foot</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>14</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_HairballBite</li></capacities>
+							<power>28</power>
+							<cooldownTime>1.3</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.64</MeleeCritChance>
+				<MeleeParryChance>0.2</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Scratch</li>
+								<li>Stab</li>
+							</capacities>
+							<power>31</power>
+							<cooldownTime>1.8</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>7</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left paw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right paw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>24</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>16</power>
+							<cooldownTime>2.0</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>11</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.78</MeleeCritChance>
+				<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>7</baseHealthScale>
+					</value>
+				</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Cut</li><li>Stab</li></capacities>
+							<power>56</power>
+							<cooldownTime>2.36</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationSharp>20</armorPenetrationSharp>
+							<armorPenetrationBlunt>40</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>36</power>
+							<cooldownTime>2.35</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>
+				<MeleeCritChance>0.7</MeleeCritChance>
+				<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>GR_VeryToxicBite</li></capacities>
+							<power>40</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
+							<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>GR_VeryToxicBite</li>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+					                                <chanceFactor>0.3</chanceFactor>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>21</power>
+							<cooldownTime>2.3</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_WolfhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_WolfhybridsCE.xml
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Genetic Rim</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.26</MeleeDodgeChance>
+				<MeleeCritChance>0.14</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>10</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.15</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.35</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>10</power>
+							<cooldownTime>1</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.15</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.35</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>28</power>
+							<cooldownTime>1.65</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>18</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				<MeleeCritChance>0.14</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.26</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.06</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.55</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.26</MeleeDodgeChance>
+				<MeleeCritChance>0.1</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>6</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>20</power>
+							<cooldownTime>1.9</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.25</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+						
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<MeleeCritChance>0.27</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>7</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities><li>Scratch</li></capacities>
+							<power>7</power>
+							<cooldownTime>0.8</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>16</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities><li>Bite</li></capacities>
+							<power>21</power>
+							<cooldownTime>1.75</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities><li>Blunt</li></capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
Supports for all vanilla Genetic Rim animals+Alpha Animal Hybrids, including any new weapons, materials and implants. Further tweaks might be added in the immediate future.

## Testing

Check tests you have performed:
- [ x ] Compiles without warnings
- [ x ] Game runs without errors
- [ x ] (For compatibility patches) ...with and without patched mod loaded
- [ x ] Playtested a colony (specify how long)
