### PR TITLE
Added VFEM_MeleeWeapon_HeavyMace patch

### DIFF
--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
@@ -92,9 +92,9 @@
 								<capacities>
 									<li>Poke</li>
 								</capacities>
-								<power>3</power>
-								<cooldownTime>1.73</cooldownTime>
-								<armorPenetrationBlunt>0.875</armorPenetrationBlunt>
+								<power>4</power>
+								<cooldownTime>1.84</cooldownTime>
+								<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
 								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 							</li>
 							<li Class="CombatExtended.ToolCE">
@@ -102,10 +102,10 @@
 								<capacities>
 									<li>Blunt</li>
 								</capacities>
-								<power>20</power>
-								<cooldownTime>2.24</cooldownTime>
+								<power>23</power>
+								<cooldownTime>3.51</cooldownTime>
 								<chanceFactor>1.33</chanceFactor>
-								<armorPenetrationBlunt>7.875</armorPenetrationBlunt>
+								<armorPenetrationBlunt>9.375</armorPenetrationBlunt>
 								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 							</li>
 						</tools>
@@ -116,9 +116,9 @@
 					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]</xpath>
 					<value>
 						<equippedStatOffsets>
-							<MeleeCritChance>0.42</MeleeCritChance>
-							<MeleeParryChance>0.36</MeleeParryChance>
-							<MeleeDodgeChance>0.3</MeleeDodgeChance>	
+							<MeleeCritChance>1.5</MeleeCritChance>
+							<MeleeParryChance>0.4</MeleeParryChance>
+							<MeleeDodgeChance>0.4</MeleeDodgeChance>	
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -127,7 +127,7 @@
 					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/statBases</xpath>
 					<value>
 						<Bulk>4.5</Bulk>
-						<MeleeCounterParryBonus>.36</MeleeCounterParryBonus>
+						<MeleeCounterParryBonus>.53</MeleeCounterParryBonus>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
@@ -81,7 +81,64 @@
                     </stuffCategories>    
                     </value>
                 </li>
-					
+				
+				<!-- Heavy Mace -->	
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.73</cooldownTime>
+								<armorPenetrationBlunt>0.875</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>20</power>
+								<cooldownTime>2.24</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>7.875</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.42</MeleeCritChance>
+							<MeleeParryChance>0.36</MeleeParryChance>
+							<MeleeDodgeChance>0.3</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/statBases</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<MeleeCounterParryBonus>.36</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/stuffCategories</xpath>
+                    <value>
+                    <stuffCategories>
+                        <li>Steeled</li>
+                    </stuffCategories>    
+                    </value>
+                </li>	
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions

Added a patch for the heavy mace from Vanilla Factions Expanded - Medieval 

## Reasoning

Values for the heavy mace were calculated using the vanilla mace on the melee stats sheet, but I increased the mass from 1.25 to 1.75, and range from 60 to 90. 

I also increased the bulk slightly, from 3.5 to 4.5, since this is a larger weapon.

## Testing

Check tests you have performed:
- [x] Compiles without warnings (im assuming this is fine since no code changes)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (I crafted a heavy mace and whacked some dudes with it)
