### PR TITLE
Fixing Glitter Tech Compatibility Error

### DIFF
--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -241,11 +241,9 @@
 	<!-- Auto Mortar Top -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]</xpath>
+		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
 		<value>
-			<statBases>
 				<SightsEfficiency>0.5</SightsEfficiency>
-			</statBases>
 		</value>
 	</Operation>
 

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -239,12 +239,25 @@
 	</Operation>
 
 	<!-- Auto Mortar Top -->
+	
+	<!-- Glitter Tech Fix -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
-		<value>
+	<Operation Class="PatchOperationConditional">
+    		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]</xpath>
+			<value>
+				<statBases>
+					<SightsEfficiency>0.5</SightsEfficiency>
+				</statBases>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
+			<value>
 				<SightsEfficiency>0.5</SightsEfficiency>
-		</value>
+			</value>
+		</match>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -296,4 +309,4 @@
 	</Operation>
 
 	
-</Patch>	
+</Patch>


### PR DESCRIPTION
Quick change to Royality patch file to remove error caused by Glitter Tech.

The original patch added a second version of statBases to the AutoMortar (the first added by Glitter Tech), confusing RimWorld.
This version checks for its existence first, to avoid duplication.

## Additions

None

## Changes

Fixed an incompatibility with Glitter Tech.

## Reasoning

Removing Console Spam (Error)

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (manipulated ShotValue to prove that statBases was updated)

## Notes

I did not test if values make sense, i just made sure that they were correctly added.