### PR TITLE
Use Core abstracts for CE PawnKinds

### DIFF
--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-  <PawnKindDef Name="MercenaryBase" Abstract="True">
-    <race>Human</race>
-    <defaultFactionType>Pirate</defaultFactionType>
-    <backstoryCategories>
-      <li>Raider</li>
-    </backstoryCategories>
-    <chemicalAddictionChance>0.1</chemicalAddictionChance>
-    <invNutrition>2.55</invNutrition>
-    <itemQuality>Normal</itemQuality>
-    <backstoryCryptosleepCommonality>0.08</backstoryCryptosleepCommonality>
-    <maxGenerationAge>65</maxGenerationAge>
-    <combatEnhancingDrugsChance>0.15</combatEnhancingDrugsChance>
-    <combatEnhancingDrugsCount>
-      <min>0</min>
-      <max>2</max>
-    </combatEnhancingDrugsCount>
-  </PawnKindDef>
-
   <PawnKindDef ParentName="MercenaryBase">
     <defName>MercenaryMachineGunner</defName>
     <label>mercenary machine gunner</label>
@@ -50,10 +32,6 @@
       <min>1000</min>
       <max>1500</max>
     </techHediffsMoney>
-    <combatEnhancingDrugsCount>
-      <min>0</min>
-      <max>2</max>
-    </combatEnhancingDrugsCount>
     <techHediffsTags>
       <li>Advanced</li>
     </techHediffsTags>
@@ -78,21 +56,6 @@
   </PawnKindDef>
 
   <!-- ========== Tribals ========== -->
-
-  <PawnKindDef Name="TribalBase" Abstract="True">
-    <race>Human</race>
-    <defaultFactionType>TribeCivil</defaultFactionType>
-    <backstoryCategories>
-      <li>Tribal</li>
-    </backstoryCategories>
-    <maxGenerationAge>60</maxGenerationAge>
-    <chemicalAddictionChance>0.05</chemicalAddictionChance>
-    <invNutrition>2.55</invNutrition>
-    <invFoodDef>Pemmican</invFoodDef>
-    <apparelTags>
-      <li>Neolithic</li>
-    </apparelTags>
-  </PawnKindDef>
 
   <PawnKindDef ParentName="TribalBase">
     <defName>TribalGrenadier</defName>


### PR DESCRIPTION
## Changes
- Remove the PawnKind abstract defs that CE PawnKinds like MercenaryMachineGunner and TribalGrenadier use. Instead, these PawnKinds now extend the Core abstracts that the CE abstracts were based on.

## Reasoning
- The PawnKind abstracts in CE are effectively copies of their Core equivalents, and haven't been updated for 1.1. Using the Core abstracts instead of CE's copies reduces maintenance and avoids bugs caused by outdated def elements (e.g: the backstoryCategories element currently in CE's MercenaryBase should not be used in 1.1, and causes occasional errors when spawning MercenaryMachineGunner pawns).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Couple minutes spawning pawns with the dev tools)
