### PR TITLE
War Mongrel Helmets nerf to PASGT Levels

### DIFF
--- a/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_Apparel_Armor_Headgear.xml
@@ -42,7 +42,7 @@
 				<value>
 					<Bulk>4.5</Bulk>
 					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					<ArmorRating_Blunt>16</ArmorRating_Blunt>
 					<ArmorRating_Heat>0.54</ArmorRating_Heat>
 				</value>

--- a/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
+++ b/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_Apparel_Armor_Headgear_Crafting_Rimfeller.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[RH] Faction: War Mongrels</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<li Class="PatchOperationFindMod">
+					<mods>
+						<li>Rimefeller</li>
+					</mods>
+					
+					<!-- If Rimefeller is also installed, have the 6B7M helmets require Synthamide for crafting -->					
+					<match Class="PatchOperationSequence">
+						<operations>
+						
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[
+				defName="RNApparel_6B71MHelmet_M89C" or
+				defName="RNApparel_6B71MHelmet_M89C_Bali" or
+				defName="RNApparel_6B71MHelmet_M89C_Cobra"
+								]/costList</xpath>
+								<value>
+									<costList>
+										<Synthamide>10</Synthamide>
+									</costList>
+								</value>
+							</li>
+						</operations>
+					</match>
+					
+					<!-- Otherwise, default to Devilstrand -->		
+					<nomatch Class="PatchOperationSequence">
+						<operations>
+						
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/ThingDef[
+				defName="RNApparel_6B71MHelmet_M89C" or
+				defName="RNApparel_6B71MHelmet_M89C_Bali" or
+				defName="RNApparel_6B71MHelmet_M89C_Cobra"
+								]/costList</xpath>
+								<value>
+									<costList>
+										<DevilstrandCloth>10</DevilstrandCloth>
+									</costList>
+								</value>
+							</li>
+						</operations>
+						
+					</nomatch>
+					
+				</li>
+				
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Rimfeller Synthamide is probably kevlar as such we can PROBABLY subsitute it for devilstrand in some manafacturing cases, this patch nerfs War Mongrel M89 Helmets to PASGT levels since they were  the essentially the same.