### PR TITLE
Misc Tweaks

### DIFF
--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -21,6 +21,14 @@
 	</Operation>
 
 	<!-- ========== Mini-turret ========== -->
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/description</xpath>
+    
+    <value>
+      <description>A portable automatic turret. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
+    </value>
+  </Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/thingClass</xpath>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -515,7 +515,7 @@
 			  <recoilAmount>1.20</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>true</hasStandardCommand>
-			  <defaultProjectile>Bullet_763x25mmMauser_FMJ</defaultProjectile>
+			  <defaultProjectile>Bullet_792x57mmMauser_FMJ</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
 			  <range>62</range>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
@@ -531,7 +531,7 @@
 			<AmmoUser>
 			  <magazineSize>75</magazineSize>
 			  <reloadTime>4.9</reloadTime>
-			  <ammoSet>AmmoSet_763x25mmMauser</ammoSet>
+			  <ammoSet>AmmoSet_792x57mmMauser</ammoSet>
 			</AmmoUser>
 			<FireModes>
 			  <aimedBurstShotCount>5</aimedBurstShotCount>


### PR DESCRIPTION
## Changes

Core
- Removes references to barrel refurbishing and explosion chance when damaged from the mini-turret.

Patches
- Kaiser Armory MG-15 now uses the correct ammunition (7.63x25 > 7.92x57).

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
