### PR TITLE
Patch Vanilla Weapons Expanded - Grenades

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -112,7 +112,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>0.8</warmupTime>
+        <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -185,7 +185,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>7.0</range>
-        <warmupTime>0.8</warmupTime>
+        <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -252,7 +252,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>0.8</warmupTime>
+        <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -325,7 +325,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>0.8</warmupTime>
+        <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Grenades</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- Frag Grenade Belt -->
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>throw frag grenade</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>10</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>ThrowGrenade</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Proj_GrenadeFrag</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+		</li>
+
+		<!-- Molotov Belt -->
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>throw molotov</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>0.8</warmupTime>
+					<range>10</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>ThrowMolotovCocktail</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Proj_GrenadeMolotov</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+		</li>
+
+		<!-- EMP Grenade Belt -->
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>throw EMP grenade</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>0.8</warmupTime>
+					<range>10</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>ThrowGrenade</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>Proj_GrenadeEMP</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+		</li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>
+

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
@@ -10,6 +10,22 @@
 
 		<!-- Frag Grenade Belt -->
 		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/costList</xpath>
+		<value>
+			<costList>
+			<Weapon_GrenadeFrag>5</Weapon_GrenadeFrag>
+			</costList>	
+		</value>
+		</li>	
+
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
 		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/verbs</xpath>
 		<value>
 			<verbs>
@@ -39,6 +55,22 @@
 
 		<!-- Molotov Belt -->
 		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/costList</xpath>
+		<value>
+			<costList>		
+			<Weapon_GrenadeMolotov>5</Weapon_GrenadeMolotov>
+			</costList>			
+		</value>
+		</li>		
+
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
 		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/verbs</xpath>
 		<value>
 			<verbs>
@@ -49,7 +81,7 @@
 					<onlyManualCast>True</onlyManualCast>
 					<warmupTime>0.8</warmupTime>
 					<range>10</range>
-					<minRange>5</minRange>
+					<minRange>3</minRange>
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowMolotovCocktail</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
@@ -68,6 +100,22 @@
 
 		<!-- EMP Grenade Belt -->
 		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/costList</xpath>
+		<value>
+			<costList>		
+			<Weapon_GrenadeEMP>5</Weapon_GrenadeEMP>
+			</costList>			
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
 		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/verbs</xpath>
 		<value>
 			<verbs>
@@ -78,7 +126,7 @@
 					<onlyManualCast>True</onlyManualCast>
 					<warmupTime>0.8</warmupTime>
 					<range>10</range>
-					<minRange>5</minRange>
+					<minRange>3</minRange>
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowGrenade</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
@@ -112,7 +112,7 @@
           <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
           <hasStandardCommand>true</hasStandardCommand>
           <defaultProjectile>VWE_Projectile_ToxicGrenade</defaultProjectile>
-          <range>16</range>
+          <range>12</range>
           <warmupTime>1.8</warmupTime>
           <soundCast>ThrowGrenade</soundCast>
           <noiseRadius>4</noiseRadius>

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -96,10 +96,6 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/destroyOnDrop</xpath>
-        </li>
-
-        <li Class="PatchOperationRemove">
           <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/costStuffCount</xpath>
         </li>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -144,6 +144,7 @@ Vanilla Factions Expanded - Medieval	|
 Vanilla Factions Expanded - Settlers	|
 Vanilla Vehicles Expanded	|
 Vanilla Weapons Expanded |
+Vanilla Weapons Expanded - Greandes |
 Vanilla Weapons Expanded Quickdraw	|
 Vanilla-Friendly Animal Surgery	|
 Vanilla-Friendly Weapon Expansion	|


### PR DESCRIPTION
Patches the core grenades (frag, emp, and molotovs) for VWE - Grenades. The remaining grenade belts are patched within VWE - Grenades itself.