### PR TITLE
Androids Expanded Patch

### DIFF
--- a/Patches/Androids Expanded/AlienRace/AlienRace_Droids.xml
+++ b/Patches/Androids Expanded/AlienRace/AlienRace_Droids.xml
@@ -212,30 +212,19 @@
 						<armorPenetrationSharp>24</armorPenetrationSharp>
 					  </li>
 					  <li Class="CombatExtended.ToolCE">
-						<label>giant body slam</label>
+						<label>head</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
-						<power>65</power>
+						<power>11</power>
 						<chanceFactor>0.33</chanceFactor>
-						<cooldownTime>4.17</cooldownTime>
-						<linkedBodyPartsGroup>Torso</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>30</armorPenetrationBlunt>
+						<cooldownTime>2.52</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					  </li>
 					</tools>
 				  </value>
 				</li>
-				
-			<li Class="PatchOperationAdd">
-			 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/alienRace/raceRestriction/whiteApparelList</xpath>
-				  <value>
-					<li>Apparel_TacVest</li>
-					<li>Apparel_Backpack</li>
-					<li>Apparel_TribalBackpack</li>
-					<li>Apparel_BallisticShield</li>
-					<li>Apparel_MeleeShield</li>
-				  </value>
-			</li>
 				
 			  </operations>
 			</match>

--- a/Patches/Androids Expanded/AlienRace/AlienRace_Droids.xml
+++ b/Patches/Androids Expanded/AlienRace/AlienRace_Droids.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+	  <operations>
+		<li Class="PatchOperationFindMod">
+		
+		  <mods><li>Androids Expanded</li></mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+				<!--Test for comps-->
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationAddModExtension">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ChjSpacerDroid" or
+				  defName="ChjSpacerBattleDroid"
+				  ]</xpath>
+				  <value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+					  <bodyShape>Humanoid</bodyShape>
+					</li>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ChjSpacerDroid" or
+				  defName="ChjSpacerBattleDroid"
+				  ]/comps</xpath>
+				  <value>
+				    <li>
+					  <compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+				  </value>
+				</li>
+				
+				
+				<!--Worker Droid-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--2mm Plasteel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>4</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<!--Equivalent to bionics-->
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerDroid"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Advanced Battledroid-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/statBases</xpath>
+				  <value>
+					<MeleeCritChance>1.4</MeleeCritChance>
+					<MeleeParryChance>1.5</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--Recon Armor Equivalent-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>16</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>36</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left razor-fist</label>
+						<capacities>
+						  <li>Cut</li>
+						  <li>Stab</li>
+						  <li>Blunt</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.76</cooldownTime>
+						<linkedBodyPartsGroup>LeftDroidHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						<armorPenetrationSharp>24</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>right razor-fist</label>
+						<capacities>
+						  <li>Cut</li>
+						  <li>Stab</li>
+						  <li>Blunt</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.76</cooldownTime>
+						<linkedBodyPartsGroup>RightDroidHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						<armorPenetrationSharp>24</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>lower left razor-fist</label>
+						<capacities>
+						  <li>Cut</li>
+						  <li>Stab</li>
+						  <li>Blunt</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.76</cooldownTime>
+						<linkedBodyPartsGroup>LeftDroidHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						<armorPenetrationSharp>24</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>lower right razor-fist</label>
+						<capacities>
+						  <li>Cut</li>
+						  <li>Stab</li>
+						  <li>Blunt</li>
+						</capacities>
+						<power>27</power>
+						<cooldownTime>1.76</cooldownTime>
+						<linkedBodyPartsGroup>LowerRightDroidHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>60</armorPenetrationBlunt>
+						<armorPenetrationSharp>24</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>giant body slam</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>65</power>
+						<chanceFactor>0.33</chanceFactor>
+						<cooldownTime>4.17</cooldownTime>
+						<linkedBodyPartsGroup>Torso</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>30</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ChjSpacerBattleDroid"]/alienRace/raceRestriction/whiteApparelList</xpath>
+				  <value>
+					<li>Apparel_TacVest</li>
+					<li>Apparel_Backpack</li>
+					<li>Apparel_TribalBackpack</li>
+					<li>Apparel_BallisticShield</li>
+					<li>Apparel_MeleeShield</li>
+				  </value>
+			</li>
+				
+			  </operations>
+			</match>
+	    </li>
+		
+	  </operations>
+	</Operation>
+</Patch>

--- a/Patches/Androids Expanded/AlienRace/AlienRace_Drones.xml
+++ b/Patches/Androids Expanded/AlienRace/AlienRace_Drones.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+	  <operations>
+		<li Class="PatchOperationFindMod">
+		
+		  <mods><li>Androids Expanded</li></mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+				<!--Test for comps-->
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NChefDrone"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NChefDrone"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NEngiDrone"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NEngiDrone"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NMedicDrone"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NMedicDrone"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationAddModExtension">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]</xpath>
+				  <value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+					  <bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]/comps</xpath>
+				  <value>
+				    <li>
+					  <compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+				  </value>
+				</li>
+				
+				
+				<!--Drones-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.5</MeleeDodgeChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--0.5mm Steel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>0.75</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="NChefDrone" or
+				  defName="NEngiDrone" or
+				  defName="NMedicDrone"
+				  ]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>tool strike</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>1.688</cooldownTime>
+						<linkedBodyPartsGroup>DroneHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.525</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+			  </operations>
+			</match>
+	    </li>
+		
+	  </operations>
+	</Operation>
+</Patch>

--- a/Patches/Androids Expanded/Bodies/Bodies_DroidsExpanded.xml
+++ b/Patches/Androids Expanded/Bodies/Bodies_DroidsExpanded.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Androids Expanded</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+        <!-- === Droid === -->
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[
+            def="DroidNeck"
+			]
+          </xpath>
+
+          <value>
+            <groups/>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[
+            def="Chasis" or 
+            def="Head" or 
+            def="DroidNeck" or 
+            def="Jaw" or 
+            def="Frame" or 
+            def="LeftDroidShoulder" or 
+			def="LeftDroidArm" or 
+			def="LeftDroidHand" or 
+			def="LeftHandDroidPinky" or 
+			def="LeftHandDroidMiddleFinger" or 
+			def="LeftHandDroidIndexFinger" or 
+			def="LeftHandDroidThumb" or 
+			def="RightDroidShoulder" or 
+			def="RightDroidArm" or 
+			def="RightDroidHand" or 
+			def="RightHandDroidPinky" or 
+			def="RightHandDroidMiddleFinger" or 
+			def="RightHandDroidIndexFinger" or 
+			def="RightHandDroidThumb" or 
+			def="LeftDroidLeg" or 
+			def="LeftDroidFoot" or 
+			def="RightDroidLeg" or 
+			def="RightDroidFoot"
+			]/groups
+          </xpath>
+
+          <value>
+            <li>CoveredByNaturalArmor</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[def="LeftDroidShoulder"]/groups
+          </xpath>
+          <value>
+            <li>LeftShoulder</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[def="LeftDroidArm"]/groups
+          </xpath>
+          <value>
+            <li>LeftArm</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[def="RightDroidShoulder"]/groups
+          </xpath>
+          <value>
+            <li>RightShoulder</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[def="RightDroidArm"]/groups
+          </xpath>
+          <value>
+            <li>RightArm</li>
+          </value>
+        </li>
+		
+		<!-- === Wardroid === -->
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="WardroidBody"]//*[
+            def="DroidNeck"
+			]
+          </xpath>
+
+          <value>
+            <groups/>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="WardroidBody"]//*[
+            def="Chasis" or 
+            def="Head" or 
+            def="DroidNeck" or 
+            def="Jaw" or 
+            def="Frame" or 
+            def="LeftDroidShoulder" or 
+			def="LeftDroidArm" or 
+			def="LeftDroidHand" or 
+			def="LeftHandDroidPinky" or 
+			def="LeftHandDroidMiddleFinger" or 
+			def="LeftHandDroidIndexFinger" or 
+			def="LeftHandDroidThumb" or 
+			def="RightDroidShoulder" or 
+			def="RightDroidArm" or 
+			def="RightDroidHand" or 
+			def="RightHandDroidPinky" or 
+			def="RightHandDroidMiddleFinger" or 
+			def="RightHandDroidIndexFinger" or 
+			def="RightHandDroidThumb" or 
+			def="LowerLeftDroidShoulder" or 
+			def="LowerLeftDroidArm" or 
+			def="LowerLeftDroidHand" or 
+			def="LowerLeftHandDroidPinky" or 
+			def="LowerLeftHandDroidMiddleFinger" or 
+			def="LowerLeftHandDroidIndexFinger" or 
+			def="LowerLeftHandDroidThumb" or 
+			def="LowerRightDroidShoulder" or 
+			def="LowerRightDroidArm" or 
+			def="LowerRightDroidHand" or 
+			def="LowerRightHandDroidPinky" or 
+			def="LowerRightHandDroidMiddleFinger" or 
+			def="LowerRightHandDroidIndexFinger" or 
+			def="LowerRightHandDroidThumb" or 
+			def="LeftDroidLeg" or 
+			def="LeftDroidFoot" or 
+			def="RightDroidLeg" or 
+			def="RightDroidFoot"
+			]/groups
+          </xpath>
+
+          <value>
+            <li>CoveredByNaturalArmor</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="WardroidBody"]//*[def="LeftDroidShoulder"]/groups
+          </xpath>
+          <value>
+            <li>LeftShoulder</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="WardroidBody"]//*[def="LeftDroidArm"]/groups
+          </xpath>
+          <value>
+            <li>LeftArm</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="WardroidBody"]//*[def="RightDroidShoulder"]/groups
+          </xpath>
+          <value>
+            <li>RightShoulder</li>
+          </value>
+        </li>
+		
+		<li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroidBody"]//*[def="RightDroidArm"]/groups
+          </xpath>
+          <value>
+            <li>RightArm</li>
+          </value>
+        </li>
+		
+		<!-- === Drone Body === -->
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroneBody"]//*[
+            def="DroneNeck"
+			]
+          </xpath>
+
+          <value>
+            <groups/>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="DroneBody"]//*[
+            def="DroneShell" or 
+            def="DroneNeck" or 
+            def="DroneHead" or 
+            def="DroneShoulder" or 
+            def="DroneArm" or 
+            def="DroneHand" or 
+			def="LeftDroneLeg" or 
+			def="LeftDroneFoot" or 
+			def="RightDroneLeg" or 
+			def="RightDroneFoot"
+			]/groups
+          </xpath>
+
+          <value>
+            <li>CoveredByNaturalArmor</li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

Race appropriate defs (Bodies, RaceDefs) for Androids Expanded. Androids expanded overrides the drone bodydef from the original with one that has significantly more HP for some reason, which means they get a power increase in general but it works, probably just needs a reduction on their HP (The advanced battledroid, for example, can tank A HEAT rocket to the torso as long as it doesn't hit an internal 'organ', thanks to its 400 hp).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
