### PR TITLE
Fix heavy charge blaster info window error

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1152,8 +1152,8 @@
     </weaponTags>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_ChargeBlasterHeavy"]</xpath>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="Gun_ChargeBlasterHeavyBase"]/tools</xpath>
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
## Changes
- Fix unpatched tool in Gun_ChargeBlasterHeavy, that causes errors when opening the info window for this weapon.