### PR TITLE
Dragon's Descent Tweak

### DIFF
--- a/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
+++ b/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
@@ -18,13 +18,6 @@
 						</li>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ScenarioDef[defName="DragonThieves"]/scenario/parts/li[thingDef="Pila"]</xpath>
-					<value>
-						<count>20</count>
-					</value>
-				</li>
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes
Recently Dragon's Decent removed the Pila from their starting scenario and the operation adding the extras failed, this fixes it.