### PR TITLE
Vanilla Brewing Expanded

### DIFF
--- a/Patches/Vanilla Brewing Expanded/Alcohol.xml
+++ b/Patches/Vanilla Brewing Expanded/Alcohol.xml
@@ -1,120 +1,105 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Brewing Expanded</li>
-    </mods>
-    <match Class="PatchOperationSequence">
-      <operations>
-	  
-	    <!-- === Alcohol === -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Brewing Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[
-		  defName="VBE_Gin" or
-		  defName="VBE_Tequila" or
-		  defName="VBE_Vodka" or
-		  defName="VBE_Whiskey" or
-		  defName="VBE_DoubleWhiskey"
-		  ]/tools</xpath>
-          <value>
-            <tools>
-				<li Class="CombatExtended.ToolCE">
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>2.22</cooldownTime>
-					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+				<!-- === Alcohol === -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="DrugWithTools" or defName="VBE_Soda"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.1</MeleeCritChance>
+							<MeleeParryChance>0.33</MeleeParryChance>
+							<MeleeDodgeChance>0.07</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
 				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>neck</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>3.33</cooldownTime>
-					<armorPenetrationBlunt>0.150</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[@Name="DrugWithTools"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>2.22</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>neck</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>3.33</cooldownTime>
+								<armorPenetrationBlunt>0.150</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
 				</li>
-            </tools>
-          </value>
-        </li>
-		
-		<li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VBE_Soda"]/tools</xpath>
-          <value>
-            <tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>soda bottle</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>2.22</cooldownTime>
-					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VBE_Soda"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>soda bottle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>2.22</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
 				</li>
-            </tools>
-          </value>
-        </li>
-		
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[
-				defName="VBE_Gin" or
-				defName="VBE_Tequila" or
-				defName="VBE_Vodka" or
-				defName="VBE_Whiskey" or
-				defName="VBE_DoubleWhiskey" or
-				defName="VBE_Soda"
-				]</xpath>
-			<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.1</MeleeCritChance>
-					<MeleeParryChance>0.33</MeleeParryChance>
-					<MeleeDodgeChance>0.07</MeleeDodgeChance>	
-				</equippedStatOffsets>
-			</value>
-		</li>
-		
-		<!-- === Mixing === -->
-		
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/HediffDef[defName="VBE_WhiskeyAsIngredient"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
-			<value>
-				<ShootingAccuracyPawn>3</ShootingAccuracyPawn>
-				<AimingAccuracy>1.5</AimingAccuracy>
-			</value>
-		</li>
-		
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/HediffDef[defName="VBE_VodkaAsIngredient"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
-			<value>
-				<MeleeDodgeChance>2</MeleeDodgeChance>
-			</value>
-		</li>
-		
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="VBE_ConsumedGoStock"]/stages/li[1]</xpath>
-			<value>
-				<statOffsets>
-					<Suppressability>-0.10</Suppressability>
-				</statOffsets>
-			</value>
-		</li>
-		
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="VBE_RBMeadAsIngredient"]/stages/li[1]/statOffsets</xpath>
-			<value>
-				<SmokeSensitivity>-0.10</SmokeSensitivity>
-			</value>
-		</li>
-        
-      </operations>
-    </match>
-  </Operation>
+
+				<!-- === Mixing === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="VBE_WhiskeyAsIngredient"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+						<ShootingAccuracyPawn>3</ShootingAccuracyPawn>
+						<AimingAccuracy>1.5</AimingAccuracy>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="VBE_VodkaAsIngredient"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
+					<value>
+						<MeleeDodgeChance>2</MeleeDodgeChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/HediffDef[defName="VBE_ConsumedGoStock"]/stages/li[1]</xpath>
+					<value>
+						<statOffsets>
+							<Suppressability>-0.10</Suppressability>
+						</statOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/HediffDef[defName="VBE_RBMeadAsIngredient"]/stages/li[1]/statOffsets</xpath>
+					<value>
+						<SmokeSensitivity>-0.10</SmokeSensitivity>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>

--- a/Patches/Vanilla Brewing Expanded/Alcohol.xml
+++ b/Patches/Vanilla Brewing Expanded/Alcohol.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Beverages === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="DrugWithTools"]</xpath>
+					<xpath>/Defs/ThingDef[@Name="VBE_DrugToolBase"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeCritChance>0.1</MeleeCritChance>
@@ -21,7 +21,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="DrugWithTools"]/tools</xpath>
+					<xpath>/Defs/ThingDef[@Name="VBE_DrugToolBase"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Brewing Expanded/Alcohol.xml
+++ b/Patches/Vanilla Brewing Expanded/Alcohol.xml
@@ -8,9 +8,9 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-				<!-- === Alcohol === -->
+				<!-- === Beverages === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="DrugWithTools" or defName="VBE_Soda"]</xpath>
+					<xpath>/Defs/ThingDef[@Name="DrugWithTools"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeCritChance>0.1</MeleeCritChance>
@@ -43,24 +43,6 @@
 								<cooldownTime>3.33</cooldownTime>
 								<armorPenetrationBlunt>0.150</armorPenetrationBlunt>
 								<linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
-							</li>
-						</tools>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VBE_Soda"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>soda bottle</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>2</power>
-								<cooldownTime>2.22</cooldownTime>
-								<chanceFactor>1.33</chanceFactor>
-								<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
 							</li>
 						</tools>
 					</value>

--- a/Patches/Vanilla Brewing Expanded/ThingDefs_Items.xml
+++ b/Patches/Vanilla Brewing Expanded/ThingDefs_Items.xml
@@ -1,64 +1,64 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-  <Operation Class="PatchOperationFindMod">
-    <mods>
-      <li>Vanilla Brewing Expanded</li>
-    </mods>
-    <match Class="PatchOperationSequence">
-      <operations>
-  		
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_Cigarettes"]/statBases</xpath>
-			<value>
-				<Bulk>0.01</Bulk>
-			</value>
-		</li>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Brewing Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_Cigars"]/statBases</xpath>
-			<value>
-				<Bulk>0.05</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_Cigarettes"]/statBases</xpath>
+					<value>
+						<Bulk>0.01</Bulk>
+					</value>
+				</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_Tea"]/statBases</xpath>
-			<value>
-				<Bulk>0.20</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_Cigars"]/statBases</xpath>
+					<value>
+						<Bulk>0.05</Bulk>
+					</value>
+				</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_Soda"]/statBases</xpath>
-			<value>
-				<Bulk>0.25</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_Tea"]/statBases</xpath>
+					<value>
+						<Bulk>0.20</Bulk>
+					</value>
+				</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_Juice"]/statBases</xpath>
-			<value>
-				<Bulk>1.75</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_Soda"]/statBases</xpath>
+					<value>
+						<Bulk>0.25</Bulk>
+					</value>
+				</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_EnergyDrink"]/statBases</xpath>
-			<value>
-				<Bulk>0.70</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_Juice"]/statBases</xpath>
+					<value>
+						<Bulk>1.75</Bulk>
+					</value>
+				</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="VBE_HotCoffee" or defName="VBE_IcedCoffee"]/statBases</xpath>
-			<value>
-				<Bulk>0.40</Bulk>
-			</value>
-		</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_EnergyDrink"]/statBases</xpath>
+					<value>
+						<Bulk>0.70</Bulk>
+					</value>
+				</li>
 
-      </operations>
-    </match>
-  </Operation>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VBE_HotCoffee" or defName="VBE_IcedCoffee"]/statBases</xpath>
+					<value>
+						<Bulk>0.40</Bulk>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
 
 </Patch>


### PR DESCRIPTION
## Changes

Rewrote the alcohol patches to match the new structure of Brewing Expanded.

For testing purposes, here's my local version of [Vanilla Brewing Expanded](https://github.com/CombatExtended-Continued/CombatExtended/files/5087406/VanillaBrewingExpanded.zip)

**Currently Oskar is on holidays and the mod won't be updated until he comes back**

## Reasoning

Cider is added through a patch so we can't normally patch it like other drinks unless CE is loaded after Plants / Brewing Expanded, the case is that this isn't very user friendly and knowing that users will not always load CE after these mods and will cause errors we decided to add a new base drug that inherits from the vanilla drug that includes tools. If Brewing Expanded detects that Plants Expanded is installed and adds the cider to the game this won't error because the necessary patches will already be applied through the base drug def.

## TL;DR

- A new drug that inherits from the vanilla DrugBase will be added with tools included.
- All drinks with tools will change to this new base.
- CE will patch the new base tools.
- If Cider gets injected into the game, there won't be any tool related errors because it would be inheriting from the already patched no matter load order.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested
