### PR TITLE
Patch update for Moyo from the depth

### DIFF
--- a/Patches/Moyo from the depth/PawnKindDefs/Moyo_PawnKind.xml
+++ b/Patches/Moyo from the depth/PawnKindDefs/Moyo_PawnKind.xml
@@ -20,6 +20,7 @@
 				defName="Moyo_MiddleSmuggler" or
 				defName="Moyo_SoldierLight" or
 				defName="Moyo_SoliderStandard" or
+				defName="Moyo_leader" or
 				defName="Moyo_Guardian" or
 				defName="Moyo_GuardianAssault"
 				]</xpath>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -20,6 +20,15 @@
 				</value>
 			</li>
 			
+			<!--Shirt And boots-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_SnB"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.25</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
 			<!--Parka-->
 			
 			<li Class="PatchOperationAdd">
@@ -113,6 +122,14 @@
 				<xpath>Defs/ThingDef[defName="Moyo_Bodysuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.3</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Bodysuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
 				</value>
 			</li>
 			

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -45,7 +45,7 @@
 			<!--Royal Robe-->
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_RoyalRobeA"]/statBases</xpath>
+				<xpath>Defs/ThingDef[@Name="Moyo_RoyalcoatBase"]/statBases</xpath>
 				<value>
 					<Bulk>7.5</Bulk>
 					<WornBulk>1</WornBulk>
@@ -53,7 +53,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Moyo_RoyalRobeA"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[@Name="Moyo_RoyalcoatBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 					<ArmorRating_Electric>0.60</ArmorRating_Electric>
@@ -61,7 +61,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Moyo_RoyalRobeA"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[@Name="Moyo_RoyalcoatBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
 				</value>


### PR DESCRIPTION
## Additions

Added armor value for new apparel, added loadout comp to new pawndef

## Changes

Changed one of the patches to target a base so it now affects all variations of that apparel. Added hand/feet coverage to basic bodysuit so it matches composite/royal variants.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
