### PR TITLE
Misc. tweaks

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -30,7 +30,7 @@
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo12GaugeCharged</li>

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+      		<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Railgun ammo isn't handloaded because it contains no propellant, and the sabots must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -29,6 +29,10 @@
     <thingCategories>
       <li>Ammo60x225mmGammaShell</li>
     </thingCategories>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
+		</tradeTags>    
     <stackLimit>50</stackLimit>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/6mmRailgun.xml
+++ b/Defs/Ammo/Advanced/6mmRailgun.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+      		<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Railgun ammo isn't handloaded because it contains no propellant, and the sabots must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -30,7 +30,7 @@
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo6x18mmCharged</li>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -30,7 +30,7 @@
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo6x24mmCharged</li>

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -31,6 +31,9 @@
 			<li>Ammo70mmMechanoidGrenades</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
+		<tradeTags>
+			<li>CE_AutoEnableTrade_Sellable</li>
+		</tradeTags>		
 		<cookOffFlashScale>25</cookOffFlashScale>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+      		<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Railgun ammo isn't handloaded because it contains no propellant, and the sabots must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -30,7 +30,7 @@
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo8x35mmCharged</li>

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/PlasmaCellPistol.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellPistol.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Advanced/PlasmaCellRifle.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellRifle.xml
@@ -31,7 +31,7 @@
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
-			<li>CE_AutoEnableCrafting_TableMachining</li>
+			<li>CE_AutoEnableCrafting_FabricationBench</li>
 			<!-- Plasma ammo can't be handloaded, and the containment cell must be precision-machined anyway -->
 		</tradeTags>
 		<thingCategories>

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -124,7 +124,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>7</speed>
+			<speed>10</speed>
 		</projectile>
 	</ThingDef>
 
@@ -141,8 +141,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationBlunt>0.44</armorPenetrationBlunt>
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
 			<preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Stone</preExplosionSpawnThingDef>
@@ -157,10 +157,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>2.26</armorPenetrationBlunt>
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>10</speed>			
+			<speed>17</speed>			
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -174,10 +174,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationBlunt>2.72</armorPenetrationBlunt>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationBlunt>8.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<speed>11</speed>				
+			<speed>19</speed>				
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
 		</projectile>
@@ -192,10 +192,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>2.72</armorPenetrationBlunt>
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-      <speed>11</speed>	
+      <speed>17</speed>	
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -210,10 +210,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Flame</damageDef>
-			<damageAmountBase>3</damageAmountBase>
-			<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
+			<damageAmountBase>4</damageAmountBase>
+			<armorPenetrationBlunt>3.28</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>
-      <speed>11</speed>	
+      <speed>17</speed>	
 		</projectile>
 	</ThingDef>
 

--- a/Defs/SoundDefs/AmmoSounds.xml
+++ b/Defs/SoundDefs/AmmoSounds.xml
@@ -24,4 +24,29 @@
     </subSounds>
   </SoundDef>
 
+  <SoundDef>
+    <defName>HissFlamethrower</defName>  
+    <sustain>false</sustain>  
+    <context>MapOnly</context>
+    <eventNames />  
+    <priorityMode>PrioritizeNearest</priorityMode>  
+    <subSounds>
+      <li>   
+        <grains>
+          <li Class="AudioGrain_Clip">
+            <clipPath>Misc/Hiss/HissSmall</clipPath>
+          </li>
+        </grains>      
+        <volumeRange>
+          <min>15</min>        
+          <max>15</max>
+        </volumeRange>      
+        <pitchRange>
+          <min>1.042391</min>        
+          <max>1.021195</max>
+        </pitchRange>   
+      </li>
+    </subSounds>
+  </SoundDef>
+
 </Defs>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -96,8 +96,8 @@
         </primaryMagazineCount>
         <forcedSidearm>
           <sidearmMoney>
-            <min>250</min>
-            <max>100</max>
+            <min>100</min>
+            <max>250</max>
           </sidearmMoney>
           <weaponTags>
             <li>CE_Sidearm</li>

--- a/Patches/Kaiser Armory/105x155mmR.xml
+++ b/Patches/Kaiser Armory/105x155mmR.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Kaiser Armory [1.1]</li>
+			<li>Kaiser Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Kaiser Armory/77x230mmR.xml
+++ b/Patches/Kaiser Armory/77x230mmR.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Kaiser Armory [1.1]</li>
+			<li>Kaiser Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.1]</li>
+		<li>Kaiser Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.1]</li>
+		<li>Kaiser Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Kaiser Armory/KaiserArmory_Melee.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Melee.xml
@@ -3,14 +3,14 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.1]</li>
+		<li>Kaiser Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>
 
         <!-- === Shovel === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/statBases</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_KA"]/statBases</xpath>
           <value>
             <Bulk>6</Bulk>
             <MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/equippedStatOffsets</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_KA"]/equippedStatOffsets</xpath>
           <value>
             <MeleeCritChance>0.2</MeleeCritChance>
             <MeleeParryChance>0.40</MeleeParryChance>
@@ -27,7 +27,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/tools</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_KA"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Kaiser Armory/KaiserArmory_Turrets.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Turrets.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.1]</li>
+		<li>Kaiser Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Reich Armory/15cmNebelwerfer.xml
+++ b/Patches/Reich Armory/15cmNebelwerfer.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/30mm Rifle Grenade.xml
+++ b/Patches/Reich Armory/30mm Rifle Grenade.xml
@@ -3,7 +3,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/37x249mmR.xml
+++ b/Patches/Reich Armory/37x249mmR.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/75cm leIG18.xml
+++ b/Patches/Reich Armory/75cm leIG18.xml
@@ -3,7 +3,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/75x714mmR.xml
+++ b/Patches/Reich Armory/75x714mmR.xml
@@ -3,7 +3,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/80mm Panzerfaust.xml
+++ b/Patches/Reich Armory/80mm Panzerfaust.xml
@@ -3,7 +3,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Reich Armory [1.1]</li>
+			<li>Reich Armory [1.2]</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Reich Armory/ReichArmory_GrenadeRecipe.xml
+++ b/Patches/Reich Armory/ReichArmory_GrenadeRecipe.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Reich Armory [1.1]</li>
+		<li>Reich Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Reich Armory/ReichArmory_Guns.xml
+++ b/Patches/Reich Armory/ReichArmory_Guns.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Reich Armory [1.1]</li>
+		<li>Reich Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Reich Armory/ReichArmory_Melee.xml
+++ b/Patches/Reich Armory/ReichArmory_Melee.xml
@@ -3,14 +3,14 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Reich Armory [1.1]</li>
+		<li>Reich Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>
 
         <!-- === Shovel === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/statBases</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_RA"]/statBases</xpath>
           <value>
             <Bulk>6</Bulk>
             <MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/equippedStatOffsets</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_RA"]/equippedStatOffsets</xpath>
           <value>
             <MeleeCritChance>0.2</MeleeCritChance>
             <MeleeParryChance>0.40</MeleeParryChance>
@@ -27,7 +27,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="MeleeWeapon_Feldspaten"]/tools</xpath>
+          <xpath>/Defs/ThingDef[@Name="Feldspaten_RA"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Reich Armory/ReichArmory_Turrets.xml
+++ b/Patches/Reich Armory/ReichArmory_Turrets.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Reich Armory [1.1]</li>
+		<li>Reich Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Soviet Armory/SovietArmory_CE_Patch_Turrets.xml
+++ b/Patches/Soviet Armory/SovietArmory_CE_Patch_Turrets.xml
@@ -5,7 +5,7 @@
 		<operations>
 		
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Soviet Armory [1.1]</modName>
+				<modName>Soviet Armory [1.2]</modName>
 			</li>
 			
 			<!-- ========== Mounted AGS-17 Plamya ========== -->

--- a/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
+++ b/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
@@ -5,7 +5,7 @@
 		<operations>
 
 			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Soviet Armory [1.1]</modName>
+				<modName>Soviet Armory [1.2]</modName>
 			</li>
 
 			<!-- ========== AK-12 ========== -->

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.1]</li>
+		<li>Tsar Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Tsar Armory/TsarArmory_Recipes.xml
+++ b/Patches/Tsar Armory/TsarArmory_Recipes.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.1]</li>
+		<li>Tsar Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Tsar Armory/TsarArmory_Turrets.xml
+++ b/Patches/Tsar Armory/TsarArmory_Turrets.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.1]</li>
+		<li>Tsar Armory [1.2]</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/VFWE/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/VFWE/ThingDefs_Misc/Weapons_Guns.xml
@@ -316,7 +316,7 @@
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_15x65mmDiffusingCharged_Buck</defaultProjectile>
+					<defaultProjectile>Bullet_12GaugeCharged</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
 					<range>16</range>
 					<soundCast>Shot_ChargeBlaster</soundCast>
@@ -326,7 +326,7 @@
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
 					<reloadTime>1.6</reloadTime>
-					<ammoSet>AmmoSet_15x65mmDiffusingCharged</ammoSet>
+					<ammoSet>AmmoSet_12GaugeCharged</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -156,8 +156,8 @@
             <WorkToMake>36000</WorkToMake>
             <Mass>2.80</Mass>
             <Bulk>5.00</Bulk>
-            <SwayFactor>0.16</SwayFactor>
-            <ShotSpread>0.75</ShotSpread>
+            <SwayFactor>0.75</SwayFactor>
+            <ShotSpread>0.16</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>
             <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
           </statBases>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -129,6 +129,11 @@ Rim of Madness - Bones	|
 Rimefeller	|
 RimEffect - Asari of the Rims	|
 Rimfire	|
+Rimsenal - Core |
+Rimsenal - Enhanced Vanilla |
+Rimsenal - Federation Faction Pack |
+Rimsenal - Feral Faction Pack |
+Rimsenal - Security Pack |
 Rimworld: Altered Carbon |
 Rimworld - The Dark Descent |
 Rimworld - Witcher Monster Hunt |


### PR DESCRIPTION
Various tweaks:
- Buff crossbow bolts.
- Add FlameThrowerHiss sound to base Combat Extended, instead of having it in CE Guns.
- Charged and Plasma munitions are now made at the Fabrication Bench, instead of the Machining Table.
- Adjust advanced grenadier sidearm
- Update Armory patches, resolve field shovel duplicate when RA and KA are running.
- Update a VFWE weapon to no longer use mech shotgun ammo.