### PR TITLE
Clothing Changes

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -19,6 +19,27 @@
 			<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Pants"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>20</costStuffCount>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_BasicShirt"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>20</costStuffCount>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_CollarShirt"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>25</costStuffCount>
+		</value>
+	</Operation>
 
 	<!-- ========== Parka, Duster and Jacket ========== -->
 
@@ -57,6 +78,27 @@
 		<value>
 			<Bulk>5</Bulk>
 			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Parka"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>110</costStuffCount>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Parka"]/statBases/Mass</xpath>
+		<value>
+			<Mass>2.5</Mass>
+		</value>
+	</Operation>
+	
+		<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Jacket"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>60</costStuffCount>
 		</value>
 	</Operation>
 
@@ -201,7 +243,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakJacket"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -242,7 +284,7 @@
 			<stuffCategories>
 				<li>Fabric</li>
 			</stuffCategories>
-			<costStuffCount>85</costStuffCount>
+			<costStuffCount>70</costStuffCount>
 		</value>
 	</Operation>
 
@@ -272,7 +314,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

-Increase parka cost from 80 material to 110
-Increase parka mass from 2kg to 2.5
-Reduce jacket cost from 70 to 60
-Reduce flak jacket stuff cost from 85 to 70
-Increase flak jacket base MPa Armor value from 0.5 to 1.5
-Increase flak pants base MPa Armor value from 0.5 to 1.5
-Reduce T Shirt stuff cost from 40 to 20
-Reduce Button up T shirt stuff cost from 45 to 25
-Reduce pants cost stuff cost from 40 to 20

## Reasoning

These were originally Tostov's proposed changes and here's their reasoning for [it.](https://media.discordapp.net/attachments/305582566210273290/747364415023874068/unknown.png)

I support these changes because Parka + Tribalwear is the most cost efficient use of your materials. You pay more for less protection with normal clothes and flak jackets. These reduced costs in theory will allow more freedom in what to wear since the costs are less high.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
