### PR TITLE
Updates for Better Infestations, Vanilla Armor Expanded and Vanilla Apparel Expanded mod patches.

### DIFF
--- a/Patches/Better Infestations/Race_Insect.xml
+++ b/Patches/Better Infestations/Race_Insect.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Better Infestations 1.1</li>
+			<li>Better Infestations 1.2</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
@@ -22,12 +22,6 @@
 					</value>
 				</li>
 				<!-- Miscellaneous -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/costStuffCount</xpath>
-					<value>
-						<costStuffCount>15</costStuffCount>
-					</value>
-				</li>
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/equippedStatOffsets</xpath>
 				</li>
@@ -44,7 +38,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_Shoes"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>10</costStuffCount>
+						<costStuffCount>20</costStuffCount>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Footwear.xml
@@ -1,41 +1,53 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- There's a snake in my boot! -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Footwear_Boots == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/statBases/Mass</xpath>
+					<value>
+						<WornBulk>0.5</WornBulk>
+						<Mass>0.8</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>15</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/equippedStatOffsets</xpath>
+				</li>
 
-			<!-- == VAE_Footwear_Boots == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/statBases/Mass</xpath>
-				<value>
-					<WornBulk>0.5</WornBulk>
-					<Mass>0.8</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_Boots"]/equippedStatOffsets</xpath>
-			</li>
-
-			<!-- == VAE_Footwear_Shoes == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_Shoes"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Footwear_Shoes == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Shoes"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_Shoes"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>10</costStuffCount>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Handwear.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Handwear.xml
@@ -18,7 +18,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_Gloves"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>10</costStuffCount>
+						<costStuffCount>15</costStuffCount>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Handwear.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Handwear.xml
@@ -1,21 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- I've got nothin' to say. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
-
-			<!-- == VAE_Handwear_Gloves == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_Gloves"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-		</operations>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Handwear_Gloves == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_Gloves"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_Gloves"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>10</costStuffCount>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
@@ -77,6 +77,12 @@
 						<StuffEffectMultiplierArmor>1.4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform"]/costList/Steel</xpath>
+					<value>
+						<Steel>10</Steel>
+					</value>
+				</li>
 
 				<!-- == VAE_Apparel_BuildersJacket == -->
 				<!-- statBases -->
@@ -85,7 +91,7 @@
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
-						<ArmorRating_Sharp>0.55</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -94,11 +100,17 @@
 						<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 					</value>
 				</li>
-				<!-- cloth cost -->
+				<!-- material cost -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/costList/Cloth</xpath>
 					<value>
-						<Cloth>20</Cloth>
+						<Cloth>60</Cloth>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/costList/Silver</xpath>
+					<value>
+						<Silver>10</Silver>
 					</value>
 				</li>
 
@@ -107,7 +119,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_DoctorScrubs"]/costList/Cloth</xpath>
 					<value>
-						<Cloth>30</Cloth>
+						<Cloth>50</Cloth>
 					</value>
 				</li>
 
@@ -119,13 +131,6 @@
 						<Bulk>7.5</Bulk>
 						<WornBulk>1</WornBulk>
 						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
-					</value>
-				</li>
-				<!-- cloth cost -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_LabCoat"]/costList/Cloth</xpath>
-					<value>
-						<Cloth>40</Cloth>
 					</value>
 				</li>
 
@@ -146,30 +151,29 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt" or defName="VAE_Apparel_Trousers"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>20</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_FleeceShirt" or defName="VAE_Apparel_SheriffShirt"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_FleeceShirt" or defName="VAE_Apparel_SheriffShirt" or defName="VAE_Apparel_Trousers"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>25</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_ChefsUniform" or defName="VAE_Apparel_MilitaryUniform"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_ChefsUniform"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>30</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_SuitJacket" or defName="VAE_Apparel_MilitaryJacket" or defName="VAE_Apparel_Jumpsuit"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform" or defName="VAE_Apparel_Jumpsuit" or defName="VAE_Apparel_MilitaryJacket" or defName="VAE_Apparel_SuitJacket"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>40</costStuffCount>
+						<costStuffCount>60</costStuffCount>
 					</value>
 				</li>
-				<!-- Hopefully I don't forget to remove the content of the comments because they're more or less more helpful for me to distinguish when a new tier of cost count begins. -->
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
@@ -1,121 +1,176 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- CJ: "Ah ####, here we go again." -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_CasualTShirt, VAE_Apparel_ShirtandTie, VAE_Apparel_Trousers, VAE_Headgear_Fedora, VAE_Apparel_Overalls, VAE_Apparel_Hoodie and VAE_Apparel_FleeceShirt == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Trousers" or defName="VAE_Headgear_Fedora" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_FleeceShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_CasualTShirt, VAE_Apparel_ShirtandTie, VAE_Apparel_Trousers, VAE_Headgear_Fedora, VAE_Apparel_Overalls, VAE_Apparel_Hoodie and VAE_Apparel_FleeceShirt == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Trousers" or defName="VAE_Headgear_Fedora" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_FleeceShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Shorts, VAE_Apparel_Skirt and VAE_Apparel_TankTop == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt" or defName="VAE_Apparel_TankTop"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Shorts, VAE_Apparel_Skirt and VAE_Apparel_TankTop == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt" or defName="VAE_Apparel_TankTop"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>0.5</Bulk>
-					<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_SuitJacket == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_SuitJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_SuitJacket == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_SuitJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Jeans and VAE_Apparel_Jumpsuit == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_Jumpsuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+						<StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Jeans and VAE_Apparel_Jumpsuit == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_Jumpsuit"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>1.5</Bulk>
-					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_ChefsUniform == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_ChefsUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_ChefsUniform == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_ChefsUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_MilitaryJacket == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_MilitaryJacket == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_MilitaryUniform == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>2</Bulk>
+						<WornBulk>0.5</WornBulk>
+						<StuffEffectMultiplierArmor>1.4</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_MilitaryUniform == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>2</Bulk>
-					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>1.4</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_BuildersJacket == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>0.55</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+					</value>
+				</li>
+				<!-- cloth cost -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/costList/Cloth</xpath>
+					<value>
+						<Cloth>20</Cloth>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_BuildersJacket == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>0.55</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_DoctorScrubs == -->
+				<!-- cloth cost -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_DoctorScrubs"]/costList/Cloth</xpath>
+					<value>
+						<Cloth>30</Cloth>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_LabCoat == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LabCoat"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<Bulk>7.5</Bulk>
-					<WornBulk>1</WornBulk>
-					<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_LabCoat == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LabCoat"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- cloth cost -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LabCoat"]/costList/Cloth</xpath>
+					<value>
+						<Cloth>40</Cloth>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_SheriffShirt == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_SheriffShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.1</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Apparel_SheriffShirt == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_SheriffShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1.1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- == costStuffCounts == -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TankTop"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>15</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt" or defName="VAE_Apparel_Trousers"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>20</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_FleeceShirt" or defName="VAE_Apparel_SheriffShirt"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>25</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_ChefsUniform" or defName="VAE_Apparel_MilitaryUniform"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>30</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_SuitJacket" or defName="VAE_Apparel_MilitaryJacket" or defName="VAE_Apparel_Jumpsuit"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>40</costStuffCount>
+					</value>
+				</li>
+				<!-- Hopefully I don't forget to remove the content of the comments because they're more or less more helpful for me to distinguish when a new tier of cost count begins. -->
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
@@ -33,7 +33,7 @@
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
-						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -44,7 +44,7 @@
 					<value>
 						<Bulk>7.5</Bulk>
 						<WornBulk>1.5</WornBulk>
-						<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -77,7 +77,7 @@
 
 				<!-- == costStuffCounts == -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse" or defName="VAE_Apparel_Apron"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>20</costStuffCount>
 					</value>
@@ -89,7 +89,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Apron" or defName="VAE_Apparel_Cape"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Cape"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>30</costStuffCount>
 					</value>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Medieval.xml
@@ -1,81 +1,100 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- CJ: "Ah ####, here we go again." -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_Tunic == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Tunic"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Tunic == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Tunic"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>1.5</Bulk>
-					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Blouse == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Blouse == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Apron == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Apron"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Apron == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Apron"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Cape == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Cape"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Cape == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Cape"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>7.5</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Headgear_TrapperHat == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrapperHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<StuffEffectMultiplierArmor>2.2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_TrapperHat == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_TrapperHat"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>1.5</Bulk>
-					<StuffEffectMultiplierArmor>2.2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Headgear_SummerHat == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_SummerHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				
+				<!-- == VAE_Headgear_SummerHat and VAE_Headgear_TrapperHat layers == -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_SummerHat" or defName="VAE_Headgear_TrapperHat"]/apparel/layers</xpath>
+					<value>
+						<li>MiddleHead</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_SummerHat == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_SummerHat"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			
-			<!-- == VAE_Headgear_SummerHat and VAE_Headgear_TrapperHat layers == -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_SummerHat" or defName="VAE_Headgear_TrapperHat"]/apparel/layers</xpath>
-				<value>
-					<li>MiddleHead</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == costStuffCounts == -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>20</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Tunic"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>25</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Apron" or defName="VAE_Apparel_Cape"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>30</costStuffCount>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Neolithic.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Neolithic.xml
@@ -1,53 +1,52 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- CJ: "Ah ####, here we go again." -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_PeltCoat == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PeltCoat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>3</WornBulk>
+						<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_PeltCoat == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PeltCoat"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>7.5</Bulk>
-					<WornBulk>3</WornBulk>
-					<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_TribalPoncho == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalPoncho"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_TribalPoncho == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalPoncho"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>4</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_TribalKilt == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalKilt"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_TribalKilt == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalKilt"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-
-			<!-- == VAE_Headgear_Hood == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hood"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Headgear_Hood == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hood"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<WornBulk>0.5</WornBulk>
+						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -1,147 +1,146 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- CJ: "Ah ####, here we go again." -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Apparel Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Apparel Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Headgear_Scarf == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<SmokeSensitivity>-0.2</SmokeSensitivity>
+							<ToxicSensitivity>-0.1</ToxicSensitivity>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>StrappedHead</li>
+						</layers>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_Scarf == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>0.5</Bulk>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<SmokeSensitivity>-0.2</SmokeSensitivity>
-						<ToxicSensitivity>-0.1</ToxicSensitivity>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/apparel/layers</xpath>
-				<value>
-					<layers>
-						<li>StrappedHead</li>
-					</layers>
-				</value>
-			</li>
+				<!-- == VAE_Headgear_Beret, VAE_Headgear_BaseballCap and VAE_Headgear_ChefsToque == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap" or defName="VAE_Headgear_ChefsToque"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<AimingAccuracy>0.05</AimingAccuracy>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BaseballCap"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>MiddleHead</li>
+						</layers>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_Beret, VAE_Headgear_BaseballCap and VAE_Headgear_ChefsToque == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap" or defName="VAE_Headgear_ChefsToque"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<AimingAccuracy>0.05</AimingAccuracy>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BaseballCap"]/apparel/layers</xpath>
-				<value>
-					<layers>
+				<!-- == VAE_Headgear_Hardhat, VAE_Headgear_ChefsToque == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque"]/apparel/layers</xpath>
+					<value>
 						<li>MiddleHead</li>
-					</layers>
-				</value>
-			</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_Hardhat, VAE_Headgear_ChefsToque == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque"]/apparel/layers</xpath>
-				<value>
-					<li>MiddleHead</li>
-				</value>
-			</li>
+				<!-- == VAE_Headgear_GasMask == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+						<Bulk>2</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/equippedStatOffsets</xpath>
+					<value>
+						<AimingAccuracy>-0.1</AimingAccuracy>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>StrappedHead</li>
+						</layers>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName = "VAE_Headgear_GasMask"]</xpath>
+					<value>
+						<li Class="CombatExtended.ApparelHediffExtension">
+							<hediff>WearingGasMask</hediff>
+						</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_GasMask == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-					<Bulk>2</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/equippedStatOffsets</xpath>
-				<value>
-					<AimingAccuracy>-0.1</AimingAccuracy>
-					<SmokeSensitivity>-1</SmokeSensitivity>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/apparel/layers</xpath>
-				<value>
-					<layers>
-						<li>StrappedHead</li>
-					</layers>
-				</value>
-			</li>
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName = "VAE_Headgear_GasMask"]</xpath>
-				<value>
-					<li Class="CombatExtended.ApparelHediffExtension">
-						<hediff>WearingGasMask</hediff>
-					</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Headgear_Sunglasses and VAE_Headgear_Glasses == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/statBases</xpath>
-				<value>
-					<Bulk>0.5</Bulk>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/apparel/layers</xpath>
-				<value>
-					<layers>
-						<li>OnHead</li>
-					</layers>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Headgear_Sunglasses and VAE_Headgear_Glasses == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>OnHead</li>
+						</layers>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -1,107 +1,106 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Footwear_PlateBoots == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>2</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
+					<value>
+						<Mass>2</Mass>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeDodgeChance>-0.02</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
+					<value>
+						<li>Shell</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Footwear_PlateBoots == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>2</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
-				<value>
-					<Mass>2</Mass>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeDodgeChance>-0.02</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
-				<value>
-					<li>Shell</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Footwear_MarineBoots == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>6.7</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<Mass>3.35</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>240</MaxHitPoints>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
-				<value>
-					<label>power armor boots</label>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/description</xpath>
-				<value>
-					<description>A standalone pair of power armor boots.\n\nThe outer layer is plated with plasteel, while the basic servomotor systems allow the user to wear these without most problems.\n\nEven though most power armor already comes with boots, some are unable to buy the full suit, hence why these exist.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Hyperweave</xpath>
-				<value>
-					<DevilstrandCloth>10</DevilstrandCloth>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<CarryWeight>1</CarryWeight>
-						<CarryBulk>0.5</CarryBulk>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
-				<value>
-					<li>Shell</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Footwear_MarineBoots == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>6.7</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<Mass>3.35</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>240</MaxHitPoints>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
+					<value>
+						<label>power armor boots</label>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/description</xpath>
+					<value>
+						<description>A standalone pair of power armor boots.\n\nThe outer layer is plated with plasteel, while the basic servomotor systems allow the user to wear these without most problems.\n\nEven though most power armor already comes with boots, some are unable to buy the full suit, hence why these exist.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Hyperweave</xpath>
+					<value>
+						<DevilstrandCloth>10</DevilstrandCloth>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<CarryWeight>1</CarryWeight>
+							<CarryBulk>0.5</CarryBulk>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
+					<value>
+						<li>Shell</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -1,109 +1,108 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Handwear_PlateGloves == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>2</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
+					<value>
+						<Mass>1.5</Mass>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeHitChance>-0.05</MeleeHitChance>
+						<AimingAccuracy>-0.05</AimingAccuracy>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
+					<value>
+						<description>A pair of simple metal gloves. Due to the thickness of the material, it restricts the wearer's manipulation capabilities.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
+					<value>
+						<li>Shell</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Handwear_PlateGloves == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>2</Bulk>
-					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
-				<value>
-					<Mass>1.5</Mass>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
-				<value>
-					<MeleeHitChance>-0.05</MeleeHitChance>
-					<AimingAccuracy>-0.05</AimingAccuracy>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
-				<value>
-					<description>A pair of simple metal gloves. Due to the thickness of the material, it restricts the wearer's manipulation capabilities.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
-				<value>
-					<li>Shell</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Handwear_MarineGloves == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>6.7</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<Mass>3.35</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>240</MaxHitPoints>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
-				<value>
-					<label>power armor gloves</label>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/description</xpath>
-				<value>
-					<description>A standalone pair of power armor gloves.\n\nThese come with grip assistance and embedded recoil stabilisers, but no servomotors.\n\nEven though most power armor already comes with gloves, some are unable to buy the full suit, hence why these exist.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
-				<value>
-					<DevilstrandCloth>10</DevilstrandCloth>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
-				<value>
-					<Plasteel>15</Plasteel>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
-				<value>
-					<li>Shell</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Handwear_MarineGloves == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>6.7</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<Mass>3.35</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>240</MaxHitPoints>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
+					<value>
+						<label>power armor gloves</label>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/description</xpath>
+					<value>
+						<description>A standalone pair of power armor gloves.\n\nThese come with grip assistance and embedded recoil stabilisers, but no servomotors.\n\nEven though most power armor already comes with gloves, some are unable to buy the full suit, hence why these exist.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
+					<value>
+						<DevilstrandCloth>10</DevilstrandCloth>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>15</Plasteel>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
+					<value>
+						<li>Shell</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -1,151 +1,150 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_BulletproofVest == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<Mass>3.5</Mass>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Sharp</xpath>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Blunt</xpath>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>125</MaxHitPoints>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/description</xpath>
+					<value>
+						<description>An armor vest made from flexible and resistant fabric or leather. Despite being cheaper and lighter than other armor vests, it still offers some protection against gunfire.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/label</xpath>
+					<value>
+						<label>soft armor vest</label>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/costList</xpath>
+				</li>
+				<!-- The bulletproof vest is now makeable from any fabric or leather that's sufficiently protective. Pretty much like a flak jacket or pants, but now in vest form. -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]</xpath>
+					<value>
+						<costStuffCount>50</costStuffCount>
+						<stuffCategories>
+							<li>SoftArmor</li>
+						</stuffCategories>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_BulletproofVest == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<Mass>3.5</Mass>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Sharp</xpath>
-			</li>
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Blunt</xpath>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>125</MaxHitPoints>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/description</xpath>
-				<value>
-					<description>An armor vest made from flexible and resistant fabric or leather. Despite being cheaper and lighter than other armor vests, it still offers some protection against gunfire.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/label</xpath>
-				<value>
-					<label>soft armor vest</label>
-				</value>
-			</li>
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/costList</xpath>
-			</li>
-			<!-- The bulletproof vest is now makeable from any fabric or leather that's sufficiently protective. Pretty much like a flak jacket or pants, but now in vest form. -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]</xpath>
-				<value>
-					<costStuffCount>50</costStuffCount>
-					<stuffCategories>
-						<li>SoftArmor</li>
-					</stuffCategories>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_GhillieSuit == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
+					<value>
+						<Bulk>31</Bulk>
+						<WornBulk>4.7</WornBulk>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+						<AimingAccuracy>0.05</AimingAccuracy>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_GhillieSuit == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
-				<value>
-					<Bulk>31</Bulk>
-					<WornBulk>4.7</WornBulk>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
-				<value>
-					<AimingAccuracy>0.05</AimingAccuracy>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_AdvancedVest == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>3</WornBulk>
+						<Mass>15</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>175</MaxHitPoints>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
+					<value>
+						<costList>
+							<Plasteel>20</Plasteel>
+							<ComponentIndustrial>1</ComponentIndustrial>
+						</costList>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>60</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/stuffCategories/li[.="Metallic"]</xpath>
+					<value>
+						<li>Steeled</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_AdvancedVest == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>3</WornBulk>
-					<Mass>15</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>175</MaxHitPoints>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
-				<value>
-					<costList>
-						<Plasteel>20</Plasteel>
-						<ComponentIndustrial>1</ComponentIndustrial>
-					</costList>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
-				<value>
-					<costStuffCount>60</costStuffCount>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/stuffCategories/li[.="Metallic"]</xpath>
-				<value>
-					<li>Steeled</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Apparel_HAZMATSuit == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
-				<value>
-					<Bulk>93.33</Bulk>
-					<WornBulk>14</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<li>Hands</li>
-					<li>Feet</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Apparel_HAZMATSuit == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
+					<value>
+						<Bulk>93.33</Bulk>
+						<WornBulk>14</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Hands</li>
+						<li>Feet</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
@@ -1,249 +1,248 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_Gambeson == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
+					<value>
+						<Bulk>2.5</Bulk>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor> <!-- actual thickness is 10mm, but the gambeson isn't made entirely out of leather -->
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
+					<value>
+						<ArmorRating_Sharp>0.06</ArmorRating_Sharp> <!-- remaining 6mm is of cloth, 0.01*6=0.06 -->
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>0.09</ArmorRating_Blunt> <!-- remaining 6mm is of cloth, 0.015*6=0.09 -->
+					</value>
+				</li>
+				<!-- other -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>30</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
+					<value>
+						<costList>
+							<Cloth>40</Cloth>
+						</costList>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Gambeson == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
-				<value>
-					<Bulk>2.5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor> <!-- actual thickness is 10mm, but the gambeson isn't made entirely out of leather -->
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
-				<value>
-					<ArmorRating_Sharp>0.06</ArmorRating_Sharp> <!-- remaining 6mm is of cloth, 0.01*6=0.06 -->
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
-				<value>
-					<ArmorRating_Blunt>0.09</ArmorRating_Blunt> <!-- remaining 6mm is of cloth, 0.015*6=0.09 -->
-				</value>
-			</li>
-			<!-- other -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
-				<value>
-					<costStuffCount>30</costStuffCount>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
-				<value>
-					<costList>
-						<Cloth>45</Cloth>
-					</costList>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_QuiltedVest == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<value>
+						<Bulk>1.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor> <!-- found a photo of some dude wearing it - got the image proportions and measured my own arm. 60mm*2mm/10mm=12mm. it isn't made entirely out of leather. -->
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<value>
+						<ArmorRating_Sharp>0.07</ArmorRating_Sharp> <!-- remaining 7mm is of cloth, 0.01*7=0.07 -->
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>0.105</ArmorRating_Blunt> <!-- remaining 7mm is of cloth, 0.015*7=0.105 -->
+					</value>
+				</li>
+				<!-- other -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>20</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
+					<value>
+						<costList>
+							<Cloth>30</Cloth>
+						</costList>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_QuiltedVest == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
-				<value>
-					<Bulk>1.5</Bulk>
-					<WornBulk>0.5</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor> <!-- found a photo of some dude wearing it - got the image proportions and measured my own arm. 60mm*2mm/10mm=12mm. it isn't made entirely out of leather. -->
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
-				<value>
-					<ArmorRating_Sharp>0.07</ArmorRating_Sharp> <!-- remaining 7mm is of cloth, 0.01*7=0.07 -->
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
-				<value>
-					<ArmorRating_Blunt>0.105</ArmorRating_Blunt> <!-- remaining 7mm is of cloth, 0.015*7=0.105 -->
-				</value>
-			</li>
-			<!-- other -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
-				<value>
-					<costStuffCount>25</costStuffCount>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
-				<value>
-					<costList>
-						<Cloth>35</Cloth>
-					</costList>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_LightPlateArmor == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>52.5</Bulk>
+						<WornBulk>8</WornBulk>
+						<Mass>8</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<value>
+						<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeDodgeChance>-0.08</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_LightPlateArmor == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>52.5</Bulk>
-					<WornBulk>8</WornBulk>
-					<Mass>8</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
-				<value>
-					<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeDodgeChance>-0.08</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_PlateShoulderpads == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<Mass>1.5</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<value>
+						<StuffEffectMultiplierInsulation_Cold>0</StuffEffectMultiplierInsulation_Cold>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_PlateShoulderpads == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>4.5</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<Mass>1.5</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
-				<value>
-					<StuffEffectMultiplierInsulation_Cold>0</StuffEffectMultiplierInsulation_Cold>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Chestplate == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>30</Bulk>
+						<WornBulk>4.5</WornBulk>
+						<Mass>4.5</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeDodgeChance>-0.045</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Chestplate == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>30</Bulk>
-					<WornBulk>4.5</WornBulk>
-					<Mass>4.5</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeDodgeChance>-0.045</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
+				<!-- == VAE_Apparel_Chainmail == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1.341</StuffEffectMultiplierArmor> <!-- did some actual calulations in a game. this isn't precisely it, but it's closer. -->
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeDodgeChance>-0.1</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_Chainmail == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
-				<value>
-					<Bulk>10</Bulk>
-					<WornBulk>5</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.341</StuffEffectMultiplierArmor> <!-- did some actual calulations in a game. this isn't precisely it, but it's closer. -->
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeDodgeChance>-0.1</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-
-			<!-- == VAE_Apparel_PlateHelmet == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>0.5</WornBulk>
-					<Mass>3</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<AimingAccuracy>-0.1</AimingAccuracy>
-						<MeleeHitChance>-0.5</MeleeHitChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
-				<value>
-					<stuffCategories>
-						<li>Steeled</li>
-					</stuffCategories>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<bodyPartGroups>
-						<li>UpperHead</li>
-						<li>Eyes</li>
-						<li>Teeth</li>
-					</bodyPartGroups>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Apparel_PlateHelmet == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>0.5</WornBulk>
+						<Mass>3</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<AimingAccuracy>-0.1</AimingAccuracy>
+							<MeleeHitChance>-0.5</MeleeHitChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
+					<value>
+						<stuffCategories>
+							<li>Steeled</li>
+						</stuffCategories>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<bodyPartGroups>
+							<li>UpperHead</li>
+							<li>Eyes</li>
+							<li>Teeth</li>
+						</bodyPartGroups>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
@@ -1,88 +1,87 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Apparel_WoodenArmor == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>5</WornBulk>
+						<Mass>12</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.9</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>75</MaxHitPoints>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
+					<value>
+						<description>A vest with wooden logs and planks covering the front and back. No one should be using this in an actual firefight, but anything is better than nothing.</description>
+					</value>
+				</li>
 
-			<!-- == VAE_Apparel_WoodenArmor == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>5</WornBulk>
-					<Mass>15</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>0.3</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>75</MaxHitPoints>
-				</value>
-			</li>
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
-				<value>
-					<description>A vest with wooden logs and planks covering the front and back. Not as effective or durable as an armor vest, but anything is better than nothing.</description>
-				</value>
-			</li>
-
-			<!-- == VAE_Headgear_StoneWarMask == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>6</Bulk>
-					<WornBulk>1.5</WornBulk>
-					<Mass>5.1</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
-				<value>
-					<Suppressability>-0.1</Suppressability>
-					<AimingAccuracy>-0.2</AimingAccuracy>
-					<MeleeHitChance>-1</MeleeHitChance>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
-				<value>
-					<li>OnHead</li>
-					<li>MiddleHead</li>
-					<li>StrappedHead</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Headgear_StoneWarMask == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+						<Mass>5.1</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
+					<value>
+						<Suppressability>-0.1</Suppressability>
+						<AimingAccuracy>-0.2</AimingAccuracy>
+						<MeleeHitChance>-1</MeleeHitChance>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
+					<value>
+						<li>OnHead</li>
+						<li>MiddleHead</li>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -1,153 +1,152 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Headgear_HeavyMarineHelmet == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<WornBulk>2.5</WornBulk>
+						<Mass>9</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>20.8</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>240</MaxHitPoints>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/label</xpath>
+					<value>
+						<label>heavy power armor helmet</label>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/description</xpath>
+					<value>
+						<description>A part of the heavy power armor set, mostly used by imperial stormtroopers.\n\nHas integrated neuro-memetic servo-motors to assist the wearer's muscles in holding the helmet, aswell as double-layered plasteel plating to increase protection. To eliminate a weakspot in the standard edition - the visor, this edition has no visor, but instead a built-in camera with a display HUD, containing the latest combat software, which runs real-time simulations for bullet trajectories and alerts the wearer any threats capable of piercing the armor.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<PsychicSensitivity>-0.3</PsychicSensitivity>
+							<AimingAccuracy>0.3</AimingAccuracy>
+							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<CarryWeight>5.4</CarryWeight>
+							<CarryBulk>1</CarryBulk>
+							<SmokeSensitivity>-1</SmokeSensitivity>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
+					<value>
+						<costList>
+							<Plasteel>55</Plasteel>
+							<DevilstrandCloth>20</DevilstrandCloth>
+							<Hyperweave>5</Hyperweave>
+							<ComponentSpacer>3</ComponentSpacer>
+						</costList>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel/layers</xpath>
+					<value>
+						<li>OnHead</li>
+						<li>MiddleHead</li>
+						<li>StrappedHead</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_HeavyMarineHelmet == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>10</Bulk>
-					<WornBulk>2.5</WornBulk>
-					<Mass>9</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>48</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>240</MaxHitPoints>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/label</xpath>
-				<value>
-					<label>heavy power armor helmet</label>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/description</xpath>
-				<value>
-					<description>A part of the heavy power armor set, mostly used by imperial stormtroopers.\n\nHas integrated, neuro-memetic servo-motors to assist the wearer's muscles in holding the heavy helmet, aswell as double-layered plasteel plating to increase protection. To eliminate a weakspot in the standard edition - the visor, this edition has no visor, but instead a built-in camera with a display HUD, containing the latest combat software, which runs real-time simulations for bullet trajectories and alerts the wearer any threats capable of piercing the armor.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<PsychicSensitivity>-0.3</PsychicSensitivity>
-						<AimingAccuracy>0.3</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
-						<CarryWeight>5.4</CarryWeight>
-						<CarryBulk>1</CarryBulk>
-						<SmokeSensitivity>-1</SmokeSensitivity>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
-				<value>
-					<costList>
-						<Plasteel>55</Plasteel>
-						<DevilstrandCloth>20</DevilstrandCloth>
+				<!-- == VAE_Apparel_HeavyMarineArmor == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>120</Bulk>
+						<WornBulk>20</WornBulk>
+						<Mass>80</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>60</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>500</MaxHitPoints>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/label</xpath>
+					<value>
+						<label>heavy power armor</label>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/description</xpath>
+					<value>
+						<description>Heavy powered armor usually used by imperial heavy stormtroopers from advanced glitterworld planets.\n\nOnly stupid and fearless stand in it's way, as it transforms any soldier into a humanoid tank: the double layers of plasteel-weave plates are incredibly effective at protecting from both projectiles and explosions, while the neuro-memetic servo-motors allow a human to wear the armor without restricting movement, at the same time improving weapon-handling.\n\nA built-in blast shield allows the wearer to survive a direct hit from a rocket, upon which the shield requires time to recharge.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<CarryWeight>100</CarryWeight>
+							<CarryBulk>20</CarryBulk>
+							<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
+							<ToxicSensitivity>-0.5</ToxicSensitivity>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Hands</li>
+						<li>Feet</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
+					<value>
+						<DevilstrandCloth>50</DevilstrandCloth>
 						<Hyperweave>10</Hyperweave>
-						<ComponentSpacer>3</ComponentSpacer>
-					</costList>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel/layers</xpath>
-				<value>
-					<li>OnHead</li>
-					<li>MiddleHead</li>
-					<li>StrappedHead</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Apparel_HeavyMarineArmor == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Mass</xpath>
-				<value>
-					<Bulk>166.67</Bulk>
-					<WornBulk>25</WornBulk>
-					<Mass>83.33</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>25</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>60</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/MaxHitPoints</xpath>
-				<value>
-					<MaxHitPoints>500</MaxHitPoints>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/label</xpath>
-				<value>
-					<label>heavy power armor</label>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/description</xpath>
-				<value>
-					<description>Heavy powered armor usually used by imperial heavy stormtroopers from advanced glitterworld planets.\n\nOnly stupid and fearless stand in it's way, as it transforms any soldier into a humanoid tank: the double layers of plasteel-weave plates are incredibly effective at protecting from both projectiles and explosions, while the neuro-memetic servo-motors allow a human to wear the armor without restricting movement, at the same time improving weapon-handling.\n\nA built-in blast shield allows the wearer to survive a direct hit from a rocket, upon which the shield requires time to recharge.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<CarryWeight>106.67</CarryWeight>
-						<CarryBulk>16.67</CarryBulk>
-						<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<li>Hands</li>
-					<li>Feet</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
-				<value>
-					<DevilstrandCloth>50</DevilstrandCloth>
-					<Hyperweave>25</Hyperweave>
-				</value>
-			</li>
-		</operations>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -1,171 +1,170 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Let's get this brea- mod patched. -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Vanilla Armour Expanded</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == VAE_Headgear_Balaclava == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>OnHead</li>
+						</layers>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<bodyPartGroups>
+							<li>UpperHead</li>
+							<li>Teeth</li>
+						</bodyPartGroups>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_Balaclava == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<Bulk>0.5</Bulk>
-					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
-				<value>
-					<layers>
-						<li>OnHead</li>
-					</layers>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<bodyPartGroups>
-						<li>UpperHead</li>
-						<li>Teeth</li>
-					</bodyPartGroups>
-				</value>
-			</li>
-
-			<!-- == VAE_Headgear_NightVisionGoggles == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<AimingAccuracy>0.15</AimingAccuracy>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/apparel/layers</xpath>
-				<value>
-					<li>MiddleHead</li>
-					<li>StrappedHead</li>
-				</value>
-			</li>
-
-			<!-- == VAE_Headgear_BallisticGoggles == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<Bulk>0.5</Bulk>
-					<WornBulk>0.5</WornBulk>
-					<ArmorRating_Sharp>6</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>9</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.366</ArmorRating_Heat>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/description</xpath>
-				<value>
-					<description>A pair of reinforced goggles capable of stopping a bullet. They seem to be tinted, stopping the glare from the sun, allowing the wearer to fire a bit more precisely.</description>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/costList</xpath>
-				<value>
-					<DevilstrandCloth>10</DevilstrandCloth>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/equippedStatOffsets</xpath>
-				<value>
-					<equippedStatOffsets>
-						<AimingAccuracy>0.05</AimingAccuracy>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/apparel/layers</xpath>
-				<value>
-					<layers>
+				<!-- == VAE_Headgear_NightVisionGoggles == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
+						<WornBulk>1</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<AimingAccuracy>0.15</AimingAccuracy>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/apparel/layers</xpath>
+					<value>
 						<li>MiddleHead</li>
-					</layers>
-				</value>
-			</li>
+						<li>StrappedHead</li>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_GhillieHood == -->
-			<!-- statBases -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
-				<value>
-					<Bulk>2</Bulk>
-					<WornBulk>0.5</WornBulk>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
-				<value>
-					<AimingAccuracy>0.1</AimingAccuracy>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/apparel/layers</xpath>
-				<value>
-					<li>MiddleHead</li>
-				</value>
-			</li>
+				<!-- == VAE_Headgear_BallisticGoggles == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>9</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.366</ArmorRating_Heat>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/description</xpath>
+					<value>
+						<description>A pair of reinforced goggles capable of stopping a bullet. They seem to be tinted, stopping the glare from the sun, allowing the wearer to fire a bit more precisely.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/costList</xpath>
+					<value>
+						<DevilstrandCloth>10</DevilstrandCloth>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<AimingAccuracy>0.05</AimingAccuracy>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>MiddleHead</li>
+						</layers>
+					</value>
+				</li>
 
-			<!-- == VAE_Headgear_HAZMATMask == -->
-			<!-- statBases -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
-					<Bulk>6</Bulk>
-					<WornBulk>1.5</WornBulk>
-				</value>
-			</li>
-			<!-- Miscellaneous -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
-				<value>
-					<SmokeSensitivity>-1</SmokeSensitivity>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
-				<value>
-					<li>MiddleHead</li>
-					<li>StrappedHead</li>
-				</value>
-			</li>
-		</operations>
+				<!-- == VAE_Headgear_GhillieHood == -->
+				<!-- statBases -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
+					<value>
+						<Bulk>2</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+						<AimingAccuracy>0.1</AimingAccuracy>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/apparel/layers</xpath>
+					<value>
+						<li>MiddleHead</li>
+					</value>
+				</li>
+
+				<!-- == VAE_Headgear_HAZMATMask == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+				<!-- Miscellaneous -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
+					<value>
+						<SmokeSensitivity>-1</SmokeSensitivity>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
+					<value>
+						<li>MiddleHead</li>
+						<li>StrappedHead</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>


### PR DESCRIPTION
## Changes

- Updated Better Infestations patch's mod name check to account for version change;
- Updated Vanilla Armor Expanded and Vanilla Apparel Expanded mod checks to use the one supplied by vanilla RimWorld in case `CombatExtended.PatchOperationFindMod` stops working;
- Modified VArE's heavy marine armor's stats to make it more in line with Royalty DLC's cataphract armor;
- Modified material costs for VAppE's shirts, pants, shoes and gloves and VarE's fabric-based medieval armors to account for the changes of vanilla shirts' and pants' costs;
- Porbably some other things that I forgot to document.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
