### PR TITLE
Balance Power Armor vs Recon Armor weight/speed

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -507,6 +507,7 @@
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>8</CarryBulk>
 			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<MoveSpeed>0.1</MoveSpeed>
 		</equippedStatOffsets>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -468,7 +468,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/statBases/Mass</xpath>
 		<value>
-			<Mass>40</Mass>
+			<Mass>30</Mass>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
Addresses a quirk between the Power Armor and Recon Armor, wherein pawns wearing the Power Armor are faster than ones in Recon Armor because they're less affected by the move speed malus associated with weight carried, because the penalty is a function of weight/total capacity.