### PR TITLE
Fixes .50 AE AP being the same as HP

### DIFF
--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -15,7 +15,7 @@
 		<label>.50 AE</label>
 		<ammoTypes>
 			<Ammo_50AE_FMJ>Bullet_50AE_FMJ</Ammo_50AE_FMJ>
-			<Ammo_50AE_AP>Bullet_50AE_HP</Ammo_50AE_AP>			
+			<Ammo_50AE_AP>Bullet_50AE_AP</Ammo_50AE_AP>			
 			<Ammo_50AE_HP>Bullet_50AE_HP</Ammo_50AE_HP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>


### PR DESCRIPTION
## Additions
None

## Changes
Makes .50 AP use the correct bullet.

## References
I had posted about it on discord earlier.

## Reasoning
Saw the bug yesterday, might aswell fix it.

## Alternatives
None

## Testing
Before and after
![deagle](https://user-images.githubusercontent.com/45199549/91640225-2d681080-ea1c-11ea-9d4f-bc08581f21c8.png)
![deagleammo](https://user-images.githubusercontent.com/45199549/91640226-2f31d400-ea1c-11ea-8490-e3c7521c4a2b.png)

