### PR TITLE
Bomb Damage Adjustment

### DIFF
--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -138,6 +138,20 @@
       <minDamageToFragment>4</minDamageToFragment>
     </value>
   </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/DamageDef[defName="Bomb"]/defaultDamage</xpath>
+    <value>
+      <defaultDamage>635</defaultDamage>
+    </value>
+  </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/DamageDef[defName="Bomb"]/defaultArmorPenetration</xpath>
+    <value>
+      <defaultArmorPenetration>63.5</defaultArmorPenetration>
+    </value>
+  </Operation>
 
   <!-- ========== Remove vanilla DamageWorker ========== -->
 


### PR DESCRIPTION
## Changes

Increases the damage and armor penetration of the base bomb damage def, since this is what orbital strikes inherit their damage from. The damage has gone up to 635 and the penetration to 63.5MPa, based on 20L thermobaric payload.

It is worth noting that this also increases the damage of the 'blast' from falling meteors and ship parts, which I don't see as an issue, but could be individually altered if required (altering the orbital bombardment skyfaller doesn't seem to be possible via pure XML outside of indirectly doing it via altering the bomb damage def)

## Reasoning

This fixes the longstanding issue where orbital bombardment targeter strikes have done little to nothing to armored targets

## Alternatives

While it may be difficult, it could be possible to make the orbital bombardment skyfaller/verb operate using CE specific projectiles rather than the current effect where it just makes blasts alongside the motes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
