### PR TITLE
Increase ballista fillPercent

### DIFF
--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -32,7 +32,8 @@
         <li Class="PatchOperationReplace">
         <xpath>Defs/ThingDef[	
 			defName = "VFES_Turret_HMGComplex" or
-			defName = "VFES_Turret_ChargeComplex"	
+			defName = "VFES_Turret_ChargeComplex" or
+			defName = "VFES_Turret_Ballista"
 		]/fillPercent</xpath>
         <value>
           <fillPercent>0.85</fillPercent>


### PR DESCRIPTION
## Changes
- Increased the fillPercent of the Ballista to 0.85 because it had a value of 0.4 meaning it couldn't fire over any kind of cover.