### PR TITLE
Fixed Ammo label

### DIFF
--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -84,7 +84,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
     <defName>Ammo_20x110mmHispano_Sabot</defName>
-    <label>14.5x114mm cartridge (Sabot)</label>
+    <label>20x110mm Hispano cartridge (Sabot)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/Sabot</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
Fixed wrong label of 20x110mm Hispano cartridge (Sabot)
