### PR TITLE
Swap power core and coolant tank capacities

### DIFF
--- a/Defs/Bodies/BodyParts_Mechanoid_Internal.xml
+++ b/Defs/Bodies/BodyParts_Mechanoid_Internal.xml
@@ -12,7 +12,7 @@
     <solid>true</solid>
 	<bleedRate>0</bleedRate>
     <tags>
-      <li>MetabolismSource</li>
+      <li>BloodPumpingSource</li>
     </tags>
   </BodyPartDef>
 
@@ -72,7 +72,7 @@
     <solid>true</solid>
 	<bleedRate>0</bleedRate>
     <tags>
-      <li>BloodPumpingSource</li>
+      <li>MetabolismSource</li>
     </tags>
   </BodyPartDef>
 


### PR DESCRIPTION

## Changes

Swap the capacites on coolant tank and power core so that them being damage matches the capacites for a mechanoid that are being reduced.

## Reasoning

Coolant tank reduced the ingame capacity for power generation, and conversely the power core reduced the coolant ability.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
