### PR TITLE
Fixes/tweaks to Federation apparel

### DIFF
--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -187,7 +187,6 @@
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
-					<li>Feet</li>
 				</value>
 			</li>
 
@@ -201,7 +200,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 		
@@ -215,16 +214,16 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Blunt</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -258,7 +257,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Foerum"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
-					<StuffPower_Armor_Sharp>1.8</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Sharp>2</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 


### PR DESCRIPTION


## Changes

Fixed xpath for unity guard helmet patches.
Reduced unity guard armor blunt armor to equal to steel vest, as even with full frame foerum provides terrible blunt impact resistance.
Removed feet coverage on unity guard armor as it doesn't cover the legs either
Slightly tweaked foerum sharp armor to match plasteel.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
