### PR TITLE
Help mono figure out how to cast with possible null values

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -350,7 +350,8 @@ namespace CombatExtended
                         }
                     }
                     //Reload apparel option
-                    foreach (var apparel in SelPawnForGear?.apparel?.WornApparel)
+		    var worn_apparel = SelPawnForGear?.apparel?.WornApparel;
+                    foreach (var apparel in worn_apparel)
                     {
                         var compReloadable = apparel.TryGetComp<CompReloadable>();
                         if (compReloadable != null && compReloadable.AmmoDef == thing.def && compReloadable.NeedsReload(true))

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -350,7 +350,7 @@ namespace CombatExtended
                         }
                     }
                     //Reload apparel option
-		    IEnumerable<thing> worn_apparel = SelPawnForGear?.apparel?.WornApparel ?? Enumerable.Empty<Thing>();
+		            IEnumerable<Apparel> worn_apparel = SelPawnForGear?.apparel?.WornApparel ?? Enumerable.Empty<Apparel>();
                     foreach (var apparel in worn_apparel)
                     {
                         var compReloadable = apparel.TryGetComp<CompReloadable>();

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -350,7 +350,7 @@ namespace CombatExtended
                         }
                     }
                     //Reload apparel option
-		    var worn_apparel = SelPawnForGear?.apparel?.WornApparel;
+		    IEnumerable<thing> worn_apparel = SelPawnForGear?.apparel?.WornApparel ?? Enumerable.Empty<Thing>();
                     foreach (var apparel in worn_apparel)
                     {
                         var compReloadable = apparel.TryGetComp<CompReloadable>();


### PR DESCRIPTION
## Changes
No change in the output assembly, just helps the mono compiler figure out to iterate over worn apparel.

## Reasoning
Without this fix, `mcs` (the mono compiler) fails to compile with 

    error CS0266: Cannot implicitly convert type `System.Collections.Generic.List<RimWorld.Apparel>.Enumerator?' to `System.Collections.Generic.List<RimWorld.Apparel>.Enumerator'. An explicit conversion exists (are you missing a cast?)

## Alternatives

It's probably possible to specify the cast in a single line, but that is likely less readable.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (minutes)
