### PR TITLE
Rabbie the Moon Rabbit Fixes

### DIFF
--- a/Patches/Rabbie The Moonrabbit/PawnKindDefs/RB_PawnKind.xml
+++ b/Patches/Rabbie The Moonrabbit/PawnKindDefs/RB_PawnKind.xml
@@ -8,6 +8,23 @@
 			
 		<match Class="PatchOperationSequence">
 		<operations>
+		
+			<!--Backpack-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[
+				defName="RB_Wanderer" or
+				defName="RB_SubOfficer" or
+				defName="RB_EliteOfficer" or
+				defName="RB_FSniper" or
+				defName="RB_FMachinegunner"
+				]/apparelRequired</xpath>
+				<value>
+					<li>Apparel_Backpack</li>
+				</value>
+			</li>
+			
+			
 			<!--Regular-->
 			
 			<li Class="PatchOperationAddModExtension">

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -36,6 +36,46 @@
 					<li>SoftArmor</li>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moonsilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moonsilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moonsilk"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.5</StuffPower_Armor_Heat>
+					<StuffPower_Armor_Electric>0.08</StuffPower_Armor_Electric>
+					<Bulk>0.2</Bulk>
+					<WornBulk>0.5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moonsilk"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>1.3</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moonsilk"]/stuffProps/categories</xpath>
+				<value>
+					<li>SoftArmor</li>
+				</value>
+			</li>
+			
+			
 		</operations>
 		</match>	
 	  </li>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -30,13 +30,6 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moonthread"]/stuffProps/categories</xpath>
-				<value>
-					<li>SoftArmor</li>
-				</value>
-			</li>
-			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moonsilk"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>


### PR DESCRIPTION
## Additions

Added CE stats for Moon Silk material
Added forced backpack to some pawn type defs to ensure they spawn with ammo.

## Changes

Removed SoftArmor catergory from moonweave, as the armor value is probably too low to be considered for soft armor type apparels.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
