### PR TITLE
Rimefeller Composite Fix

### DIFF
--- a/Patches/Rimefeller/Items_Resource_Stuff.xml
+++ b/Patches/Rimefeller/Items_Resource_Stuff.xml
@@ -83,6 +83,14 @@
 						<StuffPower_Armor_Heat>0.2</StuffPower_Armor_Heat>
 					</value>
 				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="FiberComposite"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+						<li>Steeled</li>
+					</value>
+				</li>
 
 				<!-- === Synthylene === -->
 				<li Class="PatchOperationReplace">


### PR DESCRIPTION

## Changes

Adds CE specific stuff catergories so armored vests and melee weapons can be made of rimefeller composite

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
