### PR TITLE
Increase grenade launcher grenade fragmentation effect

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -128,8 +128,7 @@
 		<comps>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-			  <Fragment_Large>1</Fragment_Large>
-			  <Fragment_Small>3</Fragment_Small>
+			  <Fragment_Small>11</Fragment_Small>
 			</fragments>
 		  </li>
 		</comps>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -87,7 +87,7 @@
     <statBases>
       <MarketValue>1.30</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -129,8 +129,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>3</Fragment_Small>
+          <Fragment_Small>13</Fragment_Small>
         </fragments>
       </li>
     </comps>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -88,7 +88,7 @@
     <statBases>
       <MarketValue>1.42</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -170,8 +170,7 @@
 		<comps>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-			  <Fragment_Large>1</Fragment_Large>
-			  <Fragment_Small>3</Fragment_Small>
+			  <Fragment_Small>24</Fragment_Small>
 			</fragments>
 		</li>
 		</comps>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -103,7 +103,7 @@
     <statBases>
       <MarketValue>1.93</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -131,8 +131,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>4</Fragment_Small>
+          <Fragment_Small>28</Fragment_Small>
         </fragments>
       </li>
     </comps>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -89,7 +89,7 @@
     <statBases>
       <MarketValue>2.31</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 			<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -88,7 +88,7 @@
     <statBases>
       <MarketValue>1.77</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -128,8 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>3</Fragment_Small>
+          <Fragment_Small>20</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -88,7 +88,7 @@
     <statBases>
       <MarketValue>1.84</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -128,8 +128,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>4</Fragment_Small>
+          <Fragment_Small>19</Fragment_Small>
         </fragments>
       </li>
     </comps>

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -128,8 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>4</Fragment_Small>
+          <Fragment_Small>20</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -88,7 +88,7 @@
     <statBases>
       <MarketValue>1.88</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -128,8 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-          <Fragment_Large>2</Fragment_Large>
-          <Fragment_Small>4</Fragment_Small>
+          <Fragment_Small>35</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -88,7 +88,7 @@
     <statBases>
       <MarketValue>2.35</MarketValue>
     </statBases>
-    <ammoClass>Smoke</ammoClass>
+    <ammoClass>Smoke</ammoClass><generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -128,8 +128,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>6</Fragment_Small>
+          <Fragment_Small>22</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -89,6 +89,7 @@
       <MarketValue>1.90</MarketValue>
     </statBases>
     <ammoClass>Smoke</ammoClass>
+	<generateAllowChance>0</generateAllowChance>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -129,8 +129,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>2</Fragment_Large>
-					<Fragment_Small>5</Fragment_Small>
+					<Fragment_Small>40</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -89,6 +89,7 @@
 		<MarketValue>3.38</MarketValue>
 		</statBases>
 		<ammoClass>Smoke</ammoClass>
+		<generateAllowChance>0</generateAllowChance>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 			<damageAmountBase>5</damageAmountBase>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -144,8 +144,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-          <Fragment_Large>1</Fragment_Large>
-          <Fragment_Small>83</Fragment_Small>
+          <Fragment_Small>80</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>


### PR DESCRIPTION
## Changes

Changes launcher HE grenades to use the fragmentation calculation for frag ammo type rather than HE, increasing the frag count and removing large fragments from the pool.

Remove/reduce chance of smoke from avaliable options for loadout generation because the AI cannot make effective use of it.

## Reasoning

In their current state, grenade launched HE grenades are largely ineffective in their anti-personnel due to low overall damage + penetration and the requirement that they practically need to score direct hits to inflict damage on a target, while a relatavely low velocity projectile and high innate deviation.

## Alternatives

Give HE fragmentation grenades a new ammo type on the sheet that applies/uses a different fragmentation amount formula, and possibly uses a different fragmentation projectile.

lperkins2 mentioned using an expanding radius, but idk how that works.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
