### PR TITLE
Kijin Fireblade Patch

### DIFF
--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Melee.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Melee.xml
@@ -205,6 +205,61 @@
 				</value>
 			</li>
 			
+			<!--Fireblade : Royalty Only-->
+			
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="Kijin_FlameSword"]</xpath>
+				<match Class="PatchOperationSequence">
+				<operations>
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="Kijin_FlameSword"]/tools</xpath>
+						<value>
+							<tools>
+								<li Class="CombatExtended.ToolCE">
+									<label>edge</label>
+									<capacities>
+										<li>KijinSword</li>
+									</capacities>
+									<power>32</power>
+									<cooldownTime>2.06</cooldownTime>
+									<chanceFactor>1.33</chanceFactor>
+									<armorPenetrationBlunt>0</armorPenetrationBlunt>
+									<armorPenetrationSharp>0</armorPenetrationSharp>
+									<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+								</li>
+							</tools>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ManeuverDef[defName="Kijin_Sword"]/verb/verbClass</xpath>
+						<value>
+							<verbClass>CombatExtended.Verb_MeleeAttackCE</verbClass>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Kijin_FlameSword"]/statBases</xpath>
+						<value>
+							<Bulk>8.5</Bulk>
+							<MeleeCounterParryBonus>0.90</MeleeCounterParryBonus>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Kijin_FlameSword"]</xpath>
+						<value>
+							<equippedStatOffsets>
+								<MeleeCritChance>1.10</MeleeCritChance>
+								<MeleeParryChance>0.70</MeleeParryChance>
+								<MeleeDodgeChance>0.50</MeleeDodgeChance>	
+							</equippedStatOffsets>
+						</value>
+					</li>
+					<!-- -->
+				</operations>
+				</match>
+			</li>
 			
 		</operations>
 		</match>	

--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Melee.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Melee.xml
@@ -220,7 +220,7 @@
 									<capacities>
 										<li>KijinSword</li>
 									</capacities>
-									<power>32</power>
+									<power>22</power>
 									<cooldownTime>2.06</cooldownTime>
 									<chanceFactor>1.33</chanceFactor>
 									<armorPenetrationBlunt>0</armorPenetrationBlunt>
@@ -228,6 +228,16 @@
 									<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 								</li>
 							</tools>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>Defs</xpath>
+						<value>
+						  <DamageDef ParentName="Flame">
+							<defName>Flame_Nopenetration</defName>
+							<harmAllLayersUntilOutside>false</harmAllLayersUntilOutside>
+						  </DamageDef>
 						</value>
 					</li>
 					
@@ -256,7 +266,7 @@
 							</equippedStatOffsets>
 						</value>
 					</li>
-					<!-- -->
+					
 				</operations>
 				</match>
 			</li>


### PR DESCRIPTION
## Additions

Adds patch for Kijin fireblade weapon

* Note: Due to the implementation method on their end, the patch may not always work (i.e. it only works if CE is loaded after the kijin mod, afaik) since the weapon is a patched in def. There's not really much that can be done about that on our end afaik.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors*
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
