### PR TITLE
Patch Strong Back from SYR Individuality like Strong Back from FalloutTraits

### DIFF
--- a/Patches/Individuality/Traits_Patch_CE.xml
+++ b/Patches/Individuality/Traits_Patch_CE.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Individuality</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationRemove">
+				<xpath>/Defs/TraitDef[defName = "SYR_StrongBack"]/degreeDatas/li[1]/statOffsets/CarryingCapacity</xpath>			
+				</li>
+				
+				<li Class="PatchOperationAdd">
+				<xpath>/Defs/TraitDef[defName = "SYR_StrongBack"]/degreeDatas/li[1]/statOffsets</xpath>
+					<value>
+						  <CarryWeight>+20</CarryWeight>
+					</value>				
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>/Defs/TraitDef[defName = "SYR_StrongBack"]/degreeDatas/li[1]/statOffsets</xpath>
+					<value>
+						  <CarryBulk>+20</CarryBulk>
+					</value>				
+				</li>
+			</operations>
+		</match>
+	</Operation>
+		
+</Patch>


### PR DESCRIPTION
## Additions

Strong Back from Individuality now 20 CarryWeight and 20 CarryBulk instead of 20 CarryCapacity

## Reasoning

CarryCapacity is not used.  FalloutTraits also offers a Strong Back trait, with the same carry capacity boost.  It is replaced with a 20pt bulk and mass boost, so I used the same here.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded (Not tested)
- [ ] Playtested a colony (specify how long)
