### PR TITLE
Tweaks to Vanilla Factions Expanded Chitin

### DIFF
--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
@@ -54,6 +54,13 @@
 				<Mass>0.7</Mass>
 			</value>
 		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEI_Chitin"]/statBases/BluntDamageMultiplier</xpath>
+			<value>
+				<BluntDamageMultiplier>0.65</BluntDamageMultiplier>
+			</value>
+		</li>
 
         <!-- === Spidersilk === -->
         <li Class="PatchOperationReplace">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
@@ -39,6 +39,21 @@
             <StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
           </value>
         </li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI_Chitin"]/stuffProps/categories</xpath>
+			<value>
+				<li>Metallic_Weapon</li>
+				<li>Steeled</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEI_Chitin"]/stuffProps/statFactors</xpath>
+			<value>
+				<Mass>0.7</Mass>
+			</value>
+		</li>
 
         <!-- === Spidersilk === -->
         <li Class="PatchOperationReplace">


### PR DESCRIPTION

## Changes

Added stuff catergories for chitin so weapons/armor vests can be made of it in CE.
Buffed chitin by reducing weight of stuff made of it, since it in vanilla has a very quick attack rate. Lowed blunt damage for weapons made of it since it already attacks quite quickly.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
