### PR TITLE
The GiantRace CE patch

### DIFF
--- a/Patches/The GiantRace/PawnKindDefs/Giant_PawnKind.xml
+++ b/Patches/The GiantRace/PawnKindDefs/Giant_PawnKind.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--Ammo-->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				@Name="GIBasePawnKind"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>6</min>
+						<max>20</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<!--Points reductions across the board, along the same lines as tribals-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Gi_Warrior"]/combatPower</xpath>
+				<value>
+					<combatPower>210</combatPower>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Gi_Thrower"]/combatPower</xpath>
+				<value>
+					<combatPower>240</combatPower>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Gi_ExpertWarrior"]/combatPower</xpath>
+				<value>
+					<combatPower>285</combatPower>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Gi_ExpertThrower"]/combatPower</xpath>
+				<value>
+					<combatPower>300</combatPower>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Gi_Champion"]/combatPower</xpath>
+				<value>
+					<combatPower>375</combatPower>
+				</value>
+			</li>
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/Scenario/Giant_Scenario.xml
+++ b/Patches/The GiantRace/Scenario/Giant_Scenario.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[defName="GI_Scenario"]/scenario/parts</xpath>
+				<value>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_Arrow_Stone</thingDef>
+						<count>100</count>
+					</li>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_GiantRags"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					<Bulk>6</Bulk>
+					<WornBulk>3</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Clothes"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<Bulk>8</Bulk>
+					<WornBulk>3</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Brigandine"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+					<Bulk>140</Bulk>
+					<WornBulk>25</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Brigandine"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Brigandine"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Brigandine"]/statBases/Mass</xpath>
+				<value>
+					<Mass>35</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="GI_Brigandine"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Shadehat"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Potlid"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<Bulk>8</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<!--Note, techincally a thrumbohorn weighs like, 50kg, but we're not going to bother changing the mass for this-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Thrumboskull"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					<Bulk>8</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Thrumboskull"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>9</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_MaskandhelmF" or defName="GI_MaskandhelmM"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
+					<Bulk>25</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_MaskandhelmF" or defName="GI_MaskandhelmM"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_MaskandhelmF" or defName="GI_MaskandhelmM"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Insignia"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>8</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Bonepauldron"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<Bulk>18</Bulk>
+					<WornBulk>6</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Bonepauldron"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Booty"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>8</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Pauldron"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+					<Bulk>140</Bulk>
+					<WornBulk>25</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Pauldron"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Pauldron"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+				</value>
+			</li>
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
@@ -12,18 +12,18 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_GiantRags"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					<Bulk>6</Bulk>
-					<WornBulk>3</WornBulk>
+					<WornBulk>0</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_Clothes"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
 					<Bulk>8</Bulk>
-					<WornBulk>3</WornBulk>
+					<WornBulk>0</WornBulk>
 				</value>
 			</li>
 			
@@ -100,7 +100,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_MaskandhelmF" or defName="GI_MaskandhelmM"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					<Bulk>25</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>
@@ -132,7 +132,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_Bonepauldron"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 					<Bulk>18</Bulk>
 					<WornBulk>6</WornBulk>
 				</value>
@@ -141,7 +141,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_Bonepauldron"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -157,9 +157,9 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="GI_Pauldron"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					<Bulk>140</Bulk>
-					<WornBulk>25</WornBulk>
+					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Melee.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Melee.xml
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--========= Melee =========-->
+			
+			<!--Log Club-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_GiantClub"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>2.51</cooldownTime>
+							<armorPenetrationBlunt>3.76</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>36</power>
+							<cooldownTime>3.76</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationBlunt>15.6</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_GiantClub"]/statBases</xpath>
+				<value>
+					<Bulk>15.5</Bulk>
+					<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_GiantClub"]/equippedStatOffsets</xpath>
+				<value>
+						<MeleeCritChance>0.65</MeleeCritChance>
+						<MeleeParryChance>0.15</MeleeParryChance>
+						<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--Ivory Pick-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_IvoryClub"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>14</power>
+							<cooldownTime>2.51</cooldownTime>
+							<armorPenetrationBlunt>5.1</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Stab</li>
+								<li>Scratch</li>
+							</capacities>
+							<power>44</power>
+							<cooldownTime>4.02</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationSharp>0.91</armorPenetrationSharp>
+							<armorPenetrationBlunt>20.4</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_IvoryClub"]/statBases</xpath>
+				<value>
+					<Bulk>15.5</Bulk>
+					<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_IvoryClub"]/equippedStatOffsets</xpath>
+				<value>
+						<MeleeCritChance>0.65</MeleeCritChance>
+						<MeleeParryChance>0.15</MeleeParryChance>
+						<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--Mammoth Hammer-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_MammothHammer"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>16</power>
+							<cooldownTime>2.79</cooldownTime>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Stab</li>
+								<li>Scratch</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>4.19</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationSharp>2.29</armorPenetrationSharp>
+							<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_MammothHammer"]/statBases</xpath>
+				<value>
+					<Bulk>18.5</Bulk>
+					<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_MammothHammer"]/equippedStatOffsets</xpath>
+				<value>
+						<MeleeCritChance>0.67</MeleeCritChance>
+						<MeleeParryChance>0.24</MeleeParryChance>
+						<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--Thrumbo Blade-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_ThrumboSpineBlade"]/tools</xpath>
+				<value>
+					<tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>base</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>20</power>
+						<cooldownTime>2.98</cooldownTime>
+						<armorPenetrationBlunt>7.8</armorPenetrationBlunt>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>108</power>
+						<cooldownTime>1.75</cooldownTime>
+						<chanceFactor>1.165</chanceFactor>
+						<armorPenetrationBlunt>22.542</armorPenetrationBlunt>
+						<armorPenetrationSharp>3.01</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>45</power>
+						<cooldownTime>2.98</cooldownTime>
+						<chanceFactor>1.165</chanceFactor>
+						<armorPenetrationBlunt>7.8</armorPenetrationBlunt>
+						<armorPenetrationSharp>15.6</armorPenetrationSharp>
+					  </li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_ThrumboSpineBlade"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+					<Bulk>22.5</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_ThrumboSpineBlade"]/equippedStatOffsets</xpath>
+				<value>
+					  <MeleeCritChance>1</MeleeCritChance>
+					  <MeleeParryChance>0.6</MeleeParryChance>
+					  <MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--Cleaver-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Cleaver"]/tools</xpath>
+				<value>
+					<tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>base</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>14</power>
+						<cooldownTime>2.72</cooldownTime>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>97</power>
+						<cooldownTime>2.53</cooldownTime>
+						<chanceFactor>1.165</chanceFactor>
+						<armorPenetrationBlunt>17.496</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.7</armorPenetrationSharp>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>45</power>
+						<cooldownTime>2.72</cooldownTime>
+						<chanceFactor>1.165</chanceFactor>
+						<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+						<armorPenetrationSharp>6.75</armorPenetrationSharp>
+					  </li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Cleaver"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+					<Bulk>17.75</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Cleaver"]/equippedStatOffsets</xpath>
+				<value>
+					  <MeleeCritChance>0.63</MeleeCritChance>
+					  <MeleeParryChance>0.75</MeleeParryChance>
+					  <MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--Warhammer-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Hammer"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>2.93</cooldownTime>
+							<armorPenetrationBlunt>7.25</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>74</power>
+							<cooldownTime>3.99</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationBlunt>35.09</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Hammer"]/statBases</xpath>
+				<value>
+					<Bulk>18.25</Bulk>
+					<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Hammer"]/equippedStatOffsets</xpath>
+				<value>
+						<MeleeCritChance>2.5</MeleeCritChance>
+						<MeleeParryChance>0.18</MeleeParryChance>
+						<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--War Ram-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Ram"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>31</power>
+							<cooldownTime>3.39</cooldownTime>
+							<armorPenetrationBlunt>13</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>105</power>
+							<cooldownTime>5.95</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationBlunt>51.84</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Ram"]/statBases</xpath>
+				<value>
+					<Bulk>25.25</Bulk>
+					<MeleeCounterParryBonus>0.05</MeleeCounterParryBonus>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="GI_Ram"]/equippedStatOffsets</xpath>
+				<value>
+						<MeleeCritChance>1.5</MeleeCritChance>
+						<MeleeParryChance>0.05</MeleeParryChance>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
@@ -1,0 +1,920 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--========= Ranged =========-->
+			<!-- Comps and Classes -->
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[@Name="GiantBaseRange"]</xpath>
+			  <attribute>ParentName</attribute>
+			  <value>BaseWeaponAndAmmoNeolithic</value>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Jackstones_limestone"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_limestone"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_limestone"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Jackstones_granite"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Javelin"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Javelin"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Javelin"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Scrapmetal"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Scrapmetal"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Scrapmetal"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_granite"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_granite"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_granite"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAttributeSet">
+			  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_Marble"]</xpath>
+			  <attribute>Class</attribute>
+			  <value>CombatExtended.AmmoDef</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+			  <success>Always</success>
+			  <operations>
+				<li Class="PatchOperationTest">
+				  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_Marble"]/comps</xpath>
+				  <success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="GI_Rockpillar_Marble"]</xpath>
+				  <value>
+					<comps />
+				  </value>
+				</li>
+			  </operations>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite" or
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal" or
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]</xpath>
+				<value>
+					<stackLimit>25</stackLimit>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite" or
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal" or
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]/costList</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite" or
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal" or
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]/statBases/WorkToMake</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite" or
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal" or
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]/recipeMaker</xpath>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite" or
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal" or
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]/statBases</xpath>
+				<value>
+					<MarketValue>0.05</MarketValue>
+					<MarketValue>0.18</MarketValue>
+					<MarketValue>0.09</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Jackstones_limestone" or
+				defName="GI_Jackstones_granite"
+				]/statBases</xpath>
+				<value>
+					<MarketValue>0.05</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Javelin" or
+				defName="GI_Scrapmetal"
+				]/statBases</xpath>
+				<value>
+					<MarketValue>0.18</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="GI_Rockpillar_granite" or
+				defName="GI_Rockpillar_Marble"
+				]/statBases</xpath>
+				<value>
+					<MarketValue>0.09</MarketValue>
+				</value>
+			</li>
+
+			
+			
+			
+			<!-- == Recipes == -->
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_GI_Jackstones_limestone</defName>
+				  <label>make limestone jackstones x10</label>
+				  <description>Craft 10 limestone jackstones.</description>
+				  <jobString>Making limestone jackstones.</jobString>
+				  <workAmount>500</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>BlocksLimestone</li>
+					  </thingDefs>
+					</filter>
+					<count>25</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>BlocksLimestone</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>CraftingSpot</li>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Jackstones_limestone>10</GI_Jackstones_limestone>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_GI_Jackstones_granite</defName>
+				  <label>make granite jackstones x10</label>
+				  <description>Craft 10 granite jackstones.</description>
+				  <jobString>Making granite jackstones.</jobString>
+				  <workAmount>500</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+					</filter>
+					<count>25</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>CraftingSpot</li>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Jackstones_granite>10</GI_Jackstones_granite>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_GI_Javelin</defName>
+				  <label>make giant javelin x10</label>
+				  <description>Craft 10 giant javelins.</description>
+				  <jobString>Making giant javelins.</jobString>
+				  <workAmount>8500</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>WoodLog</li>
+					  </thingDefs>
+					</filter>
+					<count>120</count>
+				  </li>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>ElephantTusk</li>
+					  </thingDefs>
+					</filter>
+					<count>3</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>WoodLog</li>
+						<li>ElephantTusk</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>CraftingSpot</li>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Javelin>10</GI_Javelin>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_GI_Scrapmetal</defName>
+				  <label>make scrapmetal bundle x25</label>
+				  <description>Craft 10 scrapmetal bundles.</description>
+				  <jobString>Making scrapmetal bundles.</jobString>
+				  <workAmount>3800</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>Steel</li>
+					  </thingDefs>
+					</filter>
+					<count>120</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Scrapmetal>25</GI_Scrapmetal>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_Rockpillar_granite</defName>
+				  <label>make granite rockpillar x25</label>
+				  <description>Craft 10 granite rockpillars.</description>
+				  <jobString>Making granite rockpillars.</jobString>
+				  <workAmount>18500</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+					</filter>
+					<count>250</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Rockpillar_granite>25</GI_Rockpillar_granite>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			  <xpath>Defs</xpath>
+			  <value>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+				  <defName>Make_Rockpillar_marble</defName>
+				  <label>make marble rockpillar x25</label>
+				  <description>Craft 25 marble rockpillars.</description>
+				  <jobString>Making marble rockpillars.</jobString>
+				  <workAmount>18500</workAmount>
+				  <ingredients>
+				  <li>
+					<filter>
+					  <thingDefs>
+						<li>BlocksMarble</li>
+					  </thingDefs>
+					</filter>
+					<count>250</count>
+				  </li>
+				  </ingredients>
+				  <fixedIngredientFilter>
+					  <thingDefs>
+						<li>BlocksGranite</li>
+					  </thingDefs>
+				  </fixedIngredientFilter>
+				  <recipeUsers>
+					<li>ElectricSmithy</li>
+					<li>FueledSmithy</li>
+				  </recipeUsers>
+				  <products>
+					<GI_Rockpillar_Marble>25</GI_Rockpillar_Marble>
+				  </products>
+				</RecipeDef>
+			  </value>
+			</li>
+			
+			<!-- Compat -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Jackstones_granite</defName>
+			  <statBases>
+				<Mass>8</Mass>
+				<Bulk>5</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>1.5</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<label>throw jackstone</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Jackstones_granite_Thrown</defaultProjectile>
+				<range>12</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			  </FireModes>
+			  <AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Jackstones_granite"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stone fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>19</power>
+							<cooldownTime>2.25</cooldownTime>
+							<armorPenetrationBlunt>7.56</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Jackstones_limestone</defName>
+			  <statBases>
+				<Mass>8</Mass>
+				<Bulk>5</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>1.5</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<label>throw jackstone</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Jackstones_granite_Thrown</defaultProjectile>
+				<range>12</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <FireModes />
+			  <AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Jackstones_limestone"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stone fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>19</power>
+							<cooldownTime>2.25</cooldownTime>
+							<armorPenetrationBlunt>7.56</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Javelin</defName>
+			  <statBases>
+				<Mass>10.2</Mass>
+				<Bulk>12</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>1.5</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<label>throw jackstone</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Javelin_Thrown</defaultProjectile>
+				<range>16</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <FireModes />
+			  <AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Javelin"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>16</power>
+							<cooldownTime>2.79</cooldownTime>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>4.19</cooldownTime>
+							<chanceFactor>2</chanceFactor>
+							<armorPenetrationSharp>2.29</armorPenetrationSharp>
+							<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Scrapmetal</defName>
+			  <statBases>
+				<Mass>6.6</Mass>
+				<Bulk>5</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>10</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<label>throw jackstone</label>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Scrapmetal_Thrown</defaultProjectile>
+				<range>12</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <FireModes />
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Scrapmetal"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>scrap fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>19</power>
+							<cooldownTime>2.25</cooldownTime>
+							<armorPenetrationBlunt>7.56</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Rockpillar_granite</defName>
+			  <statBases>
+				<Mass>18</Mass>
+				<Bulk>14</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>1.5</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Rockpillar_Marble_Thrown</defaultProjectile>
+				<range>8</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <FireModes />
+			  <AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Rockpillar_granite"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>pillar</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>2.93</cooldownTime>
+							<armorPenetrationBlunt>7.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			  <defName>GI_Rockpillar_Marble</defName>
+			  <statBases>
+				<Mass>18</Mass>
+				<Bulk>14</Bulk>
+				<MarketValue>0.09</MarketValue>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				<ShotSpread>1.5</ShotSpread>
+				<SwayFactor>2.5</SwayFactor>
+			  </statBases>
+			  <Properties>
+				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>GI_Rockpillar_Marble_Thrown</defaultProjectile>
+				<range>8</range>
+				<warmupTime>1.8</warmupTime>
+				<soundCast>Interact_BeatFire</soundCast>
+				<noiseRadius>4</noiseRadius>
+				<ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+			  </Properties>
+			  <AllowWithRunAndGun>false</AllowWithRunAndGun>
+			  <FireModes />
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Rockpillar_Marble"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>pillar</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>18</power>
+							<cooldownTime>2.93</cooldownTime>
+							<armorPenetrationBlunt>7.25</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!--Ammo-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Jackstones_granite_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Jackstones_granite_Thrown</defName>
+						<label>Jackstones</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Neolithic/GI_Jackstones_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>1.0</drawSize>
+						  <color>(155,145,147)</color>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>RangedBlunt</damageDef>
+							<damageAmountBase>39</damageAmountBase>
+							<speed>4</speed>
+							<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
+							<preExplosionSpawnThingDef>GI_Jackstones_granite</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Jackstones_limestone_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Jackstones_limestone_Thrown</defName>
+						<label>Jackstones</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Neolithic/GI_Jackstones_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>1.0</drawSize>
+						  <color>(208,203,185)</color>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>RangedBlunt</damageDef>
+							<damageAmountBase>39</damageAmountBase>
+							<speed>4</speed>
+							<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
+							<preExplosionSpawnThingDef>GI_Jackstones_granite</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Javelin_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Javelin_Thrown</defName>
+						<label>Javelin</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Neolithic/GI_Javelin_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>2.6</drawSize>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageAmountBase>45</damageAmountBase>
+							<speed>5</speed>
+							<armorPenetrationBlunt>67.5</armorPenetrationBlunt>
+							<armorPenetrationSharp>5</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.50</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
+							<preExplosionSpawnThingDef>GI_Javelin</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Scrapmetal_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Scrapmetal_Thrown</defName>
+						<label>Scrapmetal</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Neolithic/GI_Scrapmetal_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>1.2</drawSize>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<pelletCount>12</pelletCount>
+							<spreadMult>2</spreadMult>
+							<damageAmountBase>12</damageAmountBase>
+							<speed>5</speed>
+							<armorPenetrationBlunt>3.12</armorPenetrationBlunt>
+							<armorPenetrationSharp>2</armorPenetrationSharp>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Rockpillar_granite_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Rockpillar_granite_Thrown</defName>
+						<label>Jackstones</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Medieval/GI_Rockpillar_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>3.2</drawSize>
+						  <color>(155,145,147)</color>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>RangedBlunt</damageDef>
+							<damageAmountBase>57</damageAmountBase>
+							<speed>4</speed>
+							<armorPenetrationBlunt>72</armorPenetrationBlunt>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.25</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
+							<preExplosionSpawnThingDef>GI_Rockpillar_granite</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="GI_Rockpillar_Marble_Thrown"]</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>GI_Rockpillar_Marble_Thrown</defName>
+						<label>Rockpillar</label>
+						<graphicData>
+						  <texPath>Giant/Weapons/Medieval/GI_Rockpillar_Thrown</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						  <drawSize>3.2</drawSize>
+						  <color>(132,135,132)</color>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>RangedBlunt</damageDef>
+							<damageAmountBase>57</damageAmountBase>
+							<speed>4</speed>
+							<armorPenetrationBlunt>72</armorPenetrationBlunt>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.25</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
+							<preExplosionSpawnThingDef>GI_Rockpillar_Marble</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
@@ -73,24 +73,22 @@
 			
 			<!--Giant size prevents use of loadbearing gear, and reasonably, shields.-->
 			
-			<!--Comps at the end because I am 100% sure the basepawn name type is going to change, and putting it here should prevent it from breaking as badly when that happens-->
-			
 			<li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+                    <xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
                     <value>
                         <li>CombatExtended.ITab_Inventory</li>
                     </value>
 			</li>
 
             <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+                    <xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/comps</xpath>
                     <value>
                         <li Class="CombatExtended.CompProperties_Inventory" />
                     </value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+				<xpath>/Defs/ThingDef[@Name="GI_PawnBase"]/comps</xpath>
 				<value>
 					<li>
 					<compClass>CombatExtended.CompPawnGizmo</compClass>

--- a/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
@@ -9,30 +9,6 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 			
-			<li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-                    <value>
-                        <li>CombatExtended.ITab_Inventory</li>
-                    </value>
-			</li>
-
-            <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
-                    <value>
-                        <li Class="CombatExtended.CompProperties_Inventory" />
-                    </value>
-			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
-				<value>
-					<li>
-					<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable" />
-				</value>
-			</li>
-			
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="HC_Giant"]</xpath>
 				<value>
@@ -97,6 +73,31 @@
 			
 			<!--Giant size prevents use of loadbearing gear, and reasonably, shields.-->
 			
+			<!--Comps at the end because I am 100% sure the basepawn name type is going to change, and putting it here should prevent it from breaking as badly when that happens-->
+			
+			<li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+                    <value>
+                        <li>CombatExtended.ITab_Inventory</li>
+                    </value>
+			</li>
+
+            <li Class="PatchOperationAdd">
+                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+                    <value>
+                        <li Class="CombatExtended.CompProperties_Inventory" />
+                    </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+				<value>
+					<li>
+					<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
 		</operations>
 		</match>	
 	  </li>

--- a/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+                    <value>
+                        <li>CombatExtended.ITab_Inventory</li>
+                    </value>
+			</li>
+
+            <li Class="PatchOperationAdd">
+                    <xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+                    <value>
+                        <li Class="CombatExtended.CompProperties_Inventory" />
+                    </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[@Name="RS_PawnBase"]/comps</xpath>
+				<value>
+					<li>
+					<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="HC_Giant"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="HC_Giant"]/statBases</xpath>
+				  <value>
+					<!--Significant size results in ease of powerful strikes and difficulty in parrying their blows-->
+					<MeleeCritChance>1.6</MeleeCritChance>
+					<MeleeParryChance>1.8</MeleeParryChance>
+					<!--Mentally simpler and also generally just less attendant to most small arms shooting them-->
+					<Suppressability>0.5</Suppressability>
+					<SmokeSensitivity>1</SmokeSensitivity>
+				  </value>
+			</li>
+			
+			<!--Very heavy blows-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="HC_Giant"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>19</power>
+							<cooldownTime>2.25</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7.56</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right fist</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>19</power>
+							<cooldownTime>2.25</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>7.56</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>22</power>
+							<cooldownTime>6.66</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>9.045</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!--Giant size prevents use of loadbearing gear, and reasonably, shields.-->
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/AlienRace_Giantlike.xml
@@ -27,6 +27,7 @@
 					<!--Mentally simpler and also generally just less attendant to most small arms shooting them-->
 					<Suppressability>0.5</Suppressability>
 					<SmokeSensitivity>1</SmokeSensitivity>
+					<CarryBulk>25</CarryBulk>
 				  </value>
 			</li>
 			

--- a/Patches/The GiantRace/ThingDefs_Races/Giant_Mammoth.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/Giant_Mammoth.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>The GiantRace</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HC_WoollyMammoth"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>5</MoveSpeed>
+					<MeleeDodgeChance>0.08</MeleeDodgeChance>
+					<MeleeCritChance>0.79</MeleeCritChance>
+					<MeleeParryChance>0.51</MeleeParryChance>
+					<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
+					<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HC_WoollyMammoth"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>67</power>
+							<cooldownTime>3.57</cooldownTime>
+							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>31.226</armorPenetrationBlunt>	
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left foot</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>31</power>
+							<cooldownTime>2.57</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12.960</armorPenetrationBlunt>	
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right foot</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>31</power>
+							<cooldownTime>2.57</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>12.960</armorPenetrationBlunt>	
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>55</power>
+							<cooldownTime>3.99</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>25</armorPenetrationBlunt>	
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="HC_WoollyMammoth"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="HC_WoollyMammoth"]/combatPower</xpath>
+				<value>
+					<combatPower>250</combatPower>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/The GiantRace/ThingDefs_Races/Giant_Mammoth.xml
+++ b/Patches/The GiantRace/ThingDefs_Races/Giant_Mammoth.xml
@@ -16,8 +16,8 @@
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
 					<MeleeCritChance>0.79</MeleeCritChance>
 					<MeleeParryChance>0.51</MeleeParryChance>
-					<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
-					<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
+					<ArmorRating_Blunt>0.325</ArmorRating_Blunt>
+					<ArmorRating_Sharp>0.17</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -153,6 +153,7 @@ Soviet Armory	|
 Spartan Foundry	|
 The Mantodean insectoid race	|
 T-45b Power Armor	|
+The Giantrace	|
 TouhouStyle	|
 Trading Economy	|
 Tsar Armory	|


### PR DESCRIPTION
## Additions

CE patch stuff for 'The GiantRace', for apparel/weapons/races/pawnkinds/scenario.

## Reasoning

Thanks to their generally large size, most of their weapons have significant mass thanks to square cube law, and consequentely, high blunt penetration. This mostly works fine and gears them as a offensively powerful race, but lacking in good ranged or defensive options. The raiders, since they lack consistent armor, are still fairly suppressable despite reduced suppressability, and will still go down to pain from automatic gunfire, even if they can weather some of it, but are a bit like manhunter elephants in that if they get close they can do some significant damage.

## Notes

The 'base' for the racedef shares a name with another and I wager will change in the near future, but I'd ideally like to get this patch in anyway. It should be a very quick fix to resolve afterwards.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
