### PR TITLE
Add Github Actions for automated building of CombatExtended.dll

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,64 @@
+name: Build-PR-test
+
+on:
+  # run in a read-write copy of the target of the PR (CombatExtended-Continued/CombatExtended/Development)
+  pull_request_target: 
+    branches: [ Development ]
+
+jobs:
+  build:
+    # Could use windows with dotnet, but I don't know the tooling.
+    # Also, mono is the less advanced compiler, so if it builds successfully here, it'll work anywhere.
+    runs-on: ubuntu-latest 
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: prepare rebuild
+        run: |
+          # Set up who gets blamed for the added assembly
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+          # Grab the code from the PR, using the version from the PR in case of conflicts.
+          git pull --allow-unrelated-histories -X theirs origin ${{ github.event.pull_request.head.sha }}:
+
+          # Grab the RimWorld reference assemblies from nuget
+          wget https://www.nuget.org/api/v2/package/Krafs.Rimworld.Ref/1.2.2753 -O rwref.zip
+          unzip rwref.zip -d reference
+
+          # We've checked out code from a PR, we can't trust it (it could dump environment variables or otherwise do unapproved things)
+          # So we grab the build script from the trusted repo.  It does mean changes to the build script itself won't get auto-tested,
+          # but that's unavoidable in a PR.
+          wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/Make.py -O - > Make.py
+
+      # It would be better to only create the destination branch once we know the build will succeed, but we have to commit the pull from line 23 or it chokes.
+      - uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: test-branch-${{ github.event.pull_request.head.ref }}-${{ github.run_number }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Make Test Branch
+          branch: test-branch-${{ github.event.pull_request.head.ref }}-${{ github.run_number }}
+          skip_dirty_check: true
+
+      - name: build
+        run: |
+          python3 Make.py --all-libs --reference reference/ref/net472/
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Rebuild Assembly
+          branch: test-branch-${{ github.event.pull_request.head.ref }}-${{ github.run_number }}
+          skip_dirty_check: true
+          file_pattern: ./Assemblies/CombatExtended.dll
+
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            The testing branch for this PR is [test-branch-${{ github.event.pull_request.head.ref }}-${{ github.run_number }}](https://github.com/${{ github.repository }}/tree/test-branch-${{ github.event.pull_request.head.ref }}-${{ github.run_number }})
+          

--- a/.github/workflows/rebuild-development.yml
+++ b/.github/workflows/rebuild-development.yml
@@ -1,0 +1,38 @@
+# This automates rebuilding the assembly in Development
+
+name: Build-Development
+
+on:
+  # Manually or when a commit is pushed to Development.
+  # The commit performed by this script *will not* trigger an additional build (loop)
+  workflow_dispatch:
+  push:
+    branches: [ Development ]
+
+jobs:
+  build_assembly:
+    # Could use windows with dotnet, but I don't know the tooling.
+    # Also, mono is the less advanced compiler, so if it builds successfully here, it'll work anywhere.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        # have to use a personal access token to commit back to Development despite its restricted merging.
+        with:
+          token: ${{ secrets.PAT }}
+      - name: prepare rebuild
+        # unlike in build-pr, we aren't pulling unreviewed code, so we can just use the build script from this branch.
+        run: |
+          # Get the reference assembly from nuget
+          wget https://www.nuget.org/api/v2/package/Krafs.Rimworld.Ref/1.2.2753 -O rwref.zip
+          unzip rwref.zip -d reference
+      - name: build
+        run: python3 Make.py --all-libs --reference reference/ref/net472/
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Rebuild Assembly
+          branch: Development
+          file_pattern: ./Assemblies/CombatExtended.dll
+          # --force to override the restricted merging
+          push_options: '--force'
+      


### PR DESCRIPTION
## Additions

When opening a new PR, a new test branch will be made in CombatExtended-Continued/CombatExtended, where the code from the PR will be checked out and built.  The CombatExtended.dll from the test branch is then committed to the new branch.

After merging a PR into Development, either from another branch of CombatExtended-Continued/CombatExtended, or an external PR, the CombatExtended.dll within Development will be rebuilt.  This ensures the version of CombatExtended.dll in Development always matches the code in Development.

## Changes

Currently, testers check out the source branch of the PR (or check out the pull/<number>/head branch of CombatExtended-Continued/CombatExtended) and run the game to test a PR.  This change would require them to checkout `test-branch-<pr-branch-name>-<run-number>` instead (a link to the correct branch is provided via comment once the build completes).  

PRs which include a modified assembly will still function as they do now (getting rapidly out of date and unmergeable), but should be discouraged.

Finally, the automatic branch creation will "clutter" the repository over time.  Someone will need to periodically go through and delete all the old `test-branch-*` branches.

## Reasoning

Good developer strategy is to make each orthogonal change in its own branch, and issue a separate PR for each one.  This allows proper attention to be paid to each issue, and decreases the odds of an error slipping through.  

The current ad-hoc system causes additional friction, as it prevents simultaneously opened PRs from being sequentially merged.  The merge protections on Development prevent them from being manually merged.  This means that, after the first PR is merged, someone must check out the second PR, pull Development, rebuild the assembly, and commit it.  As that must be done by the person who opened the PR, and the merging must be done by someone with merge permission, the process requires several round-trips.  

Additionally, as a minor consideration, there is no trivial way to verify that the compiled assembly in a PR branch came from the code in that branch.  While we are a reasonably small target, building the assembly in a clean environment precludes someone uploading an infected assembly (intentionally or otherwise).

## Alternatives

#### Continue the current ad-hoc approach
This puts a significant limit on the rate we can handle small PRs (the sort of one-line bug fixes that take more time wrangling `git` than fixing the problem).  Most bugs and mod incompatibilities fall into this category (mostly null values showing up in unexpected places).  

#### Don't auto-rebuild on Development push
This is where I'm less certain how to proceed.  The current proposed rebuild development workflow will require a project member to register a personal access token (a bot account can (and should be) used for this), and to enable forced pushing of protected branches in the project setting (which allows those with write-access to override push restrictions from the command line).  I don't know if that can be restricted to only the bot account, or only project admins (if so, that's probably the best solution).  If not, we'll need to decide if it's worth doing that or not, I don't think we currently have any project members who would abuse that ability, but that doesn't necessarily apply to future members.

As an alternative, the rebuilt assembly could be either provided as a build artifact (and need manual intervention), or pushed to a dedicated "build" branch.  That would be an improvement over the current state, as opening a PR from the build branch to pull the updated assembly would be trivial.  It would, however, require more manual intervention than auto-committing to Development.  It will also effectively double the number of PRs in the project history.  (Avoiding loops is pretty easy, just check if the source branch of the PR is the build branch).  

It's also worth considering if we want to automatically rebuild the assembly on push/commit, or just manually trigger the action.  If we manually trigger it, it won't rebuild on XML-only changes, and can be triggered only once on successive PR merges, which would simplify the git history somewhat.  On the other hand, forgetting to run it could lead to the assembly being out of sync with the source.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (hours)
