### PR TITLE
Basic Fell Tribes Patch

### DIFF
--- a/Patches/Fell Tribes/PawnkindDefs/PawnKinds_Fell.xml
+++ b/Patches/Fell Tribes/PawnkindDefs/PawnKinds_Fell.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Fell Tribes</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Give ammo to bowman ========== -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>
+						/Defs/PawnKindDef[
+							defName="FellFox" or 
+							defName="FellWolf" or 
+							defName="FellLynx" or 
+							defName="FellServal" or
+							defName="FellBear"]
+					</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>12</min>
+								<max>20</max>
+							</primaryMagazineCount>
+						</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>		

--- a/Patches/Fell Tribes/ThingDefs_Races/Bear.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Bear.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- ========== Make sure the mod is there first ========== -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ========== Look for the mod ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Fell Tribes</modName>
+			</li>
+			<!-- ========== Found the mod ========== -->
+
+			<!-- ========== Now patch the basics... ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Bear"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Done! ========== -->
+			<!-- ========== Now for the gun settings and suppression ========== -->
+
+			<li Class="PatchOperationAdd">
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BasePawn === -->
+				<!-- === In which case change "BasePawn" to that name === -->
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch their default melee attacks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Bear"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Bear"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
+	<!-- === If your alien comes with extra guns and gear,	 === -->
+	<!-- === Congratulations! You're not even close to done! === -->
+</Patch>

--- a/Patches/Fell Tribes/ThingDefs_Races/Bear.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Bear.xml
@@ -93,29 +93,6 @@
 					</tools>
 				</value>
 			</li>
-			<!-- ===================================== -->
-			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-			<!-- ===================================== -->
-			<!-- === Adds In Inspector Tabs 	   === -->
-			<!-- === Inventory and all that jazz   === -->
-			<!-- === Again, no need to change 'em  === -->
-			<!-- === Unless you changed it         === -->
-			<!-- === then change 'em			   === -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-				<value>
-					<li>CombatExtended.ITab_Inventory</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_Inventory" />
-				</value>
-			</li>
 		</operations>
 	</Operation>
 

--- a/Patches/Fell Tribes/ThingDefs_Races/Fox.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Fox.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- ========== Make sure the mod is there first ========== -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ========== Look for the mod ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Fell Tribes</modName>
+			</li>
+			<!-- ========== Found the mod ========== -->
+
+			<!-- ========== Now patch the basics... ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Fox"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Done! ========== -->
+			<!-- ========== Now for the gun settings and suppression ========== -->
+
+			<li Class="PatchOperationAdd">
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BasePawn === -->
+				<!-- === In which case change "BasePawn" to that name === -->
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch their default melee attacks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Fox"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Fox"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
+	<!-- === If your alien comes with extra guns and gear,	 === -->
+	<!-- === Congratulations! You're not even close to done! === -->
+</Patch>

--- a/Patches/Fell Tribes/ThingDefs_Races/Fox.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Fox.xml
@@ -93,29 +93,6 @@
 					</tools>
 				</value>
 			</li>
-			<!-- ===================================== -->
-			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-			<!-- ===================================== -->
-			<!-- === Adds In Inspector Tabs 	   === -->
-			<!-- === Inventory and all that jazz   === -->
-			<!-- === Again, no need to change 'em  === -->
-			<!-- === Unless you changed it         === -->
-			<!-- === then change 'em			   === -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-				<value>
-					<li>CombatExtended.ITab_Inventory</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_Inventory" />
-				</value>
-			</li>
 		</operations>
 	</Operation>
 

--- a/Patches/Fell Tribes/ThingDefs_Races/Lynx.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Lynx.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- ========== Make sure the mod is there first ========== -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ========== Look for the mod ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Fell Tribes</modName>
+			</li>
+			<!-- ========== Found the mod ========== -->
+
+			<!-- ========== Now patch the basics... ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Lynx"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Done! ========== -->
+			<!-- ========== Now for the gun settings and suppression ========== -->
+
+			<li Class="PatchOperationAdd">
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BasePawn === -->
+				<!-- === In which case change "BasePawn" to that name === -->
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch their default melee attacks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Lynx"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Lynx"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
+	<!-- === If your alien comes with extra guns and gear,	 === -->
+	<!-- === Congratulations! You're not even close to done! === -->
+</Patch>

--- a/Patches/Fell Tribes/ThingDefs_Races/Lynx.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Lynx.xml
@@ -93,29 +93,6 @@
 					</tools>
 				</value>
 			</li>
-			<!-- ===================================== -->
-			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-			<!-- ===================================== -->
-			<!-- === Adds In Inspector Tabs 	   === -->
-			<!-- === Inventory and all that jazz   === -->
-			<!-- === Again, no need to change 'em  === -->
-			<!-- === Unless you changed it         === -->
-			<!-- === then change 'em			   === -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-				<value>
-					<li>CombatExtended.ITab_Inventory</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_Inventory" />
-				</value>
-			</li>
 		</operations>
 	</Operation>
 

--- a/Patches/Fell Tribes/ThingDefs_Races/Serval.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Serval.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- ========== Make sure the mod is there first ========== -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ========== Look for the mod ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Fell Tribes</modName>
+			</li>
+			<!-- ========== Found the mod ========== -->
+
+			<!-- ========== Now patch the basics... ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Serval"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Done! ========== -->
+			<!-- ========== Now for the gun settings and suppression ========== -->
+
+			<li Class="PatchOperationAdd">
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BasePawn === -->
+				<!-- === In which case change "BasePawn" to that name === -->
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch their default melee attacks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Serval"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Serval"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
+	<!-- === If your alien comes with extra guns and gear,	 === -->
+	<!-- === Congratulations! You're not even close to done! === -->
+</Patch>

--- a/Patches/Fell Tribes/ThingDefs_Races/Serval.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Serval.xml
@@ -93,29 +93,6 @@
 					</tools>
 				</value>
 			</li>
-			<!-- ===================================== -->
-			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-			<!-- ===================================== -->
-			<!-- === Adds In Inspector Tabs 	   === -->
-			<!-- === Inventory and all that jazz   === -->
-			<!-- === Again, no need to change 'em  === -->
-			<!-- === Unless you changed it         === -->
-			<!-- === then change 'em			   === -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-				<value>
-					<li>CombatExtended.ITab_Inventory</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_Inventory" />
-				</value>
-			</li>
 		</operations>
 	</Operation>
 

--- a/Patches/Fell Tribes/ThingDefs_Races/Wolf.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Wolf.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- ========== Make sure the mod is there first ========== -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ========== Look for the mod ========== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Fell Tribes</modName>
+			</li>
+			<!-- ========== Found the mod ========== -->
+
+			<!-- ========== Now patch the basics... ========== -->
+			<li Class="PatchOperationAddModExtension">
+				<!-- === Note to future furball compatibility nerds: 		=== -->
+				<!-- === Paste the defName of your horrible alien there   |	=== -->
+				<!-- === 												  V	=== -->
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Wolf"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Done! ========== -->
+			<!-- ========== Now for the gun settings and suppression ========== -->
+
+			<li Class="PatchOperationAdd">
+				<!-- === Shouldn't need to change this at all		  === -->
+				<!-- === Unless you changed the name of your BasePawn === -->
+				<!-- === In which case change "BasePawn" to that name === -->
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			<!-- === Patch their default melee attacks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Alien_Wolf"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.15</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+					<ReloadSpeed>1</ReloadSpeed>
+					<Suppressability>1</Suppressability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Wolf"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.15</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.462</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.37</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.02</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.923</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<!-- ===================================== -->
+			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
+			<!-- ===================================== -->
+			<!-- === Adds In Inspector Tabs 	   === -->
+			<!-- === Inventory and all that jazz   === -->
+			<!-- === Again, no need to change 'em  === -->
+			<!-- === Unless you changed it         === -->
+			<!-- === then change 'em			   === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
+				<value>
+					<li>CombatExtended.ITab_Inventory</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+
+				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+				<value>
+					<li Class="CombatExtended.CompProperties_Inventory" />
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<!-- === Congratulations! Your alien is Combat Ready!	 === -->
+	<!-- === If your alien comes with extra guns and gear,	 === -->
+	<!-- === Congratulations! You're not even close to done! === -->
+</Patch>

--- a/Patches/Fell Tribes/ThingDefs_Races/Wolf.xml
+++ b/Patches/Fell Tribes/ThingDefs_Races/Wolf.xml
@@ -93,29 +93,6 @@
 					</tools>
 				</value>
 			</li>
-			<!-- ===================================== -->
-			<!-- === BaseBodySize, ArmorRatings, MoveSpeed, and BaseHealth should already be set. I think. === -->
-			<!-- ===================================== -->
-			<!-- === Adds In Inspector Tabs 	   === -->
-			<!-- === Inventory and all that jazz   === -->
-			<!-- === Again, no need to change 'em  === -->
-			<!-- === Unless you changed it         === -->
-			<!-- === then change 'em			   === -->
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-				<value>
-					<li>CombatExtended.ITab_Inventory</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-
-				<xpath>Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
-				<value>
-					<li Class="CombatExtended.CompProperties_Inventory" />
-				</value>
-			</li>
 		</operations>
 	</Operation>
 


### PR DESCRIPTION
## Additions
Adds *very basic* support for [Fell Tribes](https://steamcommunity.com/sharedfiles/filedetails/?id=2243528541) covering pawn types, to enable suppressability/weapon UI functionality/et cetera. Based on the Xenn patch files.

## Testing
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony; current playtest run at 816 ingame days (13.5 years and change) with no issues