### PR TITLE
Revisions to FSX production

### DIFF
--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -50,7 +50,7 @@
 		<li>Thick armour instills courage against small arms fire, but its bulkiness reduces work speed.</li>
 		<li>You can rely on enemies to drop ammunition, or you can craft it yourself at a machining table or a loading bench.</li>
 		<li>Prometheum can be harvested from Blazebulb plants to create power incendiary weapons. But beware, high temperatures will cause them to combust!</li>		
-		<li>Boomalopes can be milked for FSX, a volatile compound used to manufacture various explosives.</li>
+		<li>FSX, a volatile compound used to manufacture various explosives, can be harvested from boomalopes or synthesized from chemfuel.</li>
 		<li>Cold climates benefit are favourable for growing blazebulbs, where less cooling is required to prevent them from combusting.</li>
 		<li>Warm climates benefit are favorable for rearing boomalope and boomrat, which struggle in harsh winter conditions.</li>
 		<li>Prometheum-based flamethrowers and Molotovs will soak their targets and cause even normally non-flammable enemies to burn.</li>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<RecipeDef ParentName="MakeStoneBlocksBase">
+		<defName>Make_FSXFromMeat</defName>
+		<label>Synthesize 10 FSX</label>
+		<description>Synthesize 10 FSX from a mixture of chemfuel and meat.</description>
+		<jobString>Synthesizing FSX</jobString>
+		<ingredients>
+		<li>
+		<filter>
+			<thingDefs>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</filter>
+		<count>10</count>
+		</li>
+		<li>
+			<filter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			</filter>
+			<count>40</count>
+		</li>
+		</ingredients>
+		<fixedIngredientFilter>
+		<thingDefs>
+			<li>Chemfuel</li>		
+		</thingDefs>
+		<categories>
+			<li>MeatRaw</li>
+		</categories>
+		<disallowedThingDefs>
+			<li>Meat_Boomalope</li>		  
+		</disallowedThingDefs>			
+		</fixedIngredientFilter>
+		<workAmount>800</workAmount>
+		<workSkill>Crafting</workSkill>		
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+		<effectWorking>Smith</effectWorking>
+		<soundWorking>Recipe_Drug</soundWorking>
+		<targetCountAdjustment>35</targetCountAdjustment>		
+		<recipeUsers Inherit="false">
+			<li>DrugLab</li>
+		</recipeUsers>		
+		<products>
+			<FSX>10</FSX>
+		</products>
+	</RecipeDef>
+
+	<RecipeDef ParentName="MakeStoneBlocksBase">
+		<defName>Make_FSXFromBoomMeat</defName>
+		<label>Synthesize 10 FSX from boomalope meat</label>
+		<description>Synthesize 10 FSX from the volatile chemicals in boomalope tissue.</description>
+		<jobString>Synthesizing FSX</jobString>
+		<ingredients>
+		<li>
+		<filter>
+			<thingDefs>
+				<li>Meat_Boomalope</li>
+			</thingDefs>
+		</filter>
+		<count>40</count>
+		</li>
+		</ingredients>
+		<fixedIngredientFilter>
+		<thingDefs>
+			<li>Meat_Boomalope</li>		
+		</thingDefs>
+		</fixedIngredientFilter>
+		<workAmount>800</workAmount>
+		<workSkill>Crafting</workSkill>		
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+		<effectWorking>Smith</effectWorking>
+		<soundWorking>Recipe_Drug</soundWorking>
+		<targetCountAdjustment>35</targetCountAdjustment>		
+		<recipeUsers Inherit="false">
+			<li>DrugLab</li>
+		</recipeUsers>		
+		<products>
+			<FSX>10</FSX>
+		</products>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -30,7 +30,7 @@
 			<li>DrugLab</li>
 		</recipeUsers>		
 		<products>
-			<FSX>10</FSX>
+			<FSX>7</FSX>
 		</products>
 	</RecipeDef>
 
@@ -46,7 +46,7 @@
 				<li>Chemfuel</li>
 			</thingDefs>
 		</filter>
-		<count>80</count>
+		<count>100</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -54,7 +54,7 @@
 			<li>Chemfuel</li>		
 		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>800</workAmount>
+		<workAmount>850</workAmount>
 		<workSkill>Crafting</workSkill>		
 		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
@@ -63,7 +63,7 @@
 			<li>BiofuelRefinery</li>
 		</recipeUsers>		
 		<products>
-			<FSX>10</FSX>
+			<FSX>8</FSX>
 		</products>
 	</RecipeDef>
 

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -4,7 +4,7 @@
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>Make_FSXDrugLab</defName>
 		<label>Synthesize 10 FSX</label>
-		<description>Synthesize 10 FSX from chemfuel using simple chemistry equipment.</description>
+		<description>Synthesize 10 FSX from chemfuel using chemistry equipment.</description>
 		<jobString>Synthesizing FSX</jobString>
 		<ingredients>
 		<li>
@@ -22,13 +22,16 @@
 		</thingDefs>		
 		</fixedIngredientFilter>
 		<workAmount>1000</workAmount>
-		<workSkill>Crafting</workSkill>		
+		<workSkill>Intellectual</workSkill>		
 		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
-		<effectWorking>Smith</effectWorking>
+		<effectWorking>Cook</effectWorking>
 		<soundWorking>Recipe_Drug</soundWorking>	
 		<recipeUsers Inherit="false">
 			<li>DrugLab</li>
-		</recipeUsers>		
+		</recipeUsers>	
+		<skillRequirements>
+			<Intellectual>4</Intellectual>
+		</skillRequirements>	
 		<products>
 			<FSX>7</FSX>
 		</products>
@@ -37,7 +40,7 @@
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>Make_FSXRefinery</defName>
 		<label>Synthesize 10 FSX</label>
-		<description>Synthesize 10 FSX from chemfuel using the biofuel refinery's more efficient systems.</description>
+		<description>Use the refinery to synthesize 10 FSX from chemfuel.</description>
 		<jobString>Synthesizing FSX</jobString>
 		<ingredients>
 		<li>
@@ -54,11 +57,11 @@
 			<li>Chemfuel</li>		
 		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>850</workAmount>
+		<workAmount>800</workAmount>
 		<workSkill>Crafting</workSkill>		
-		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
-		<effectWorking>Smith</effectWorking>
-		<soundWorking>Recipe_Drug</soundWorking>	
+    	<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Cremate</soundWorking>	
 		<recipeUsers Inherit="false">
 			<li>BiofuelRefinery</li>
 		</recipeUsers>		

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -2,9 +2,9 @@
 <Defs>
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
-		<defName>Make_FSXFromMeat</defName>
+		<defName>Make_FSXDrugLab</defName>
 		<label>Synthesize 10 FSX</label>
-		<description>Synthesize 10 FSX from a mixture of chemfuel and meat.</description>
+		<description>Synthesize 10 FSX from chemfuel using simple chemistry equipment.</description>
 		<jobString>Synthesizing FSX</jobString>
 		<ingredients>
 		<li>
@@ -13,34 +13,19 @@
 				<li>Chemfuel</li>
 			</thingDefs>
 		</filter>
-		<count>10</count>
-		</li>
-		<li>
-			<filter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-			</filter>
-			<count>40</count>
+		<count>100</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
 		<thingDefs>
 			<li>Chemfuel</li>		
-		</thingDefs>
-		<categories>
-			<li>MeatRaw</li>
-		</categories>
-		<disallowedThingDefs>
-			<li>Meat_Boomalope</li>		  
-		</disallowedThingDefs>			
+		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>800</workAmount>
+		<workAmount>1000</workAmount>
 		<workSkill>Crafting</workSkill>		
 		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
-		<soundWorking>Recipe_Drug</soundWorking>
-		<targetCountAdjustment>35</targetCountAdjustment>		
+		<soundWorking>Recipe_Drug</soundWorking>	
 		<recipeUsers Inherit="false">
 			<li>DrugLab</li>
 		</recipeUsers>		
@@ -50,37 +35,37 @@
 	</RecipeDef>
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
-		<defName>Make_FSXFromBoomMeat</defName>
-		<label>Synthesize 10 FSX from boomalope meat</label>
-		<description>Synthesize 10 FSX from the volatile chemicals in boomalope tissue.</description>
+		<defName>Make_FSXRefinery</defName>
+		<label>Synthesize 10 FSX</label>
+		<description>Synthesize 10 FSX from chemfuel using the biofuel refinery's more efficient systems.</description>
 		<jobString>Synthesizing FSX</jobString>
 		<ingredients>
 		<li>
 		<filter>
 			<thingDefs>
-				<li>Meat_Boomalope</li>
+				<li>Chemfuel</li>
 			</thingDefs>
 		</filter>
-		<count>40</count>
+		<count>80</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
 		<thingDefs>
-			<li>Meat_Boomalope</li>		
-		</thingDefs>
+			<li>Chemfuel</li>		
+		</thingDefs>		
 		</fixedIngredientFilter>
 		<workAmount>800</workAmount>
 		<workSkill>Crafting</workSkill>		
 		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
-		<soundWorking>Recipe_Drug</soundWorking>
-		<targetCountAdjustment>35</targetCountAdjustment>		
+		<soundWorking>Recipe_Drug</soundWorking>	
 		<recipeUsers Inherit="false">
-			<li>DrugLab</li>
+			<li>BiofuelRefinery</li>
 		</recipeUsers>		
 		<products>
 			<FSX>10</FSX>
 		</products>
 	</RecipeDef>
+
 
 </Defs>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -447,20 +447,19 @@
 			</li>
 		</operations>
 	</Operation>
-<!--
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Boomrat"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ShearableRenameable">
 				<compClass>CombatExtended.CompShearableRenameable</compClass>
-				<growthLabel>Chemical fullness</growthLabel>
+				<growthLabel>Secretion level</growthLabel>
 				<shearIntervalDays>3</shearIntervalDays>
 				<woolAmount>1</woolAmount>
 				<woolDef>FSX</woolDef>
 			</li>
 		</value>
 	</Operation>
--->
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Boomrat"]</xpath>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -447,7 +447,7 @@
 			</li>
 		</operations>
 	</Operation>
-
+<!--
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Boomrat"]/comps</xpath>
 		<value>
@@ -458,6 +458,16 @@
 				<woolAmount>1</woolAmount>
 				<woolDef>FSX</woolDef>
 			</li>
+		</value>
+	</Operation>
+-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Boomrat"]</xpath>
+		<value>
+			<butcherProducts>
+			<FSX>2</FSX>
+			</butcherProducts>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -194,26 +194,26 @@
 			</tools>
 		</value>
 	</Operation>
-<!--
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Boomalope"]/comps/li[@Class="CompProperties_Milkable"]</xpath>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Boomalope"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ShearableRenameable">
-			  <compClass>CombatExtended.CompShearableRenameable</compClass>
-			  <growthLabel>Chemical fullness</growthLabel>
-			  <shearIntervalDays>10</shearIntervalDays>
-			  <woolAmount>10</woolAmount>
-			  <woolDef>FSX</woolDef>
+				<compClass>CombatExtended.CompShearableRenameable</compClass>
+				<growthLabel>Secretion level</growthLabel>
+				<shearIntervalDays>10</shearIntervalDays>
+				<woolAmount>10</woolAmount>
+				<woolDef>FSX</woolDef>
 			</li>
 		</value>
 	</Operation>
--->
+
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Boomalope"]</xpath>
 		<value>
 			<butcherProducts>
-			<FSX>6</FSX>
+			<FSX>14</FSX>
 			</butcherProducts>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -213,7 +213,7 @@
 		<xpath>Defs/ThingDef[defName="Boomalope"]</xpath>
 		<value>
 			<butcherProducts>
-			<FSX>10</FSX>
+			<FSX>6</FSX>
 			</butcherProducts>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -194,7 +194,7 @@
 			</tools>
 		</value>
 	</Operation>
-
+<!--
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Boomalope"]/comps/li[@Class="CompProperties_Milkable"]</xpath>
 		<value>
@@ -205,6 +205,16 @@
 			  <woolAmount>10</woolAmount>
 			  <woolDef>FSX</woolDef>
 			</li>
+		</value>
+	</Operation>
+-->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Boomalope"]</xpath>
+		<value>
+			<butcherProducts>
+			<FSX>10</FSX>
+			</butcherProducts>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
For balancing discussion.

## Additions

- Boomalopes/Boomrats now yield some FSX when butchered.
- Using a drug lab, FSX can be made from chemfuel and meat or from boomalope meat.

## Changes

- Boomalopes and Boomrats are once again milked for chemfuel, rather than FSX.

## Reasoning

The current system replaces milking boomalopes/boomrats for chemfuel with milking them for FSX, which is a fairly significnat departure from vanilla and can be disruptive for players who need a steady supply of chemfuel, requiring them to invest in researching a refinery.

This revision restores milking for chemfuel, and introduces two new approaches to obtaining FSX:
1. Butchering a boomalope or boomrat now yields some FSX (10 and 2, respectively). This should mean hunting them would generally be sufficient to keep a tribal colony supplied for their modest FSX needs.
2. FSX can now also be crafted at a drug lab by combining chemfuel and meat or from just distilling boomalope meat. Essentially, chemistry logic is that the meat (really just the fat) is rendered to produce glycerol (an explosive precursor) and then combined with the chemfuel to produce FSX. For the boomalope meat, the tissue just has enough of the FSX left in it that it can be processed further to collect it.

Alternatively, FSX could be distilled directly from chemfuel, cutting out the "meat," if we feel that is more gameplay friendly.