### PR TITLE
SoS2 XML patch update

### DIFF
--- a/Patches/Save Our Ship 2/Hediffs_SOS2.xml
+++ b/Patches/Save Our Ship 2/Hediffs_SOS2.xml
@@ -25,6 +25,22 @@
 				</statOffsets>
 			</value>
 		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoSArchotechSkin"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoSArchotechSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+					<ArmorRating_Electric>0.4</ArmorRating_Electric>
+			</value>
+		</li>
 	</operations>
 	</match>
 	</li>

--- a/Patches/Save Our Ship 2/Weapons_Grenades.xml
+++ b/Patches/Save Our Ship 2/Weapons_Grenades.xml
@@ -136,7 +136,6 @@
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
 		</Properties>
 		<weaponTags>
-			<li>CE_AI_Grenade</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</li>


### PR DESCRIPTION
## Additions

Patch armor for archeotech skin implant

## Changes

Remove CE_AI_Grenade tag from the mechanite cocktail, preventing your first grenadier raider from inflicting a grey goo scenario on your map. The tag wasn't intended to be there, I just missed removing it when first doing the patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
