### PR TITLE
Updates to android tiers patch

### DIFF
--- a/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
+++ b/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
@@ -8,6 +8,49 @@
     </mods>
 	<match Class="PatchOperationSequence">
 		<operations>
+		
+		
+		<!--Hydraulics-->
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/HediffDef[defName="HydraulicArm"]/stages/li/statOffsets</xpath>
+			<value>
+				<CarryWeight>2.5</CarryWeight>
+				<CarryBulk>5</CarryBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/HediffDef[defName="HydraulicLeg"]/stages/li/statOffsets</xpath>
+			<value>
+				<CarryWeight>25</CarryWeight>
+				<MoveSpeed>-0.25</MoveSpeed>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="HydraulicLeg"]/addedPartProps/partEfficiency</xpath>
+			<value>
+				<partEfficiency>0.80</partEfficiency>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/HediffDef[defName="HydraulicFrame"]/stages/li/statOffsets</xpath>
+			<value>
+				<CarryWeight>15</CarryWeight>
+				<CarryBulk>30</CarryBulk>
+				<MoveSpeed>-0.75</MoveSpeed>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="HydraulicFrame"]/stages/li/capMods/li[capacity="Moving"]/offset</xpath>
+			<value>
+				<offset>-0.10</offset>
+			</value>
+		</li>
+		
 		<!--Arms-->
 		
 		<li Class="PatchOperationReplace">
@@ -218,6 +261,7 @@
 			<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 					<ArmorRating_Heat>0.1</ArmorRating_Heat>
+					<ArmorRating_Electric>0.1</ArmorRating_Electric>
 			</value>
 		</li>
 		

--- a/Patches/Android Tiers/Hediffs/Hediffs_CustomImplants.xml
+++ b/Patches/Android Tiers/Hediffs/Hediffs_CustomImplants.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
+    </mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="Backstory_PitFighterUpgrade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.19</cooldownTime>
+					<armorPenetrationSharp>1.6</armorPenetrationSharp>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="Backstory_TranscendantAssimilatorUpgrade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>75</power>
+					<cooldownTime>2.13</cooldownTime>
+					<armorPenetrationSharp>66.67</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+				</li>
+				</tools>
+			</value>
+		</li>
+		
+		</operations>
+	</match>
+	</Operation>
+</Patch>
+

--- a/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
+++ b/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
@@ -323,19 +323,19 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>AntiMechRifle</defName>
 				<statBases>
-					<SightsEfficiency>2.12</SightsEfficiency>
+					<SightsEfficiency>1.80</SightsEfficiency>
 					<ShotSpread>0.01</ShotSpread>
 					<SwayFactor>2.82</SwayFactor>
 					<Bulk>16</Bulk>
 					<Mass>12</Mass>
-					<RangedWeapon_Cooldown>1.16</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
 				</statBases>
 				
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-					<warmupTime>1.2</warmupTime>
+					<warmupTime>2.1</warmupTime>
 					<range>65</range>
 					<soundCast>SharpThrower</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -454,7 +454,7 @@
 						  <li>Blunt</li>
 						</capacities>
 						<power>45</power>
-						<cooldownTime>1.44</cooldownTime>
+						<cooldownTime>2.5</cooldownTime>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>20.00</armorPenetrationBlunt>
 					  </li>
@@ -465,7 +465,7 @@
 						  <li>Blunt</li>
 						</capacities>
 						<power>45</power>
-						<cooldownTime>1.44</cooldownTime>
+						<cooldownTime>2.5</cooldownTime>
 						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>20.00</armorPenetrationBlunt>
 					  </li>
@@ -491,6 +491,7 @@
 					<MeleeCritChance>1.25</MeleeCritChance>
 					<MeleeParryChance>1.25</MeleeParryChance>
 					<SmokeSensitivity>0</SmokeSensitivity>
+					<CarryBulk>40</CarryBulk>
 				  </value>
 				</li>
 				<!--150% Power Armor : brings it more in line with centipede armor rating ratio-->


### PR DESCRIPTION
## Additions

Add patches for new backstory specific implant weapons.
Fix hydralic parts to provide boosts to bulk/mass. Since their default state made this largely impossible, some of the part efficenciy decreases were instead converted to movespeed penalties.

## Changes

Tweaked the anti-mech rifle's firing cycle.
Lowered the base T5 arm attack speed.
Increased M7 mech's carry bulk to allow it to carry addtional reloads for the weapon (though still fairly limited, since the ammo is quite high bulk)

While I haven't done it here, I'd like to consider reducing the pellet count on the M7 mech's buckshot weapon, as 200 pellets with the average power of a battle rifle round is not only significantly better than every other mech weapon and hideously effective against everything else in the game due to raw damage values (it can shoot a straight line of three centipedes and kill the first two reliably while heavily damaging the third), inculding hardened targets, but also causes an noticable lag spike each time the massive swarm of pellets hits something

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
