### PR TITLE
Rabbie the moonrabbit update

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -24,5 +24,6 @@
 		<li>brrainz.harmony</li>
 		<li>Ludeon.RimWorld</li>
 		<li>Ludeon.RimWorld.Royalty</li>
+		<li>RunneLatki.RabbieRaceMod</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
@@ -88,6 +88,13 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Shell_HighExplosive"]/equippedAngleOffset</xpath>
+				<value>
+					<equippedAngleOffset>45</equippedAngleOffset>	
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Shell_HighExplosive"]/tools</xpath>
 				<value>
 				  <tools>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
@@ -47,6 +47,35 @@
 				
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RB_F_PDW"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+					  <label>grip</label>
+					  <capacities>
+						<li>Blunt</li>
+					  </capacities>
+					  <power>2</power>
+					  <cooldownTime>1.54</cooldownTime>
+					  <chanceFactor>1.5</chanceFactor>
+					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					  <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+					  <label>muzzle</label>
+					  <capacities>
+						<li>Poke</li>
+					  </capacities>
+					  <power>2</power>
+					  <cooldownTime>1.54</cooldownTime>
+					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					  <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+				  </tools>
+				</value>
+			</li>
+			
 			<!-- Mortar Changes added by mod require the following -->
 			
 			<li Class="PatchOperationAdd">
@@ -80,7 +109,6 @@
 					  <power>2</power>
 					  <cooldownTime>1.54</cooldownTime>
 					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					  <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 					</li>
 				  </tools>
 				</value>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/Weapons_Guns.xml
@@ -47,12 +47,23 @@
 				
 			</li>
 			
+			<!-- Mortar Changes added by mod require the following -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Shell_HighExplosive"]/statBases</xpath>
+				<value>
+					<SightsEfficiency>0.45</SightsEfficiency>
+					<ShotSpread>1.5</ShotSpread>
+					<SwayFactor>2.5</SwayFactor>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RB_F_PDW"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="Shell_HighExplosive"]/tools</xpath>
 				<value>
 				  <tools>
 					<li Class="CombatExtended.ToolCE">
-					  <label>grip</label>
+					  <label>Shell</label>
 					  <capacities>
 						<li>Blunt</li>
 					  </capacities>
@@ -60,10 +71,9 @@
 					  <cooldownTime>1.54</cooldownTime>
 					  <chanceFactor>1.5</chanceFactor>
 					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-					  <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 					</li>
 					<li Class="CombatExtended.ToolCE">
-					  <label>muzzle</label>
+					  <label>neck</label>
 					  <capacities>
 						<li>Poke</li>
 					  </capacities>
@@ -74,6 +84,86 @@
 					</li>
 				  </tools>
 				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Shell_HighExplosive"]/verbs/li[verbClass="Verb_ShootOneUse"]</xpath>
+				<value>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Throw_81mmMortarShell_HE</defaultProjectile>
+					<warmupTime>2.5</warmupTime>
+					<range>7</range>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</li>
+				</value>
+			</li>
+			
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/RecipeDef[defName="MakeShell_HighExplosive"]</xpath>
+				<value>
+					<recipeUsers>
+						<li>TableMachining</li>
+					</recipeUsers>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				  <ThingDef ParentName="Base81mmMortarShell">
+					<defName>Throw_81mmMortarShell_HE</defName>
+					<label>81mm mortar shell (HE)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/HE</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>5</speed>
+					  <damageDef>Bomb</damageDef>
+					  <damageAmountBase>156</damageAmountBase>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <explosionRadius>2.5</explosionRadius>
+					  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+					  <soundImpactAnticipate/>
+					  <soundAmbient/>
+					  <flyOverhead>false</flyOverhead>
+					  <dropsCasings>false</dropsCasings>
+					  <soundExplode>MortarBomb_Explode</soundExplode>
+					  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					  <ai_IsIncendiary>true</ai_IsIncendiary>
+					  <gravityFactor>2</gravityFactor>
+					</projectile>
+					<comps>
+					  <li Class="CombatExtended.CompProperties_Fragments">
+						<fragments>
+							<Fragment_Large>16</Fragment_Large>
+							<Fragment_Small>100</Fragment_Small>
+						</fragments>
+					  </li>
+					</comps>
+				  </ThingDef>
+				</value>
+			</li>
+			
+			<!--Add large machining table for VFE:Production -->
+			
+			<li Class="PatchOperationFindMod">
+				<mods>
+				  <li>Vanilla Furniture Expanded - Production</li>
+				</mods>
+				<match Class="PatchOperationAdd">
+					<xpath>Defs/RecipeDef[defName="MakeShell_HighExplosive"]/recipeUsers</xpath>
+					<value>
+						<li>VFE_TableMachiningLarge</li>
+					</value>
+				</match>
 			</li>
 			
 			</operations>


### PR DESCRIPTION
## Additions

Add patch stuff to the mortar shell since the mod now alllows them to be throwable or something, as per the base mod's changes.

## Changes

Added a load requirement to load the mod after the moonrabbit mod to avoid errors.

## Reasoning

It seems that adding tools to a ammo item breaks the ammo injector or something, causing the shell to still be able to spawn, but not have its recipe properly show up anywhere. Manually re-adding the recipe to the tables seems to fix the issue without any other problems emerging.

The load requirement was added both to avoid another error (the base mod attempting to patch the minigun's weapon tags) as well as to make the patches here fire properly (otherwise it's possible the patches will break since the mortar shell changes in the base mod are implemented as patches)

## Alternatives

It may be possible to change the ammo injector to make it no longer needed to manually re-add the workstations to the recipemaker for the shells. I don't know if there's any way to work around the load order requirement.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
