### PR TITLE
Tweaks to Moyo Patch

### DIFF
--- a/Patches/Moyo from the depth/Drugs/Belial-V_Effect.xml
+++ b/Patches/Moyo from the depth/Drugs/Belial-V_Effect.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Moyo-From the depth</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_4"]/stages/li[1]/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_4"]/stages/li[1]/statOffsets/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_4U"]/stages/li[1]/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_4U"]/stages/li[1]/statOffsets/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_5"]/stages/li[1]/statOffsets</xpath>
+				<value>
+					<Suppressability>-0.25</Suppressability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_7"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
+					<AimingAccuracy>0.15</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BelialVEffect_7U"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.6</ShootingAccuracyPawn>
+					<AimingAccuracy>0.3</AimingAccuracy>
+				</value>
+			</li>
+	
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Moyo from the depth/PawnKindDefs/Moyo_PawnKind.xml
+++ b/Patches/Moyo from the depth/PawnKindDefs/Moyo_PawnKind.xml
@@ -71,7 +71,10 @@
 				@Name="MoyoSoldierAssult" or
 				@Name="MoyoGuardian" or
 				@Name="MoyoGuardianAssault" or
-				@Name="MoyoGeneral"
+				@Name="MoyoGeneral" or
+				defName="Moyo_Engineer" or
+				defName="Moyo_Resercher" or
+				defName="Moyo_MiddleSmuggler"
 				]/apparelRequired</xpath>
 				<value>
 					<li>Apparel_Backpack</li>
@@ -89,46 +92,6 @@
 				<xpath>Defs/ThingDef[defName="Apparel_TribalBackpack"]/apparel/tags</xpath>
 				<value>
 					<li>Moyo_Neolithic</li>
-				</value>
-			</li>
-			
-			<!--Point Adjustments-->
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="MoyoSoldierLight"]/combatPower</xpath>
-				<value>
-					<combatPower>190</combatPower>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="MoyoSoliderStandard"]/combatPower</xpath>
-				<value>
-					<combatPower>220</combatPower>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="MoyoSoldierHeavy"]/combatPower</xpath>
-				<value>
-					<combatPower>220</combatPower>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="MoyoSoldierAssult"]/combatPower</xpath>
-				<value>
-					<combatPower>225</combatPower>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[
-				@Name="MoyoGuardian" or 
-				@Name="MoyoGuardianAssault" or 
-				@Name="MoyoGeneral"]/combatPower</xpath>
-				<value>
-					<combatPower>320</combatPower>
 				</value>
 			</li>
 			

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -25,7 +25,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_SnB"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3.25</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -229,7 +229,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_Evasuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+					<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
 					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
@@ -269,7 +269,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					<ArmorRating_Electric>0.60</ArmorRating_Electric>
 				</value>
 			</li>


### PR DESCRIPTION
## Changes

Reduced the armor rating on a few items by a small amount.
Removed the point cost changes, since the pawns have new point costs in the base mod that are almost identical to what I was going to bump them up to anyway.
Added forced backpack on a few more pawndefs
Added Belial V patching

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
