### PR TITLE
Update Rimsenal Melee Stats

### DIFF
--- a/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
@@ -211,7 +211,7 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>25</power>
-							<cooldownTime>5.4</cooldownTime>
+							<cooldownTime>3.2</cooldownTime>
 							<armorPenetrationBlunt>50</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 						</li>
@@ -239,43 +239,35 @@
 				</value>
 			</li>
 
-			<!-- TE - Survival Knife -->			
+			<!-- TE - Impact Knuckle -->			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="TE_Eris"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<label>handle</label>
+							<label>knuckle</label>
 							<capacities>
-								<li>Poke</li>
+								<li>Blunt</li>
 							</capacities>
-							<power>1</power>
-							<cooldownTime>1.26</cooldownTime>
-							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							<power>8</power>
+							<cooldownTime>1.25</cooldownTime>
+							<armorPenetrationBlunt>35</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<label>blade</label>
+							<label>discharger</label>
 							<capacities>
-								<li>Cut</li>
+								<li>Blunt</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>1.18</cooldownTime>
-							<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.32</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>point</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>11</power>
-							<cooldownTime>1.26</cooldownTime>
-							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.42</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							<power>8</power>
+							<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>4</amount>
+								<chance>0.5</chance>
+							</li>
+							</extraMeleeDamages>
+							<cooldownTime>1.75</cooldownTime>
+							<armorPenetrationBlunt>60</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -288,11 +280,13 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="TE_Eris"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="TE_Eris"]</xpath>
 				<value>
+					<equippedStatOffsets>
 					<MeleeCritChance>0.5</MeleeCritChance>
 					<MeleeParryChance>0.15</MeleeParryChance>
-					<MeleeDodgeChance>0.05</MeleeDodgeChance>	
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					</equippedStatOffsets>
 				</value>
 			</li>		
 			<li Class="PatchOperationAdd">


### PR DESCRIPTION

## Changes

Updated TE melee to fix errors and match new vanilla weapon specs.
Reduced the cooldown on JI hammer weapon.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
