### PR TITLE
Add just the rebuild-development workflow from #347

### DIFF
--- a/.github/workflows/rebuild-development.yml
+++ b/.github/workflows/rebuild-development.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build-Development
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the test-gh-actions branch
+on:
+  workflow_dispatch:
+  push:
+    branches: [ Development ]
+    paths: Source/**
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+      - name: prepare rebuild
+        run: |
+          wget https://www.nuget.org/api/v2/package/Krafs.Rimworld.Ref/1.2.2753 -O rwref.zip
+          unzip rwref.zip -d reference
+      - name: build
+        run: python3 Make.py --all-libs --reference reference/ref/net472/
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Rebuild Assembly
+          branch: Development
+          file_pattern: ./Assemblies/CombatExtended.dll
+          push_options: '--force'
+      

--- a/.github/workflows/rebuild-development.yml
+++ b/.github/workflows/rebuild-development.yml
@@ -34,5 +34,4 @@ jobs:
           commit_message: Rebuild Assembly
           branch: Development
           file_pattern: ./Assemblies/CombatExtended.dll
-          push_options: '--force'
       


### PR DESCRIPTION
## Additions

This workflow makes merging changes to `Source/**` trigger an automatic rebuild of the main assembly.

## References

#347 

## Reasoning

This half of #347 can be used stand-alone.  The other half requires this half.  While there's still some debate about the merits of the other half (and some interest in finding an alternative to it), any alternative is *likely* to need this regardless.

This would be useful for PRs like #375, which need the assembly rebuilt before merging.  

## Testing

Check tests you have performed:
- [X] Compiles without warnings (in the CombatExtended-Continued/CombatExtended/Workflow branch)