### PR TITLE
Added ammo to rh coalition vendors

### DIFF
--- a/Patches/Red Horse Faction Coalition/RH_Coaliton_CE_Patch_TraderKinds.xml
+++ b/Patches/Red Horse Faction Coalition/RH_Coaliton_CE_Patch_TraderKinds.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[RH] Faction: Coalition</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="RHBase_Coalition_Standard" or defName="RHVisitor_Coalition_Standard"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_Ammo</tradeTag>
+							<countRange>
+								<min>400</min>
+								<max>800</max>
+							</countRange>
+							<thingDefCountRange>
+								<min>3</min>
+								<max>8</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Category">
+							<categoryDef>Ammo</categoryDef>
+							<thingDefCountRange>
+								<min>0</min>
+								<max>0</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="RHCaravan_Coalition_MilitiaSupplier"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_Ammo</tradeTag>
+							<countRange>
+								<min>500</min>
+								<max>1000</max>
+							</countRange>
+							<thingDefCountRange>
+								<min>5</min>
+								<max>10</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Category">
+							<categoryDef>Ammo</categoryDef>
+							<thingDefCountRange>
+								<min>0</min>
+								<max>0</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
- Added new TraderKinds.xml

## Reasoning
- Custom RH faction vendors don't seem to carry any ammo for sale. This XML addition simply allows them to sell random ammos as based on the config. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (5+hrs)
