### PR TITLE
Updates for Vanilla Armor Expanded and SYR Thrumkin patches.

### DIFF
--- a/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
@@ -1,249 +1,247 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<!-- Thrumkin bodyDef -->
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Checking for the mod -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>[SYR] Thrumkin</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Thrumkin</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Let's teach them which is which arm -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
+					<value>
+						<li>LeftArm</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
+					<value>
+						<li>RightArm</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "left shoulder"]/groups</xpath>
+					<value>
+						<li>LeftShoulder</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "right shoulder"]/groups</xpath>
+					<value>
+						<li>RightShoulder</li>
+					</value>
+				</li>
 
-			<!-- Let's teach them which is which arm -->
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
-				<value>
-					<li>LeftArm</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
-				<value>
-					<li>RightArm</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "left shoulder"]/groups</xpath>
-				<value>
-					<li>LeftShoulder</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[customLabel = "right shoulder"]/groups</xpath>
-				<value>
-					<li>RightShoulder</li>
-				</value>
-			</li>
+				<!-- Changing coverage of the bodyDef (should've done this sooner, but eh) -->
+				<!-- why yes dear explorer of this file, i did just literally copy and paste the Thrumkin_Body bodytype patches -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
+					<value>
+						<coverage>0.012</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
+					<value>
+						<coverage>0.05</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
+					<value>
+						<coverage>0.05</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Heart"]/coverage</xpath>
+					<value>
+						<coverage>0.04</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Lung"]/coverage</xpath>
+					<value>
+						<coverage>0.055</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
+					<value>
+						<coverage>0.03</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Liver"]/coverage</xpath>
+					<value>
+						<coverage>0.06</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/coverage</xpath>
+					<value>
+						<coverage>0.055</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
+					<value>
+						<coverage>0.9</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
+					<value>
+						<coverage>0.05</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
+					<value>
+						<coverage>0.05</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
+					<value>
+						<coverage>0.08</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
+					<value>
+						<coverage>0.085</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
+					<value>
+						<coverage>0.06</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
+					<value>
+						<coverage>0.15</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
+					<value>
+						<coverage>0.15</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/coverage</xpath>
+					<value>
+						<coverage>0.1</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
+					<value>
+						<coverage>0.15</coverage>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
+					<value>
+						<coverage>0.15</coverage>
+					</value>
+				</li>
 
-			<!-- Changing coverage of the bodyDef (should've done this sooner, but eh) -->
-			<!-- why yes dear explorer of this file, i did just literally copy and paste the Thrumkin_Body bodytype patches -->
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
-				<value>
-					<coverage>0.012</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
-				<value>
-					<coverage>0.05</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
-				<value>
-					<coverage>0.05</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Heart"]/coverage</xpath>
-				<value>
-					<coverage>0.04</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Lung"]/coverage</xpath>
-				<value>
-					<coverage>0.055</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
-				<value>
-					<coverage>0.03</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Liver"]/coverage</xpath>
-				<value>
-					<coverage>0.06</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/coverage</xpath>
-				<value>
-					<coverage>0.055</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
-				<value>
-					<coverage>0.9</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
-				<value>
-					<coverage>0.05</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
-				<value>
-					<coverage>0.05</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
-				<value>
-					<coverage>0.08</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
-				<value>
-					<coverage>0.085</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
-				<value>
-					<coverage>0.06</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
-				<value>
-					<coverage>0.15</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
-				<value>
-					<coverage>0.15</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-				<value>
-					<coverage>0.1</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
-				<value>
-					<coverage>0.15</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
-				<value>
-					<coverage>0.15</coverage>
-				</value>
-			</li>
-
-			<!-- Adding natural armor coverage -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Tail"]</xpath>
-				<value>
-					<groups>
+				<!-- Adding natural armor coverage -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/groups</xpath>
+					<value>
 						<li>CoveredByNaturalArmor</li>
-					</groups>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]</xpath>
-				<value>
-					<groups>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Tail"]</xpath>
+					<value>
+						<groups>
+							<li>CoveredByNaturalArmor</li>
+						</groups>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/groups</xpath>
+					<value>
 						<li>CoveredByNaturalArmor</li>
-					</groups>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="HornThrumkin"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/groups</xpath>
-				<value>
-					<li>CoveredByNaturalArmor</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
-				<value>
-					<groups>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+					<value>
 						<li>CoveredByNaturalArmor</li>
-						<li>Feet</li>
-					</groups>
-				</value>
-			</li>
-		</operations>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]</xpath>
+					<value>
+						<groups>
+							<li>CoveredByNaturalArmor</li>
+						</groups>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="HornThrumkin"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
+					<value>
+						<groups>
+							<li>CoveredByNaturalArmor</li>
+							<li>Feet</li>
+						</groups>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Thrumkin/Patch_ImplantsProsthetics_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_ImplantsProsthetics_Thrumkin.xml
@@ -1,71 +1,69 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<!-- Thrumkin Prosthetics -->
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Checking for the mod -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>[SYR] Thrumkin</modName>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Thrumkin</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- SteelThrumkinHorn -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="SteelThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>steel horn</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>23</power>
+								<cooldownTime>2.6</cooldownTime>
+								<armorPenetrationSharp>0.06</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.332</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>steel horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>16</power>
+								<cooldownTime>3.12</cooldownTime>
+								<armorPenetrationSharp>0.42</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
 
-			<!-- SteelThrumkinHorn -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/HediffDef[defName="SteelThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>steel horn</label>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<power>23</power>
-							<cooldownTime>2.6</cooldownTime>
-							<armorPenetrationSharp>0.06</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.332</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>steel horn</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>16</power>
-							<cooldownTime>3.12</cooldownTime>
-							<armorPenetrationSharp>0.42</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-
-			<!-- EnhancementThrumkinHorn -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/HediffDef[defName="EnhancementThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>enhanced horn</label>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<power>53</power>
-							<cooldownTime>1.15</cooldownTime>
-							<armorPenetrationSharp>0.69</armorPenetrationSharp>
-							<armorPenetrationBlunt>6.83</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>enhanced horn</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>34</power>
-							<cooldownTime>1.38</cooldownTime>
-							<armorPenetrationSharp>4.75</armorPenetrationSharp>
-							<armorPenetrationBlunt>4.743</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-		</operations>
+				<!-- EnhancementThrumkinHorn -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="EnhancementThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>enhanced horn</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>53</power>
+								<cooldownTime>1.15</cooldownTime>
+								<armorPenetrationSharp>0.69</armorPenetrationSharp>
+								<armorPenetrationBlunt>6.83</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>enhanced horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>34</power>
+								<cooldownTime>1.38</cooldownTime>
+								<armorPenetrationSharp>4.75</armorPenetrationSharp>
+								<armorPenetrationBlunt>4.743</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Thrumkin/Patch_ImplantsProsthetics_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_ImplantsProsthetics_Thrumkin.xml
@@ -20,19 +20,19 @@
 								<li>Scratch</li>
 							</capacities>
 							<power>23</power>
-							<cooldownTime>3.59</cooldownTime>
-							<armorPenetrationSharp>0.08</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.631</armorPenetrationBlunt>
+							<cooldownTime>2.6</cooldownTime>
+							<armorPenetrationSharp>0.06</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.332</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>steel horn</label>
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>15</power>
-							<cooldownTime>3.59</cooldownTime>
-							<armorPenetrationSharp>0.73</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.631</armorPenetrationBlunt>
+							<power>16</power>
+							<cooldownTime>3.12</cooldownTime>
+							<armorPenetrationSharp>0.42</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -48,20 +48,20 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>51</power>
-							<cooldownTime>1.59</cooldownTime>
-							<armorPenetrationSharp>0.83</armorPenetrationSharp>
-							<armorPenetrationBlunt>8.256</armorPenetrationBlunt>
+							<power>53</power>
+							<cooldownTime>1.15</cooldownTime>
+							<armorPenetrationSharp>0.69</armorPenetrationSharp>
+							<armorPenetrationBlunt>6.83</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>enhanced horn</label>
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>29</power>
-							<cooldownTime>1.59</cooldownTime>
-							<armorPenetrationSharp>8.26</armorPenetrationSharp>
-							<armorPenetrationBlunt>8.256</armorPenetrationBlunt>
+							<power>34</power>
+							<cooldownTime>1.38</cooldownTime>
+							<armorPenetrationSharp>4.75</armorPenetrationSharp>
+							<armorPenetrationBlunt>4.743</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -1,261 +1,396 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<!-- Thrumkin Pawn Kinds -->
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Checking for the mod -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>[SYR] Thrumkin</modName>
-			</li>
-			<!-- Thrumkin_Penitent -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Thrumkin_Penitent"]/combatPower</xpath>
-				<value>
-					<combatPower>30</combatPower>
-				</value>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Thrumkin</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Techless -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Slave"]/combatPower</xpath>
+					<value>
+						<combatPower>20</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Archer -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_Archer"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>10</min>
-							<max>40</max>
-						</primaryMagazineCount>
-						<shieldMoney>
-							<min>100</min>
-							<max>140</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.6</shieldChance>
-						<sidearms>
-							<li>
-								<sidearmMoney>
-									<min>40</min>
-									<max>80</max>
-								</sidearmMoney>
-								<weaponTags>
-									<li>CE_Sidearm_Tribal</li>
-								</weaponTags>
-							</li>
-						</sidearms>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Tribal_Archer"]/combatPower</xpath>
-				<value>
-					<combatPower>50</combatPower>
-				</value>
-			</li>
+				<!-- Tribal -->
+				<!-- Thrumkin_Penitent -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Penitent"]/combatPower</xpath>
+					<value>
+						<combatPower>30</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Warrior -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_Warrior"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<shieldMoney>
-							<min>100</min>
-							<max>200</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.9</shieldChance>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Thrumkin_Warrior"]/combatPower</xpath>
-				<value>
-					<combatPower>42</combatPower>
-				</value>
-			</li>
+				<!-- Thrumkin_Archer -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Archer"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>40</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>100</min>
+								<max>140</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<sidearmMoney>
+										<min>40</min>
+										<max>80</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Tribal</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Tribal_Archer"]/combatPower</xpath>
+					<value>
+						<combatPower>50</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Hunter -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_Hunter"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>10</min>
-							<max>60</max>
-						</primaryMagazineCount>
-						<shieldMoney>
-							<min>100</min>
-							<max>180</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.6</shieldChance>
-						<sidearms>
-							<li>
-								<sidearmMoney>
-									<min>80</min>
-									<max>160</max>
-								</sidearmMoney>
-								<weaponTags>
-									<li>CE_Sidearm_Tribal</li>
-								</weaponTags>
-							</li>
-						</sidearms>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Thrumkin_Hunter"]/combatPower</xpath>
-				<value>
-					<combatPower>70</combatPower>
-				</value>
-			</li>
+				<!-- Thrumkin_Warrior -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Warrior"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<shieldMoney>
+								<min>100</min>
+								<max>200</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.9</shieldChance>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Warrior"]/combatPower</xpath>
+					<value>
+						<combatPower>42</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Berserker -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_Berserker"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<shieldMoney>
-							<min>100</min>
-							<max>300</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.9</shieldChance>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Thrumkin_Berserker"]/combatPower</xpath>
-				<value>
-					<combatPower>90</combatPower>
-				</value>
-			</li>
+				<!-- Thrumkin_Hunter -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Hunter"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>60</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>100</min>
+								<max>180</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<sidearmMoney>
+										<min>80</min>
+										<max>160</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Tribal</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Hunter"]/combatPower</xpath>
+					<value>
+						<combatPower>70</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_HeavyArcher -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>10</min>
-							<max>80</max>
-						</primaryMagazineCount>
-						<shieldMoney>
-							<min>100</min>
-							<max>200</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.6</shieldChance>
-						<sidearms>
-							<li>
-								<sidearmMoney>
-									<min>100</min>
-									<max>200</max>
-								</sidearmMoney>
-								<weaponTags>
-									<li>CE_Sidearm_Tribal</li>
-								</weaponTags>
-							</li>
-						</sidearms>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]/combatPower</xpath>
-				<value>
-					<combatPower>90</combatPower>
-				</value>
-			</li>
+				<!-- Thrumkin_Berserker -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Berserker"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<shieldMoney>
+								<min>100</min>
+								<max>300</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.9</shieldChance>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Berserker"]/combatPower</xpath>
+					<value>
+						<combatPower>90</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_ElderMelee -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_ElderMelee"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<shieldMoney>
-							<min>200</min>
-							<max>400</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.9</shieldChance>
-					</li>
-				</value>
-			</li>
+				<!-- Thrumkin_HeavyArcher -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>80</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>100</min>
+								<max>200</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<sidearmMoney>
+										<min>100</min>
+										<max>200</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Tribal</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]/combatPower</xpath>
+					<value>
+						<combatPower>90</combatPower>
+					</value>
+				</li>
 
-			<!-- Thrumkin_ElderRanged -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_ElderRanged"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>10</min>
-							<max>80</max>
-						</primaryMagazineCount>
-						<shieldMoney>
-							<min>100</min>
-							<max>300</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.6</shieldChance>
-						<sidearms>
-							<li>
-								<sidearmMoney>
-									<min>150</min>
-									<max>300</max>
-								</sidearmMoney>
-								<weaponTags>
-									<li>CE_Sidearm_Tribal</li>
-								</weaponTags>
-							</li>
-						</sidearms>
-					</li>
-				</value>
-			</li>
+				<!-- Thrumkin_ElderMelee -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_ElderMelee"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<shieldMoney>
+								<min>200</min>
+								<max>400</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.9</shieldChance>
+						</li>
+					</value>
+				</li>
 
-			<!-- Thrumkin_GrandElder -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[defName="Thrumkin_GrandElder"]</xpath>
-				<value>
-					<li Class="CombatExtended.LoadoutPropertiesExtension">
-						<primaryMagazineCount>
-							<min>10</min>
-							<max>40</max>
-						</primaryMagazineCount>
-						<shieldMoney>
-							<min>300</min>
-							<max>600</max>
-						</shieldMoney>
-						<shieldTags>
-							<li>TribalShield</li>
-						</shieldTags>
-						<shieldChance>0.6</shieldChance>
-						<sidearms>
-							<li>
-								<sidearmMoney>
-									<min>200</min>
-									<max>400</max>
-								</sidearmMoney>
-								<weaponTags>
-									<li>CE_Sidearm_Tribal</li>
-								</weaponTags>
-							</li>
-						</sidearms>
-					</li>
-				</value>
-			</li>
-		</operations>
+				<!-- Thrumkin_ElderRanged -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_ElderRanged"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>80</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>100</min>
+								<max>300</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<sidearmMoney>
+										<min>150</min>
+										<max>300</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Tribal</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+
+				<!-- Thrumkin_GrandElder -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_GrandElder"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>40</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>300</min>
+								<max>600</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>TribalShield</li>
+							</shieldTags>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<sidearmMoney>
+										<min>200</min>
+										<max>400</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Tribal</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+
+				<!-- Industrial -->
+				<!-- Thrumkin_Villager -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Villager"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>1</min>
+								<max>2</max>
+							</primaryMagazineCount>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<generateChance>0.5</generateChance>
+									<sidearmMoney>
+										<min>20</min>
+										<max>120</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Villager"]/combatPower</xpath>
+					<value>
+						<combatPower>45</combatPower>
+					</value>
+				</li>
+
+				<!-- Thrumkin_Guard -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Guard"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>2</min>
+								<max>4</max>
+							</primaryMagazineCount>
+							<shieldChance>0.6</shieldChance>
+							<sidearms>
+								<li>
+									<generateChance>0.5</generateChance>
+									<sidearmMoney>
+										<min>20</min>
+										<max>120</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Guard"]/combatPower</xpath>
+					<value>
+						<combatPower>65</combatPower>
+					</value>
+				</li>
+
+				<!-- Thrumkin_Gunner -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Gunner"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>2</min>
+								<max>4</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>200</min>
+								<max>600</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>OutlanderShield</li>
+							</shieldTags>
+							<shieldChance>0.8</shieldChance>
+							<sidearms>
+								<li>
+									<generateChance>0.5</generateChance>
+									<sidearmMoney>
+										<min>20</min>
+										<max>120</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Gunner"]/combatPower</xpath>
+					<value>
+						<combatPower>100</combatPower>
+					</value>
+				</li>
+
+				<!-- Thrumkin_Slasher -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[defName="Thrumkin_Slasher"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<shieldMoney>
+								<min>500</min>
+								<max>1400</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>OutlanderShield</li>
+							</shieldTags>
+							<shieldChance>0.9</shieldChance>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Slasher"]/combatPower</xpath>
+					<value>
+						<combatPower>160</combatPower>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -12,7 +12,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Thrumkin_Penitent"]/combatPower</xpath>
 				<value>
-					<combatPower>20</combatPower>
+					<combatPower>30</combatPower>
 				</value>
 			</li>
 
@@ -50,7 +50,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Tribal_Archer"]/combatPower</xpath>
 				<value>
-					<combatPower>40</combatPower>
+					<combatPower>50</combatPower>
 				</value>
 			</li>
 
@@ -73,7 +73,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Thrumkin_Warrior"]/combatPower</xpath>
 				<value>
-					<combatPower>32</combatPower>
+					<combatPower>42</combatPower>
 				</value>
 			</li>
 
@@ -111,7 +111,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Thrumkin_Hunter"]/combatPower</xpath>
 				<value>
-					<combatPower>60</combatPower>
+					<combatPower>70</combatPower>
 				</value>
 			</li>
 
@@ -134,7 +134,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Thrumkin_Berserker"]/combatPower</xpath>
 				<value>
-					<combatPower>80</combatPower>
+					<combatPower>90</combatPower>
 				</value>
 			</li>
 
@@ -172,7 +172,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Thrumkin_HeavyArcher"]/combatPower</xpath>
 				<value>
-					<combatPower>80</combatPower>
+					<combatPower>90</combatPower>
 				</value>
 			</li>
 

--- a/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -55,7 +55,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Tribal_Archer"]/combatPower</xpath>
+					<xpath>Defs/PawnKindDef[defName="Thrumkin_Archer"]/combatPower</xpath>
 					<value>
 						<combatPower>50</combatPower>
 					</value>

--- a/Patches/Thrumkin/Patch_Race_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Race_Thrumkin.xml
@@ -26,15 +26,48 @@
 					<li Class="CombatExtended.CompProperties_Suppressable" />
 				</value>
 			</li>
+			<!-- thrumkin rebalances -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases</xpath>
 				<value>
+					<!-- combat stats -->
 					<AimingAccuracy>0.9</AimingAccuracy>
 					<MeleeCritChance>1.34</MeleeCritChance>
 					<MeleeParryChance>1.27</MeleeParryChance>
 					<Suppressability>0.8</Suppressability>
 					<ReloadSpeed>0.9</ReloadSpeed>
 					<MeleeDodgeChance>1.06</MeleeDodgeChance>
+				</value>
+			</li>
+			<!-- should've modified the values sooner -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/Mass</xpath>
+				<value>
+					<Mass>120</Mass>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/LeatherAmount</xpath>
+				<value>
+					<LeatherAmount>20</LeatherAmount>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/comps/li[@Class="CompProperties_Shearable"]/woolAmount</xpath>
+				<value>
+					<woolAmount>10</woolAmount>
 				</value>
 			</li>
 			<!-- Unarmed -->
@@ -47,24 +80,24 @@
 							<capacities>
 								<li>Scratch</li>
 							</capacities>
-							<power>34</power>
-							<cooldownTime>2.39</cooldownTime>
+							<power>35</power>
+							<cooldownTime>1.73</cooldownTime>
 							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.4</chanceFactor>
-							<armorPenetrationSharp>0.25</armorPenetrationSharp>
-							<armorPenetrationBlunt>3.669</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.996</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>horn</label>
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>21</power>
-							<cooldownTime>2.39</cooldownTime>
+							<power>22</power>
+							<cooldownTime>2.08</cooldownTime>
 							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.4</chanceFactor>
-							<armorPenetrationSharp>2.45</armorPenetrationSharp>
-							<armorPenetrationBlunt>3.669</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.39</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.081</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>left fist</label>
@@ -72,7 +105,7 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>2</power>
-							<cooldownTime>1.12</cooldownTime>
+							<cooldownTime>1.16</cooldownTime>
 							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 							<surpriseAttack>
 							<extraMeleeDamages>
@@ -82,7 +115,7 @@
 								</li>
 							</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationBlunt>0.528</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right fist</label>
@@ -90,7 +123,7 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>2</power>
-							<cooldownTime>1.12</cooldownTime>
+							<cooldownTime>1.16</cooldownTime>
 							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 							<surpriseAttack>
 								<extraMeleeDamages>
@@ -100,7 +133,7 @@
 									</li>
 								</extraMeleeDamages>
 							</surpriseAttack>
-							<armorPenetrationBlunt>0.528</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>teeth</label>
@@ -108,11 +141,11 @@
 								<li>Bite</li>
 							</capacities>
 							<power>13</power>
-							<cooldownTime>1.9</cooldownTime>
+							<cooldownTime>1.94</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
 							<armorPenetrationSharp>0.01</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.467</armorPenetrationBlunt>
+							<armorPenetrationBlunt>1.561</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
@@ -120,11 +153,11 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>3</power>
-							<cooldownTime>4.78</cooldownTime>
+							<cooldownTime>3.12</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 							<chanceFactor>0.3</chanceFactor>
-							<armorPenetrationBlunt>0.917</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Thrumkin/Patch_Race_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Race_Thrumkin.xml
@@ -1,167 +1,168 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<!-- Thrumkin -->
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Checking for the mod -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>[SYR] Thrumkin</modName>
-			</li>
-			<!-- Combat -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Humanoid</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]/comps</xpath>
-				<value>
-					<li>
-						<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable" />
-				</value>
-			</li>
-			<!-- thrumkin rebalances -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases</xpath>
-				<value>
-					<!-- combat stats -->
-					<AimingAccuracy>0.9</AimingAccuracy>
-					<MeleeCritChance>1.34</MeleeCritChance>
-					<MeleeParryChance>1.27</MeleeParryChance>
-					<Suppressability>0.8</Suppressability>
-					<ReloadSpeed>0.9</ReloadSpeed>
-					<MeleeDodgeChance>1.06</MeleeDodgeChance>
-				</value>
-			</li>
-			<!-- should've modified the values sooner -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/Mass</xpath>
-				<value>
-					<Mass>120</Mass>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>3</ArmorRating_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/LeatherAmount</xpath>
-				<value>
-					<LeatherAmount>20</LeatherAmount>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/comps/li[@Class="CompProperties_Shearable"]/woolAmount</xpath>
-				<value>
-					<woolAmount>10</woolAmount>
-				</value>
-			</li>
-			<!-- Unarmed -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>horn</label>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<power>35</power>
-							<cooldownTime>1.73</cooldownTime>
-							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-							<chanceFactor>0.4</chanceFactor>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>2.996</armorPenetrationBlunt>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Thrumkin</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Combat -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>horn</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>22</power>
-							<cooldownTime>2.08</cooldownTime>
-							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-							<chanceFactor>0.4</chanceFactor>
-							<armorPenetrationSharp>1.39</armorPenetrationSharp>
-							<armorPenetrationBlunt>2.081</armorPenetrationBlunt>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]/comps</xpath>
+					<value>
+						<li>
+							<compClass>CombatExtended.CompPawnGizmo</compClass>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>left fist</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.16</cooldownTime>
-							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-							<surpriseAttack>
-							<extraMeleeDamages>
-								<li>
-									<def>Stun</def>
-									<amount>20</amount>
-								</li>
-							</extraMeleeDamages>
-							</surpriseAttack>
-							<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>right fist</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.16</cooldownTime>
-							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-							<surpriseAttack>
+						<li Class="CombatExtended.CompProperties_Suppressable" />
+					</value>
+				</li>
+				<!-- thrumkin rebalances -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases</xpath>
+					<value>
+						<!-- combat stats -->
+						<AimingAccuracy>0.9</AimingAccuracy>
+						<MeleeCritChance>1.34</MeleeCritChance>
+						<MeleeParryChance>1.27</MeleeParryChance>
+						<Suppressability>0.8</Suppressability>
+						<ReloadSpeed>0.9</ReloadSpeed>
+						<MeleeDodgeChance>1.06</MeleeDodgeChance>
+						<!-- other stats -->
+						<CarryWeight>50</CarryWeight>
+					</value>
+				</li>
+				<!-- should've modified the values sooner -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/Mass</xpath>
+					<value>
+						<Mass>120</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>3</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/LeatherAmount</xpath>
+					<value>
+						<LeatherAmount>20</LeatherAmount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/comps/li[@Class="CompProperties_Shearable"]/woolAmount</xpath>
+					<value>
+						<woolAmount>10</woolAmount>
+					</value>
+				</li>
+				<!-- Unarmed -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Thrumkin"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>35</power>
+								<cooldownTime>1.73</cooldownTime>
+								<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.4</chanceFactor>
+								<armorPenetrationSharp>0.2</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.996</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.08</cooldownTime>
+								<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.4</chanceFactor>
+								<armorPenetrationSharp>1.39</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.081</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.16</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<surpriseAttack>
 								<extraMeleeDamages>
 									<li>
 										<def>Stun</def>
 										<amount>20</amount>
 									</li>
 								</extraMeleeDamages>
-							</surpriseAttack>
-							<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>teeth</label>
-							<capacities>
-								<li>Bite</li>
-							</capacities>
-							<power>13</power>
-							<cooldownTime>1.94</cooldownTime>
-							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationSharp>0.01</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.561</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>3</power>
-							<cooldownTime>3.12</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							<chanceFactor>0.3</chanceFactor>
-							<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-		</operations>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.16</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.595</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>13</power>
+								<cooldownTime>1.94</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>0.01</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.561</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>3.12</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<chanceFactor>0.3</chanceFactor>
+								<armorPenetrationBlunt>0.925</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Thrumkin/Patch_Race_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Race_Thrumkin.xml
@@ -49,13 +49,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>3</ArmorRating_Blunt>
+						<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -68,6 +68,12 @@
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/comps/li[@Class="CompProperties_Shearable"]/woolAmount</xpath>
 					<value>
 						<woolAmount>10</woolAmount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>1.5</baseHealthScale>
 					</value>
 				</li>
 				<!-- Unarmed -->

--- a/Patches/Thrumkin/Patch_Things_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Things_Thrumkin.xml
@@ -1,192 +1,191 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>
-	<!-- Thrumkin Things -->
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<!-- Checking for the mod -->
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>[SYR] Thrumkin</modName>
-			</li>
-			<!-- WoodLog_GhostAsh -->
-			<!-- As a weapon -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>0.99</cooldownTime>
-							<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeCritChance>0.2</MeleeCritChance>
-						<MeleeParryChance>1</MeleeParryChance>
-						<MeleeDodgeChance>0.13</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases</xpath>
-				<value>
-					<Bulk>0.07</Bulk>
-					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-				</value>
-			</li>
-			<!-- As a material -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Sharp</xpath>
-				<value>
-					<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Blunt</xpath>
-				<value>
-					<StuffPower_Armor_Blunt>400</StuffPower_Armor_Blunt>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/SharpDamageMultiplier</xpath>
-				<value>
-					<SharpDamageMultiplier>0.8</SharpDamageMultiplier>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/BluntDamageMultiplier</xpath>
-				<value>
-					<BluntDamageMultiplier>0.6</BluntDamageMultiplier>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/stuffProps/statFactors</xpath>
-				<value>
-					<Mass>0.5</Mass>
-					<MeleePenetrationFactor>0.4</MeleePenetrationFactor>
-				</value>
-			</li>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[SYR] Thrumkin</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- WoodLog_GhostAsh -->
+				<!-- As a weapon -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>0.99</cooldownTime>
+								<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.2</MeleeCritChance>
+							<MeleeParryChance>1</MeleeParryChance>
+							<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases</xpath>
+					<value>
+						<Bulk>0.07</Bulk>
+						<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					</value>
+				</li>
+				<!-- As a material -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>400</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/SharpDamageMultiplier</xpath>
+					<value>
+						<SharpDamageMultiplier>0.8</SharpDamageMultiplier>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/BluntDamageMultiplier</xpath>
+					<value>
+						<BluntDamageMultiplier>0.6</BluntDamageMultiplier>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/stuffProps/statFactors</xpath>
+					<value>
+						<Mass>0.5</Mass>
+						<MeleePenetrationFactor>0.4</MeleePenetrationFactor>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Crossbow -->
-			<!-- as a gun -->
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Thrumkin_Crossbow</defName>
-				<statBases>
-					<Mass>5.44</Mass> <!-- bolt-action rfile has mass of 4.19. since this is supposed to be used by thrumkin, it should be a bit more heavier -->
-					<RangedWeapon_Cooldown>1.404</RangedWeapon_Cooldown> <!-- a bit slower than the bolt-action rifle -->
-					<SightsEfficiency>0.9</SightsEfficiency> <!-- worse than the bolt-action rifle -->
-					<ShotSpread>0.2</ShotSpread> <!-- not a gun, but better than a bow -->
-					<SwayFactor>1.58</SwayFactor> <!-- a bit more unwieldy than the bolt-action rifle -->
-					<Bulk>6.40</Bulk> <!-- similar bulk to a great bow -->
-				</statBases>
-				<Properties>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
-					<warmupTime>3.0</warmupTime>
-					<range>50</range>
-					<soundCast>Bow_Large</soundCast>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>1</magazineSize>
-					<reloadTime>3.8</reloadTime>
-					<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiAimMode>AimedShot</aiAimMode>
-				</FireModes>
-				<weaponTags>
-					<li>NeolithicThrumkinRanged</li>
-					<li>CE_AI_Rifle</li>
-				</weaponTags>
-				<researchPrerequisite>Greatbow</researchPrerequisite>
-				<AllowWithRunAndGun>false</AllowWithRunAndGun>
-			</li>
-			<!-- in melee -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Thrumkin_Crossbow"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>stock</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>1.55</cooldownTime>
-							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
+				<!-- Thrumkin_Crossbow -->
+				<!-- as a gun -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>Thrumkin_Crossbow</defName>
+					<statBases>
+						<Mass>5.44</Mass> <!-- bolt-action rfile has mass of 4.19. since this is supposed to be used by thrumkin, it should be a bit more heavier -->
+						<RangedWeapon_Cooldown>1.404</RangedWeapon_Cooldown> <!-- a bit slower than the bolt-action rifle -->
+						<SightsEfficiency>0.9</SightsEfficiency> <!-- worse than the bolt-action rifle -->
+						<ShotSpread>0.2</ShotSpread> <!-- not a gun, but better than a bow -->
+						<SwayFactor>1.58</SwayFactor> <!-- a bit more unwieldy than the bolt-action rifle -->
+						<Bulk>6.40</Bulk> <!-- similar bulk to a great bow -->
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
+						<warmupTime>3.0</warmupTime>
+						<range>50</range>
+						<soundCast>Bow_Large</soundCast>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>1</magazineSize>
+						<reloadTime>3.8</reloadTime>
+						<ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>NeolithicThrumkinRanged</li>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
+					<researchPrerequisite>Greatbow</researchPrerequisite>
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
+				<!-- in melee -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Thrumkin_Crossbow"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
 
-			<!-- Thrumkin_Sword -->
-			<!-- Used as a weapon -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>handle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>6</power>
-							<cooldownTime>2.12</cooldownTime>
-							<chanceFactor>0.1</chanceFactor>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>point</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>27</power>
-							<cooldownTime>2.12</cooldownTime>
-							<chanceFactor>0.5</chanceFactor>
-							<armorPenetrationSharp>8</armorPenetrationSharp>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>edge</label>
-							<capacities>
-								<li>Cut</li>
-							</capacities>
-							<power>56</power>
-							<cooldownTime>2.1</cooldownTime>
-							<chanceFactor>0.4</chanceFactor>
-							<armorPenetrationSharp>2.88</armorPenetrationSharp>
-							<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
-						</li>
-					</tools>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeCritChance>0.17</MeleeCritChance>
-						<MeleeParryChance>0.35</MeleeParryChance>
-						<MeleeDodgeChance>0.47</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]/statBases/Mass</xpath>
-				<value>
-					<Mass>4</Mass>
-					<Bulk>12</Bulk>
-					<MeleeCounterParryBonus>0.47</MeleeCounterParryBonus>
-				</value>
-			</li>
-		</operations>
+				<!-- Thrumkin_Sword -->
+				<!-- Used as a weapon -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>2.12</cooldownTime>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>27</power>
+								<cooldownTime>2.12</cooldownTime>
+								<chanceFactor>0.5</chanceFactor>
+								<armorPenetrationSharp>8</armorPenetrationSharp>
+								<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>56</power>
+								<cooldownTime>2.1</cooldownTime>
+								<chanceFactor>0.4</chanceFactor>
+								<armorPenetrationSharp>2.88</armorPenetrationSharp>
+								<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.17</MeleeCritChance>
+							<MeleeParryChance>0.35</MeleeParryChance>
+							<MeleeDodgeChance>0.47</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Thrumkin_Sword"]/statBases/Mass</xpath>
+					<value>
+						<Mass>4</Mass>
+						<Bulk>12</Bulk>
+						<MeleeCounterParryBonus>0.47</MeleeCounterParryBonus>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/Thrumkin/Patch_Things_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Things_Thrumkin.xml
@@ -50,7 +50,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="WoodLog_GhostAsh"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>400</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.4</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -39,7 +39,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
 					<value>
-						<description>A pair of plate boots which resemble sabatons. Because of the construction of the boots and the thickness of the material, it restricts the feet's capabilities.</description>
+						<description>A pair of plate boots which resemble sabatons. Because of the construction and weight of the boots, the wearer is somewhat slower and less nimble.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -11,24 +11,35 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<Bulk>2</Bulk>
-						<WornBulk>1</WornBulk>
+						<Bulk>3</Bulk>
+						<WornBulk>1.5</WornBulk>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
 					<value>
-						<Mass>2</Mass>
+						<Mass>2.5</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/EquipDelay</xpath>
+					<value>
+						<EquipDelay>3.5</EquipDelay>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
-						<equippedStatOffsets>
-							<MeleeDodgeChance>-0.02</MeleeDodgeChance>
-						</equippedStatOffsets>
+						<MeleeDodgeChance>-0.05</MeleeDodgeChance>
+						<MoveSpeed>-0.46</MoveSpeed> <!-- 10% of 4.6 -->
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
+					<value>
+						<description>A pair of plate boots which resemble sabatons. Because of the construction of the boots and the thickness of the material, it restricts the feet's capabilities.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
@@ -76,13 +87,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/description</xpath>
 					<value>
-						<description>A pair of standalone powered boots.\n\nThe outer shell of these boots is made from simplified plasteel-weave most commonly found in cheaper powered armors. These boots come with a basic servo-motor system, allowing the wearer to carry heavier things.\n\nAlthough most power armor variants cover the feet, these exist for those not fortunate enough to buy an entire suit.</description>
+						<description>A pair of standalone powered boots.\n\nThe outer shell of these boots is made from simplified plasteel-weave most commonly found in cheaper powered armors. These boots come with a basic servo-motor system, which helps the wearer carry more weight.\n\nAlthough most power armor variants cover the feet, these exist for those not fortunate enough to buy an entire suit.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Hyperweave</xpath>
 					<value>
-						<DevilstrandCloth>10</DevilstrandCloth>
+						<DevilstrandCloth>5</DevilstrandCloth>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -43,9 +43,9 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
 					<value>
-						<Bulk>6.7</Bulk>
+						<Bulk>6.75</Bulk>
 						<WornBulk>1.5</WornBulk>
-						<Mass>3.35</Mass>
+						<Mass>3.6</Mass>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -76,7 +76,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/description</xpath>
 					<value>
-						<description>A standalone pair of power armor boots.\n\nThe outer layer is plated with plasteel, while the basic servomotor systems allow the user to wear these without most problems.\n\nEven though most power armor already comes with boots, some are unable to buy the full suit, hence why these exist.</description>
+						<description>A pair of standalone powered boots.\n\nThe outer shell of these boots is made from simplified plasteel-weave most commonly found in cheaper powered armors. These boots come with a basic servo-motor system, allowing the wearer to carry heavier things.\n\nAlthough most power armor variants cover the feet, these exist for those not fortunate enough to buy an entire suit.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -86,11 +86,16 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>15</Plasteel>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
-							<CarryWeight>1</CarryWeight>
-							<CarryBulk>0.5</CarryBulk>
+							<CarryWeight>6</CarryWeight>
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -39,7 +39,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
 					<value>
-						<description>A pair of plate gloves which resemble gauntlets. Because of the construction of the gloves and the thickness of the material, it restricts the hands' capabilities.</description>
+						<description>A pair of plate gloves which resemble gauntlets. Because of the construction of the gloves and the thickness of the material, the wearer is somewhat less capable of manipulation work.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -12,14 +12,20 @@
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>2</Bulk>
-						<WornBulk>1.5</WornBulk>
+						<WornBulk>1</WornBulk>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
 					<value>
-						<Mass>2</Mass>
+						<Mass>1.5</Mass>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/EquipDelay</xpath>
+					<value>
+						<EquipDelay>2</EquipDelay>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
@@ -28,12 +34,13 @@
 					<value>
 						<MeleeHitChance>-0.05</MeleeHitChance>
 						<AimingAccuracy>-0.05</AimingAccuracy>
+						<WorkSpeedGlobal>-0.05</WorkSpeedGlobal>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
 					<value>
-						<description>A pair of simple metal gloves. Due to the thickness of the material, it restricts the wearer's manipulation capabilities.</description>
+						<description>A pair of plate gloves which resemble gauntlets. Because of the construction of the gloves and the thickness of the material, it restricts the hands' capabilities.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
@@ -81,7 +88,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/description</xpath>
 					<value>
-						<description>A pair of standalone powered gloves.\n\nThe outer shell of these gloves is made from simplified plasteel-weave most commonly found in cheaper powered armors. These gloves come with embedded recoil and grip assistors, helping the wearer to hold their gun steady, however they have no servomotors.\n\nAlthough most power armor variants cover the hands, these exist for those not fortunate enough to buy an entire suit.</description>
+						<description>A pair of standalone powered gloves.\n\nThe outer shell of these gloves is made from simplified plasteel-weave most commonly found in cheaper powered armors. These gloves come with embedded recoil and grip assistors, which help the wearer to hold their gun steady, however the gloves have no servomotors.\n\nAlthough most power armor variants cover the hands, these exist for those not fortunate enough to buy an entire suit.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
@@ -93,7 +100,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>15</Plasteel>
+						<Plasteel>10</Plasteel>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -12,14 +12,14 @@
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>2</Bulk>
-						<WornBulk>1</WornBulk>
+						<WornBulk>1.5</WornBulk>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
 					<value>
-						<Mass>1.5</Mass>
+						<Mass>2</Mass>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
@@ -48,9 +48,9 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
 					<value>
-						<Bulk>6.7</Bulk>
-						<WornBulk>1.5</WornBulk>
-						<Mass>3.35</Mass>
+						<Bulk>5</Bulk>
+						<WornBulk>2</WornBulk>
+						<Mass>3</Mass>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -62,13 +62,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>36</ArmorRating_Blunt>
+						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
@@ -81,7 +81,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/description</xpath>
 					<value>
-						<description>A standalone pair of power armor gloves.\n\nThese come with grip assistance and embedded recoil stabilisers, but no servomotors.\n\nEven though most power armor already comes with gloves, some are unable to buy the full suit, hence why these exist.</description>
+						<description>A pair of standalone powered gloves.\n\nThe outer shell of these gloves is made from simplified plasteel-weave most commonly found in cheaper powered armors. These gloves come with embedded recoil and grip assistors, helping the wearer to hold their gun steady, however they have no servomotors.\n\nAlthough most power armor variants cover the hands, these exist for those not fortunate enough to buy an entire suit.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -34,7 +34,6 @@
 					<value>
 						<MeleeHitChance>-0.05</MeleeHitChance>
 						<AimingAccuracy>-0.05</AimingAccuracy>
-						<WorkSpeedGlobal>-0.05</WorkSpeedGlobal>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -80,7 +80,7 @@
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>3</WornBulk>
-						<Mass>12</Mass>
+						<Mass>15</Mass>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -115,7 +115,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>80</costStuffCount>
+						<costStuffCount>100</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -79,20 +79,21 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
-						<WornBulk>2.5</WornBulk>
+						<WornBulk>3</WornBulk>
 						<Mass>12</Mass>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases</xpath>
 					<value>
-						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -106,8 +107,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>30</Plasteel>
-							<ComponentIndustrial>1</ComponentIndustrial>
+							<Plasteel>20</Plasteel>
 							<Cloth>30</Cloth>
 						</costList>
 					</value>
@@ -115,7 +115,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>90</costStuffCount>
+						<costStuffCount>80</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -12,9 +12,9 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
-						<WornBulk>1.5</WornBulk>
-						<Mass>3.5</Mass>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<WornBulk>1</WornBulk>
+						<Mass>6</Mass>
+						<StuffEffectMultiplierArmor>12</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationRemove">
@@ -49,7 +49,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]</xpath>
 					<value>
-						<costStuffCount>50</costStuffCount>
+						<costStuffCount>80</costStuffCount>
 						<stuffCategories>
 							<li>SoftArmor</li>
 						</stuffCategories>
@@ -79,20 +79,26 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
-						<WornBulk>3</WornBulk>
-						<Mass>15</Mass>
+						<WornBulk>2.5</WornBulk>
+						<Mass>12</Mass>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases</xpath>
+					<value>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/MaxHitPoints</xpath>
 					<value>
-						<MaxHitPoints>175</MaxHitPoints>
+						<MaxHitPoints>150</MaxHitPoints>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
@@ -100,15 +106,16 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>20</Plasteel>
+							<Plasteel>30</Plasteel>
 							<ComponentIndustrial>1</ComponentIndustrial>
+							<Cloth>30</Cloth>
 						</costList>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>60</costStuffCount>
+						<costStuffCount>90</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -107,7 +107,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>20</Plasteel>
+							<Plasteel>30</Plasteel>
 							<Cloth>30</Cloth>
 						</costList>
 					</value>
@@ -115,7 +115,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
 					<value>
-						<costStuffCount>100</costStuffCount>
+						<costStuffCount>90</costStuffCount>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -86,14 +86,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases</xpath>
 					<value>
-						<ArmorRating_Sharp>6</ArmorRating_Sharp>
-						<ArmorRating_Blunt>8</ArmorRating_Blunt>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Blunt>3</ArmorRating_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -107,7 +107,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>30</Plasteel>
+							<Plasteel>20</Plasteel>
 							<Cloth>30</Cloth>
 						</costList>
 					</value>


### PR DESCRIPTION
## Additions

- Updated SYR Thrumkin patch to patch the industrial tech pawns.

## Changes

- Attempted to make VAE's advanced armor vest more viable by decreasing its thickness, giving extra mm of sharp armor (when made out of steel), increasing the cost to make, decreasing max health, decreasing worn bulk by a tiny amount and decreasing weight to be 12/13 of the normal armor vest.
- Rebalanced VAE's soft armor vest to be heavier, have 12 mm thickness (up from 10mm), decreased the base worn bulk to 1 from 1.5, increased the cost to 80 materials from 50.
- Modified power armor boots and gloves to be more worth it. Power armor boots have higher carry weight bonus than own mass. Buffed power gloves armor values to be the same as power armor boots. Modified bulks, masses, descriptions of both. They now differ by devilstrand/plasteel cost. The gloves cost more devilstrand, while the boots cost more plasteel.
- Increased mass, bulk, worn bulk, wear time, dodge chance detriment and added walkspeed detriment for plate boots.
- Made SYR Thrumkin patches use vanilla's mod check function.
- Gave thrumkins natural armor. Tweaked the unarmed damage of thrumkin attacks as well as the damage of prosthetics. Made thurmkins heavier. Decreased their leather and wool harvests.
- Increased thrumkin pawn kind power values.

## Reasoning

- I felt as if VAE's advanced armor vest was worse than the normal armor vest in most circumstances, so I tried to make it more viable.
- Tried making VAE's soft armor vest better, now a devilstrand soft armor vest is enough to deflect a 5.45x39mm Soviet FMJ round.
- I felt as if both power armor gloves and (mostly) power armor boots were under used, so I tried giving them a reason to be used. Both of them fill the role of utility more than armor, as it's rare that a projectile will hit the feet or hands. The gloves were already good enough, they just needed some tweaking, while the boots were absolutely useless before, so I made their carry weight be more than their own mass, hence giving them a spot in the transition between flak armor and power armor. However, wearing both the gloves and the boots is still heavier than the boots' bonus weight carry. Also, the reason why the costs are different is that the boots offer more carry weight, while the gloves offer better handling.
- I myself don't exactly know how much they weigh, however wikipedia (what a great source, I know) mentions "Heavy or pointy metal footwear would severely hinder movement and mobility on the ground, particularly under wet or muddy conditions.", hence the walkspeed detriment.
- SYR Thrumkin patches use the vanilla mod check in case CE's mod check breaks in the future.
- I see thrumkins as scaled down, sapient thrumbos, so it kind of make sense for them to have natural armor and be heavier. Also, thrumbos drop less leather when butchered than most animals, hence the decreased leather and wool harvested amounts from thrumkins.
- Pawn kind power values got increased to compensate for the natural armor. I'd suggest testing if these values aren't out of the ordinary when fighting them.

## Testing

- [ ] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
