### PR TITLE
Use input PR number when manually running

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Create comment
       uses: peter-evans/create-or-update-comment@v1
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}
         body: |
           You can download the rebuilt assembly for this PR here: https://combatextended.lp-programming.com/CombatExtended-${{ github.run_id }}.zip
     - name: Add Label
@@ -57,5 +57,5 @@ jobs:
       with:
         github_token: ${{ secrets.github_token }}
         labels: "Download in Comments"
-        number: ${{ github.event.pull_request.number }}
+        number: ${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}
           


### PR DESCRIPTION
## Reasoning

Manually triggering a rebuild for a PR builds correctly, but fails to post the comment or label due to the PR number not being attached to those steps properly.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
