### PR TITLE
Fix ed shields with multiple maps

### DIFF
--- a/Source/CombatExtended/Compatibility/EDShields.cs
+++ b/Source/CombatExtended/Compatibility/EDShields.cs
@@ -21,6 +21,7 @@ namespace CombatExtended.Compatibility
         public static List<Building> shields;
 
         public static int lastCacheTick = 0;
+        public static Map lastCacheMap = null;
 
         public static bool CanInstall()
         {
@@ -152,10 +153,11 @@ namespace CombatExtended.Compatibility
         public static void getShields(Map map)
         {
             int thisTick = Find.TickManager.TicksAbs;
-            if (lastCacheTick != thisTick) {
+            if (lastCacheTick != thisTick || lastCacheMap != map) {
                 List<Building> buildings = map.listerBuildings.allBuildingsColonist;
                 shields = buildings.Where(b => b is Building_Shield).ToList();
                 lastCacheTick = thisTick;
+                lastCacheMap = map;
             }
         }
 

--- a/Source/CombatExtended/Compatibility/VanillaFurnitureExpandedShields.cs
+++ b/Source/CombatExtended/Compatibility/VanillaFurnitureExpandedShields.cs
@@ -12,6 +12,7 @@ namespace CombatExtended.Compatibility
     public class VanillaFurnitureExpandedShields
     {
         private static int lastCacheTick = 0;
+        private static Map lastCacheMap = null;
 
         /// <summary>
         /// Set of shields. The type if Building because RimWorld dark magic doesn't allow using types that may not exist here.
@@ -108,11 +109,12 @@ namespace CombatExtended.Compatibility
         private static void refreshShields(Map map)
         {
             int thisTick = Find.TickManager.TicksAbs;
-            if (lastCacheTick != thisTick)
+            if (lastCacheTick != thisTick || lastCacheMap != map)
             {
                 // Can't use AllBuildingsColonstOfClass because type may not exist.
                 shields = map.listerBuildings.allBuildingsColonist.Where(s => s is Building_Shield).ToHashSet();
                 lastCacheTick = thisTick;
+                lastCacheMap = map;
             }
         }
     }


### PR DESCRIPTION
## Changes

The shield caches for VFE and ED Shields malfunctions when shields are deployed on multiple maps and projectiles are in-flight on those maps at the same time.  This invalidates the cache when the map changes.

It is assumed that maps are processed sequentially.  This is likely to be incompatible with mods that process multiple maps in parallel, but it already will break in that case.

## Reasoning

For performance reasons, we cache the list of shields on the map, and update the cache once per tick.  If there are multiple maps with shields, we need to invalidate the cache when switching maps, or shields will either get missed, or provide "ghost" protection.  Or possibly have other strange side effects.

## Alternatives

Don't cache the buildings.  This would significantly impact performance on maps with lots of buildings (including walls).

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (minutes)
