### PR TITLE
Nerf to Mech Siege Turrets

### DIFF
--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -1,6 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Defs>
 
+    <ThingDef ParentName="BaseAutoTurretGun">
+      <defName>Gun_AutoBlasterTurret</defName>
+      <label>blaster turret gun</label>
+      <graphicData>
+        <texPath>Things/Building/Turrets/BlasterTurret_Top</texPath>
+        <graphicClass>Graphic_Single</graphicClass>
+      </graphicData>
+      <description>Charge blaster attached to a turret mount.</description>
+      <soundInteract>Interact_ChargeRifle</soundInteract>
+      <statBases>
+        <MarketValue>2000</MarketValue>
+        <SightsEfficiency>1</SightsEfficiency>
+        <ShotSpread>0.08</ShotSpread>
+        <SwayFactor>0.72</SwayFactor>
+        <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      </statBases>
+      <verbs>
+        <li Class="CombatExtended.VerbPropertiesCE">
+          <recoilAmount>1.1</recoilAmount>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+          <hasStandardCommand>true</hasStandardCommand>
+          <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+          <warmupTime>1.3</warmupTime>
+          <range>55</range>
+          <minRange>2</minRange>
+          <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+          <burstShotCount>10</burstShotCount>
+          <soundCast>Shot_ChargeBlaster</soundCast>
+          <soundCastTail>GunTail_Heavy</soundCastTail>
+          <muzzleFlashScale>9</muzzleFlashScale>
+          <recoilPattern>Mounted</recoilPattern>
+        </li>
+      </verbs>
+      <comps>
+        <li Class="CombatExtended.CompProperties_AmmoUser">
+          <magazineSize>100</magazineSize>
+          <reloadTime>7.8</reloadTime>
+          <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+        </li>
+        <li Class="CombatExtended.CompProperties_FireModes">
+          <aiAimMode>SuppressFire</aiAimMode>
+        </li>            
+      </comps>
+    </ThingDef>
+
   <!-- ================== Auto Heavy Charge Blaster ================== -->
 
   <ThingDef ParentName="BaseAutoTurretGun">
@@ -27,6 +72,7 @@
 		  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
 		  <warmupTime>1.3</warmupTime>
 		  <range>75</range>
+      <minRange>3</minRange>
 		  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 		  <burstShotCount>20</burstShotCount>
 		  <soundCast>Shot_ChargeBlaster</soundCast>
@@ -41,7 +87,8 @@
         <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
-      </li>	  
+        <aiAimMode>SuppressFire</aiAimMode>
+      </li>   
     </comps>
 	<tools Inherit="false" />
   </ThingDef>
@@ -80,11 +127,14 @@
       </li>
     </verbs>	
     <comps>
-      <li Class="CombatExtended.CompProperties_AmmoUser" Inherit="false">
-		<magazineSize>5</magazineSize>
-		<reloadTime>9.8</reloadTime>
-	  <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
-      </li>
+    <li Class="CombatExtended.CompProperties_AmmoUser" Inherit="false">
+      <magazineSize>5</magazineSize>
+      <reloadTime>9.8</reloadTime>
+      <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
+    </li>
+    <li Class="CombatExtended.CompProperties_FireModes">
+      <aiAimMode>SuppressFire</aiAimMode>
+    </li>         
     </comps>	
 	<tools Inherit="false" />
   </ThingDef>

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -7,8 +7,8 @@
 		<xpath>Defs/ThingDef[defName="Defoliator"]/comps/li[@Class="CompProperties_Explosive"]/wickTicks</xpath>
 		<value>
 			<wickTicks>
-			  <min>180</min>
-			  <max>240</max>
+			  <min>240</min>
+			  <max>600</max>
 			</wickTicks>	
 		</value>
 	</Operation>
@@ -17,8 +17,8 @@
 		<xpath>Defs/ThingDef[defName="UnstablePowerCell"]/comps/li[@Class="CompProperties_Explosive"]/wickTicks</xpath>
 		<value>
 			<wickTicks>
-			  <min>180</min>
-			  <max>300</max>
+			  <min>280</min>
+			  <max>660</max>
 			</wickTicks>	
 		</value>
 	</Operation>
@@ -27,8 +27,8 @@
 		<xpath>Defs/ThingDef[defName="Turret_AutoMortar"]/comps/li[@Class="CompProperties_Explosive"]/wickTicks</xpath>
 		<value>
 			<wickTicks>
-			  <min>180</min>
-			  <max>240</max>
+			  <min>280</min>
+			  <max>660</max>
 			</wickTicks>	
 		</value>
 	</Operation>
@@ -55,7 +55,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.5</AimingAccuracy>
+			<AimingAccuracy>0.35</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -69,7 +69,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases/Mass</xpath>
 		<value>
-			<Mass>25</Mass>
+			<Mass>45</Mass>
 		</value>
 	</Operation>
 
@@ -80,21 +80,21 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/fillPercent</xpath>
 		<value>
-			<fillPercent>0.65</fillPercent>
+			<fillPercent>0.85</fillPercent>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>2.6</turretBurstCooldownTime>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/building/turretGunDef</xpath>
 		<value>
-			<turretGunDef>Gun_BlasterTurret</turretGunDef>
+			<turretGunDef>Gun_AutoBlasterTurret</turretGunDef>
 		</value>
 	</Operation>
 
@@ -110,7 +110,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.5</AimingAccuracy>
+			<AimingAccuracy>0.45</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -124,7 +124,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases/Mass</xpath>
 		<value>
-			<Mass>25</Mass>
+			<Mass>85</Mass>
 		</value>
 	</Operation>
 
@@ -142,7 +142,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>3.2</turretBurstCooldownTime>
 		</value>
 	</Operation>
 
@@ -165,7 +165,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.5</AimingAccuracy>
+			<AimingAccuracy>0.25</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -179,7 +179,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases/Mass</xpath>
 		<value>
-			<Mass>25</Mass>
+			<Mass>45</Mass>
 		</value>
 	</Operation>
 
@@ -197,7 +197,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>3.2</turretBurstCooldownTime>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
A handful of changes that generally make the mech turrets and sieges somewhat less lethal.
Changes:
- Add minimum range to several turrets.
- Increase the fuse length on siege objects that explode, so they're not quite so dangerous to destroy with melee.
- Decrease accuracy of a few turrets
- Increase cooldown
- Increase Mass of several turrets (no actual balance effect, they just seemed too light.)