### PR TITLE
Mincho backpack fix

### DIFF
--- a/Patches/Mincho, The Mint Choco Slime/ThingDefs_Bodies/Mincho_Bodytype.xml
+++ b/Patches/Mincho, The Mint Choco Slime/ThingDefs_Bodies/Mincho_Bodytype.xml
@@ -25,6 +25,7 @@
 							<li>RightShoulder</li>
 							<li>LeftArm</li>
 							<li>RightArm</li>
+							<li>Shoulders</li>
 						  </value>
 						</li>
 					


### PR DESCRIPTION

## Changes

Adds the Shoulders group to the mincho body so they can't wear multiple backpacks

## Alternatives

Remove their ability to wear backpacks and just increase their default bulk

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Long)
