### PR TITLE
VWE Tweaks

### DIFF
--- a/Patches/Vanilla Weapons Expanded/Ammo/AntiGrainRocket.xml
+++ b/Patches/Vanilla Weapons Expanded/Ammo/AntiGrainRocket.xml
@@ -5,37 +5,8 @@
     <mods>
       <li>Vanilla Weapons Expanded</li>
     </mods>
-
     <match Class="PatchOperationSequence">
       <operations>
-
-        <!-- === Ammo === -->
-        <!-- <li Class="PatchOperationAdd">
-          <xpath>Defs</xpath>
-
-          <value>
-            <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBase">
-              <defName>Ammo_ChargeRL</defName>
-              <ammoClass>RocketFrag</ammoClass>
-              <statBases>
-                <Mass>1</Mass>
-                <Bulk>1</Bulk>
-              </statBases>
-              <comps>
-                <li Class="CombatExtended.CompProperties_ExplosiveCE">
-                  <explosionDamage>50</explosionDamage>
-                  <explosiveDamageType>VWE_Shock</explosiveDamageType>
-                  <explosiveRadius>1.5</explosiveRadius>
-                  <soundExplode>MortarBomb_Explode</soundExplode>
-                  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-                  <fragments>
-                    <Fragment_Large>400</Fragment_Large>
-                  </fragments>
-                </li>
-              </comps>
-            </ThingDef>
-          </value>
-        </li> -->
 
         <!-- === Projectile === -->
         <li Class="PatchOperationAdd">
@@ -45,32 +16,29 @@
             <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseSPG9Grenade">
               <defName>Bullet_AntiGrainRocket</defName>
               <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-              <label>anti grain rockets</label>
+              <label>anti-grain rocket</label>
               <graphicData>
                 <texPath>Things/Projectile/RPG/Frag</texPath>
                 <graphicClass>Graphic_Single</graphicClass>
                 <shaderType>TransparentPostLight</shaderType>
               </graphicData>
               <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                <speed>65</speed>
-                <damageDef>VWE_Shock</damageDef>
-                <damageAmountBase>100</damageAmountBase>
-                <armorPenetrationSharp>300</armorPenetrationSharp>
-                <armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-                <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+                <speed>100</speed>  
+                <damageDef>EMP</damageDef>
+                <explosionRadius>8</explosionRadius>
+                <damageAmountBase>300</damageAmountBase>
               </projectile>
               <comps>
                 <li Class="CombatExtended.CompProperties_ExplosiveCE">
-                  <damageAmountBase>50</damageAmountBase>
-                  <explosiveDamageType>VWE_Shock</explosiveDamageType>
-                  <explosiveRadius>4.5</explosiveRadius>
+                  <damageAmountBase>250</damageAmountBase>
+                  <explosiveDamageType>Bomb</explosiveDamageType>
+                  <explosiveRadius>8</explosiveRadius>
                   <explosionSound>MortarBomb_Explode</explosionSound>
                   <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                 </li>
                 <li Class="CombatExtended.CompProperties_Fragments">
                   <fragments>
-                    <Fragment_Large>5</Fragment_Large>
-                    <Fragment_Small>50</Fragment_Small>
+                    <Fragment_Small>100</Fragment_Small>
                   </fragments>
                 </li>
               </comps>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -225,23 +225,24 @@
 		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>VWE_Gun_HandCannon</defName>
 			<statBases>
-				<WorkToMake>7000</WorkToMake>
-				<Mass>1.80</Mass>
-				<Bulk>2.90</Bulk>
-				<ShotSpread>0.20</ShotSpread>
-				<SwayFactor>1.15</SwayFactor>
+				<WorkToMake>4500</WorkToMake>
+				<Mass>0.90</Mass>
+				<Bulk>2.41</Bulk>
+				<ShotSpread>0.17</ShotSpread>
+				<SwayFactor>1.10</SwayFactor>
 				<SightsEfficiency>0.7</SightsEfficiency>
-				<RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
+				<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 			</statBases>
 			<costList>
-				<Steel>35</Steel>
+				<Steel>20</Steel>
+        <WoodLog>5</WoodLog>
 				<ComponentIndustrial>2</ComponentIndustrial>
 			</costList>
 			<Properties>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Bullet_357Magnum_FMJ</defaultProjectile>
-				<warmupTime>0.7</warmupTime>
+				<warmupTime>0.6</warmupTime>
 				<range>12</range>
 				<soundCast>VWE_Shot_Handcannon</soundCast>
 				<soundCastTail>GunTail_Light</soundCastTail>


### PR DESCRIPTION
## Changes
- Tweaked the anti-grain rocket to do a mix of bomb / emp damage, it was doing nothing before.
- **Hand Cannon**
  - WorkToMake: 7000 > 4500
  - Mass: 1.8 > 0.9
  - Bulk: 2.9 > 2.41
  - ShotSpread: 0.20 > 0.17
  - SwayFactor: 1.15 > 1.10
  - RangedCooldown: 0.45 > 0.38
  - Warmup: 0.7 > 0.6
  - Cost: 35 Steel / 2 Components > 5 Wood / 20 Steel / 2 Components