### PR TITLE
Minor Fix: O21 Mechadroids

### DIFF
--- a/Patches/O21 Mechadroids/Bodies_Mechadroids.xml
+++ b/Patches/O21 Mechadroids/Bodies_Mechadroids.xml
@@ -77,20 +77,16 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName = "O21_Mechadroid"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+				<xpath>Defs/BodyDef[defName = "O21_Mechadroid"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 				<value>
-				<groups>
 				<li>CoveredByNaturalArmor</li>
-				</groups>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/BodyDef[defName = "O21_Mechadroid"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+				<xpath>Defs/BodyDef[defName = "O21_Mechadroid"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 				<value>
-				<groups>
 				<li>CoveredByNaturalArmor</li>
-				</groups>
 				</value>
 			</li>
 


### PR DESCRIPTION
Mechanical Leg and Mechanical Foot already have a groups tag. Changed so it is editing that tag instead of making another one.

