### PR TITLE
Use csc instead of mcs as compiler

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -181,7 +181,7 @@ with XMLOpen(CSPROJ) as csproj:
                     print("Directive to exclude non-existent file:", v)
     sources = [(base_dir+'/'+i) for i in sources]
 
-args = ["mcs", "-warnaserror", "-nostdlib", "-langversion:Experimental", "-target:library", f'-out:{OUTPUT}', *sources, *[f'-r:{r}' for r in libraries]]
+args = ["csc", "-warnaserror", "-nostdlib", "-target:library", f'-out:{OUTPUT}', *sources, *[f'-r:{r}' for r in libraries]]
 
 if VERBOSE:
     print(HARMONY)


### PR DESCRIPTION
## Changes

Use `csc` instead of `mcs`, and remove experimental lang version flag (under `csc`, the latest C# standard isn't experimental).

## Reasoning

csc better supports the latest C# syntax, and is most similar to the compiler used on Windows.

## Alternatives

Continue using `mcs`, and limit ourselves to C#6 syntax (no local functions is the common issue)

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (hours)
