### PR TITLE
Add gizmo to order reloading worn armor (or other CompReloadable apparel)

### DIFF
--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
@@ -11,26 +11,12 @@ namespace CombatExtended
 {
     public class Command_ReloadArmor : Command_Action
     {
-        List<Command_ReloadArmor> others;
         public CompReloadable compReloadable;
 
         public override bool GroupsWith(Gizmo other)
         {
             var order = other as Command_ReloadArmor;
             return order != null;
-        }
-
-        public override void MergeWith(Gizmo other)
-        {
-            var order = other as Command_ReloadArmor;
-
-            if (others == null)
-            {
-                others = new List<Command_ReloadArmor>();
-                others.Add(this);
-            }
-
-            others.Add(order);
         }
 
         public override void ProcessInput(Event ev)

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
@@ -12,7 +12,7 @@ namespace CombatExtended
     public class Command_ReloadArmor : Command_Action
     {
         List<Command_ReloadArmor> others;
-	public CompReloadable compReloadable;
+        public CompReloadable compReloadable;
 
         public override bool GroupsWith(Gizmo other)
         {

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_ReloadArmor.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+using UnityEngine;
+using Verse.AI;
+
+namespace CombatExtended
+{
+    public class Command_ReloadArmor : Command_Action
+    {
+        List<Command_ReloadArmor> others;
+	public CompReloadable compReloadable;
+
+        public override bool GroupsWith(Gizmo other)
+        {
+            var order = other as Command_ReloadArmor;
+            return order != null;
+        }
+
+        public override void MergeWith(Gizmo other)
+        {
+            var order = other as Command_ReloadArmor;
+
+            if (others == null)
+            {
+                others = new List<Command_ReloadArmor>();
+                others.Add(this);
+            }
+
+            others.Add(order);
+        }
+
+        public override void ProcessInput(Event ev)
+        {
+            if (compReloadable == null)
+            {
+                Log.Error("Command_ReloadArmor without reloadable comp");
+                return;
+            }
+
+            else if (compReloadable.RemainingCharges < compReloadable.MaxCharges)
+            {
+                base.ProcessInput(ev);
+            }
+
+        }
+
+        public override IEnumerable<FloatMenuOption> RightClickFloatMenuOptions
+        {
+            get
+            {
+		yield break;
+            }
+        }
+
+
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
@@ -24,9 +24,9 @@ namespace CombatExtended.HarmonyCE
 	    {
 		ThingWithComps gear = __instance.parent;
 		Pawn wearer = __instance.Wearer;
-		Job j=null;
+		Job j = null;
 		bool gotJob = Harmony_JobGiver_Reload_TryGiveJob.Prefix(wearer, ref j);
-		if (j!=null)
+		if (j != null)
 		{
 		    wearer.jobs.StartJob(j, JobCondition.InterruptForced, null, wearer.CurJob?.def != j.def, true);
 		}

--- a/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse.AI;
+using Verse;
+using UnityEngine;
+using HarmonyLib;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(CompReloadable), "CompGetWornGizmosExtra")]
+    public static class Harmony_CompReloadable_CompygetWornGizmosExtra
+    {
+	public static IEnumerable<Gizmo> Postfix(IEnumerable<Gizmo> __result, CompReloadable __instance)
+        {
+	    foreach (Gizmo g in __result)
+	    {
+		yield return g;
+	    }
+
+	    void TryReloadArmor()
+	    {
+		ThingWithComps gear = __instance.parent;
+		Pawn wearer = __instance.Wearer;
+		Job j=null;
+		bool gotJob = Harmony_JobGiver_Reload_TryGiveJob.Prefix(wearer, ref j);
+		if (j!=null)
+		{
+		    wearer.jobs.StartJob(j, JobCondition.InterruptForced, null, wearer.CurJob?.def != j.def, true);
+		}
+	    };
+	    
+	    yield return new Command_ReloadArmor
+		{
+                    compReloadable = __instance,
+                    action = TryReloadArmor,
+                    defaultLabel = (string)"CE_ReloadLabel".Translate() + " worn armor",
+                    defaultDesc = "CE_ReloadDesc".Translate(),
+                    icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload", true)
+                    
+                };
+	    
+        }
+    }
+}


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
Allows ordering drafted colonists to reload their reloadable apparel

## Reasoning

Doing it this way hooks into the existing reload logic for apparel (when pawns are not drafted).

## Alternatives

Manually create the reload job (duplicates code)

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (royalty)
