### PR TITLE
Vanilla Weapons Expanded Tweaks

### DIFF
--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -212,7 +212,7 @@
 				<ammoSet>AmmoSet_45ACP</ammoSet>
 			</AmmoUser>
 			<FireModes>
-				<aiAimMode>AimedShot</aiAimMode>
+				<aiAimMode>Snapshot</aiAimMode>
 			</FireModes>
 			<weaponTags>
 				<li>SimpleGun</li>
@@ -254,7 +254,7 @@
 				<ammoSet>AmmoSet_357Magnum</ammoSet>
 			</AmmoUser>
 			<FireModes>
-				<aiAimMode>AimedShot</aiAimMode>
+				<aiAimMode>Snapshot</aiAimMode>
 			</FireModes>
 			<weaponTags>
 				<li>SimpleGun</li>
@@ -637,7 +637,7 @@
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
 				<warmupTime>3.5</warmupTime>
-				<range>126</range>
+				<range>86</range>
 				<soundCast>VWE_Shot_AntiMaterialRifle</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
## Changes
- Changes the Combat Pistol / Hand Cannon ai aim modes to ` Snapshot `
- Reduced the range of the anti-material rifle to 86 from 126