### PR TITLE
Hunter will stay far if they're hunting an animal with revenge chance.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Hunt.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Hunt.cs
@@ -173,8 +173,6 @@ namespace CombatExtended
                 Thing thing = curJob.GetTarget(targetInd).Thing;
                 var pawnVictim = thing as Pawn;
 
-                
-
                 if (!CastPositionFinder.TryFindCastPosition(new CastPositionRequest
                 {
                     caster = toil.actor,

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Hunt.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Hunt.cs
@@ -55,7 +55,7 @@ namespace CombatExtended
             var moveIfCannotHit = Toils_Jump.JumpIf(gotoCastPos, delegate
             {
                 var verb = pawn.CurJob.verbToUse;
-                var optimalRange = HuntRangePerBodysize(Victim.RaceProps.baseBodySize, Victim.RaceProps.executionRange, verb.verbProps.range);
+                var optimalRange = GetOptimalHuntRange(pawn, Victim);
                 if (pawn.Position.DistanceTo(Victim.Position) > optimalRange)
                 {
                     return true;
@@ -172,18 +172,17 @@ namespace CombatExtended
                 Job curJob = actor.CurJob;
                 Thing thing = curJob.GetTarget(targetInd).Thing;
                 var pawnVictim = thing as Pawn;
-                IntVec3 intVec;
+
+                
+
                 if (!CastPositionFinder.TryFindCastPosition(new CastPositionRequest
                 {
                     caster = toil.actor,
                     target = thing,
                     verb = curJob.verbToUse,
-                    maxRangeFromTarget = ((closeIfDowned && pawnVictim != null && pawnVictim.Downed)
-                                          ? Mathf.Min(curJob.verbToUse.verbProps.range, (float)pawnVictim.RaceProps.executionRange)
-                                            //The following line is changed
-                                            : HuntRangePerBodysize(pawnVictim.RaceProps.baseBodySize, (float)pawnVictim.RaceProps.executionRange, curJob.verbToUse.verbProps.range)),
+                    maxRangeFromTarget = GetOptimalHuntRange(actor, pawnVictim),
                     wantCoverFromTarget = false
-                }, out intVec))
+                }, out var intVec))
                 {
                     toil.actor.jobs.EndCurrentJob(JobCondition.Incompletable, true);
                     return;
@@ -196,10 +195,57 @@ namespace CombatExtended
             return toil;
         }
 
-        //Fit for an attack range per body size curve.
-        public static float HuntRangePerBodysize(float x, float executionRange, float gunRange)
+        public static float GetOptimalHuntRange(Pawn hunter, Pawn victim)
         {
-            return Mathf.Min(Mathf.Clamp(1 + 20 * (1 - Mathf.Exp(-0.65f * x)), executionRange, 20), gunRange);
+            var curJob = hunter.CurJob;
+            var victimProps = victim.RaceProps;
+            
+            if (victim.Downed)
+            {
+                // TODO: How to detect boombats?
+                return Mathf.Min(curJob.verbToUse.verbProps.range, victimProps.executionRange);
+            }
+            
+            var normalRange = HuntRangePerBodysize(victimProps.baseBodySize, victimProps.executionRange, curJob.verbToUse.verbProps.range);
+
+            if (victimProps.manhunterOnDamageChance > 0)
+            {
+                // NOTE: I assumed 2 is a good number to consider for aim time of hunting weapons (since hunting weapons are likely to be sniper rifles)
+                // We can also get aim time from the actual weapon that the hunter is using
+                // but I didn't see the need.
+                const int aimTime = 2;
+                
+                // Determine how much target can move away from the hunter while the hunter is aiming
+                float moveOffset = CE_Utility.GetMoveSpeed(victim) * aimTime;
+
+                // Get a little bit closer when target is small. (Smaller targets don't attack that hard so it's ok from safety standpoint) 
+                // For reference, Megasloth is 4, and squirrel is 0.2
+                float bodySizeFactor = Mathf.Clamp01(victimProps.baseBodySize);
+                
+                // If the hunter's shooting skill is below skillThreshold, hunter gets closer to not miss their shots
+                // I assumed level 10 is a good enough shooter to stay at maximum distance and don't miss 
+                const float skillThreshold = 10f;
+                float skillFactor = Mathf.Clamp01(hunter.skills.GetSkill(SkillDefOf.Shooting).Level / skillThreshold);
+                
+                float weaponRange = curJob.verbToUse.verbProps.range;
+
+                // Add additional offset to create a safe margin just in case something weird happens 
+                const int additionalOffset = 5;
+                float optimal = weaponRange * bodySizeFactor * skillFactor - moveOffset - additionalOffset;
+                
+                // In some cases optimal range gets lower than the normal range that we calculated for non-manhunting animals.
+                // For example when the hunter has 0 shooting skill, optimal range will be negative.
+                // In that case we just go back to normal calculated range.
+                return Mathf.Max(optimal, normalRange);
+            }
+
+            return normalRange;
+            
+            //Fit for an attack range per body size curve.
+            float HuntRangePerBodysize(float x, float executionRange, float gunRange)
+            {
+                return Mathf.Min(Mathf.Clamp(1 + 20 * (1 - Mathf.Exp(-0.65f * x)), executionRange, 20), gunRange);
+            }
         }
 
         Toil StartCollectCorpseToil()


### PR DESCRIPTION
## Additions and Changes

Hunters will keep their distance to dangerous animals and try to shoot them down from a distance. 
Nothing changed when hunter is hunting a safe animal. 

## Reasoning

Hunters get close to dangerous animals like Megasloth when they try to hunt them even with sniper rifles like Tac-50. 
The result is if the animal enters manhunting mode, hunter will likely to get badly injured or die.
With this change even if animal enters manhunting mode, hunter can take a few more shots or run away.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Playtested on an existing colony for a few hours)
