### PR TITLE
Infinite ammo

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -52,4 +52,6 @@
   <CE_Settings_RealisticCookOff_Title>Realistic cook-off</CE_Settings_RealisticCookOff_Title>
   <CE_Settings_RealisticCookOff_Desc>Ammunition stacks won't spawn damaging projectiles on cooking off.</CE_Settings_RealisticCookOff_Desc>
 
+  <CE_Settings_InfiniteAmmo_Title>Infinite Ammo</CE_Settings_InfiniteAmmo_Title>
+  <CE_Settings_InfiniteAmmo_Desc>Weapons can use various ammo types infinitely. You still need to reload, but it doesn't cost anything.</CE_Settings_InfiniteAmmo_Desc>
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -23,11 +23,12 @@ namespace CombatExtended
     {
         public static readonly FieldInfo _allRecipesCached = typeof(ThingDef).GetField("allRecipesCached", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        public const string destroyWithAmmoDisabledTag = "CE_Ammo";               // The trade tag which automatically deleted this ammo with the ammo system disabled
-        private const string enableTradeTag = "CE_AutoEnableTrade";             // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
-        private const string enableCraftingTag = "CE_AutoEnableCrafting";        // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
+        public const string destroyWithAmmoDisabledTag = "CE_Ammo";       // The trade tag which automatically deleted this ammo with the ammo system disabled
+        private const string enableTradeTag = "CE_AutoEnableTrade";       // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
+        private const string enableCraftingTag = "CE_AutoEnableCrafting"; // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
         // these ammo classes are disabled when simplified ammo is turned on
-        private static HashSet<string> complexAmmoClasses = new HashSet<string>(new string[] {
+        private static HashSet<string> complexAmmoClasses = new HashSet<string>(new string[]
+        {
             // pistol + rifle + high caliber
             "ArmorPiercing", "HollowPoint", "Sabot", "IncendiaryAP", "ExplosiveAP",
             // shotguns
@@ -59,12 +60,12 @@ namespace CombatExtended
             {
                 Log.Error("Combat Extended :: Ammo injector failed to get injected");
             }
-            ThingSetMakerUtility.Reset();   // Reset pool of spawnable ammos for quests, etc.
+            ThingSetMakerUtility.Reset(); // Reset pool of spawnable ammos for quests, etc.
         }
 
         public static bool InjectAmmos()
         {
-            bool enabled = Controller.settings.EnableAmmoSystem;
+            bool enabled = Controller.settings.EnableAmmoSystem && !Controller.settings.InfiniteAmmo;
             bool simplifiedAmmo = Controller.settings.EnableSimplifiedAmmo;
 
             // Initialize list of all weapons
@@ -107,6 +108,8 @@ namespace CombatExtended
             }
             */
 
+            if (Controller.settings.InfiniteAmmo)
+                CE_Utility.allAmmoDefs = new Dictionary<string, AmmoDef>(ammoDefs.Count);
             // Loop through all weaponDef's unique ammoType.ammo values
             foreach (AmmoDef ammoDef in ammoDefs)
             {
@@ -220,6 +223,9 @@ namespace CombatExtended
                         }
                     }
                 }
+
+                if (Controller.settings.InfiniteAmmo)
+                    CE_Utility.allAmmoDefs.Add(ammoDef.defName, ammoDef);
             }
 
             /*
@@ -292,7 +298,7 @@ namespace CombatExtended
                     }
                 }
             }
-            _allRecipesCached.SetValue(benchDef, null);  // Set ammoCraftingStation.AllRecipes to null so it will reset
+            _allRecipesCached.SetValue(benchDef, null); // Set ammoCraftingStation.AllRecipes to null so it will reset
         }
 
         public static bool gunRecipesShowCaliber = false;
@@ -314,8 +320,8 @@ namespace CombatExtended
                         {
                             var label = x.label + (shouldHaveLabels ? " (" + (string)ammoSet.LabelCap + ")" : "");
 
-                            recipeDef.UpdateLabel("RecipeMake".Translate(label));           //Just setting recipeDef.label doesn't update Jobs nor existing recipeUsers. We need UpdateLabel.
-                            recipeDef.jobString = "RecipeMakeJobString".Translate(label);   //The jobString should also be updated to reflect the name change.
+                            recipeDef.UpdateLabel("RecipeMake".Translate(label));         //Just setting recipeDef.label doesn't update Jobs nor existing recipeUsers. We need UpdateLabel.
+                            recipeDef.jobString = "RecipeMakeJobString".Translate(label); //The jobString should also be updated to reflect the name change.
                         }
                     }
                 });

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -113,12 +113,41 @@ namespace CombatExtended
         #region Misc
         public static List<ThingDef> allWeaponDefs = new List<ThingDef>();
 
+        /// <summary>
+        /// Maps def name to ammo def. Used when Infinite Ammo is on. Otherwise is null.
+        /// </summary>
+        public static Dictionary<string, AmmoDef> allAmmoDefs;
+        /// <summary>
+        /// Holds a cached ammo thing that is lazily filled and used when Infinite Ammo is on. 
+        /// </summary>
+        public static Dictionary<string, AmmoThing> cachedAmmoThing = new Dictionary<string, AmmoThing>();
+
         public static readonly FieldInfo cachedLabelCapInfo = typeof(Def).GetField("cachedLabelCap", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static void UpdateLabel(this Def def, string label)
         {
             def.label = label;
             cachedLabelCapInfo.SetValue(def, new TaggedString(""));
+        }
+
+        public static AmmoThing GetInfiniteAmmoThing(string defName)
+        {
+	        if (cachedAmmoThing.TryGetValue(defName, out var ammoThing))
+	        {
+		        // Found a cached thing
+		        ammoThing.stackCount = int.MaxValue;
+		        return ammoThing;
+	        }
+                
+	        // Could not find a cached thing. Create one.
+	        var def = allAmmoDefs[defName];
+	        ammoThing = (AmmoThing)ThingMaker.MakeThing(def);
+	        ammoThing.stackCount = int.MaxValue;
+                
+	        // Add it to the cache for later use.
+	        cachedAmmoThing.Add(def.defName, ammoThing);
+
+	        return ammoThing;
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -108,7 +108,7 @@ namespace CombatExtended
         {
             get
             {
-                return CompInventory != null && CompInventory.ammoList.Any(x => Props.ammoSet.ammoTypes.Any(a => a.ammo == x.def));
+                return CompInventory != null && (Controller.settings.InfiniteAmmo || CompInventory.ammoList.Any(x => Props.ammoSet.ammoTypes.Any(a => a.ammo == x.def)));
             }
         }
         public bool HasMagazine => Props.magazineSize > 0;
@@ -396,7 +396,7 @@ namespace CombatExtended
             if (!HasMagazine || (Holder == null && turret == null))
                 return false; // nothing to do as we are in a bad state;
 
-            if (!UseAmmo || curMagCountInt == 0)
+            if (!UseAmmo || curMagCountInt == 0 || Controller.settings.InfiniteAmmo)
                 return true; // nothing to do but we aren't in a bad state either.  Claim success.
 
             if (Props.reloadOneAtATime && !forceUnload && selectedAmmo == CurrentAmmo && turret == null)
@@ -547,6 +547,12 @@ namespace CombatExtended
             if (CompInventory == null)
             {
                 return false;
+            }
+
+            if (Controller.settings.InfiniteAmmo)
+            {
+                ammoThing = CE_Utility.GetInfiniteAmmoThing(selectedAmmo.defName);
+                return true;
             }
 
             // Try finding suitable ammoThing for currently set ammo first

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -134,6 +134,9 @@ namespace CombatExtended
         /// <returns>int amount of AmmoDef found in AmmoList.</returns>
         public int AmmoCountOfDef(AmmoDef def)
         {
+            if (Controller.settings.InfiniteAmmo)
+                return int.MaxValue;
+            
         	return ammoListCached.Where(t => t.def == def).Sum(t => t.stackCount);
         }
 

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -158,7 +158,7 @@ namespace CombatExtended
                 return;
             }
 
-            // When infinite ammo is enabled, ammo is removed from the menus. So we should check for menuHidden variable
+            // When infinite ammo is enabled, ammo is removed from the menus. So we should not check for menuHidden variable
             if (Controller.settings.InfiniteAmmo)
             {
                 var available = compAmmo.Props.ammoSet.ammoTypes.Where(x => x.ammo.generateAllowChance > 0).Select(x => x.ammo);

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -157,6 +157,16 @@ namespace CombatExtended
                 compAmmo.ResetAmmoCount();
                 return;
             }
+
+            // When infinite ammo is enabled, ammo is removed from the menus. So we should check for menuHidden variable
+            if (Controller.settings.InfiniteAmmo)
+            {
+                var available = compAmmo.Props.ammoSet.ammoTypes.Where(x => x.ammo.generateAllowChance > 0).Select(x => x.ammo);
+                var selected = available.RandomElementByWeight(a => a.generateAllowChance);
+                compAmmo.ResetAmmoCount(selected);
+                return;
+            }
+            
             // Determine ammo
             IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && a.ammo.generateAllowChance > 0f).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
             AmmoDef ammoToLoad = availableAmmo.RandomElementByWeight(a => a.generateAllowChance);

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
@@ -96,7 +96,7 @@ namespace CombatExtended
             List<FloatMenuOption> floatOptionList = new List<FloatMenuOption>();
 
             #region Ammo type switching
-            if (compAmmo.UseAmmo)
+            if (compAmmo.UseAmmo || Controller.settings.InfiniteAmmo)
             {
                 //List of actions to be taken on choosing a new ammo type, listed by ammoCategoryDef (FMJ/AP/HP)
                 Dictionary<AmmoCategoryDef, Action> ammoClassActions = new Dictionary<AmmoCategoryDef, Action>();
@@ -118,7 +118,7 @@ namespace CombatExtended
 
                         // If we have no inventory available (e.g. manned turret), add all possible ammo types to the selection
                         // Otherwise, iterate through all suitable ammo types and check if they're in our inventory
-                        if (user.CompInventory?.ammoList?.Any(x => x.def == ammoDef) ?? true)
+                        if (Controller.settings.InfiniteAmmo || (user.CompInventory?.ammoList?.Any(x => x.def == ammoDef) ?? true))
                         {
                             if (!ammoClassAmounts.ContainsKey(ammoClass))
                                 ammoClassAmounts.Add(ammoClass, new int[2]);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -50,7 +50,8 @@ namespace CombatExtended
                 return false;
             }
 
-            if (!compAmmo.UseAmmo)
+            // No need to reserve ammo if we don't use ammo or we have InfiniteAmmo on
+            if (!compAmmo.UseAmmo || Controller.settings.InfiniteAmmo)
             {
                 return true;
             }
@@ -97,8 +98,16 @@ namespace CombatExtended
             }
             if (compReloader.UseAmmo && ammo == null)
             {
-                Log.Error(string.Concat(errorBase, "TargetThingB is either null or not an AmmoThing."));
-                yield return null;
+                if (Controller.settings.InfiniteAmmo)
+                {
+                    TargetThingB = CE_Utility.GetInfiniteAmmoThing(compReloader.SelectedAmmo.defName);
+                }
+                else
+                {
+
+                    Log.Error(string.Concat(errorBase, "TargetThingB is either null or not an AmmoThing."));
+                    yield return null;
+                }
             }
 
             AddEndCondition(delegate
@@ -119,7 +128,7 @@ namespace CombatExtended
             this.FailOn(() => compReloader.MissingToFullMagazine == 0);
 
             // Perform ammo system specific activities, failure condition and hauling
-            if (compReloader.UseAmmo)
+            if (compReloader.UseAmmo && !Controller.settings.InfiniteAmmo)
             {
                 var toilGoToCell = Toils_Goto.GotoCell(ammo.Position, PathEndMode.Touch).FailOnBurningImmobile(TargetIndex.B);
                 var toilCarryThing = Toils_Haul.StartCarryThing(TargetIndex.B).FailOnBurningImmobile(TargetIndex.B);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -104,7 +104,6 @@ namespace CombatExtended
                 }
                 else
                 {
-
                     Log.Error(string.Concat(errorBase, "TargetThingB is either null or not an AmmoThing."));
                     yield return null;
                 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -126,13 +126,23 @@ namespace CombatExtended
                 // Is the gun loaded with ammo not in a Loadout/HoldTracker?
                 if (tmpComp.UseAmmo && pawnHasLoadout && !TrackingSatisfied(pawn, ammoType, magazineSize))
 				{
-					// Do we have ammo in the inventory that the gun uses which satisfies requirements? (expensive)
-					AmmoDef matchAmmo = tmpComp.Props.ammoSet.ammoTypes
-						.Where(al => al.ammo != ammoType)
-						.Select(al => al.ammo)
-						.FirstOrDefault(ad => TrackingSatisfied(pawn, ad, magazineSize) 
-						                && inventory.AmmoCountOfDef(ad) >= magazineSize);
-					
+					AmmoDef matchAmmo;
+
+					// If we are using infinite ammo we don't need to look into inventory.
+					if (Controller.settings.InfiniteAmmo)
+					{
+						matchAmmo = CE_Utility.allAmmoDefs[ammoType.defName];
+					}
+					else
+					{
+						// Do we have ammo in the inventory that the gun uses which satisfies requirements? (expensive)
+						matchAmmo = tmpComp.Props.ammoSet.ammoTypes
+							.Where(al => al.ammo != ammoType)
+							.Select(al => al.ammo)
+							.FirstOrDefault(ad => TrackingSatisfied(pawn, ad, magazineSize) 
+								&& inventory.AmmoCountOfDef(ad) >= magazineSize);	
+					}
+
 					if (matchAmmo != null)
 					{
 						reloadWeapon = gun;

--- a/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
@@ -125,7 +125,13 @@ namespace CombatExtended.CombatExtended.Jobs.Utils
 
 		private static Thing FindBestAmmo(Pawn pawn, Building_TurretGunCE turret)
 		{
-			AmmoDef requestedAmmo = turret.CompAmmo.SelectedAmmo;	
+			AmmoDef requestedAmmo = turret.CompAmmo.SelectedAmmo;
+
+			if (Controller.settings.InfiniteAmmo)
+			{
+				return CE_Utility.GetInfiniteAmmoThing(requestedAmmo.defName);
+			}
+			
 			var bestAmmo = FindBestAmmo(pawn, requestedAmmo);   // try to find currently selected ammo first
 			if (bestAmmo == null && turret.CompAmmo.EmptyMagazine && requestedAmmo.AmmoSetDefs != null)
 			{

--- a/Source/CombatExtended/CombatExtended/LoggerUtils/CELogger.cs
+++ b/Source/CombatExtended/CombatExtended/LoggerUtils/CELogger.cs
@@ -8,7 +8,7 @@ namespace CombatExtended.CombatExtended.LoggerUtils
         /// Am I in debug mode? Set this to <c>true</c> and recompile for more log output.
         /// TODO: Maybe change this to a toggleable setting if I ever have the time to figure out how <3.
         /// </summary>
-        private static readonly bool isInDebugMode = false;
+        private static readonly bool isInDebugMode = Controller.settings.DebugLogs;
 
         public static void Message(string message, bool showOutOfDebugMode = false, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
         {

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -165,7 +165,7 @@ namespace CombatExtended
                 list.CheckboxLabeled("CE_Settings_ReuseNeolithicProjectiles_Title".Translate(), ref reuseNeolithicProjectiles, "CE_Settings_ReuseNeolithicProjectiles_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_RealisticCookOff_Title".Translate(), ref realisticCookOff, "CE_Settings_RealisticCookOff_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_EnableSimplifiedAmmo_Title".Translate(), ref enableSimplifiedAmmo, "CE_Settings_EnableSimplifiedAmmo_Desc".Translate()); ;
-                list.CheckboxLabeled("Infinite Ammo", ref infiniteAmmo, ""); ;
+                list.CheckboxLabeled("CE_Settings_InfiniteAmmo_Title".Translate(), ref infiniteAmmo, "CE_Settings_InfiniteAmmo_Desc".Translate()); ;
             }
             else
             {
@@ -177,7 +177,7 @@ namespace CombatExtended
                 list.Label("CE_Settings_ReuseNeolithicProjectiles_Title".Translate());
                 list.Label("CE_Settings_RealisticCookOff_Title".Translate());
                 list.Label("CE_Settings_EnableSimplifiedAmmo_Title".Translate());
-                list.Label("Infinite Ammo");
+                list.Label("CE_Settings_InfiniteAmmo_Title".Translate());
 
                 GUI.contentColor = Color.white;
             }

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -38,6 +38,7 @@ namespace CombatExtended
         private bool reuseNeolithicProjectiles = true;
         private bool realisticCookOff = false;
         private bool enableSimplifiedAmmo = false;
+        private bool infiniteAmmo = false;
 
         public bool EnableAmmoSystem => enableAmmoSystem;
         public bool RightClickAmmoSelect => rightClickAmmoSelect;
@@ -47,6 +48,7 @@ namespace CombatExtended
         public bool ReuseNeolithicProjectiles => reuseNeolithicProjectiles;
         public bool RealisticCookOff => realisticCookOff;
         public bool EnableSimplifiedAmmo => enableSimplifiedAmmo;
+        public bool InfiniteAmmo => infiniteAmmo;
 
         // Debug settings - make sure all of these default to false for the release build
         private bool debugDrawPartialLoSChecks = false;
@@ -55,6 +57,7 @@ namespace CombatExtended
         private bool debugShowTreeCollisionChance = false;
         private bool debugShowSuppressionBuildup = false;
         private bool debugDrawInterceptChecks = false;
+        private bool debugLogs = false;
 
         public bool DebugDrawInterceptChecks => debugDrawInterceptChecks;
         public bool DebugDrawPartialLoSChecks => debugDrawPartialLoSChecks;
@@ -62,6 +65,7 @@ namespace CombatExtended
         public bool DebugDrawTargetCoverChecks => debugDrawTargetCoverChecks;
         public bool DebugShowTreeCollisionChance => debugShowTreeCollisionChance;
         public bool DebugShowSuppressionBuildup => debugShowSuppressionBuildup;
+        public bool DebugLogs => debugLogs;
 
         #endregion
 
@@ -87,6 +91,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref debugDrawTargetCoverChecks, "debugDrawTargetCoverChecks", false);
             Scribe_Values.Look(ref debugShowTreeCollisionChance, "debugShowTreeCollisionChance", false);
             Scribe_Values.Look(ref debugShowSuppressionBuildup, "debugShowSuppressionBuildup", false);
+            Scribe_Values.Look(ref debugLogs, "debugLogs", false);
 #endif
 
             // Ammo settings
@@ -98,6 +103,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref reuseNeolithicProjectiles, "reuseNeolithicProjectiles", true);
             Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", false);
             Scribe_Values.Look(ref enableSimplifiedAmmo, "enableSimplifiedAmmo", false);
+            Scribe_Values.Look(ref infiniteAmmo, "infiniteAmmo", false);
 
             Scribe_Values.Look(ref ShowTutorialPopup, "ShowTutorialPopup", true);
 
@@ -137,6 +143,7 @@ namespace CombatExtended
             list.CheckboxLabeled("Enable inventory validation", ref debugEnableInventoryValidation, "Inventory will refresh its cache every tick and log any discrepancies.");
             list.CheckboxLabeled("Display tree collision chances", ref debugShowTreeCollisionChance, "Projectiles will display chances of coliding with trees as they pass by.");
             list.CheckboxLabeled("Display suppression buildup", ref debugShowSuppressionBuildup, "Pawns will display buildup numbers when taking suppression.");
+            list.CheckboxLabeled("Debug Logs", ref debugLogs, "Prints additional logs");
 #endif
 
             // Do ammo settings
@@ -158,6 +165,7 @@ namespace CombatExtended
                 list.CheckboxLabeled("CE_Settings_ReuseNeolithicProjectiles_Title".Translate(), ref reuseNeolithicProjectiles, "CE_Settings_ReuseNeolithicProjectiles_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_RealisticCookOff_Title".Translate(), ref realisticCookOff, "CE_Settings_RealisticCookOff_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_EnableSimplifiedAmmo_Title".Translate(), ref enableSimplifiedAmmo, "CE_Settings_EnableSimplifiedAmmo_Desc".Translate()); ;
+                list.CheckboxLabeled("Infinite Ammo", ref infiniteAmmo, ""); ;
             }
             else
             {
@@ -169,6 +177,7 @@ namespace CombatExtended
                 list.Label("CE_Settings_ReuseNeolithicProjectiles_Title".Translate());
                 list.Label("CE_Settings_RealisticCookOff_Title".Translate());
                 list.Label("CE_Settings_EnableSimplifiedAmmo_Title".Translate());
+                list.Label("Infinite Ammo");
 
                 GUI.contentColor = Color.white;
             }


### PR DESCRIPTION
## Additions and Changes

Added a new option to use full ammo system and ammo types without the micro-management of ammo crafting.
This mode can be turned on in options with enabling `Infinite Ammo` under `Enable Ammo System` category.
With this mode turned on, you can switch ammo to any ammo type in both pawns and turrets. Raiders also can have any of the ammo types.

This mode does not remove the need to reload.

## Reasoning

This mode is for people who like the ammo system and the fact that every ammo type should be used against a specific target but they hate the micro-management of crafting ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (On a new colony with development mode, 2-3 hours)
