### PR TITLE
Rimsec-Security patch

### DIFF
--- a/Patches/RimSec-Security/AlienBase.xml
+++ b/Patches/RimSec-Security/AlienBase.xml
@@ -173,6 +173,14 @@
 				  </value>
 				</li>
 
+				<!-- Reduce health scale since they have adequate armor-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/race/baseHealthScale</xpath>
+				  <value>
+				    <baseHealthScale>1.6</baseHealthScale>
+				  </value>
+				</li>
+
 
 				<!--Sentinel Series-->
 				
@@ -238,6 +246,14 @@
 						<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					  </li>
 					</tools>
+				  </value>
+				</li>
+
+				<!-- Reduce health scale since they have adequate armor-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/race/baseHealthScale</xpath>
+				  <value>
+				    <baseHealthScale>2.5</baseHealthScale>
 				  </value>
 				</li>
 				

--- a/Patches/RimSec-Security/AlienBase.xml
+++ b/Patches/RimSec-Security/AlienBase.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+	  <operations>
+		<li Class="PatchOperationFindMod">
+		
+		  <mods><li>Rimsec Security</li></mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+
+				<!-- Body Shape -->
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  @Name="RSPeacekeeperDefenderBase" or
+				  @Name="RSPeacekeeperEnforcerBase" or
+				  @Name="RSPeacekeeperSentinelBase"
+				  ]/modExtensions</xpath>
+				  <value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+					  <bodyShape>Humanoid</bodyShape>
+					</li>
+				  </value>
+				</li>
+				
+				<!-- Gizmos -->
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  @Name="RSPeacekeeperDefenderBase" or
+				  @Name="RSPeacekeeperEnforcerBase" or
+				  @Name="RSPeacekeeperSentinelBase"
+				  ]/comps</xpath>
+				  <value>
+				    <li>
+					  <compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+				  </value>
+				</li>
+				
+				
+				<!--Defender Series-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.2</MeleeCritChance>
+					<MeleeParryChance>1.2</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+					<CarryBulk>60</CarryBulk>
+					<CarryWeight>60</CarryWeight>
+				  </value>
+				</li>
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>12</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>26</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Enforcer Series-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>1.2</MeleeDodgeChance>
+					<MeleeCritChance>1.3</MeleeCritChance>
+					<MeleeParryChance>1.3</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+					<CarryBulk>60</CarryBulk>
+					<CarryWeight>60</CarryWeight>
+				  </value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>16</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>34</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+
+
+				<!--Sentinel Series-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases</xpath>
+				  <value>
+					<MeleeCritChance>1.6</MeleeCritChance>
+					<MeleeParryChance>1.6</MeleeParryChance>
+					<SmokeSensitivity>0</SmokeSensitivity>
+					<CarryBulk>60</CarryBulk>
+					<CarryWeight>60</CarryWeight>
+				  </value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>20</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>42</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.42</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>24</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.42</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>24</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>3.52</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>4</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+			  </operations>
+			</match>
+	    </li>
+		
+	  </operations>
+	</Operation>
+</Patch>

--- a/Patches/RimSec-Security/AlienBase.xml
+++ b/Patches/RimSec-Security/AlienBase.xml
@@ -1,266 +1,256 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-	<Operation Class="PatchOperationSequence">
-	  <operations>
-		<li Class="PatchOperationFindMod">
-		
-		  <mods><li>Rimsec Security</li></mods>
-			<match Class="PatchOperationSequence">
-			  <operations>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsec Security</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
 
 				<!-- Body Shape -->
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
-				  @Name="RSPeacekeeperDefenderBase" or
-				  @Name="RSPeacekeeperEnforcerBase" or
-				  @Name="RSPeacekeeperSentinelBase"
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[ @Name="RSPeacekeeperDefenderBase" or @Name="RSPeacekeeperEnforcerBase" or @Name="RSPeacekeeperSentinelBase"
 				  ]/modExtensions</xpath>
-				  <value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-					  <bodyShape>Humanoid</bodyShape>
-					</li>
-				  </value>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
+						</li>
+					</value>
 				</li>
-				
+
 				<!-- Gizmos -->
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
-				  @Name="RSPeacekeeperDefenderBase" or
-				  @Name="RSPeacekeeperEnforcerBase" or
-				  @Name="RSPeacekeeperSentinelBase"
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[ @Name="RSPeacekeeperDefenderBase" or @Name="RSPeacekeeperEnforcerBase" or @Name="RSPeacekeeperSentinelBase"
 				  ]/comps</xpath>
-				  <value>
-				    <li>
-					  <compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-				  </value>
+					<value>
+						<li>
+							<compClass>CombatExtended.CompPawnGizmo</compClass>
+						</li>
+					</value>
 				</li>
-				
-				
+
+
 				<!--Defender Series-->
-				
+
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases</xpath>
-				  <value>
-				    <MeleeDodgeChance>1</MeleeDodgeChance>
-					<MeleeCritChance>1.2</MeleeCritChance>
-					<MeleeParryChance>1.2</MeleeParryChance>
-					<SmokeSensitivity>0</SmokeSensitivity>
-					<CarryBulk>60</CarryBulk>
-					<CarryWeight>60</CarryWeight>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>1</MeleeDodgeChance>
+						<MeleeCritChance>1.2</MeleeCritChance>
+						<MeleeParryChance>1.2</MeleeParryChance>
+						<SmokeSensitivity>0</SmokeSensitivity>
+						<CarryBulk>60</CarryBulk>
+						<CarryWeight>60</CarryWeight>
+					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Sharp</xpath>
-				  <value>
-				    <ArmorRating_Sharp>12</ArmorRating_Sharp>
-				  </value>
-				</li>
-				
-				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Blunt</xpath>
-				  <value>
-				    <ArmorRating_Blunt>26</ArmorRating_Blunt>
-				  </value>
-				</li>
-				
-				
-				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/tools</xpath>
-				  <value>
-				    <tools>
-					  <li Class="CombatExtended.ToolCE">
-						<label>left fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>5</power>
-						<cooldownTime>1.11</cooldownTime>
-						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>right fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>5</power>
-						<cooldownTime>1.11</cooldownTime>
-						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>2</power>
-						<cooldownTime>4.49</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
-					  </li>
-					</tools>
-				  </value>
-				</li>
-				
-				<!--Enforcer Series-->
-				
-				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases</xpath>
-				  <value>
-					<MeleeDodgeChance>1.2</MeleeDodgeChance>
-					<MeleeCritChance>1.3</MeleeCritChance>
-					<MeleeParryChance>1.3</MeleeParryChance>
-					<SmokeSensitivity>0</SmokeSensitivity>
-					<CarryBulk>60</CarryBulk>
-					<CarryWeight>60</CarryWeight>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Sharp</xpath>
-				  <value>
-				    <ArmorRating_Sharp>16</ArmorRating_Sharp>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>26</ArmorRating_Blunt>
+					</value>
 				</li>
-				
+
+
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Blunt</xpath>
-				  <value>
-				    <ArmorRating_Blunt>34</ArmorRating_Blunt>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperDefenderBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>4.49</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
 				</li>
-				
+
+				<!--Enforcer Series-->
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>1.2</MeleeDodgeChance>
+						<MeleeCritChance>1.3</MeleeCritChance>
+						<MeleeParryChance>1.3</MeleeParryChance>
+						<SmokeSensitivity>0</SmokeSensitivity>
+						<CarryBulk>60</CarryBulk>
+						<CarryWeight>60</CarryWeight>
+					</value>
+				</li>
+
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/tools</xpath>
-				  <value>
-				    <tools>
-					  <li Class="CombatExtended.ToolCE">
-						<label>left fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>5</power>
-						<cooldownTime>1.11</cooldownTime>
-						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>right fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>5</power>
-						<cooldownTime>1.11</cooldownTime>
-						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>2</power>
-						<cooldownTime>4.49</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
-					  </li>
-					</tools>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>34</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1.11</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>4.49</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
 				</li>
 
 				<!-- Reduce health scale since they have adequate armor-->
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/race/baseHealthScale</xpath>
-				  <value>
-				    <baseHealthScale>1.6</baseHealthScale>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperEnforcerBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>1.6</baseHealthScale>
+					</value>
 				</li>
 
 
 				<!--Sentinel Series-->
-				
+
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases</xpath>
-				  <value>
-					<MeleeCritChance>1.6</MeleeCritChance>
-					<MeleeParryChance>1.6</MeleeParryChance>
-					<SmokeSensitivity>0</SmokeSensitivity>
-					<CarryBulk>60</CarryBulk>
-					<CarryWeight>60</CarryWeight>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases</xpath>
+					<value>
+						<MeleeCritChance>1.6</MeleeCritChance>
+						<MeleeParryChance>1.6</MeleeParryChance>
+						<SmokeSensitivity>0</SmokeSensitivity>
+						<CarryBulk>60</CarryBulk>
+						<CarryWeight>60</CarryWeight>
+					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Sharp</xpath>
-				  <value>
-				    <ArmorRating_Sharp>20</ArmorRating_Sharp>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Blunt</xpath>
-				  <value>
-				    <ArmorRating_Blunt>42</ArmorRating_Blunt>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>42</ArmorRating_Blunt>
+					</value>
 				</li>
-				
+
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/tools</xpath>
-				  <value>
-				    <tools>
-					  <li Class="CombatExtended.ToolCE">
-						<label>left fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>18</power>
-						<cooldownTime>1.42</cooldownTime>
-						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>24</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>right fist</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>18</power>
-						<cooldownTime>1.42</cooldownTime>
-						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>24</armorPenetrationBlunt>
-					  </li>
-					  
-					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
-						<capacities>
-						  <li>Blunt</li>
-						</capacities>
-						<power>8</power>
-						<cooldownTime>3.52</cooldownTime>
-						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>4</armorPenetrationBlunt>
-					  </li>
-					</tools>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>1.42</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>1.42</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>3.52</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
 				</li>
 
 				<!-- Reduce health scale since they have adequate armor-->
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/race/baseHealthScale</xpath>
-				  <value>
-				    <baseHealthScale>2.5</baseHealthScale>
-				  </value>
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[@Name="RSPeacekeeperSentinelBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>2.5</baseHealthScale>
+					</value>
 				</li>
-				
-			  </operations>
-			</match>
-	    </li>
-		
-	  </operations>
+
+			</operations>
+		</match>
 	</Operation>
 </Patch>

--- a/Patches/RimSec-Security/Ammo/SRS Ammo.xml
+++ b/Patches/RimSec-Security/Ammo/SRS Ammo.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Rimsec Security</li>
+        </mods>
+
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!-- ======== 6x24mm SRS ======== -->
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <CombatExtended.AmmoSetDef>
+                            <defName>AmmoSet_6x24mmSRS</defName>
+                            <label>6x24mm Charged Bullet (DLG)</label>
+                            <ammoTypes>
+                                <Ammo_6x24mmCharged>Bullet_6x24mmSRS</Ammo_6x24mmCharged>
+                                <Ammo_6x24mmCharged_AP>Bullet_6x24mmSRS_AP</Ammo_6x24mmCharged_AP>
+                                <Ammo_6x24mmCharged_Ion>Bullet_6x24mmSRS_Ion</Ammo_6x24mmCharged_Ion>
+                            </ammoTypes>
+                        </CombatExtended.AmmoSetDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+                            <defName>Bullet_6x24mmSRS</defName>
+                            <label>6x24mm Charged SRS bullet</label>
+                            <graphicData>
+                                <texPath>Things/laserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>160</speed>
+                                <damageAmountBase>13</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>4</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>12</armorPenetrationSharp>
+                                <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+                            <defName>Bullet_6x24mmSRS_AP</defName>
+                            <label>6x24mm Charged SRS bullet (Conc.)</label>
+                            <graphicData>
+                                <texPath>Things/laserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>160</speed>
+                                <damageAmountBase>10</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>2</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>24</armorPenetrationSharp>
+                                <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+                            <defName>Bullet_6x24mmSRS_Ion</defName>
+                            <label>6x24mm Charged SRS bullet (Ion)</label>
+                            <graphicData>
+                                <texPath>Things/laserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>160</speed>
+                                <damageAmountBase>10</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>EMP</def>
+                                        <amount>6</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>18</armorPenetrationSharp>
+                                <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+                                <empShieldBreakChance>0.2</empShieldBreakChance>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+
+
+                <!-- ======== 6x18mm SRS ======== -->
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <CombatExtended.AmmoSetDef>
+                            <defName>AmmoSet_6x18mmSRS</defName>
+                            <label>6x18mm Charged Bullet (EHG)</label>
+                            <ammoTypes>
+                                <Ammo_6x18mmCharged>Bullet_6x18mmSRS</Ammo_6x18mmCharged>
+                                <Ammo_6x18mmCharged_AP>Bullet_6x18mmSRS_AP</Ammo_6x18mmCharged_AP>
+                                <Ammo_6x18mmCharged_Ion>Bullet_6x18mmSRS_Ion</Ammo_6x18mmCharged_Ion>
+                            </ammoTypes>
+                        </CombatExtended.AmmoSetDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+                            <defName>Bullet_6x18mmSRS</defName>
+                            <label>6x18mm Charged SRS bullet</label>
+                            <graphicData>
+                                <texPath>Things/purplelaserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>120</speed>
+                                <damageAmountBase>10</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>3</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>8</armorPenetrationSharp>
+                                <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+                            <defName>Bullet_6x18mmSRS_AP</defName>
+                            <label>6x18mm Charged SRS bullet (Conc.)</label>
+                            <graphicData>
+                                <texPath>Things/purplelaserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>120</speed>
+                                <damageAmountBase>8</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>1</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>16</armorPenetrationSharp>
+                                <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+                            <defName>Bullet_6x18mmSRS_Ion</defName>
+                            <label>6x18mm Charged SRS bullet (Ion)</label>
+                            <graphicData>
+                                <texPath>Things/purplelaserbolt</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <speed>120</speed>
+                                <damageAmountBase>8</damageAmountBase>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>EMP</def>
+                                        <amount>5</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>12</armorPenetrationSharp>
+                                <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+                                <empShieldBreakChance>1</empShieldBreakChance>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+
+
+                <!-- ======== 8x35mm SRS ======== -->
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <CombatExtended.AmmoSetDef>
+                            <defName>AmmoSet_8x35mmSRS</defName>
+                            <label>8x35mm Charged Bullet (HLT)</label>
+                            <ammoTypes>
+                                <Ammo_8x35mmCharged>Bullet_8x35mmSRS</Ammo_8x35mmCharged>
+                                <Ammo_8x35mmCharged_AP>Bullet_8x35mmSRS_AP</Ammo_8x35mmCharged_AP>
+                                <Ammo_8x35mmCharged_Ion>Bullet_8x35mmSRS_Ion</Ammo_8x35mmCharged_Ion>
+                            </ammoTypes>
+                        </CombatExtended.AmmoSetDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+                            <defName>Bullet_8x35mmSRS</defName>
+                            <label>8x35mm Charged SRS bullet</label>
+                            <graphicData>
+                                <texPath>Things/Building/Turrets/HLT/HLT_projectile</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <damageAmountBase>19</damageAmountBase>
+                                <speed>160</speed>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>6</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>14</armorPenetrationSharp>
+                                <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+                            <defName>Bullet_8x35mmSRS_AP</defName>
+                            <label>8x35mm Charged SRS bullet (Conc.)</label>
+                            <graphicData>
+                                <texPath>Things/Building/Turrets/HLT/HLT_projectile</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <damageAmountBase>15</damageAmountBase>
+                                <speed>160</speed>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>Bomb_Secondary</def>
+                                        <amount>2</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>28</armorPenetrationSharp>
+                                <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs</xpath>
+                    <value>
+                        <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+                            <defName>Bullet_8x35mmSRS_Ion</defName>
+                            <label>8x35mm Charged SRS bullet (Ion)</label>
+                            <graphicData>
+                                <texPath>Things/Building/Turrets/HLT/HLT_projectile</texPath>
+                                <graphicClass>Graphic_Single</graphicClass>
+                            </graphicData>
+                            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                                <damageAmountBase>15</damageAmountBase>
+                                <speed>160</speed>
+                                <secondaryDamage>
+                                    <li>
+                                        <def>EMP</def>
+                                        <amount>9</amount>
+                                    </li>
+                                </secondaryDamage>
+                                <armorPenetrationSharp>21</armorPenetrationSharp>
+                                <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+                                <empShieldBreakChance>0.2</empShieldBreakChance>
+                            </projectile>
+                        </ThingDef>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/RimSec-Security/Bodies.xml
+++ b/Patches/RimSec-Security/Bodies.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Rimsec Security</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+       <!-- Add missing group nodes -->
+		   <li Class="PatchOperationAdd">
+          <xpath>
+            /Defs/BodyDef[defName="RSPeacekeeperBody"]//*[
+            def="MechanicalShoulder" or
+            def="MechanicalArm" or
+            def="MechanicalHand"
+			      ]
+          </xpath>
+          <value>
+            <groups/>
+          </value>
+        </li>
+
+        <!-- Shoulder & Arm Groups -->
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="right shoulder"]/groups</xpath>
+        <value>
+          <li>RightShoulder</li>
+        </value>
+      </li>
+	
+		  <li Class="PatchOperationAdd">
+        <xpath>/Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="left shoulder"]/groups</xpath>
+        <value>
+          <li>LeftShoulder</li>
+        </value>
+      </li>
+		  <li Class="PatchOperationAdd">
+        <xpath>/Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="right arm"]/groups</xpath>
+        <value>
+          <li>RightArm</li>
+        </value>
+      </li>
+		  <li Class="PatchOperationAdd">
+        <xpath>/Defs/BodyDef[defName="RSPeacekeeperBody"]//*[customLabel="left arm"]/groups</xpath>
+        <value>
+          <li>LeftArm</li>
+        </value>
+      </li>
+
+      <!-- Natural Armor -->
+      <li Class="PatchOperationAdd">
+        <xpath>
+          /Defs/BodyDef[defName="RSPeacekeeperBody"]//*[
+          def="MechanicalThorax" or 
+          def="MechanicalNeck" or 
+          def="RSPeacekeeperHead" or 
+          def="MechanicalShoulder" or
+          def="MechanicalArm" or
+          def="MechanicalHand" or
+			    def="MechanicalFinger" or 
+			    def="MechanicalLeg" or 
+			    def="MechanicalFoot"
+			    ]/groups
+        </xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/RimSec-Security/Buildings.xml
+++ b/Patches/RimSec-Security/Buildings.xml
@@ -154,6 +154,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[ @Name="RSTurretLLTBase" or @Name="RSTurretHLTBase" or @Name="RSTurretHAACBase"
+				]/fillPercent</xpath>
+					<value>
+						<fillPercent>0.85</fillPercent>
+					</value>
+				</li>
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[ defName="RSTurretLLT" or defName="RSTurretHLT" or defName="RSTurretHAAC"
 				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>

--- a/Patches/RimSec-Security/Buildings.xml
+++ b/Patches/RimSec-Security/Buildings.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimsec Security</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ========== Light Laser Turret ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RSTurretLLTGun</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>2</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>0.65</SwayFactor>
+					<Bulk>13.70</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.70</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>62</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>15</burstShotCount>
+					<soundCast>RSLLTProjectileLaunch</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>12</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>6.0</reloadTime>
+					<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+
+            <!-- ========== Heavy Laser Turret ========== -->
+
+            <!-- Replace the custom verb with the a common vanilla one, since custom verbs are not patchable -->
+            <li Class="PatchOperationReplace">
+				  <xpath>Defs/ThingDef[defName="RSTurretHLTGun"]/verbs/li[1]/verbClass</xpath>
+				  <value>
+				    <verbClass>Verb_Shoot</verbClass>
+				  </value>
+			</li>
+
+            <!-- Replace the custom place worker with the vanilla one -->
+            <li Class="PatchOperationReplace">
+				  <xpath>Defs/ThingDef[@Name="RSTurretHLTBase"]/placeWorkers/li[2]</xpath>
+				  <value>
+				    <li>PlaceWorker_ShowTurretRadius</li>
+				  </value>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RSTurretHLTGun</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.8</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>0.95</SwayFactor>
+					<Bulk>40</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.90</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+					<warmupTime>1.5</warmupTime>
+					<range>78</range>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<burstShotCount>15</burstShotCount>
+					<soundCast>RSHLTProjectileLaunch</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>12</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>350</magazineSize>
+					<reloadTime>9.5</reloadTime>
+					<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+					<aimedBurstShotCount>8</aimedBurstShotCount>
+				</FireModes>
+			</li>
+
+
+            <!-- ========== HAAC ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RSTurretHAACGun</defName>
+				<statBases>
+					<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+					<SightsEfficiency>3.2</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>0.40</SwayFactor>
+					<Bulk>62</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.70</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+					<warmupTime>2.3</warmupTime>
+					<range>116</range>
+                    <minRange>4</minRange>
+					<soundCast>RSHAACProjectileLaunch</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>18</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>50</magazineSize>
+					<reloadTime>9.5</reloadTime>
+					<ammoSet>AmmoSet_12mmRailgun</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+				</FireModes>
+			</li>
+
+            <!-- ========== Common to all Turrets ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+					@Name="RSTurretLLTBase" or
+                    @Name="RSTurretHLTBase" or
+                    @Name="RSTurretHAACBase"
+				]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[
+					defName="RSTurretLLT" or
+                    defName="RSTurretHLT" or
+                    defName="RSTurretHAAC"
+				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="RSTurretLLT" or
+                    defName="RSTurretHLT" or
+                    defName="RSTurretHAAC"
+				]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1</AimingAccuracy>
+				</value>
+			</li>
+
+            <li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+                defName="RSTurretLLT" or
+                defName="RSTurretHLT" or
+                defName="RSTurretHAAC"
+                ]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/RimSec-Security/Buildings.xml
+++ b/Patches/RimSec-Security/Buildings.xml
@@ -7,185 +7,173 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<!-- ========== Light Laser Turret ========== -->
+				<!-- ========== Light Laser Turret ========== -->
 
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>RSTurretLLTGun</defName>
-				<statBases>
-					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-					<SightsEfficiency>2</SightsEfficiency>
-					<ShotSpread>0.06</ShotSpread>
-					<SwayFactor>0.65</SwayFactor>
-					<Bulk>13.70</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>0.70</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-					<warmupTime>1.3</warmupTime>
-					<range>62</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<burstShotCount>15</burstShotCount>
-					<soundCast>RSLLTProjectileLaunch</soundCast>
-					<soundCastTail>GunTail_Heavy</soundCastTail>
-					<targetParams>
-						<canTargetLocations>true</canTargetLocations>
-					</targetParams>
-					<muzzleFlashScale>12</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>150</magazineSize>
-					<reloadTime>6.0</reloadTime>
-					<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>SuppressFire</aiAimMode>
-					<aimedBurstShotCount>5</aimedBurstShotCount>
-				</FireModes>
-			</li>
-
-
-            <!-- ========== Heavy Laser Turret ========== -->
-
-            <!-- Replace the custom verb with the a common vanilla one, since custom verbs are not patchable -->
-            <li Class="PatchOperationReplace">
-				  <xpath>Defs/ThingDef[defName="RSTurretHLTGun"]/verbs/li[1]/verbClass</xpath>
-				  <value>
-				    <verbClass>Verb_Shoot</verbClass>
-				  </value>
-			</li>
-
-            <!-- Replace the custom place worker with the vanilla one -->
-            <li Class="PatchOperationReplace">
-				  <xpath>Defs/ThingDef[@Name="RSTurretHLTBase"]/placeWorkers/li[2]</xpath>
-				  <value>
-				    <li>PlaceWorker_ShowTurretRadius</li>
-				  </value>
-			</li>
-
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>RSTurretHLTGun</defName>
-				<statBases>
-					<RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
-					<SightsEfficiency>1.8</SightsEfficiency>
-					<ShotSpread>0.09</ShotSpread>
-					<SwayFactor>0.95</SwayFactor>
-					<Bulk>40</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>0.90</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
-					<warmupTime>1.5</warmupTime>
-					<range>78</range>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-					<burstShotCount>15</burstShotCount>
-					<soundCast>RSHLTProjectileLaunch</soundCast>
-					<soundCastTail>GunTail_Heavy</soundCastTail>
-					<targetParams>
-						<canTargetLocations>true</canTargetLocations>
-					</targetParams>
-					<muzzleFlashScale>12</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>350</magazineSize>
-					<reloadTime>9.5</reloadTime>
-					<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>SuppressFire</aiAimMode>
-					<aimedBurstShotCount>8</aimedBurstShotCount>
-				</FireModes>
-			</li>
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RSTurretLLTGun</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+						<SightsEfficiency>2</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>0.65</SwayFactor>
+						<Bulk>13.70</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.70</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_6x24mmSRS</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>62</range>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<burstShotCount>15</burstShotCount>
+						<soundCast>RSLLTProjectileLaunch</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<muzzleFlashScale>12</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>150</magazineSize>
+						<reloadTime>6.0</reloadTime>
+						<ammoSet>AmmoSet_6x24mmSRS</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>SuppressFire</aiAimMode>
+						<aimedBurstShotCount>5</aimedBurstShotCount>
+					</FireModes>
+				</li>
 
 
-            <!-- ========== HAAC ========== -->
+				<!-- ========== Heavy Laser Turret ========== -->
 
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>RSTurretHAACGun</defName>
-				<statBases>
-					<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
-					<SightsEfficiency>3.2</SightsEfficiency>
-					<ShotSpread>0.05</ShotSpread>
-					<SwayFactor>0.40</SwayFactor>
-					<Bulk>62</Bulk>
-				</statBases>
-				<Properties>
-					<recoilAmount>2.70</recoilAmount>
-					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
-					<warmupTime>2.3</warmupTime>
-					<range>116</range>
-                    <minRange>4</minRange>
-					<soundCast>RSHAACProjectileLaunch</soundCast>
-					<soundCastTail>GunTail_Heavy</soundCastTail>
-					<targetParams>
-						<canTargetLocations>true</canTargetLocations>
-					</targetParams>
-					<muzzleFlashScale>18</muzzleFlashScale>
-					<recoilPattern>Mounted</recoilPattern>
-				</Properties>
-				<AmmoUser>
-					<magazineSize>50</magazineSize>
-					<reloadTime>9.5</reloadTime>
-					<ammoSet>AmmoSet_12mmRailgun</ammoSet>
-				</AmmoUser>
-				<FireModes>
-					<aiUseBurstMode>FALSE</aiUseBurstMode>
-					<aiAimMode>AimedShot</aiAimMode>
-					<noSnapshot>true</noSnapshot>
-				</FireModes>
-			</li>
+				<!-- Replace the custom verb with the a common vanilla one, since custom verbs are not patchable -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RSTurretHLTGun"]/verbs/li[1]/verbClass</xpath>
+					<value>
+						<verbClass>Verb_Shoot</verbClass>
+					</value>
+				</li>
 
-            <!-- ========== Common to all Turrets ========== -->
+				<!-- Replace the custom place worker with the vanilla one -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RSTurretHLTBase"]/placeWorkers/li[2]</xpath>
+					<value>
+						<li>PlaceWorker_ShowTurretRadius</li>
+					</value>
+				</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-					@Name="RSTurretLLTBase" or
-                    @Name="RSTurretHLTBase" or
-                    @Name="RSTurretHAACBase"
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RSTurretHLTGun</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.8</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>0.95</SwayFactor>
+						<Bulk>40</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.90</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_8x35mmSRS</defaultProjectile>
+						<warmupTime>1.5</warmupTime>
+						<range>78</range>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<burstShotCount>15</burstShotCount>
+						<soundCast>RSHLTProjectileLaunch</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<muzzleFlashScale>12</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>350</magazineSize>
+						<reloadTime>9.5</reloadTime>
+						<ammoSet>AmmoSet_8x35mmSRS</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>SuppressFire</aiAimMode>
+						<aimedBurstShotCount>8</aimedBurstShotCount>
+					</FireModes>
+				</li>
+
+
+				<!-- ========== HAAC ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RSTurretHAACGun</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.95</RangedWeapon_Cooldown>
+						<SightsEfficiency>3.2</SightsEfficiency>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>0.40</SwayFactor>
+						<Bulk>62</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>2.70</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+						<warmupTime>2.3</warmupTime>
+						<range>116</range>
+						<minRange>5</minRange>
+						<soundCast>RSHAACProjectileLaunch</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<muzzleFlashScale>18</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+					<AmmoUser>
+						<magazineSize>50</magazineSize>
+						<reloadTime>9.5</reloadTime>
+						<ammoSet>AmmoSet_12mmRailgun</ammoSet>
+					</AmmoUser>
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<noSnapshot>true</noSnapshot>
+					</FireModes>
+				</li>
+
+				<!-- ========== Common to all Turrets ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[ @Name="RSTurretLLTBase" or @Name="RSTurretHLTBase" or @Name="RSTurretHAACBase"
 				]/thingClass</xpath>
-				<value>
-					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-				</value>
-			</li>
+					<value>
+						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+					</value>
+				</li>
 
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[
-					defName="RSTurretLLT" or
-                    defName="RSTurretHLT" or
-                    defName="RSTurretHAAC"
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[ defName="RSTurretLLT" or defName="RSTurretHLT" or defName="RSTurretHAAC"
 				]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
-			</li>
+				</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[
-					defName="RSTurretLLT" or
-                    defName="RSTurretHLT" or
-                    defName="RSTurretHAAC"
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[ defName="RSTurretLLT" or defName="RSTurretHLT" or defName="RSTurretHAAC"
 				]/statBases</xpath>
-				<value>
-					<AimingAccuracy>1</AimingAccuracy>
-				</value>
-			</li>
+					<value>
+						<AimingAccuracy>1</AimingAccuracy>
+					</value>
+				</li>
 
-            <li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-                defName="RSTurretLLT" or
-                defName="RSTurretHLT" or
-                defName="RSTurretHAAC"
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[ defName="RSTurretLLT" or defName="RSTurretHLT" or defName="RSTurretHAAC"
                 ]/statBases/ShootingAccuracyTurret</xpath>
-				<value>
-					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
-				</value>
-			</li>
+					<value>
+						<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+					</value>
+				</li>
 
 			</operations>
 		</match>

--- a/Patches/RimSec-Security/PawnKinds.xml
+++ b/Patches/RimSec-Security/PawnKinds.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Rimsec Security</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		 <operations>
+
+			<!-- ======= Ammo ======= -->
+
+            <!-- Defender Series -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+                        @Name="RSPeacekeeperDefenderPawnKindBase"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>3</min>
+						<max>6</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+            <!-- Enforcer Series -->
+            <li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+                        @Name="RSPeacekeeperEnforcerPawnKindBase"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>2</min>
+						<max>3</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+            <!-- Sentinel Series -->
+            <li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+                        @Name="RSPeacekeeperSentinelPawnKindBase"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>5</min>
+						<max>8</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+
+            <!-- ======= Combat Power ======= -->
+
+            <!-- Defender Series -->
+            <li Class="PatchOperationReplace">
+			<xpath>/Defs/PawnKindDef[
+            defName="RSPeacekeeperDefenderPawnKind" or
+            defName="RSPeacekeeperDefenderForestPawnKind" or
+            defName="RSPeacekeeperDefenderDesertPawnKind" or
+            defName="RSPeacekeeperDefenderWinterPawnKind"
+            ]/combatPower</xpath>
+				<value>
+					<combatPower>180</combatPower>
+				</value>
+			</li>
+
+
+            <!-- Enforcer Series -->
+            <li Class="PatchOperationReplace">
+			<xpath>/Defs/PawnKindDef[
+            defName="RSPeacekeeperEnforcerPawnKind" or
+            defName="RSPeacekeeperEnforcerForestPawnKind" or
+            defName="RSPeacekeeperEnforcerDesertPawnKind" or
+            defName="RSPeacekeeperEnforcerWinterPawnKind"
+            ]/combatPower</xpath>
+				<value>
+					<combatPower>225</combatPower>
+				</value>
+			</li>
+
+            <!-- Defender Series -->
+            <li Class="PatchOperationReplace">
+			<xpath>/Defs/PawnKindDef[
+            defName="RSPeacekeeperSentinelPawnKind" or
+            defName="RSPeacekeeperSentinelForestPawnKind" or
+            defName="RSPeacekeeperSentinelDesertPawnKind" or
+            defName="RSPeacekeeperSentinelWinterPawnKind"
+            ]/combatPower</xpath>
+				<value>
+					<combatPower>400</combatPower>
+				</value>
+			</li>
+
+			</operations>
+			</match>
+		</Operation>
+	</Patch>

--- a/Patches/RimSec-Security/Traits.xml
+++ b/Patches/RimSec-Security/Traits.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Rimsec Security</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<!-- Security Model -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="RSTraitSecurity"]/degreeDatas/li/statOffsets/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="RSTraitSecurity"]/degreeDatas/li/statOffsets/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+				</value>
+			</li>
+
+            <!-- Forest Model -->
+            <li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="RSTraitForest"]/degreeDatas/li/statOffsets</xpath>
+				<value>
+                  <statOffsets>
+					<MeleeDodgeChance>0.2</MeleeDodgeChance>
+					<MeleeCritChance>0.2</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
+                    <MoveSpeed>1</MoveSpeed>
+                  </statOffsets>
+				</value>
+			</li>
+
+            <!-- Winter Model-->
+            <li Class="PatchOperationReplace">
+				<xpath>Defs/TraitDef[defName="RSTraitWinter"]/degreeDatas/li/statOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<AimingAccuracy>1.2</AimingAccuracy>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/RimSec-Security/WeaponDefs.xml
+++ b/Patches/RimSec-Security/WeaponDefs.xml
@@ -11,10 +11,7 @@
 
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[
-          defName="RSWeaponDLG" or 
-          defName="RSWeaponEHG" or
-          defName="RSWeaponSHAG"
+          <xpath>/Defs/ThingDef[ defName="RSWeaponDLG" or defName="RSWeaponEHG" or defName="RSWeaponSHAG"
           ]/tools</xpath>
           <value>
             <tools>
@@ -71,7 +68,7 @@
             <recoilAmount>1.30</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+            <defaultProjectile>Bullet_6x24mmSRS</defaultProjectile>
             <burstShotCount>6</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
             <warmupTime>0.6</warmupTime>
@@ -84,7 +81,7 @@
           <AmmoUser>
             <magazineSize>30</magazineSize>
             <reloadTime>4</reloadTime>
-            <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+            <ammoSet>AmmoSet_6x24mmSRS</ammoSet>
           </AmmoUser>
 
           <FireModes>
@@ -121,7 +118,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+            <defaultProjectile>Bullet_6x18mmSRS</defaultProjectile>
             <burstShotCount>50</burstShotCount>
             <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
             <warmupTime>2.5</warmupTime>
@@ -135,7 +132,7 @@
           <AmmoUser>
             <magazineSize>500</magazineSize>
             <reloadTime>9.2</reloadTime>
-            <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+            <ammoSet>AmmoSet_6x18mmSRS</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>SuppressFire</aiAimMode>

--- a/Patches/RimSec-Security/WeaponDefs.xml
+++ b/Patches/RimSec-Security/WeaponDefs.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Rimsec Security</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Tools === -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[
+          defName="RSWeaponDLG" or 
+          defName="RSWeaponEHG" or
+          defName="RSWeaponSHAG"
+          ]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>stock</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <chanceFactor>1.5</chanceFactor>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>5</power>
+                <cooldownTime>2.02</cooldownTime>
+                <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>muzzle</label>
+                <capacities>
+                  <li>Poke</li>
+                </capacities>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+
+        <!-- === DLG-20 === -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>RSWeaponDLG</defName>
+
+          <statBases>
+            <Mass>3.5</Mass>
+            <Bulk>6.2</Bulk>
+            <SwayFactor>1.04</SwayFactor>
+            <ShotSpread>0.09</ShotSpread>
+            <SightsEfficiency>1.2</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+          </statBases>
+
+          <Properties>
+            <recoilAmount>1.30</recoilAmount>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+            <burstShotCount>6</burstShotCount>
+            <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+            <warmupTime>0.6</warmupTime>
+            <range>55</range>
+            <soundCast>Shot_HeavySMG</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+          </Properties>
+
+          <AmmoUser>
+            <magazineSize>30</magazineSize>
+            <reloadTime>4</reloadTime>
+            <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+          </AmmoUser>
+
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+            <aiUseBurstMode>True</aiUseBurstMode>
+            <aimedBurstShotCount>3</aimedBurstShotCount>
+          </FireModes>
+
+          <weaponTags>
+            <li>RSDLG20</li>
+            <li>RSPeacekeeperGun</li>
+          </weaponTags>
+        </li>
+
+        <!-- === EHG-22 === -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>RSWeaponEHG</defName>
+
+          <statBases>
+            <WorkToMake>75500</WorkToMake>
+            <Mass>32.0</Mass>
+            <Bulk>28.0</Bulk>
+            <SwayFactor>1.35</SwayFactor>
+            <ShotSpread>0.10</ShotSpread>
+            <SightsEfficiency>1</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+          </statBases>
+          <costList>
+            <Steel>150</Steel>
+            <Plasteel>15</Plasteel>
+            <Chemfuel>20</Chemfuel>
+            <ComponentIndustrial>10</ComponentIndustrial>
+          </costList>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+            <burstShotCount>50</burstShotCount>
+            <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+            <warmupTime>2.5</warmupTime>
+            <range>62</range>
+            <soundCast>Shot_ChargeRifle</soundCast>
+            <soundCastTail>GunTail_Medium</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+            <recoilAmount>1.24</recoilAmount>
+            <recoilPattern>Regular</recoilPattern>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>500</magazineSize>
+            <reloadTime>9.2</reloadTime>
+            <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>SuppressFire</aiAimMode>
+            <aimedBurstShotCount>20</aimedBurstShotCount>
+          </FireModes>
+          <weaponTags>
+            <li>RSEHG22</li>
+            <li>RSPeacekeeperGun</li>
+          </weaponTags>
+          <AllowWithRunAndGun>false</AllowWithRunAndGun>
+        </li>
+
+        <!-- === SHAG-1 === -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>RSWeaponSHAG</defName>
+
+          <statBases>
+            <WorkToMake>80000</WorkToMake>
+            <Mass>48.0</Mass>
+            <Bulk>42.0</Bulk>
+            <SwayFactor>1.40</SwayFactor>
+            <ShotSpread>0.10</ShotSpread>
+            <SightsEfficiency>1.10</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.66</RangedWeapon_Cooldown>
+          </statBases>
+
+          <costList>
+            <Steel>350</Steel>
+            <Plasteel>20</Plasteel>
+            <Chemfuel>20</Chemfuel>
+            <ComponentIndustrial>25</ComponentIndustrial>
+          </costList>
+
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_8mmRailgun_Sabot</defaultProjectile>
+            <burstShotCount>6</burstShotCount>
+            <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+            <warmupTime>1.5</warmupTime>
+            <range>90</range>
+            <soundCast>RSShot_Shag</soundCast>
+            <soundCastTail>GunTail_Medium</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+            <recoilAmount>1.75</recoilAmount>
+          </Properties>
+
+          <AmmoUser>
+            <magazineSize>60</magazineSize>
+            <reloadTime>5</reloadTime>
+            <ammoSet>AmmoSet_8mmRailgun</ammoSet>
+          </AmmoUser>
+
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+            <aimedBurstShotCount>3</aimedBurstShotCount>
+          </FireModes>
+
+          <weaponTags>
+            <li>RSSHAG1</li>
+            <li>RSPeacekeeperGun</li>
+          </weaponTags>
+
+          <AllowWithRunAndGun>false</AllowWithRunAndGun>
+        </li>
+
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
Mod link - https://steamcommunity.com/sharedfiles/filedetails/?id=2323762086

The droids and turrets are strictly better than vanilla counter parts. This is because nothing in this mod is spammable. You need special components to craft each and every item so I've considered that before patching.  The special components are sold by a trader that ONLY visits 3 times a year. They are expensive as well. But still the mod should be reasonably balanced. :) I'm open to balancing suggestions 


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) - 2hrs
