### PR TITLE
Adjust fire growth rate based on clothing worn by pawn. 

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Fire.cs
@@ -125,6 +125,43 @@ namespace CombatExtended.HarmonyCE
                 }
             }
         }
+        internal static void Postfix(Fire __instance)
+        {
+            if (__instance.Spawned && __instance.parent is Pawn pawn)
+            {
+                __instance.fireSize -= pawn.GetStatValue(StatDefOf.Flammability, true) * 150 * 0.00055f;
+                float mult = 0.0f;
+                var apparel = pawn.apparel?.WornApparel ?? null;
+                if (apparel==null)
+                {
+                    return;
+                }
+                var parts = pawn.health.hediffSet.GetNotMissingParts(BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                float coverageAbs = 0;
+                foreach (var part in parts)
+                {
+                    coverageAbs += part.coverageAbs;
+                }
+                foreach (var part in parts)
+                {
+                    float combustibility = 1.0f;
+                    foreach (Apparel item in apparel)
+                    {
+                        if (item.def.apparel.CoversBodyPart(part))
+                        {
+                            combustibility = ((item.GetStatValue(StatDefOf.Flammability, true)) - 0.1f) / 0.50f;
+                            break;
+                        }
+                    }
+                    mult += part.coverageAbs / coverageAbs * combustibility;
+                }
+                __instance.fireSize += 0.00055f * mult * 1.5f;
+                if (__instance.fireSize < Fire.MinFireSize) {
+                    __instance.Destroy(DestroyMode.Vanish);
+                }
+            }
+        }
+
     }
 
     [HarmonyPatch(typeof(Fire), "TrySpread")]

--- a/Source/CombatExtended/Harmony/Harmony_Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Fire.cs
@@ -141,9 +141,6 @@ namespace CombatExtended.HarmonyCE
                 foreach (var part in parts)
                 {
                     coverageAbs += part.coverageAbs;
-                }
-                foreach (var part in parts)
-                {
                     float combustibility = 1.0f;
                     foreach (Apparel item in apparel)
                     {
@@ -153,8 +150,9 @@ namespace CombatExtended.HarmonyCE
                             break;
                         }
                     }
-                    mult += part.coverageAbs / coverageAbs * combustibility;
+                    mult += part.coverageAbs * combustibility;
                 }
+                mult /= coverageAbs;
                 __instance.fireSize += 0.00055f * mult * 1.5f;
                 if (__instance.fireSize < Fire.MinFireSize) {
                     __instance.Destroy(DestroyMode.Vanish);


### PR DESCRIPTION
 If clothing is sufficiently non-burnable, shrink the fire

## Changes

Pawns on fire now can have the fire go out on its own if they are wearing sufficiently flame-retardant material.  Makes fire-arrows against armored opponents not break the AI.


## Reasoning
x
- Easy to implement
- Getting someone sufficiently lit on fire to not just go out, especially when they are not wearing cotton or similar cloth, is actually rather difficult.

## Alternatives

Remove fire arrows?

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (minutes)
