### PR TITLE
Vanilla Armor Expanded Update

### DIFF
--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -1,122 +1,128 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Footwear_PlateBoots == -->
-				<!-- statBases -->
+				
+				<!-- === Plate Boots === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>1.5</WornBulk>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
 					<value>
 						<Mass>2.5</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/EquipDelay</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/EquipDelay</xpath>
 					<value>
 						<EquipDelay>3.5</EquipDelay>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<MeleeDodgeChance>-0.05</MeleeDodgeChance>
 						<MoveSpeed>-0.46</MoveSpeed> <!-- 10% of 4.6 -->
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
 					<value>
 						<description>A pair of plate boots which resemble sabatons. Because of the construction and weight of the boots, the wearer is somewhat slower and less nimble.</description>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
 				</li>
 
-				<!-- == VAE_Footwear_MarineBoots == -->
-				<!-- statBases -->
+				<!-- === Marine Boots === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>6.75</Bulk>
 						<WornBulk>1.5</WornBulk>
 						<Mass>3.6</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+				
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
 					<value>
 						<label>power armor boots</label>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/description</xpath>
-					<value>
-						<description>A pair of standalone powered boots.\n\nThe outer shell of these boots is made from simplified plasteel-weave most commonly found in cheaper powered armors. These boots come with a basic servo-motor system, which helps the wearer carry more weight.\n\nAlthough most power armor variants cover the feet, these exist for those not fortunate enough to buy an entire suit.</description>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Hyperweave</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Hyperweave</xpath>
 					<value>
 						<DevilstrandCloth>5</DevilstrandCloth>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Plasteel</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Plasteel</xpath>
 					<value>
 						<Plasteel>15</Plasteel>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>6</CarryWeight>
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
 				</li>
+				
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -1,114 +1,120 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Handwear_PlateGloves == -->
-				<!-- statBases -->
+				
+				<!-- === Plate Gloves === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>1</WornBulk>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
 					<value>
 						<Mass>1.5</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/EquipDelay</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/EquipDelay</xpath>
 					<value>
 						<EquipDelay>2</EquipDelay>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+				
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
 					<value>
 						<MeleeHitChance>-0.05</MeleeHitChance>
 						<AimingAccuracy>-0.05</AimingAccuracy>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
 					<value>
 						<description>A pair of plate gloves which resemble gauntlets. Because of the construction of the gloves and the thickness of the material, the wearer is somewhat less capable of manipulation work.</description>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
 				</li>
 
-				<!-- == VAE_Handwear_MarineGloves == -->
-				<!-- statBases -->
+				<!-- === Marine Gloves === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>2</WornBulk>
 						<Mass>3</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
 					<value>
 						<label>power armor gloves</label>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/description</xpath>
-					<value>
-						<description>A pair of standalone powered gloves.\n\nThe outer shell of these gloves is made from simplified plasteel-weave most commonly found in cheaper powered armors. These gloves come with embedded recoil and grip assistors, which help the wearer to hold their gun steady, however the gloves have no servomotors.\n\nAlthough most power armor variants cover the hands, these exist for those not fortunate enough to buy an entire suit.</description>
-					</value>
-				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>10</DevilstrandCloth>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
 					<value>
 						<Plasteel>10</Plasteel>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Apparel_BulletproofVest == -->
-				<!-- statBases -->
+
+				<!-- === Bulletproof Vest === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -17,37 +18,38 @@
 						<StuffEffectMultiplierArmor>12</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>
+						/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Sharp |
+						/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Blunt |
+						/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/costList
+					</xpath>
 				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/ArmorRating_Blunt</xpath>
-				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>125</MaxHitPoints>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/description</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/description</xpath>
 					<value>
 						<description>An armor vest made from flexible and resistant fabric or leather. Despite being cheaper and lighter than other armor vests, it still offers some protection against gunfire.</description>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/label</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/label</xpath>
 					<value>
 						<label>soft armor vest</label>
 					</value>
 				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/costList</xpath>
-				</li>
-				<!-- The bulletproof vest is now makeable from any fabric or leather that's sufficiently protective. Pretty much like a flak jacket or pants, but now in vest form. -->
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]</xpath>
 					<value>
 						<costStuffCount>80</costStuffCount>
 						<stuffCategories>
@@ -56,55 +58,56 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_GhillieSuit == -->
-				<!-- statBases -->
+				<!-- === Ghillie Suit === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
 					<value>
 						<Bulk>31</Bulk>
 						<WornBulk>4.7</WornBulk>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<AimingAccuracy>0.05</AimingAccuracy>
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_AdvancedVest == -->
-				<!-- statBases -->
+				<!-- === Advanced Vest === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>3</WornBulk>
 						<Mass>15</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases</xpath>
 					<value>
 						<ArmorRating_Sharp>2</ArmorRating_Sharp>
 						<ArmorRating_Blunt>3</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>150</MaxHitPoints>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>20</Plasteel>
@@ -112,46 +115,51 @@
 						</costList>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>90</costStuffCount>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/stuffCategories/li[.="Metallic"]</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_AdvancedVest"]/stuffCategories/li[.="Metallic"]</xpath>
 					<value>
 						<li>Steeled</li>
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_HAZMATSuit == -->
-				<!-- statBases -->
+				<!-- === HAZMAT Suit === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
 					<value>
 						<Bulk>93.33</Bulk>
 						<WornBulk>14</WornBulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
@@ -1,47 +1,40 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Apparel_Gambeson == -->
-				<!-- statBases -->
+
+				<!-- === Gambeson === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
 					<value>
 						<Bulk>2.5</Bulk>
 						<WornBulk>1</WornBulk>
+						<ArmorRating_Sharp>0.06</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.09</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor> <!-- actual thickness is 10mm, but the gambeson isn't made entirely out of leather -->
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
-					<value>
-						<ArmorRating_Sharp>0.06</ArmorRating_Sharp> <!-- remaining 6mm is of cloth, 0.01*6=0.06 -->
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
-					<value>
-						<ArmorRating_Blunt>0.09</ArmorRating_Blunt> <!-- remaining 6mm is of cloth, 0.015*6=0.09 -->
-					</value>
-				</li>
-				<!-- other -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>30</costStuffCount>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
 					<value>
 						<costList>
 							<Cloth>40</Cloth>
@@ -49,42 +42,45 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_QuiltedVest == -->
-				<!-- statBases -->
+				<!-- === Quilted Vest === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
 						<Bulk>1.5</Bulk>
 						<WornBulk>0.5</WornBulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor> <!-- found a photo of some dude wearing it - got the image proportions and measured my own arm. 60mm*2mm/10mm=12mm. it isn't made entirely out of leather. -->
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
-						<ArmorRating_Sharp>0.07</ArmorRating_Sharp> <!-- remaining 7mm is of cloth, 0.01*7=0.07 -->
+						<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
-						<ArmorRating_Blunt>0.105</ArmorRating_Blunt> <!-- remaining 7mm is of cloth, 0.015*7=0.105 -->
+						<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
 					</value>
 				</li>
-				<!-- other -->
+				
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>20</costStuffCount>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
 					<value>
 						<costList>
 							<Cloth>30</Cloth>
@@ -92,31 +88,32 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_LightPlateArmor == -->
-				<!-- statBases -->
+				<!-- === Light Plate Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>52.5</Bulk>
 						<WornBulk>8</WornBulk>
 						<Mass>8</Mass>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
 					<value>
 						<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.08</MeleeDodgeChance>
@@ -124,48 +121,49 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_PlateShoulderpads == -->
-				<!-- statBases -->
+				<!-- === Plate Shoulderpads === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>4.5</Bulk>
 						<WornBulk>1.5</WornBulk>
 						<Mass>1.5</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
 					<value>
 						<StuffEffectMultiplierInsulation_Cold>0</StuffEffectMultiplierInsulation_Cold>
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_Chestplate == -->
-				<!-- statBases -->
+				<!-- === Chestplate === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>30</Bulk>
 						<WornBulk>4.5</WornBulk>
 						<Mass>4.5</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.045</MeleeDodgeChance>
@@ -173,24 +171,24 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_Chainmail == -->
-				<!-- statBases -->
+				<!-- === Chainmail === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
 					<value>
 						<Bulk>10</Bulk>
 						<WornBulk>5</WornBulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>1.341</StuffEffectMultiplierArmor> <!-- did some actual calulations in a game. this isn't precisely it, but it's closer. -->
+						<StuffEffectMultiplierArmor>1.341</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.1</MeleeDodgeChance>
@@ -198,25 +196,25 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_PlateHelmet == -->
-				<!-- statBases -->
+				<!-- === Plate Helmet === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>0.5</WornBulk>
 						<Mass>3</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>-0.1</AimingAccuracy>
@@ -224,16 +222,18 @@
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
 					<value>
 						<stuffCategories>
 							<li>Steeled</li>
 						</stuffCategories>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<bodyPartGroups>
 							<li>UpperHead</li>
@@ -242,7 +242,9 @@
 						</bodyPartGroups>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+	
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
@@ -1,87 +1,96 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Apparel_WoodenArmor == -->
-				<!-- statBases -->
+				
+				<!-- === Wooden Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>5</WornBulk>
 						<Mass>12</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.9</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>75</MaxHitPoints>
 					</value>
 				</li>
+
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
 					<value>
 						<description>A vest with wooden logs and planks covering the front and back. No one should be using this in an actual firefight, but anything is better than nothing.</description>
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_StoneWarMask == -->
-				<!-- statBases -->
+				<!-- === Stone War Mask === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>1.5</WornBulk>
 						<Mass>5.1</Mass>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<Suppressability>-0.1</Suppressability>
 						<AimingAccuracy>-0.2</AimingAccuracy>
 						<MeleeHitChance>-1</MeleeHitChance>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
 					<value>
 						<li>OnHead</li>
 						<li>MiddleHead</li>
 						<li>StrappedHead</li>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -1,54 +1,163 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Patch>	
+<Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Headgear_HeavyMarineHelmet == -->
-				<!-- statBases -->
+
+				<!-- === Trooper Helmet === -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases</xpath>
+					<value>
+						<Bulk>4.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>12.8</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>27</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>240</MaxHitPoints>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/equippedStatOffsets</xpath>
+					<value>
+						<PsychicSensitivity>-0.1</PsychicSensitivity>
+						<AimingDelayFactor>-0.05</AimingDelayFactor>
+						<ToxicSensitivity>-0.1</ToxicSensitivity>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>25</Plasteel>
+						<DevilstrandCloth>10</DevilstrandCloth>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/apparel/layers</xpath>
+					<value>
+						<li>MiddleHead</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Eyes</li>
+					</value>
+				</li>
+
+				<!-- === Trooper Armor === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/Mass</xpath>
+					<value>
+						<Bulk>46.67</Bulk>
+						<WornBulk>7</WornBulk>
+						<Mass>24</Mass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>33.75</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>500</MaxHitPoints>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryWeight>60</CarryWeight>
+						<CarryBulk>7.5</CarryBulk>
+						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
+						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<MoveSpeed>0.92</MoveSpeed>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Feet</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/costList</xpath>
+					<value>
+						<DevilstrandCloth>25</DevilstrandCloth>
+					</value>
+				</li>
+
+				<!-- === Siegebreaker Helmet === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>10</Bulk>
 						<WornBulk>2.5</WornBulk>
 						<Mass>9</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>20.8</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>48</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/label</xpath>
-					<value>
-						<label>heavy power armor helmet</label>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/description</xpath>
-					<value>
-						<description>A part of the heavy power armor set, mostly used by imperial stormtroopers.\n\nHas integrated neuro-memetic servo-motors to assist the wearer's muscles in holding the helmet, aswell as double-layered plasteel plating to increase protection. To eliminate a weakspot in the standard edition - the visor, this edition has no visor, but instead a built-in camera with a display HUD, containing the latest combat software, which runs real-time simulations for bullet trajectories and alerts the wearer any threats capable of piercing the armor.</description>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<PsychicSensitivity>-0.3</PsychicSensitivity>
@@ -57,11 +166,13 @@
 							<CarryWeight>5.4</CarryWeight>
 							<CarryBulk>1</CarryBulk>
 							<SmokeSensitivity>-1</SmokeSensitivity>
+							<PainShockThreshold>0.05</PainShockThreshold>
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>55</Plasteel>
@@ -71,8 +182,9 @@
 						</costList>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel/layers</xpath>
 					<value>
 						<li>OnHead</li>
 						<li>MiddleHead</li>
@@ -80,73 +192,68 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_HeavyMarineArmor == -->
-				<!-- statBases -->
+				<!-- === Siegebreaker Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Mass</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>120</Bulk>
 						<WornBulk>20</WornBulk>
 						<Mass>80</Mass>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>26</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>60</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>500</MaxHitPoints>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/label</xpath>
-					<value>
-						<label>heavy power armor</label>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/description</xpath>
-					<value>
-						<description>Heavy powered armor usually used by imperial heavy stormtroopers from advanced glitterworld planets.\n\nOnly stupid and fearless stand in it's way, as it transforms any soldier into a humanoid tank: the double layers of plasteel-weave plates are incredibly effective at protecting from both projectiles and explosions, while the neuro-memetic servo-motors allow a human to wear the armor without restricting movement, at the same time improving weapon-handling.\n\nA built-in blast shield allows the wearer to survive a direct hit from a rocket, upon which the shield requires time to recharge.</description>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>100</CarryWeight>
 							<CarryBulk>20</CarryBulk>
 							<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<PainShockThreshold>0.05</PainShockThreshold>
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/apparel/bodyPartGroups</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>50</DevilstrandCloth>
 						<Hyperweave>10</Hyperweave>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -1,30 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>	
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Armour Expanded</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
-				<!-- == VAE_Headgear_Balaclava == -->
-				<!-- statBases -->
+				
+				<!-- === Balaclava === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>0.5</Bulk>
 						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
 					<value>
 						<layers>
 							<li>OnHead</li>
 						</layers>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<bodyPartGroups>
 							<li>UpperHead</li>
@@ -33,138 +36,128 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_NightVisionGoggles == -->
-				<!-- statBases -->
+				<!-- === Omni-Spectrum Goggles === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 						<WornBulk>1</WornBulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+			
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/equippedStatOffsets</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>0.15</AimingAccuracy>
 						</equippedStatOffsets>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/apparel/layers</xpath>
 					<value>
-						<li>MiddleHead</li>
 						<li>StrappedHead</li>
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_BallisticGoggles == -->
-				<!-- statBases -->
+				<!-- === Flak Goggles === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<Bulk>0.5</Bulk>
 						<WornBulk>0.5</WornBulk>
 						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>9</ArmorRating_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Heat</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/statBases/ArmorRating_Heat</xpath>
 					<value>
 						<ArmorRating_Heat>0.366</ArmorRating_Heat>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/description</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/costList/Cloth</xpath>
 					<value>
-						<description>A pair of reinforced goggles capable of stopping a bullet. They seem to be tinted, stopping the glare from the sun, allowing the wearer to fire a bit more precisely.</description>
+						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/costList</xpath>
-					<value>
-						<DevilstrandCloth>10</DevilstrandCloth>
-					</value>
-				</li>
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/equippedStatOffsets</xpath>
-					<value>
-						<equippedStatOffsets>
-							<AimingAccuracy>0.05</AimingAccuracy>
-						</equippedStatOffsets>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/apparel/layers</xpath>
 					<value>
 						<layers>
-							<li>MiddleHead</li>
+							<li>StrappedHead</li>
 						</layers>
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_GhillieHood == -->
-				<!-- statBases -->
+				<!-- === Ghillie Hood === -->
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>0.5</WornBulk>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<AimingAccuracy>0.1</AimingAccuracy>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/apparel/layers</xpath>
 					<value>
 						<li>MiddleHead</li>
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_HAZMATMask == -->
-				<!-- statBases -->
+				<!-- === HAZMAT Mask === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 						<Bulk>6</Bulk>
 						<WornBulk>1.5</WornBulk>
 					</value>
 				</li>
-				<!-- Miscellaneous -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
 					<value>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
 					<value>
 						<li>MiddleHead</li>
 						<li>StrappedHead</li>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes
- Added trooper armor (uses old light marine armor stats)
- Removed description and name changes to the HMA
- Changed the NVGs apparel layer so they can be used with other hats
- Removed some redundant operations

Prestige version of both the trooper armor and siegebreaker armor are added via a patchOperation that checks for Royalty, so their patches must be handled on VAE's side. Path to this file is ` 1814988282\1.2\Patches\Royalty.xml ` no need to say to replace the orignal file with the one included here [Prestige Armors Patch](https://github.com/CombatExtended-Continued/CombatExtended/files/5897923/Royalty.zip)

