### PR TITLE
Build assembly for all PRs

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,7 +7,6 @@ on:
         required: true
   pull_request_target:
     branches: [ master, Development ]
-    paths: Source/**
 
 jobs:
   build:


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- All PRs will get a downloadable zipfile added in the comments, giving a uniform way to download and test PRs.

## Reasoning

Currently XML-only PRs require the tester (or eager players) to navigate to the originating branch and download the branch as a snapshot.  C#-affecting PRs require the tester to either compile the branch locally or use the compiled version provided via download link in the comments.  This was done to test out the CI system without impacting the XML-modding workflow until the kinks were worked out.  The kinks are now worked out, and there have been a few people asking how to get the patches which *don't* have an obvious download link.  Including asking if PRs without download links are not suitable for actual use.  Unifying the way novices obtain PRs for testing or early adoption should reduce this friction.  

## Alternatives

Continue using two different ways to obtain PRs for testing.  This would save on the storage space for additional builds, but that is a fairly minor concern.  

Require testers to build PRs locally.  This would freeze out enthusiastic novices who often don't even have a compiler locally.  

