### PR TITLE
Fix pawns dropping forced pick-up weapons after equipping them

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -196,9 +196,14 @@ namespace CombatExtended
             if (loadout == null || (loadout != null && loadout.Slots.NullOrEmpty()) || pawn.equipment?.Primary == null)
                 return false;
 
+            //Check if equipment is part of the loadout
             LoadoutSlot eqSlot = loadout.Slots.FirstOrDefault(s => s.count >= 1 && ((s.thingDef != null && s.thingDef == pawn.equipment.Primary.def)
                                                                                     || (s.genericDef != null && s.genericDef.lambda(pawn.equipment.Primary.def))));
-            if (eqSlot == null)
+
+            //Check if equipment is in the forced pick-up items list
+            HoldRecord eqRecord = pawn.GetHoldRecords()?.FirstOrDefault(s => s.count >= 1 && s.thingDef != null && s.thingDef == pawn.equipment.Primary.def);
+
+            if (eqSlot == null && eqRecord == null)
             {
                 dropEquipment = pawn.equipment.Primary;
                 return true;


### PR DESCRIPTION
## Changes
- Updated the loadout behaviour to treat equipped weapons by the same rules as inventory items (keep item if it's part of the loadout or if forced pick-up), as opposed to checking just loadout.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (15 minutes)
