### PR TITLE
Patch for Civilization Beyond Earth Armor Sets

### DIFF
--- a/Patches/Civilization Beyond Earth Armor Sets/Apparel_T1Armor.xml
+++ b/Patches/Civilization Beyond Earth Armor Sets/Apparel_T1Armor.xml
@@ -28,21 +28,14 @@
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-				<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				<ArmorRating_Sharp>12</ArmorRating_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<ArmorRating_Blunt>36</ArmorRating_Blunt>
-			</value>
-		</li>
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/costList</xpath>
-			<value>
-				<DevilstrandCloth>40</DevilstrandCloth>
+				<ArmorRating_Blunt>32</ArmorRating_Blunt>
 			</value>
 		</li>
 
@@ -88,7 +81,7 @@
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				<ArmorRating_Blunt>18</ArmorRating_Blunt>
 			</value>
 		</li>
 

--- a/Patches/Civilization Beyond Earth Armor Sets/Apparel_T1Armor.xml
+++ b/Patches/Civilization Beyond Earth Armor Sets/Apparel_T1Armor.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Civilization Beyond Earth Armor Sets</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- T1 Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases</xpath>
+			<value>
+				<Bulk>80</Bulk>
+				<WornBulk>15</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases</xpath>
+			<value>
+				<Flammability>0</Flammability>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>36</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/costList</xpath>
+			<value>
+				<DevilstrandCloth>40</DevilstrandCloth>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryBulk>8</CarryBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Armor"]/apparel/bodyPartGroups</xpath>
+			<value>
+				<li>Hands</li>
+				<li>Feet</li>
+			</value>
+		</li>
+
+		<!-- T1 Helmet -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/statBases</xpath>
+			<value>
+				<Bulk>4</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/statBases</xpath>
+			<value>
+				<Flammability>0</Flammability>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>10</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>24</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Tier1_Helmet"]/apparel/layers</xpath>
+			<value>
+			<li>OnHead</li>
+			<li>StrappedHead</li>
+			<li>MiddleHead</li>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+
+</Patch>
+

--- a/Patches/Civilization Beyond Earth Armor Sets/Weapons_T1Guns.xml
+++ b/Patches/Civilization Beyond Earth Armor Sets/Weapons_T1Guns.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Civilization Beyond Earth Armor Sets</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		 <operations>
+
+		<!-- ========== Tools ========== -->
+
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Tier1_Carbine_Soldier"]/tools</xpath>
+		<value>
+			<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>stock</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+				<li>Blunt</li>
+				</capacities>
+				<power>5</power>
+				<cooldownTime>2.02</cooldownTime>
+				<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+				<li>Poke</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+			</tools>
+		</value>
+		</li>
+
+		<!-- ========== T1 Carbine ========== -->
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Tier1_Carbine_Soldier</defName>
+			<statBases>
+				<Mass>3.5</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.1</SightsEfficiency>
+				<ShotSpread>0.07</ShotSpread>
+				<SwayFactor>1.33</SwayFactor>
+				<Bulk>10.03</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.53</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+				<warmupTime>1.1</warmupTime>
+				<range>42</range>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+				<soundCast>Tier1_SMG_Gun_Sound</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>60</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_Rifle</li>
+			</weaponTags>
+			<researchPrerequisite>GasOperation</researchPrerequisite>
+		</li>
+
+			</operations>
+			</match>
+		</Operation>
+	</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -58,6 +58,7 @@ Beeralope Squad	|
 Better Infestations	|
 Black Widows	|
 Carbon	|
+Civilization Beyond Earth Armor Sets    |
 Clay Soldier Race |
 Combat Enthusiast’s Collection	|
 Cupro's Alloys	|


### PR DESCRIPTION
Simple patch for Civilization Beyond Earth Armor Sets. Patches one set of armor and one rifle.
- Armor is weaker than recon armor without the loadbearing bonuses.
- Rifle is essentially an assault rifle with a larger mag, shorter range, higher rate of fire, and more recoil. It only needs Gas Operation vs Precision Rifling, but that's from the base mod and I decided to let that stand.