### PR TITLE
Add NewRatkinPlus to modlist (retroactive)

### DIFF
--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -137,6 +137,7 @@ More Utility Packs	|
 More Vanilla Turrets	|
 Moyo - From the Depth   |
 Nearmare Race	|
+NewRatkinPlus |
 Ni'Hal	|
 Orassans	|
 Palm Cats   |


### PR DESCRIPTION
## Additions

- (Retroactively) add NewRatkinPlus to `SupportedThirdPartyMods.md`

## Reasoning

- Ratkin patches already existed as far back as May 2020, but for some reason were never listed in the supported mods list.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded (not applicable)
- [x] Playtested a colony (not applicable)
