### PR TITLE
Vanilla Apparel Expanded Tweaks

### DIFF
--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -52,7 +52,7 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_Hardhat == -->
+				<!-- == VAE_Headgear_Hardhat / Chef's Toque == -->
 				<!-- statBases -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
@@ -64,6 +64,12 @@
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque"]/apparel/layers</xpath>
+					<value>
+						<li>MiddleHead</li>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -51,16 +51,8 @@
 						</equippedStatOffsets>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_BaseballCap"]/apparel/layers</xpath>
-					<value>
-						<layers>
-							<li>MiddleHead</li>
-						</layers>
-					</value>
-				</li>
 
-				<!-- == VAE_Headgear_Hardhat, VAE_Headgear_ChefsToque == -->
+				<!-- == VAE_Headgear_Hardhat == -->
 				<!-- statBases -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
@@ -72,13 +64,6 @@
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
-					</value>
-				</li>
-				<!-- Miscellaneous -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque"]/apparel/layers</xpath>
-					<value>
-						<li>MiddleHead</li>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes
- Baseball Cap layers reverted to Overhead.

Poking around noticed that VAE was the only mod that moved these hats to the MiddleHead layer causing issues when other apparel mods were loaded (double baseball caps, double helmets, etc) and so on. This change simply aims to fix that.