### PR TITLE
Burst shots for some smgs, (Uzi and MP5K).

### DIFF
--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -301,6 +301,7 @@
 			<FireModes>
 				<aiAimMode>Snapshot</aiAimMode>
 				<aiUseBurstMode>True</aiUseBurstMode>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
 			</FireModes>
 			<weaponTags>
 				<li>IndustrialGunAdvanced</li>
@@ -346,6 +347,7 @@
 			<FireModes>
 				<aiAimMode>Snapshot</aiAimMode>
 				<aiUseBurstMode>True</aiUseBurstMode>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
 			</FireModes>
 			<weaponTags>
 				<li>IndustrialGunAdvanced</li>


### PR DESCRIPTION
IIrc Uzi and MP5K both have 3 round burst modes. At least MP5K does. Uzi can be fired with good discipline with 3 round bursts.

## Additions

UZI and MP5 burst fire

## Changes

Added burst fire for said guns
=

## Reasoning

Make them more usable to preserve ammo. MP5K totally has burst fire mode irl. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
