### PR TITLE
Genetic Rim Tweaks

### DIFF
--- a/Patches/Genetic Rim/Bodies/GeneticRim_CE_Patch_Bodies.xml
+++ b/Patches/Genetic Rim/Bodies/GeneticRim_CE_Patch_Bodies.xml
@@ -9,7 +9,7 @@
 				<operations>
 
 			<!-- ====== Adding custom bodytype for TurtleLike creatures ======= -->
-
+<!--
 					<li Class="PatchOperationAdd">
 					<xpath>/Defs</xpath>
 						<value>
@@ -204,7 +204,7 @@
 							<body>GR_Arachnid</body>
 						</value>
 					</li>
-
+-->
 			
 					<li Class="PatchOperationAdd">
 					<xpath>/Defs</xpath>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CosmicHorrors_HybridCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_CosmicHorrors_HybridCE.xml
@@ -373,7 +373,7 @@
 				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>BirdLike</bodyShape>
+					<bodyShape>Birdlike</bodyShape>
 				</li>
 				</value>
 			</li>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Dino_HybridCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Dino_HybridCE.xml
@@ -11,85 +11,84 @@
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]</xpath>
 				<value>
-				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>Quadruped</bodyShape>
-				</li>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
 				</value>
 			</li>
 						
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.09</MeleeDodgeChance>
-				<MeleeCritChance>0.42</MeleeCritChance>
-				<MeleeParryChance>0.2</MeleeParryChance>
+					<MeleeDodgeChance>0.09</MeleeDodgeChance>
+					<MeleeCritChance>0.42</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]/tools</xpath>
 				<value>
-
-				<tools>
-				<li Class="CombatExtended.ToolCE">
-				<label>left leg</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>21</power>
-				<cooldownTime>1.55</cooldownTime>
-				<linkedBodyPartsGroup>LeftLeg</linkedBodyPartsGroup>
-				<surpriseAttack>
-					<extraMeleeDamages>
-						<li>
-							<def>Stun</def>
-							<amount>22</amount>
-						</li>
-					</extraMeleeDamages>
-				</surpriseAttack>
-				<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-				<label>right leg</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>21</power>
-				<cooldownTime>1.55</cooldownTime>
-				<linkedBodyPartsGroup>RightLeg</linkedBodyPartsGroup>
-				<surpriseAttack>
-					<extraMeleeDamages>
-						<li>
-							<def>Stun</def>
-							<amount>22</amount>
-						</li>
-					</extraMeleeDamages>
-				</surpriseAttack>
-				<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
-				</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>teeth</label>
-							<capacities>
-								<li>Bite</li>
-							</capacities>
-							<power>43</power>
-							<cooldownTime>1.72</cooldownTime>
-							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>2.5</armorPenetrationSharp>
-							<armorPenetrationBlunt>6</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>8</power>
-							<cooldownTime>2.48</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							<armorPenetrationBlunt>6</armorPenetrationBlunt>
-							<chanceFactor>0.1</chanceFactor>
-						</li>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>left leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>21</power>
+					<cooldownTime>1.55</cooldownTime>
+					<linkedBodyPartsGroup>LeftLeg</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>22</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right leg</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>1.55</cooldownTime>
+						<linkedBodyPartsGroup>RightLeg</linkedBodyPartsGroup>
+						<surpriseAttack>
+							<extraMeleeDamages>
+								<li>
+									<def>Stun</def>
+									<amount>22</amount>
+								</li>
+							</extraMeleeDamages>
+						</surpriseAttack>
+						<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>43</power>
+						<cooldownTime>1.72</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<armorPenetrationSharp>2.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>2.48</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+						<armorPenetrationBlunt>6</armorPenetrationBlunt>
+						<chanceFactor>0.1</chanceFactor>
+					</li>
 					</tools>
 				</value>
 			</li>
@@ -98,18 +97,18 @@
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ThingDef[defName="GR_Parasaurolope"]</xpath>
 				<value>
-				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>Quadruped</bodyShape>
-				</li>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
 				</value>
 			</li>
 						
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Parasaurolope"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.2</MeleeDodgeChance>
-				<MeleeCritChance>0.37</MeleeCritChance>
-				<MeleeParryChance>0.24</MeleeParryChance>
+					<MeleeDodgeChance>0.2</MeleeDodgeChance>
+					<MeleeCritChance>0.37</MeleeCritChance>
+					<MeleeParryChance>0.24</MeleeParryChance>
 				</value>
 			</li>
 			
@@ -144,8 +143,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Chickennathus"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.8</MeleeDodgeChance>
-				<MeleeCritChance>0.07</MeleeCritChance>
+					<MeleeDodgeChance>0.8</MeleeDodgeChance>
+					<MeleeCritChance>0.07</MeleeCritChance>
 				</value>
 			</li>
 			
@@ -153,40 +152,40 @@
 				<xpath>/Defs/ThingDef[defName="GR_Chickennathus"]/tools</xpath>
 				<value>
 					<tools>
-						<li Class="CombatExtended.ToolCE">
-				<label>left claw</label>
-				<capacities>
-					<li>Scratch</li>
-					<li>Stab</li>
-				</capacities>
-				<power>9</power>
-				<cooldownTime>0.85</cooldownTime>
-				<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.25</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<li Class="CombatExtended.ToolCE">
+						<label>left claw</label>
+						<capacities>
+							<li>Scratch</li>
+							<li>Stab</li>
+						</capacities>
+						<power>9</power>
+						<cooldownTime>0.85</cooldownTime>
+						<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0.25</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right claw</label>
+						<capacities>
+							<li>Scratch</li>
+							<li>Stab</li>
+						</capacities>
+						<power>9</power>
+						<cooldownTime>0.85</cooldownTime>
+						<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0.25</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-				<label>right claw</label>
-				<capacities>
-					<li>Scratch</li>
-					<li>Stab</li>
-				</capacities>
-				<power>9</power>
-				<cooldownTime>0.85</cooldownTime>
-				<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.25</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-				<label>teeth</label>
-				<capacities>
-					<li>Bite</li>
-				</capacities>
-				<power>16</power>
-				<cooldownTime>1.56</cooldownTime>
-				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.78</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>16</power>
+						<cooldownTime>1.56</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0.78</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -196,7 +195,7 @@
 				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>BirdLike</bodyShape>
+					<bodyShape>Birdlike</bodyShape>
 				</li>
 				</value>
 			</li>
@@ -204,11 +203,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.12</MeleeDodgeChance>
-				<MeleeCritChance>1</MeleeCritChance>
-				<MeleeParryChance>0.2</MeleeParryChance>
-				<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
-				<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+					<MeleeDodgeChance>0.12</MeleeDodgeChance>
+					<MeleeCritChance>1</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
+					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -216,43 +215,43 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-						<label>left leg</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>38</power>
-						<cooldownTime>3.6</cooldownTime>
-						<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>33</armorPenetrationBlunt>
+							<label>left leg</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>38</power>
+							<cooldownTime>3.6</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>33</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-						<label>right leg</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>38</power>
-						<cooldownTime>3.6</cooldownTime>
-						<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>33</armorPenetrationBlunt>
+							<label>right leg</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>38</power>
+							<cooldownTime>3.6</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>33</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-						<label>tail</label>
-						<capacities>
-							<li>Blunt</li>
-						</capacities>
-						<power>56</power>
-						<cooldownTime>5.1</cooldownTime>
-						<linkedBodyPartsGroup>TailAttackTool</linkedBodyPartsGroup>
-						<surpriseAttack>
-						<extraMeleeDamages>
-						<li>
-							<def>Stun</def>
-							<amount>20</amount>
-						</li>
-						</extraMeleeDamages>
-						</surpriseAttack>
-						<chanceFactor>0.25</chanceFactor>
-						<armorPenetrationBlunt>56</armorPenetrationBlunt>
+							<label>tail</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>56</power>
+							<cooldownTime>5.1</cooldownTime>
+							<linkedBodyPartsGroup>TailAttackTool</linkedBodyPartsGroup>
+							<surpriseAttack>
+							<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+							</extraMeleeDamages>
+							</surpriseAttack>
+							<chanceFactor>0.25</chanceFactor>
+							<armorPenetrationBlunt>56</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -270,9 +269,9 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Triceraffalo"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.08</MeleeDodgeChance>
-				<MeleeCritChance>0.4</MeleeCritChance>
-				<MeleeParryChance>0.4</MeleeParryChance>
+					<MeleeDodgeChance>0.08</MeleeDodgeChance>
+					<MeleeCritChance>0.4</MeleeCritChance>
+					<MeleeParryChance>0.4</MeleeParryChance>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -282,9 +281,9 @@
 						<li Class="CombatExtended.ToolCE">
 							<label>horn</label>
 							<capacities>
-                                                                                                               <li>Scratch</li>
-					                               <li>Stab</li>
-                                                                                                               </capacities>
+								<li>Scratch</li>
+								<li>Stab</li>
+							</capacities>
 							<power>31</power>
 							<cooldownTime>2.48</cooldownTime>
 							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
@@ -292,7 +291,7 @@
 							<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-				                                                <label>head</label>
+				            <label>head</label>
 							<capacities><li>Blunt</li></capacities>
 							<power>24</power>
 							<cooldownTime>3.17</cooldownTime>
@@ -316,9 +315,9 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Raptortoise"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.5</MeleeDodgeChance>
-				<MeleeCritChance>0.23</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<MeleeDodgeChance>0.5</MeleeDodgeChance>
+					<MeleeCritChance>0.23</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 			
@@ -368,7 +367,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-					                                                 <li>GR_VeryToxicBite</li>
+					        	<li>GR_VeryToxicBite</li>
 							</capacities>
 							<power>28</power>
 							<cooldownTime>1.55</cooldownTime>
@@ -421,38 +420,38 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-        						<label>tail</label>
-        						<capacities>
-         		  				<li>Blunt</li>
-        						</capacities>
-        						<power>48</power>
-        						<cooldownTime>3.2</cooldownTime>
-        						<linkedBodyPartsGroup>TailAttackTool</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>55</armorPenetrationBlunt>
+							<label>tail</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>48</power>
+							<cooldownTime>3.2</cooldownTime>
+							<linkedBodyPartsGroup>TailAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>55</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-        						<label>head</label>
-        						<capacities>
-		  					<li>Cut</li>
-        						</capacities>
-        						<power>48</power>
-        						<cooldownTime>2.88</cooldownTime>
-        						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationSharp>1</armorPenetrationSharp>
-						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+							<label>head</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>48</power>
+							<cooldownTime>2.88</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationSharp>1</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-        						<label>head</label>
-        						<capacities>
-          							<li>Stab</li>
-        						</capacities>
-        						<power>36</power>
-        						<cooldownTime>2.78</cooldownTime>
-        						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-						<chanceFactor>0.2</chanceFactor>
-						<armorPenetrationSharp>4</armorPenetrationSharp>
-						<armorPenetrationBlunt>4</armorPenetrationBlunt>
+							<label>head</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>36</power>
+							<cooldownTime>2.78</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationSharp>4</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>
@@ -462,7 +461,7 @@
 				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>BirdLike</bodyShape>
+					<bodyShape>Birdlike</bodyShape>
 				</li>
 				</value>
 			</li>
@@ -470,18 +469,18 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/statBases</xpath>
 				<value>
-				<MeleeDodgeChance>0.5</MeleeDodgeChance>
-				<MeleeCritChance>0.14</MeleeCritChance>
-				<MeleeParryChance>0.2</MeleeParryChance>
+					<MeleeDodgeChance>0.5</MeleeDodgeChance>
+					<MeleeCritChance>0.14</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
 
-		                 <li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>1.2</baseHealthScale>
-					</value>
-		                </li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>1.2</baseHealthScale>
+				</value>
+			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/tools</xpath>
@@ -493,8 +492,8 @@
 							<power>14</power>
 							<cooldownTime>0.9</cooldownTime>
 							<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.56</armorPenetrationSharp>
-								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.56</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>right claw</label>
@@ -502,24 +501,24 @@
 							<power>14</power>
 							<cooldownTime>0.9</cooldownTime>
 							<linkedBodyPartsGroup>FootClawAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.56</armorPenetrationSharp>
-								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.56</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities><li>Bite</li></capacities>
 							<power>23</power>
 							<cooldownTime>1.5</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-		                                			<surpriseAttack>
-					   			<extraMeleeDamages>
-								<li>
-								<def>Stun</def>
-								<amount>20</amount>
-								</li>
-								</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationSharp>2</armorPenetrationSharp>
-								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+							<surpriseAttack>
+							<extraMeleeDamages>
+							<li>
+							<def>Stun</def>
+							<amount>20</amount>
+							</li>
+							</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationSharp>2</armorPenetrationSharp>
+							<armorPenetrationBlunt>4</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>head</label>
@@ -528,7 +527,7 @@
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
-				                                                <chanceFactor>0.2</chanceFactor>
+							<chanceFactor>0.2</chanceFactor>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_MechanoidhybridsCE.xml
@@ -20,11 +20,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.1</MeleeDodgeChance>
-				<MeleeCritChance>0.45</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.1</MeleeDodgeChance>
+					<MeleeCritChance>0.45</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -92,11 +92,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.35</MeleeDodgeChance>
-				<MeleeCritChance>0.3</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.35</MeleeDodgeChance>
+					<MeleeCritChance>0.3</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -141,11 +141,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>2.6</AimingAccuracy>
-			                <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.65</MeleeDodgeChance>
-				<MeleeCritChance>0.1</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>2.6</AimingAccuracy>
+					<ShootingAccuracyPawn>2.6</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.65</MeleeDodgeChance>
+					<MeleeCritChance>0.1</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -197,11 +197,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1.6</AimingAccuracy>
-			                <ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.36</MeleeDodgeChance>
-				<MeleeCritChance>0.4</MeleeCritChance>
-				<MeleeParryChance>0.2</MeleeParryChance>
+					<AimingAccuracy>1.6</AimingAccuracy>
+					<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.36</MeleeDodgeChance>
+					<MeleeCritChance>0.4</MeleeCritChance>
+					<MeleeParryChance>0.2</MeleeParryChance>
 				</value>
 			</li>
 
@@ -237,22 +237,6 @@
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>13</armorPenetrationBlunt>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<capacities><li>Stab</li><li>Cut</li></capacities>
-							<power>35</power>
-							<cooldownTime>1.65</cooldownTime>
-							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-							<surpriseAttack>
-								<extraMeleeDamages>
-									<li>
-										<def>Stun</def>
-										<amount>18</amount>
-									</li>
-								</extraMeleeDamages>
-							</surpriseAttack>
-							<armorPenetrationSharp>16</armorPenetrationSharp>
-							<armorPenetrationBlunt>16</armorPenetrationBlunt>
-						</li>
 					</tools>
 				</value>
 			</li>
@@ -269,11 +253,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.05</MeleeDodgeChance>
-				<MeleeCritChance>0.5</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -325,11 +309,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>0.8</AimingAccuracy>
-			                <ShootingAccuracyPawn>0.8</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.33</MeleeDodgeChance>
-				<MeleeCritChance>0.03</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>0.8</AimingAccuracy>
+					<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					<MeleeCritChance>0.03</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -382,11 +366,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1.6</AimingAccuracy>
-			                <ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.05</MeleeDodgeChance>
-				<MeleeCritChance>0.5</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1.6</AimingAccuracy>
+					<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -437,11 +421,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.05</MeleeDodgeChance>
-				<MeleeCritChance>0.5</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -501,11 +485,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.05</MeleeDodgeChance>
-				<MeleeCritChance>0.75</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.75</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -522,13 +506,12 @@
 				</value>
 			</li>
 
-
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>6</baseHealthScale>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>6</baseHealthScale>
+				</value>
+			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/tools</xpath>
@@ -554,6 +537,7 @@
 					</tools>
 				</value>
 			</li>
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]</xpath>
 				<value>
@@ -566,11 +550,11 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>1</AimingAccuracy>
-			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.75</MeleeDodgeChance>
-				<MeleeCritChance>0.25</MeleeCritChance>
-				<MeleeParryChance>0.1</MeleeParryChance>
+					<AimingAccuracy>1</AimingAccuracy>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.75</MeleeDodgeChance>
+					<MeleeCritChance>0.25</MeleeCritChance>
+					<MeleeParryChance>0.1</MeleeParryChance>
 				</value>
 			</li>
 
@@ -618,7 +602,6 @@
 					</tools>
 				</value>
 			</li>
-
 
 		</operations>
 		</match>


### PR DESCRIPTION
A few tweaks to Genetic Rim and associated mod patches.
- Comment out the GR_Arachnid bodyType, as it seems unnecessary and causes some errors.
- Fix capitalization error with `Birdlike`.
- Remove mechaspider bite attack, since it doesn't have one in the base mod.
- Fix some formatting.