### PR TITLE
[O21] Outer Rim compatibility Patch

### DIFF
--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
@@ -13,7 +13,7 @@
 			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]</xpath>
 			<value>
 				<equippedStatOffsets>
-				  <CarryBulk>60</CarryBulk>
+				  <CarryBulk>40</CarryBulk>
 				</equippedStatOffsets>
 			</value>
 		</li>
@@ -29,7 +29,7 @@
 			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]/statBases</xpath>
 			<value>
 				<Bulk>7.5</Bulk>
-				<WornBulk>1</WornBulk>
+				<WornBulk>2</WornBulk>
 			</value>
 		</li>
 		

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
@@ -47,7 +47,14 @@
 				<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
 			</value>
 		</li>
-			
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Leather_Jawa"]/statBases</xpath>
+			<value>
+				<StuffPower_Armor_Blunt>0.02</StuffPower_Armor_Blunt>
+			</value>
+		</li>
+		
 			
 		</operations>
 		</match>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Apparel.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Outer Rim - Tatooine (Continued)</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				  <CarryBulk>60</CarryBulk>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]/statBases</xpath>
+			<value>
+				<Bulk>7.5</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]/apparel/layers</xpath>
+			<value>
+				<li>Backpack</li>
+				<li>Webbing</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Leather_Jawa"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<value>
+				<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+			</value>
+		</li>
+			
+			
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Factions.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Factions.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Outer Rim - Faction - Tatooine (Continued)</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			
+		  <li Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[
+			defName="O21_NPC_TuskenRaiderTrooperRanged" or
+			defName="O21_NPC_TuskenRaiderOfficer" or
+			defName="O21_NPC_TuskenRaiderCommander"
+			]</xpath>
+			<value>
+			  <li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+				  <min>2</min>
+				  <max>4</max>
+				</primaryMagazineCount>
+				<sidearms>
+				  <li>
+					<generateChance>0.3</generateChance>
+					<sidearmMoney>
+					  <min>20</min>
+					  <max>120</max>
+					</sidearmMoney>
+					<weaponTags>
+					  <li>TuskenRaiderWeapons</li>
+					</weaponTags>
+				  </li>
+				</sidearms>
+			  </li>
+			</value>
+		  </li>
+			
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[
+			defName="O21_NPC_JawaChief" or
+			defName="O21_NPC_JawaTrader" or
+			defName="O21_NPC_JawaScavenger" or
+			defName="O21_NPC_JawaMechanic" or
+			defName="O21_NPC_JawaShaman" or
+			defName="O21_NPC_JawaVillager"
+			]</xpath>
+			<value>
+			  <li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+				  <min>2</min>
+				  <max>4</max>
+				</primaryMagazineCount>
+			  </li>
+			</value>
+		  </li>
+			
+			
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Races.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Races.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Outer Rim - Tatooine (Continued)</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<!-- Jawa -->
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>1.35</MeleeDodgeChance>
+				<MeleeCritChance>0.75</MeleeCritChance>
+				<MeleeParryChance>0.9</MeleeParryChance>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>0.8</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>0.8</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1.6</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationSequence">
+		<success>Always</success>
+			<operations>
+				<li Class="PatchOperationTest">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/comps</xpath>
+				<success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]</xpath>
+				<value>
+					<comps />
+				</value>
+				</li>
+			</operations>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/comps</xpath>
+			<value>
+				<li>
+				  <compClass>CombatExtended.CompPawnGizmo</compClass>
+				</li>
+				<li Class="CombatExtended.CompProperties_Suppressable" />
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/race/baseBodySize</xpath>
+			<value>
+				  <baseBodySize>0.8</baseBodySize>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Jawa"]/race/baseHealthScale</xpath>
+			<value>
+				  <baseHealthScale>0.8</baseHealthScale>
+			</value>
+		</li>
+		
+		<!-- Tusken -->
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>0.9</MeleeDodgeChance>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1.1</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1.1</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>2.2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationSequence">
+		<success>Always</success>
+			<operations>
+				<li Class="PatchOperationTest">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/comps</xpath>
+				<success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]</xpath>
+				<value>
+					<comps />
+				</value>
+				</li>
+			</operations>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/comps</xpath>
+			<value>
+				<li>
+				  <compClass>CombatExtended.CompPawnGizmo</compClass>
+				</li>
+				<li Class="CombatExtended.CompProperties_Suppressable" />
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/race/baseBodySize</xpath>
+			<value>
+				  <baseBodySize>1.1</baseBodySize>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Alien_TuskenRaider"]/race/baseHealthScale</xpath>
+			<value>
+				  <baseHealthScale>1.1</baseHealthScale>
+			</value>
+		</li>
+		
+		
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Resources.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Resources.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>[O21] Outer Rim - Core</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="O21_OuterRim_Durasteel" or defName="O21_OuterRim_Beskar"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>	
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="O21_OuterRim_Blaster"]/armorCategory</xpath>
+				<value>
+					<armorCategory>Sharp</armorCategory>
+				</value>
+			</li>	
+			
+			
+			
+			
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_SandCrawler.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_SandCrawler.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Outer Rim - Tatooine Sandcrawler (Continued)</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<CombatExtended.BodyShapeDef>
+						<defName>Sandcrawler_Shape</defName>
+						<width>0.25</width>
+						<widthLaying>0.25</widthLaying>
+						<height>0.001</height>
+						<heightLaying>0.001</heightLaying>
+					</CombatExtended.BodyShapeDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Sandcrawler_Shape</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]/statBases</xpath>
+				<value>
+					<CarryWeight>400</CarryWeight>
+					<CarryBulk>80</CarryBulk>
+					<MeleeDodgeChance>0</MeleeDodgeChance>
+					<MeleeCritChance>0</MeleeCritChance>
+					<MeleeParryChance>0</MeleeParryChance>
+					<MaxHitPoints>1000</MaxHitPoints>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				</value>
+			</li>
+			
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>5</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<armorPenetrationBlunt>0</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="MechanicalSandcrawler"]//*[def="FrontHatch"]/groups</xpath>
+				<value>
+					<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName="MechanicalSandcrawler"]//*[def="FrontWindow" or def="Reactor" or def="FluidReprocessor"]</xpath>
+				<value>
+					<groups>
+						<li>CoveredByNaturalArmor</li>
+					</groups>
+				</value>
+			</li>
+		
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_SandCrawler.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_SandCrawler.xml
@@ -15,9 +15,16 @@
 						<defName>Sandcrawler_Shape</defName>
 						<width>0.25</width>
 						<widthLaying>0.25</widthLaying>
-						<height>0.001</height>
-						<heightLaying>0.001</heightLaying>
+						<height>0.01</height>
+						<heightLaying>0.01</heightLaying>
 					</CombatExtended.BodyShapeDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Sandcrawler"]/race/baseBodySize</xpath>
+				<value>
+					<baseBodySize>10</baseBodySize>
 				</value>
 			</li>
 			
@@ -62,18 +69,18 @@
 				<xpath>Defs/ThingDef[defName="Sandcrawler"]/tools</xpath>
 				<value>
 					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>1</power>
-							<cooldownTime>5</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0</armorPenetrationSharp>
-							<armorPenetrationBlunt>0</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-						</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>35</power>
+						<cooldownTime>3.51</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0</armorPenetrationSharp>
+						<armorPenetrationBlunt>15</armorPenetrationBlunt>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
 					</tools>
 				</value>
 			</li>

--- a/Patches/[O21] Outer Rim/Patch_OuterRim_Weapons.xml
+++ b/Patches/[O21] Outer Rim/Patch_OuterRim_Weapons.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Outer Rim - Tatooine (Continued)</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
+			
+			  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+				<defName>Bullet_Ion_Energy</defName>
+				<label>Ion Energy</label>
+				<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				<graphicData>
+				  <texPath>Things/Projectile/Bullet_Ion_Energy</texPath>
+				  <graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				  <damageDef>EMP</damageDef>
+				  <damageAmountBase>23</damageAmountBase>
+				  <speed>60</speed>
+				  <gravityFactor>0.5</gravityFactor>
+				  <explosionRadius>1.5</explosionRadius>
+				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				</projectile>
+			  </ThingDef>
+			  
+			  <CombatExtended.AmmoSetDef>
+				<defName>AmmoSet_Tusken</defName>
+				<label>12 Gauge</label>
+				<ammoTypes>
+				  <Ammo_12Gauge_Slug>Bullet_12Gauge_Slug</Ammo_12Gauge_Slug>
+				</ammoTypes>
+			  </CombatExtended.AmmoSetDef>
+				
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+		defName="O21_JawaIonBlaster" or
+		defName="O21_TuskenCycler"
+		]/tools</xpath>
+		<value>
+		  <tools>
+			<li Class="CombatExtended.ToolCE">
+			  <label>stock</label>
+			  <capacities>
+				<li>Blunt</li>
+			  </capacities>
+			  <power>8</power>
+			  <cooldownTime>1.55</cooldownTime>
+			  <chanceFactor>1.5</chanceFactor>
+			  <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+			  <label>barrel</label>
+			  <capacities>
+				<li>Blunt</li>
+			  </capacities>
+			  <power>5</power>
+			  <cooldownTime>2.02</cooldownTime>
+			  <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+			  <label>muzzle</label>
+			  <capacities>
+				<li>Poke</li>
+			  </capacities>
+			  <power>8</power>
+			  <cooldownTime>1.55</cooldownTime>
+			  <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+		  </tools>
+		</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>O21_JawaIonBlaster</defName>
+				<statBases>
+				  <SightsEfficiency>0.7</SightsEfficiency>
+				  <ShotSpread>0.21</ShotSpread>
+				  <SwayFactor>1.32</SwayFactor>
+				  <Bulk>3.00</Bulk>
+				  <Mass>4.10</Mass>
+				  <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Ion_Energy</defaultProjectile>
+					<warmupTime>2</warmupTime>
+					<range>35</range>
+					<soundCast>Shot_Shotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+					<targetParams>
+					  <canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<!--
+				<AmmoUser>
+					<magazineSize>18</magazineSize>
+					<reloadTime>3.7</reloadTime>
+					<ammoSet>AmmoSet_SWPlasmaGasCartridgeJawa</ammoSet>
+				</AmmoUser>
+				-->
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>O21_TuskenCycler</defName>
+				<statBases>
+				  <SightsEfficiency>0.9</SightsEfficiency>
+				  <ShotSpread>0.5</ShotSpread>
+				  <SwayFactor>1.8</SwayFactor>
+				  <Bulk>3.00</Bulk>
+				  <Mass>4.10</Mass>
+				  <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Slug</defaultProjectile>
+					<warmupTime>2</warmupTime>
+					<range>45</range>
+					<ticksBetweenBurstShots>12</ticksBetweenBurstShots>
+					<burstShotCount>2</burstShotCount>
+					<soundCast>Shot_Shotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<AmmoUser>
+					<magazineSize>16</magazineSize>
+					<reloadTime>4.0</reloadTime>
+					<ammoSet>AmmoSet_Tusken</ammoSet>
+				</AmmoUser>
+		</li>
+		
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="O21_Gaderffii"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>shaft</label>
+						<capacities>
+							<li>Blunt</li>
+							<li>Poke</li>
+						</capacities>
+						<power>16</power>
+						<cooldownTime>1</cooldownTime>
+						<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+						<!--<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>-->
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>23</power>
+						<cooldownTime>3.5</cooldownTime>
+						<armorPenetrationBlunt>0.956</armorPenetrationBlunt>
+						<armorPenetrationSharp>2</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="O21_Gaderffii"]/statBases</xpath>
+			<value>
+				<Bulk>8.5</Bulk>
+				<MeleeCounterParryBonus>1.68</MeleeCounterParryBonus>				
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="O21_Gaderffii"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.17</MeleeCritChance>
+					<MeleeParryChance>1.45</MeleeParryChance>
+					<MeleeDodgeChance>0.9</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>


### PR DESCRIPTION
## Additions

Adds [O21] Outer Rim compatibility Patch.
Patches: [O21] Outer Rim - Core, Outer Rim - Tatooine (Continued), Outer Rim - Faction - Tatooine (Continued) and Outer Rim - Tatooine Sandcrawler (Continued)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
