### PR TITLE
Readded and updated Dragon's Descent patch.

### DIFF
--- a/Patches/Dragon's Descent/AbilityDefs/Dragon.xml
+++ b/Patches/Dragon's Descent/AbilityDefs/Dragon.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Dragon Breath -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonBreath"]/verbProperties/range</xpath>
+					<value>
+						<range>17</range>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonBreath"]/verbProperties/minRange</xpath>
+					<value>
+						<minRange>3</minRange>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonBreath"]/comps/li[@Class="DD.AbilityCompProperties_CastVerb"]/verbProperties/li</xpath>
+					<value>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+							<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
+							<range>17</range>
+							<burstShotCount>25</burstShotCount>
+							<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+							<minRange>3</minRange>
+							<soundCast>DragonBreathShot</soundCast>
+							<muzzleFlashScale>1</muzzleFlashScale>
+							<recoilAmount>1</recoilAmount>
+							<recoilPattern>Mounted</recoilPattern> <!-- Less vertical, more horizontal recoil. -->
+						</li>
+					</value>
+				</li>
+				<!-- Dragon Spit -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonSpit"]/verbProperties/range</xpath>
+					<value>
+						<range>30</range>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonSpit"]/verbProperties/minRange</xpath>
+					<value>
+						<minRange>9</minRange>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonSpit"]/verbProperties/warmupTime</xpath>
+					<value>
+						<warmupTime>1</warmupTime>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/AbilityDef[defName="DragonSpit"]/comps/li[@Class="DD.AbilityCompProperties_CastVerb"]/verbProperties/li</xpath>
+					<value>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+							<defaultProjectile>Projectile_DragonSpit</defaultProjectile>
+							<range>30</range>
+							<burstShotCount>3</burstShotCount>
+							<ticksBetweenBurstShots>18</ticksBetweenBurstShots>
+							<minRange>9</minRange>
+							<soundCast>DragonBreathShot</soundCast>
+							<muzzleFlashScale>1</muzzleFlashScale>
+							<recoilAmount>0.4</recoilAmount>
+							<recoilPattern>Mounted</recoilPattern> <!-- Less vertical, more horizontal recoil. -->
+						</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/BodyDefs/Bodies_Animal_Dragon.xml
+++ b/Patches/Dragon's Descent/BodyDefs/Bodies_Animal_Dragon.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Wing"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Wing"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Wing"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Tail"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Tail"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Tail"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Paw"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Paw"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Paw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
+
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</nomatch>
+
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="QuadrupedeAnimalWithClawsDragon"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/DamageDefs/Damage_Dragons.xml
+++ b/Patches/Dragon's Descent/DamageDefs/Damage_Dragons.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- === Add DefModExtension === -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/DamageDef[defName="Rend" or defName="Skull_Bash" or defName="Frost_Bite" or defName="Pyro_Bite"]</xpath>
+
+					<value>
+						<li Class="CombatExtended.DamageDefExtensionCE">
+							<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>
+						</li>
+					</value>
+				</li>
+
+				<!-- === Remove vanilla DamageWorker === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="Frost_Bite"]/workerClass</xpath>
+
+					<value>
+						<workerClass>DamageWorker_AddInjury</workerClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/DamageDef[defName="Skull_Bash"]/workerClass</xpath>
+					
+					<value>
+						<workerClass>CombatExtended.DamageWorker_BluntCE</workerClass>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
+++ b/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Hooray, more updating -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== DraconicAmbrosia (Draconic ambrosia) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DraconicAmbrosia"]/statBases</xpath>
+					<value>
+						<Bulk>0.2</Bulk>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
+++ b/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Hooray, more updating -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== DragonsBlood (Dragon's blood potion) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DragonsBlood"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+					</value>
+				</li>
+
+				<!-- ======== DragonsBloodHigh ======== -->
+				<!-- ====== stages ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/HediffDef[defName="DragonsBloodHigh"]/stages/li[1]</xpath>
+					<value>
+						<statOffsets>
+							<Suppressability>-0.25</Suppressability>
+						</statOffsets>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/HediffDefs/Hediffs.xml
+++ b/Patches/Dragon's Descent/HediffDefs/Hediffs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<!-- === Filthy_Wound === -->
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/HediffDef[defName="Filthy_Wound"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
+
+			<value>
+				<li Class="CombatExtended.HediffCompProperties_InfecterCE">
+					<infectionChancePerHourUntended>0.1</infectionChancePerHourUntended>
+				</li>
+			</value>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/Projectiles/Projectile_Animal.xml
+++ b/Patches/Dragon's Descent/Projectiles/Projectile_Animal.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!-- Fire Breath -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonBreath"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonBreath"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>26</speed>
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Flame</damageDef>
+						<damageAmountBase>5</damageAmountBase>
+						<soundExplode>DragonBreathFire</soundExplode>
+						<explosionRadius>1.5</explosionRadius>
+						<ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+				</value>
+			</li>
+			<!-- Fire Spit -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonSpit"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonSpit"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>38</speed>
+						<damageDef>PrometheumFlame</damageDef> <!-- Applies "promethium soaked" to hit pawns. -->
+						<explosionRadius>4.5</explosionRadius>
+						<damageAmountBase>16</damageAmountBase>
+						<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+						<preExplosionSpawnChance>0.3</preExplosionSpawnChance>
+						<ai_IsIncendiary>true</ai_IsIncendiary>
+						<arcHeightFactor>0.2</arcHeightFactor>
+						<shadowSize>1</shadowSize>
+					</projectile>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
+++ b/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ScenarioDef[defName="DragonThieves"]/scenario/parts</xpath>
+					<value>
+						<li Class="ScenPart_StartingThing_Defined">
+						  <def>StartingThing_Defined</def>
+						  <thingDef>Ammo_Arrow_Stone</thingDef>
+						  <count>100</count>
+						</li>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Items/Items_Exotic.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Items/Items_Exotic.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- === DragonHorn === -->
+				<li Class="PatchOperationRemove">
+					<xpath>/Defs/ThingDef[defName="DragonHorn"]/tools</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="DragonHorn"]/statBases/Mass</xpath>
+
+					<value>
+						<Mass>50</Mass>
+						<Bulk>25</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAttributeSet">
+					<xpath>/Defs/ThingDef[defName="DragonHorn"]</xpath>
+					<attribute>ParentName</attribute>
+					<value>ResourceBase</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Items/Items_Resource_Leather.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Items/Items_Resource_Leather.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- === Dragon_Leather === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Dragon_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
+
+					<value>
+						<StuffPower_Armor_Sharp>0.907</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
+					
+					<value>
+						<StuffPower_Armor_Blunt>0.24</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
+
+					<value>
+						<StuffPower_Armor_Heat>0.178</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Dragon_Leather"]/stuffProps</xpath>
+
+					<value>
+						<categories>
+							<li>SoftArmor</li>
+						</categories>
+					</value>
+				</li>
+
+				<!-- === Rich_Dragon_Leather === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
+
+					<value>
+						<StuffPower_Armor_Sharp>1.079</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
+
+					<value>
+						<StuffPower_Armor_Blunt>0.279</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
+
+					<value>
+						<StuffPower_Armor_Heat>0.2</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/stuffProps</xpath>
+
+					<value>
+						<categories>
+							<li>SoftArmor</li>
+						</categories>
+					</value>
+				</li>
+
+				<!-- === True_Dragon_Leather === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
+
+					<value>
+						<StuffPower_Armor_Sharp>1.282</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
+
+					<value>
+						<StuffPower_Armor_Blunt>0.324</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
+
+					<value>
+						<StuffPower_Armor_Heat>0.226</StuffPower_Armor_Heat>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="True_Dragon_Leather"]/stuffProps</xpath>
+
+					<value>
+						<categories>
+							<li>SoftArmor</li>
+						</categories>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== Common Dragons ======== -->
+				<!-- ====== Tools ====== -->
+				<!-- ==== Base Tools ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>
+						/Defs/ThingDef[
+							defName="Black_Dragon" or 
+							defName="Blue_Dragon" or 
+							defName="Green_Dragon" or
+							defName="Purple_Dragon" or 
+							defName="Red_Dragon" or 
+							defName="White_Dragon" or 
+							defName="Yellow_Dragon"]/tools
+					</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>86</power>
+								<chanceFactor>0.3</chanceFactor>
+								<cooldownTime>3.5</cooldownTime>
+								<armorPenetrationSharp>24.09</armorPenetrationSharp>
+								<armorPenetrationBlunt>120.417</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>86</power>
+								<chanceFactor>0.3</chanceFactor>
+								<cooldownTime>3.5</cooldownTime>
+								<armorPenetrationSharp>24.09</armorPenetrationSharp>
+								<armorPenetrationBlunt>120.417</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>92</power>
+								<chanceFactor>0.2</chanceFactor>
+								<cooldownTime>4.41</cooldownTime>
+								<armorPenetrationSharp>4.75</armorPenetrationSharp>
+								<armorPenetrationBlunt>301.042</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>69</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>11.12</cooldownTime>
+								<armorPenetrationSharp>0.84</armorPenetrationSharp>
+								<armorPenetrationBlunt>16.725</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>38</power>
+								<chanceFactor>0.1</chanceFactor>
+								<cooldownTime>11.12</cooldownTime>
+								<armorPenetrationSharp>1.68</armorPenetrationSharp>
+								<armorPenetrationBlunt>16.725</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ==== Unique Tools ==== -->
+				<!-- == Black Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Black_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.94</cooldownTime>
+							<power>131</power>
+							<capacities>
+								<li>Rend</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>10.67</armorPenetrationSharp>
+							<armorPenetrationBlunt>677.344</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Blue Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Blue_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.12</cooldownTime>
+							<power>111</power>
+							<capacities>
+								<li>Frost_Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>7.26</armorPenetrationSharp>
+							<armorPenetrationBlunt>460.97</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Green Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Green_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.12</cooldownTime>
+							<power>111</power>
+							<capacities>
+								<li>ToxicBite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>7.26</armorPenetrationSharp>
+							<armorPenetrationBlunt>460.97</armorPenetrationBlunt>
+							<chanceFactor>0.2</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Purple Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Purple_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>8.81</cooldownTime>
+							<power>147</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							<label>head</label>
+							<armorPenetrationBlunt>75.26</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>6.66</cooldownTime>
+							<power>110</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>54.611</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Red Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Red_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.12</cooldownTime>
+							<power>111</power>
+							<capacities>
+								<li>Pyro_Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>7.26</armorPenetrationSharp>
+							<armorPenetrationBlunt>460.97</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>6.66</cooldownTime>
+							<power>110</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>54.611</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == White Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="White_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.12</cooldownTime>
+							<power>111</power>
+							<capacities>
+								<li>Frost_Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>7.26</armorPenetrationSharp>
+							<armorPenetrationBlunt>460.97</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>8.81</cooldownTime>
+							<power>147</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							<label>head</label>
+							<armorPenetrationBlunt>75.26</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Yellow Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Yellow_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>8.81</cooldownTime>
+							<power>147</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							<label>head</label>
+							<armorPenetrationBlunt>75.26</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>6.66</cooldownTime>
+							<power>110</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>54.611</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+
+				<!-- ====== Wildness (descending order) ====== -->
+				<!-- ==== Black Dragon and Red Dragon ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Black_Dragon" or defName="Red_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.99</wildness>
+					</value>
+				</li>
+				<!-- ==== Green Dragon ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Green_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.97</wildness>
+					</value>
+				</li>
+				<!-- ==== Purple Dragon ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Purple_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.94</wildness>
+					</value>
+				</li>
+				<!-- ==== Blue Dragon and White Dragon and Yellow Dragon ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Blue_Dragon" or defName="White_Dragon" or defName="Yellow_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.89</wildness>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- I took 3 months off of RimWorld and I've forgotten how to do patches. Great. -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== BaseDragon (Dragon Base) ======== -->
+				<!-- ====== ModExtension ====== -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[@Name="BaseDragon"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Birdlike</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<!-- ======== DragonRaceBase (Common Dragon Base) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						<MeleeCritChance>1.75</MeleeCritChance>
+						<MeleeParryChance>0.54</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- ====== race (Race Properties) ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>10</baseHealthScale>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
+					<value>
+						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
+					</value>
+				</li>
+				<!-- ====== verbs (Because XPath dumb) ======== -->
+				<!--<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DragonRaceBase"]</xpath>
+					<value>
+						<verbs Inherit="false">
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
+								<burstShotCount>25</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<warmupTime>5</warmupTime>
+								<range>25</range>
+								<minRange>2</minRange>
+								<soundCast>DragonBreathShot</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>0.9</commonality>
+								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0.4</recoilAmount>
+							</li>
+						</verbs>
+					</value>
+				</li>-->
+
+				<!-- ======== RDragonRaceBase (Rare Dragon Base) ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						<MeleeCritChance>1.96</MeleeCritChance>
+						<MeleeParryChance>0.64</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>48</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>19.2</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- ====== race (Race Properties) ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>12</baseHealthScale>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]/race/manhunterOnTameFailChance</xpath>
+					<value>
+						<manhunterOnTameFailChance>0.51</manhunterOnTameFailChance>
+					</value>
+				</li>
+				<!-- ====== verbs (Because XPath dumb) ======== -->
+				<!--<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RDragonRaceBase"]</xpath>
+					<value>
+						<verbs Inherit="false">
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>Projectile_DragonBreath</defaultProjectile>
+								<burstShotCount>25</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<warmupTime>5</warmupTime>
+								<range>25</range>
+								<minRange>2</minRange>
+								<soundCast>DragonBreathShot</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>0.9</commonality>
+								<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0.4</recoilAmount>
+							</li>
+						</verbs>
+					</value>
+				</li>-->
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dragon's Descent</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======== Rare Dragons ======== -->
+				<!-- ====== Tools ====== -->
+				<!-- ==== Base Tools ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[
+							defName="Gold_Dragon" or 
+							defName="Silver_Dragon" or 
+							defName="Jade_Dragon"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>100</power>
+								<cooldownTime>3.71</cooldownTime>
+								<chanceFactor>0.3</chanceFactor>
+								<armorPenetrationSharp>30.11</armorPenetrationSharp>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>150.521</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>100</power>
+								<cooldownTime>3.71</cooldownTime>
+								<chanceFactor>0.3</chanceFactor>
+								<armorPenetrationSharp>30.11</armorPenetrationSharp>
+								<armorPenetrationBlunt>150.521</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>107</power>
+								<cooldownTime>4.66</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>5.93</armorPenetrationSharp>
+								<armorPenetrationBlunt>376.302</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>77</power>
+								<cooldownTime>11.75</cooldownTime>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationSharp>1.05</armorPenetrationSharp>
+								<armorPenetrationBlunt>20.906</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>39</power>
+								<cooldownTime>11.75</cooldownTime>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationSharp>2.1</armorPenetrationSharp>
+								<armorPenetrationBlunt>20.906</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ==== Unique Tools ==== -->
+				<!-- == Gold Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Gold_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.24</cooldownTime>
+							<power>122</power>
+							<capacities>
+								<li>Pyro_Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>9.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>576.213</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>7.04</cooldownTime>
+							<power>135</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>68.263</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Silver Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Silver_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>2.24</cooldownTime>
+							<power>122</power>
+							<capacities>
+								<li>Frost_Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<label>teeth</label>
+							<armorPenetrationSharp>9.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>576.213</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>7.04</cooldownTime>
+							<power>135</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>68.263</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- == Jade Dragon == -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Jade_Dragon"]/tools</xpath>
+					<value>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>ToxicBite</li>
+							</capacities>
+							<power>122</power>
+							<cooldownTime>2.24</cooldownTime>
+							<chanceFactor>0.1</chanceFactor>
+							<armorPenetrationSharp>9.08</armorPenetrationSharp>
+							<armorPenetrationBlunt>576.213</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>7.04</cooldownTime>
+							<power>135</power>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<surpriseAttack>
+							  <extraMeleeDamages>
+								<li>
+								  <def>Stun</def>
+								  <amount>20</amount>
+								</li>
+							  </extraMeleeDamages>
+							</surpriseAttack>
+							<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							<label>tail</label>
+							<armorPenetrationBlunt>68.263</armorPenetrationBlunt>
+							<chanceFactor>0.1</chanceFactor>
+						</li>
+					</value>
+				</li>
+				<!-- ====== Wildness ====== -->
+				<!-- ==== Gold Dragon and Silver Dragon and Jade Dragon ==== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Gold_Dragon" or defName="Silver_Dragon" or defName="Jade_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.89</wildness>
+					</value>
+				</li>
+
+				<!-- ======== True Dragon ======== -->
+				<!-- ====== statBases ====== -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="True_Dragon"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.14</MeleeDodgeChance>
+						<MeleeCritChance>2.34</MeleeCritChance>
+						<MeleeParryChance>0.64</MeleeParryChance>
+						<SightsEfficiency>1</SightsEfficiency>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>57.5</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>23</ArmorRating_Sharp>
+					</value>
+				</li>
+				<!-- ====== Tools ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>105</power>
+								<cooldownTime>3.5</cooldownTime>
+								<chanceFactor>0.25</chanceFactor>
+								<armorPenetrationSharp>33.75</armorPenetrationSharp>
+								<armorPenetrationBlunt>168.75</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>105</power>
+								<cooldownTime>3.5</cooldownTime>
+								<chanceFactor>0.25</chanceFactor>
+								<armorPenetrationSharp>33.75</armorPenetrationSharp>
+								<armorPenetrationBlunt>168.75</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>112</power>
+								<cooldownTime>4.4</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>6.65</armorPenetrationSharp>
+								<armorPenetrationBlunt>421.875</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>Pyro_Bite</li>
+								</capacities>
+								<power>128</power>
+								<cooldownTime>2.11</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>10.18</armorPenetrationSharp>
+								<armorPenetrationBlunt>645.996</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>teeth</label>
+								<capacities>
+									<li>ToxicBite</li>
+								</capacities>
+								<power>128</power>
+								<cooldownTime>2.11</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>10.18</armorPenetrationSharp>
+								<armorPenetrationBlunt>645.996</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>80</power>
+								<cooldownTime>11.1</cooldownTime>
+								<chanceFactor>0.05</chanceFactor>
+								<armorPenetrationSharp>1.18</armorPenetrationSharp>
+								<armorPenetrationBlunt>23.438</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>30</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>40</power>
+								<cooldownTime>11.1</cooldownTime>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationSharp>2.35</armorPenetrationSharp>
+								<armorPenetrationBlunt>23.438</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>199</power>
+								<cooldownTime>8.8</cooldownTime>
+								<chanceFactor>0.05</chanceFactor>
+								<armorPenetrationBlunt>105.469</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Horns</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>tail</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<power>150</power>
+								<cooldownTime>6.65</cooldownTime>
+								<chanceFactor>0.1</chanceFactor>
+								<armorPenetrationBlunt>76.531</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Tail</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- ====== Wildness ====== -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="True_Dragon"]/race/wildness</xpath>
+					<value>
+						<wildness>0.99</wildness>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

- Readded Dragon's Descent patch after updating it.
- Dragon's Descent's ranged attacks work now.

## Changes

- Modified dragon breath attack to act like a better (Combat Extended Guns) flamethrower.
- Modified dragon spit attack to be similar to an incendiary launcher.

## References

- Probably closes #452.

## Reasoning

- To me the flamethrower is probably the most similar weapon to the dragon breath attack. Some notable changes are that dragon breath has better range than the flamethrower, fires faster, has worse "recoil" and a "mounted" recoil pattern meant for spreading shots out horizontally, explosion damage is 5, better explosive coverage (3x3 square instead of 3x3 plus) and uses the `Flame` damage type because I didn't want it to apply the "promethium soaked" health status effect.
- I used the incendiary launcher as an example for the dragon spit attack. The notable things about it are that it (probably) fires a bit slower than the dragon breath (but still faster than the incendiary launcher), has worse range than the incendiary launcher (Dragon's Descent's base dragon spit attack is close-ranged), uses the "mounted" recoil pattern to spread the projectiles out more horizontally, the projectile's stats are based in-between the incendiary and the thermobaric 30x64mm fuel cell as it has the explosion diameter of 9 cells, deals 16 damage and applies the "promethium soaking" health status effect.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings;
- [x] Game runs without errors;
- [x] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony (specify how long).

Other tests:
- Checked the status screen of a dragon;
- Had a dragon use a dragon breath attack;
- Had a dragon use a dragon spit attack.
