### PR TITLE
Update embrasure terrain affordance

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
@@ -112,7 +112,8 @@
     <rotatable>false</rotatable>
     <selectable>true</selectable>
     <neverMultiSelect>true</neverMultiSelect>
-    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+    <useStuffTerrainAffordance>true</useStuffTerrainAffordance>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded> <!-- Best affordance needed for stone -->
     <holdsRoof>true</holdsRoof>
     <designationCategory>Structure</designationCategory>
     <staticSunShadowHeight>1</staticSunShadowHeight>


### PR DESCRIPTION
## Changes
- Updated embrasure terrain affordance from medium to material-based.

## Reasoning
- Makes embrasures have the same placement restrictions as walls, where minimum affordance is light for wood, medium for steel, and heavy for stone. This allows wooden embrasures to be built over bridges.