### PR TITLE
EFT Apparel Tweaks

### DIFF
--- a/Patches/JDS EFT Apparel/Apparel_Backpacks.xml
+++ b/Patches/JDS EFT Apparel/Apparel_Backpacks.xml
@@ -9,6 +9,20 @@
       <operations>
 
         <!-- === Backpacks  === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[@Name="JDSFrontierBackpackBase"]/apparel/bodyPartGroups</xpath>
+          <value>
+            <li>Shoulders</li>
+          </value>
+        </li>
+        
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[@Name="JDSFrontierBackpackBase"]/apparel/layers</xpath>
+          <value>
+            <li>Backpack</li>
+          </value>
+        </li>
+        
         <li Class="PatchOperationRemove">
           <xpath>
             /Defs/ThingDef[

--- a/Patches/JDS EFT Apparel/Apparel_ChestRigs.xml
+++ b/Patches/JDS EFT Apparel/Apparel_ChestRigs.xml
@@ -9,7 +9,13 @@
       <operations>
 
         <!-- === Armored === -->
-
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[@Name="JDSFrontierChestRigBase"]/apparel/layers</xpath>
+          <value>
+            <li>Webbing</li>
+          </value>
+        </li>
+        
         <!-- == Remove CarryingCapacity == -->
         <li Class="PatchOperationRemove">
           <xpath>


### PR DESCRIPTION
## Changes

- Pawns no longer equip two backpacks.
- Pawns no longer equip armored chest rigs + load bearing chest rigs.