### PR TITLE
Patch Ancient Fallout Armory

### DIFF
--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -104,7 +104,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>20</Mass>
+					<Mass>18</Mass>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -71,6 +71,13 @@
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor" or defName="Fallarmory_MediumCombatArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>25</Mass>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/statBases</xpath>
 				<value>
@@ -82,7 +89,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>12</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>11</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
@@ -90,6 +97,13 @@
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>20</Mass>
 				</value>
 			</li>
 
@@ -104,14 +118,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>7</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
 			<!-- === Pre-War Armor === -->	
 
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS" or defName="Fallarmory_MediumMetalArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/equippedStatOffsets/MoveSpeed</xpath>
 			</li>
 
 			<li Class="PatchOperationAdd">
@@ -119,6 +133,13 @@
 				<value>
 					<Bulk>100</Bulk>
 					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/statBases/Mass</xpath>
+				<value>
+					<Mass>25</Mass>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -161,7 +161,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>14</ArmorRating_Blunt>
+					<ArmorRating_Blunt>16</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -97,6 +97,7 @@
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+					<CarryBulk>8</CarryBulk>
 				</value>
 			</li>
 
@@ -112,6 +113,13 @@
 				<value>
 					<Bulk>80</Bulk>
 					<WornBulk>10</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>5</CarryBulk>
 				</value>
 			</li>
 
@@ -161,6 +169,7 @@
 				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/equippedStatOffsets</xpath>
 				<value>
 					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+					<CarryBulk>8</CarryBulk>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Ancient Fallout Armory</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Materials === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="FallArmory_HeavyMetalArmor" or
+				defName="Fallarmory_MediumMetalArmor" or
+				defName="Fallarmory_MetalArmorHelmetB" or
+				defName="FallArmory_HeavyCombatArmor" or 
+				defName="Fallarmory_MediumCombatArmor"
+				]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+						<li>Steeled</li>
+					</stuffCategories>
+				</value>
+			</li>
+
+			<!-- === Metal Armor === -->	
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyMetalArmor" or defName="Fallarmory_MediumMetalArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyMetalArmor"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyMetalArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyMetalArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumMetalArmor"]/statBases</xpath>
+				<value>
+					<Bulk>80</Bulk>
+					<WornBulk>10</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumMetalArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Combat Armor === -->	
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor" or defName="Fallarmory_MediumCombatArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>12</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/statBases</xpath>
+				<value>
+					<Bulk>80</Bulk>
+					<WornBulk>10</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Fallarmory_MediumCombatArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Pre-War Armor === -->	
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS" or defName="Fallarmory_MediumMetalArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>14</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_HeavyCombatArmorUS"]/equippedStatOffsets</xpath>
+				<value>
+					<MeleeDodgeChance>-0.15</MeleeDodgeChance>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
+++ b/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Ancient Fallout Armory</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Materials === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Fallarmory_FlightHelmet" or
+				defName="Fallarmory_MetalArmorHelmetA" or
+				defName="Fallarmory_MetalArmorHelmetB" or
+				defName="Fallarmory_CombatarmorHelmet"
+				]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+						<li>Steeled</li>
+					</stuffCategories>
+				</value>
+			</li>
+
+			<!-- === Flight Helmet === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_USFlightHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_USFlightHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/apparel/layers</xpath>
+				<value>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- === Metal Helmet === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_MetalArmorHelmetA" or defName="Fallarmory_MetalArmorHelmetB"]/statBases</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_MetalArmorHelmetA" or defName="Fallarmory_MetalArmorHelmetB"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Combat Helmet === -->			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_CombatarmorHelmet" or defName="FallArmory_CombatarmorHelmetUS"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_CombatarmorHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="FallArmory_CombatarmorHelmetUS"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>9</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="FallArmory_CombatarmorHelmetUS"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>14</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -46,6 +46,7 @@ Mod |
 [SYR] Thrumkin	|
 A Dog Said...	|
 Alpha Animals |
+Ancient Fallout Armory  |
 Android Tiers	|
 Android Tiers++	|
 Androids	|


### PR DESCRIPTION
Patches the sets of armor added by the mod.

The metal armor is fairly low quality, well-suited for melee, but not as useful against gunfire.

The medium combat armor is essentially a flak jacket with better coverage.

The heavy and pre-war combat armor is between flak armor and recon armor, which I think is pretty good for its fairly low material cost (doesn't require advanced components). If we're not happy with it, we could potentially increase the protection and perhaps require devilstrand to make it more like power armor.