### PR TITLE
Added both proper shotguns mods to <incompatibleWith>

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -19,6 +19,8 @@
 	<incompatibleWith>
 		<li>Flyfire2002.FieldMedic</li>
 		<li>hobtook.mortaraccuracy</li>
+		<li>XeoNovaDan.ProperShotguns</li>
+		<li>swedishmask.ProperShotgunsPatch</li>		
 	</incompatibleWith>
 	<loadAfter>
 		<li>brrainz.harmony</li>


### PR DESCRIPTION
## Changes

Added both proper shotguns mods to < incompatibleWith > in the About.xml

## Reasoning

Will help new people and stop some of the bug reports caused by these mods when people use them with CE.

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)