### PR TITLE
Fix permanent scar chance patch applying to wrong organs

### DIFF
--- a/Patches/Core/Bodies/BodyParts_Organs.xml
+++ b/Patches/Core/Bodies/BodyParts_Organs.xml
@@ -54,10 +54,10 @@
 
   <!-- ========== Modify old injury chance ========== -->
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyPartDef[defName="Heart" or "Lung" or "Kidney" or "Liver" or "Stomach"]/permanentInjuryChanceFactor</xpath>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyPartDef[defName="Heart" or defName="Lung" or defName="Kidney" or defName="Liver" or defName="Stomach"]</xpath>
     <value>
-      <permanentInjuryChanceFactor>0.5</permanentInjuryChanceFactor>
+      <permanentInjuryChanceFactor>5</permanentInjuryChanceFactor>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes
- Fix permanent scars having a much lower chance than they should
- Set a sensible permanent injury factor for internal organ wounds

## Reasoning
- The xpath fix is fairly straightforward: `or "Lung"` is interpreted as `or true` so it needs to be fixed to `or defname="Lung"`, otherwise this patch ends up targeting every single BodyPartDef in the game, which is why things like permanent brain injuries are almost non-existent in CE.
- As for why I changed the factor to 5, some context: In vanilla, body parts have a default permanentInjuryChanceFactor of 1. Some parts, like most bones, have 0 (so they never scar), while others, like eyes (15) and brain (9999999) have higher values to make scars more likely.
But this patch [is way older than that](https://github.com/CombatExtended-Continued/CombatExtended/commit/08a4b91e21d69a182bb0529dc237ff6678f09883), from a time the scarring chance was still set via oldInjuryBaseChance. Based on the commit's message, the intention was to make internal organs be *more* likely to scar compared to the baseline, and now that the baseline is 1, setting these organs to 0.5 doesn't make sense anymore, as it does the opposite of what it should. I picked 5 just to fix it, but feel free to edit the PR if something else would be better.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
