### PR TITLE
Change M1911's mag size from 7 to 8.

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -170,7 +170,7 @@
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <AmmoUser>
-      <magazineSize>7</magazineSize>
+      <magazineSize>8</magazineSize>
       <reloadTime>4</reloadTime>
       <ammoSet>AmmoSet_45ACP</ammoSet>
     </AmmoUser>


### PR DESCRIPTION
Change the magazine size of M1911 from 7 to 8. It would make sense realism wise as most of M1911 owners prefer 8 rounders since they have no disadvantage, that would make Autopistol in game more versatile and generally more usable as a sidearm. Revolver still has damage upper hand, but Colt1911 would have two more rounds to shoot. Instead of just one when revolver is objectively better.

## Additions

Changed mag size from 7 to 8

## Changes

Stated above


## Reasoning

Probably change the magazine size of M1911 from 7 to 8? It would make sense realism wise as most of M1911 owners prefer 8 rounders since they have no disadvantage, that would make Autopistol in game more versatile and generally more usable as a sidearm. Revolver still has damage upper hand, but colt would have two more rounds to shoot. Instead of just one when revolver is objectively better.

## Alternatives

Do not use M1911 since revolver is better.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 
I had a playtest actually on my colony. I made a patch myself that makes these changes. It works just fine and is fairly balanced, I would say. 
