### PR TITLE
Adjustments to Revolver Balance

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -118,7 +118,7 @@
     </Properties>
     <AmmoUser>
       <magazineSize>6</magazineSize>
-      <reloadTime>3.5</reloadTime>
+      <reloadTime>4.6</reloadTime>
       <ammoSet>AmmoSet_44Magnum</ammoSet>
     </AmmoUser>
     <FireModes>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -95,7 +95,7 @@
     <defName>Gun_Revolver</defName>
     <statBases>
       <Mass>1.39</Mass>
-      <RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
       <SightsEfficiency>0.7</SightsEfficiency>
       <ShotSpread>0.18</ShotSpread>
       <SwayFactor>1.27</SwayFactor>

--- a/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
+++ b/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
@@ -1881,7 +1881,7 @@
 
 				<AmmoUser>
 					<magazineSize>5</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_500SWMagnum</ammoSet>
 				</AmmoUser>
 

--- a/Patches/JDS The Forge - NCR Armory/Defs_Weapons.xml
+++ b/Patches/JDS The Forge - NCR Armory/Defs_Weapons.xml
@@ -157,7 +157,8 @@
 			</Properties>
 			<AmmoUser>
 				<magazineSize>5</magazineSize>
-				<reloadTime>3.5</reloadTime>
+				<reloadOneAtATime>true</reloadOneAtATime>
+				<reloadTime>0.95</reloadTime>
 				<ammoSet>AmmoSet_4570Gov</ammoSet>
 			</AmmoUser>
 			<FireModes>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_UK.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_UK.xml
@@ -535,7 +535,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_455Webley</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_Revolvers.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_Revolvers.xml
@@ -39,7 +39,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_38Special</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
@@ -191,7 +191,7 @@
 				</Properties>
 				<AmmoUser>
 					<magazineSize>5</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_500SWMagnum</ammoSet>
 				</AmmoUser>
 				<FireModes>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
@@ -321,7 +321,8 @@
 
 				<AmmoUser>
 					<magazineSize>7</magazineSize>
-					<reloadTime>4.6</reloadTime>
+					<reloadOneAtATime>true</reloadOneAtATime>
+					<reloadTime>0.85</reloadTime>
 					<ammoSet>AmmoSet_762x38mmR</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Revolvers.xml
@@ -39,7 +39,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_38Special</ammoSet>
 				</AmmoUser>
 
@@ -86,7 +86,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_45Colt</ammoSet>
 				</AmmoUser>
 
@@ -133,7 +133,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_45Colt</ammoSet>
 				</AmmoUser>
 
@@ -180,7 +180,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_357Magnum</ammoSet>
 				</AmmoUser>
 
@@ -227,7 +227,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_454Casull</ammoSet>
 				</AmmoUser>
 
@@ -274,7 +274,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_357Magnum</ammoSet>
 				</AmmoUser>
 
@@ -321,7 +321,7 @@
 
 				<AmmoUser>
 					<magazineSize>7</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_762x38mmR</ammoSet>
 				</AmmoUser>
 
@@ -368,7 +368,7 @@
 
 				<AmmoUser>
 					<magazineSize>5</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_454Casull</ammoSet>
 				</AmmoUser>
 
@@ -415,7 +415,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_45Colt</ammoSet>
 				</AmmoUser>
 
@@ -462,7 +462,7 @@
 
 				<AmmoUser>
 					<magazineSize>6</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_44Magnum</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -168,7 +168,7 @@
 				</Properties>
 				<AmmoUser>
 					<magazineSize>5</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_500SWMagnum</ammoSet>
 				</AmmoUser>
 				<FireModes>

--- a/Patches/SYR Naga/Patch_ThingsWeapons_Naga.xml
+++ b/Patches/SYR Naga/Patch_ThingsWeapons_Naga.xml
@@ -39,7 +39,7 @@
 
 					<AmmoUser>
 						<magazineSize>6</magazineSize>
-						<reloadTime>3.5</reloadTime>
+						<reloadTime>4.6</reloadTime>
 						<ammoSet>AmmoSet_44MagnumCharged</ammoSet>
 					</AmmoUser>
 

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -155,7 +155,8 @@
 	      	</Properties>
 	      	<AmmoUser>
 	      	  <magazineSize>7</magazineSize>
-	      	  <reloadTime>5.95</reloadTime>
+			  <reloadOneAtATime>true</reloadOneAtATime>
+			  <reloadTime>0.85</reloadTime>
 	      	  <ammoSet>AmmoSet_762x38mmR</ammoSet>
 	      	</AmmoUser>
 	      	<FireModes>

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
@@ -215,7 +215,7 @@
 
 				<AmmoUser>
 					<magazineSize>7</magazineSize>
-					<reloadTime>3.5</reloadTime>
+					<reloadTime>4.6</reloadTime>
 					<ammoSet>AmmoSet_762x38mmR</ammoSet>
 				</AmmoUser>
 

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
@@ -215,7 +215,8 @@
 
 				<AmmoUser>
 					<magazineSize>7</magazineSize>
-					<reloadTime>4.6</reloadTime>
+					<reloadOneAtATime>true</reloadOneAtATime>
+					<reloadTime>0.85</reloadTime>
 					<ammoSet>AmmoSet_762x38mmR</ammoSet>
 				</AmmoUser>
 

--- a/Patches/turk's guns/Patch_Guns.xml
+++ b/Patches/turk's guns/Patch_Guns.xml
@@ -341,7 +341,7 @@
 			  </Properties>
 			  <AmmoUser>
 				<magazineSize>5</magazineSize>
-				<reloadTime>3.5</reloadTime>
+				<reloadTime>4.6</reloadTime>
 				<ammoSet>AmmoSet_45Colt410Bore</ammoSet>
 			  </AmmoUser>
 			  <FireModes>


### PR DESCRIPTION
## Changes

- Increased the reloading time of all revolvers that use speedloaders from 3.5 to 4.6.
- Increased the Revolver's cooldown time from 0.42 to 0.49.
- Changed the Fallout Armory Hunting Revolver and several M1895 Nagant revolvers from using a speedloader to a handload weapons.

## Reasoning

Some adjustments to stats to reflect two changes I've made to the Gun Stats spreadsheet to make the revolvers more true to their real-life functionality and more distinct within CE from semi-auto handguns. The two changes I made to the spreadsheet:
- Increase the reloadTime of the "speedloader" from 3.5 to 4.6
- Increase the Cooldown of the "Double" action type from 0.35 to 0.45.

Previously, revolver speed loaders actually reloaded _faster_ than magazines (3.5 vs 4), which is not accurate to real life. Opening a revolver cylinder, manually ejecting the spent casings (most don't have a functionality like the Webley), employing a speedloader, and then finally closing the cylinder back up is a far more complex series of actions than ejecting an empty magazine, popping in a new one, and dropping the slide--it would make sense for the former to take more time.

Additionally, I increased the cooldowntime to simulate the longer trigger pull of the double-action necessary to index the cylinder. While it could be argued that increasing the warmup time would be more appropriate, we generally don't touch the warmupTime in relation to the firearm's action, and I don't see a good enough reason to make revolvers a special case

The changes to individual firearms like the Nagant and the Hunting Revolver were just details overlooked the first time--both are gate-loading revolvers than cannot use speedloaders.
