### PR TITLE
Pawns with two-handed weapons don't automatically wear shields

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
+++ b/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
@@ -15,7 +15,7 @@ namespace CombatExtended.HarmonyCE
     {
         internal static bool Prefix(Pawn pawn, Apparel ap, ref float __result)
         {
-            if (ap is Apparel_Shield && pawn?.equipment?.Primary != null && pawn?.equipment?.Primary?.def?.weaponTags?.Contains(Apparel_Shield.OneHandedTag) != true)
+            if (ap is Apparel_Shield && (pawn?.equipment?.Primary?.def?.weaponTags?.Contains(Apparel_Shield.OneHandedTag) ?? false))
             {
                 __result = -1000f;
                 return false;

--- a/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
+++ b/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended.HarmonyCE
+{
+    ///Give melee/ballistic shields a negative apparel score if the pawn has a two-handed weapon.
+    ///Mimics vanilla behavior regarding shield belts and ranged weapons.
+    [HarmonyPatch(typeof(JobGiver_OptimizeApparel), "ApparelScoreGain_NewTmp")]
+    internal static class Harmony_JobGiver_OptimizeApparel_ApparelScoreGain
+    {
+        internal static bool Prefix(Pawn pawn, Apparel ap, ref float __result)
+        {
+            if (ap is Apparel_Shield && pawn?.equipment?.Primary != null && pawn?.equipment?.Primary?.def?.weaponTags?.Contains(Apparel_Shield.OneHandedTag) != true)
+            {
+                __result = -1000f;
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- If a pawn is equipped with a two-handed weapon, they won't wear melee/ballistic shields when updating their apparel, even if their outfit restrictions allow it.

## References
- Closes #311