### PR TITLE
Firefoam clears prometheum-soaked hediff

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Prometheum.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Prometheum.cs
@@ -18,6 +18,12 @@ namespace CombatExtended
 
             if (Pawn.IsHashIntervalTick(GenTicks.TicksPerRealSecond))
             {
+                if (Pawn.Position.GetThingList(Pawn.Map).Any(x => x.def == ThingDefOf.Filth_FireFoam))
+                {
+                    //clear prometheum-soaked hediff
+                    severityAdjustment = -1000;
+                    return;
+                }
                 Fire fire = Pawn.GetAttachment(ThingDefOf.Fire) as Fire;
                 if (fire == null && Pawn.Spawned)
                 {


### PR DESCRIPTION
## Changes
- Prometheum-soaked hediff is cleared if the pawn comes into contact with firefoam

## Reasoning
- Firefoam already has the ability to render prometheum puddles inert, it makes sense to also apply it for prometheum fires on pawns