### PR TITLE
Allow non-violent pawns to use non-lethal weapons

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -14,6 +14,7 @@
     <maxValue>6.5</maxValue>
     <toStringStyle>PercentTwo</toStringStyle>
     <showOnAnimals>false</showOnAnimals>
+    <neverDisabled>true</neverDisabled>
     <skillNeedFactors>
       <li Class="SkillNeed_BaseBonus">
         <skill>Shooting</skill>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -101,7 +101,7 @@
     </statBases>
     <weaponTags>
       <li>CE_GrenadeFlashbang</li>
-      <li>CE_AI_Nonlethal</li>
+      <li>CE_Nonlethal_Ranged</li>
     </weaponTags>
     <thingCategories>
       <li>Grenades</li>
@@ -240,8 +240,8 @@
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
-      <li>CE_AI_Nonlethal</li>
-      <li>GrenadeSmoke</li>	  
+      <li>GrenadeSmoke</li>
+      <li>CE_Nonlethal_Ranged</li>
     </weaponTags>
     <thingCategories>
       <li>Grenades</li>
@@ -314,7 +314,7 @@
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
-      <li>CE_AI_Nonlethal</li>
+      <li>CE_Nonlethal_Ranged</li>
     </weaponTags>
     <thingCategories>
       <li>Grenades</li>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -235,6 +235,14 @@
 			<noSkillFactor>2.6</noSkillFactor>
 		</value>
 	</Operation>
+    
+    <!-- Prevent consistency check errors, as non-violent pawns can use non-lethal weapons in CE. -->
+    <Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]</xpath>
+		<value>
+			<neverDisabled>true</neverDisabled>
+		</value>
+	</Operation>
 
 	<!-- Move speed -->
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -323,7 +323,7 @@ namespace CombatExtended
                 newEq = meleeWeaponListCached.FirstOrDefault();
 
             // Equip the weapon
-            if (newEq != null && (newEq?.def?.IsNonLethalWeapon() == true || !parentPawn.WorkTagIsDisabled(WorkTags.Violent)))
+            if (newEq != null && (newEq?.def?.IsNonLethalWeapon() ?? false || !parentPawn.WorkTagIsDisabled(WorkTags.Violent)))
             {
                 TrySwitchToWeapon(newEq);
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -323,7 +323,7 @@ namespace CombatExtended
                 newEq = meleeWeaponListCached.FirstOrDefault();
 
             // Equip the weapon
-            if (newEq != null)
+            if (newEq != null && (newEq?.def?.IsNonLethalWeapon() == true || !parentPawn.WorkTagIsDisabled(WorkTags.Violent)))
             {
                 TrySwitchToWeapon(newEq);
             }

--- a/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
+++ b/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
@@ -11,7 +11,7 @@ namespace CombatExtended
     {
         public static bool IsNonLethalWeapon(this ThingDef thingDef)
         {
-            return thingDef?.weaponTags?.Contains("CE_AI_Nonlethal") == true;
+            return thingDef?.weaponTags?.Contains("CE_AI_Nonlethal") ?? false;
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
+++ b/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
@@ -11,7 +11,17 @@ namespace CombatExtended
     {
         public static bool IsNonLethalWeapon(this ThingDef thingDef)
         {
-            return thingDef?.weaponTags?.Contains("CE_AI_Nonlethal") ?? false;
+            return IsNonLethalMeleeWeapon(thingDef) || IsNonLethalRangedWeapon(thingDef);
+        }
+
+        public static bool IsNonLethalMeleeWeapon(this ThingDef thingDef)
+        {
+            return thingDef?.weaponTags?.Contains("CE_Nonlethal_Melee") ?? false;
+        }
+
+        public static bool IsNonLethalRangedWeapon(this ThingDef thingDef)
+        {
+            return thingDef?.weaponTags?.Contains("CE_Nonlethal_Ranged") ?? false;
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
+++ b/Source/CombatExtended/CombatExtended/Extensions/Extensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace CombatExtended
+{
+    public static class Extensions
+    {
+        public static bool IsNonLethalWeapon(this ThingDef thingDef)
+        {
+            return thingDef?.weaponTags?.Contains("CE_AI_Nonlethal") == true;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -339,7 +339,7 @@ namespace CombatExtended
                                 }
                                 equipOption = new FloatMenuOption(
                                     equipOptionLabel,
-                                    (SelPawnForGear.story != null && SelPawnForGear.WorkTagIsDisabled(WorkTags.Violent))
+                                    (SelPawnForGear.story != null && SelPawnForGear.WorkTagIsDisabled(WorkTags.Violent) && !eq.def.IsNonLethalWeapon())
                                     ? null
                                     : new Action(delegate
                                     {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -530,7 +530,7 @@ namespace CombatExtended
             if (ShooterPawn != null)
             {
                 // Check for capable of violence
-                if (ShooterPawn.story != null && ShooterPawn.WorkTagIsDisabled(WorkTags.Violent))
+                if (ShooterPawn.story != null && ShooterPawn.WorkTagIsDisabled(WorkTags.Violent) && ShooterPawn?.equipment?.Primary?.def?.IsNonLethalWeapon() != true)
                 {
                     report = "IsIncapableOfViolenceLower".Translate(ShooterPawn.Name.ToStringShort);
                     return false;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -530,7 +530,7 @@ namespace CombatExtended
             if (ShooterPawn != null)
             {
                 // Check for capable of violence
-                if (ShooterPawn.story != null && ShooterPawn.WorkTagIsDisabled(WorkTags.Violent) && ShooterPawn?.equipment?.Primary?.def?.IsNonLethalWeapon() != true)
+                if (ShooterPawn.story != null && ShooterPawn.WorkTagIsDisabled(WorkTags.Violent) && !(ShooterPawn?.equipment?.Primary?.def?.IsNonLethalWeapon() ?? false))
                 {
                     report = "IsIncapableOfViolenceLower".Translate(ShooterPawn.Name.ToStringShort);
                     return false;

--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -425,23 +425,10 @@ namespace CombatExtended.HarmonyCE
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            bool patchApplied = false;
-            List<CodeInstruction> instructionsArray = instructions.ToList();
-            for (int i = 0; i < instructions.Count(); i++)
-            {
-                if (instructionsArray[i].opcode == OpCodes.Callvirt && ReferenceEquals(instructionsArray[i].operand, AccessTools.PropertyGetter(typeof(ThingDef), nameof(ThingDef.IsWeapon))))
-                {
-                    instructionsArray[i].opcode = OpCodes.Call;
-                    instructionsArray[i].operand = AccessTools.Method(typeof(Harmony_FloatMenuMakerMap_AddHumanlikeOrders_Patch), nameof(IsLethalWeapon));
-                    patchApplied = true;
-                    break;
-                }
-            }
-            if (!patchApplied)
-            {
-                Log.Error($"{MethodBase.GetCurrentMethod().DeclaringType} did not find opcode to apply transpiler patch.");
-            }
-            return instructionsArray;
+            return instructions.MethodReplacer(
+                AccessTools.PropertyGetter(typeof(ThingDef), nameof(ThingDef.IsWeapon)),
+                AccessTools.Method(typeof(Harmony_FloatMenuMakerMap_AddHumanlikeOrders_Patch), nameof(IsLethalWeapon))
+            );
         }
 
         private static bool IsLethalWeapon(ThingDef thingDef)

--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -446,7 +446,7 @@ namespace CombatExtended.HarmonyCE
 
         private static bool IsLethalWeapon(ThingDef thingDef)
         {
-            return thingDef?.IsNonLethalWeapon() != true;
+            return !(thingDef?.IsNonLethalWeapon() ?? false);
         }
     }
 }

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -26,23 +26,10 @@ namespace CombatExtended.HarmonyCE
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            bool patchApplied = false;
-            List<CodeInstruction> instructionsArray = instructions.ToList();
-            for (int i = 0; i < instructions.Count(); i++)
-            {
-                if ((instructionsArray[i].opcode == OpCodes.Call || instructionsArray[i].opcode == OpCodes.Callvirt) && ReferenceEquals(instructionsArray[i].operand, AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled))))
-                {
-                    instructionsArray[i].opcode = OpCodes.Call;
-                    instructionsArray[i].operand = AccessTools.Method(typeof(Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch), nameof(WorkTagIsDisabledExceptNonLethal));
-                    patchApplied = true;
-                    break;
-                }
-            }
-            if (!patchApplied)
-            {
-                Log.Error($"{MethodBase.GetCurrentMethod().DeclaringType} did not find opcode to apply transpiler patch.");
-            }
-            return instructionsArray;
+            return instructions.MethodReplacer(
+                AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled)),
+                AccessTools.Method(typeof(Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch), nameof(WorkTagIsDisabledExceptNonLethal))
+            );
         }
 
         private static bool WorkTagIsDisabledExceptNonLethal(Pawn pawn, WorkTags workTags)

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -47,7 +47,7 @@ namespace CombatExtended.HarmonyCE
 
         private static bool WorkTagIsDisabledExceptNonLethal(Pawn pawn, WorkTags workTags)
         {
-            if (workTags == WorkTags.Violent && pawn.equipment?.Primary?.def?.IsNonLethalWeapon() == true)
+            if (workTags == WorkTags.Violent && (pawn.equipment?.Primary?.def?.IsNonLethalWeapon() ?? false))
             {
                 return false;
             }

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -11,15 +11,40 @@ using Verse.AI;
 
 namespace CombatExtended.HarmonyCE
 {
-    //Make non-lethal weapons useable by non-violent pawns
+    //Make non-lethal weapons useable by non-violent pawns (general)
     [HarmonyPatch]
-    class Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch
+    class Harmony_NonViolentNonLethal_Patch
     {
         public static IEnumerable<MethodBase> TargetMethods()
         {
             yield return AccessTools.Method(typeof(Pawn), nameof(Pawn.TryStartAttack));
-            yield return AccessTools.Method(typeof(VerbTracker), "CreateVerbTargetCommand");
-            yield return AccessTools.Method(typeof(FloatMenuUtility), nameof(FloatMenuUtility.GetRangedAttackAction));
+        }
+
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return instructions.MethodReplacer(
+                AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled)),
+                AccessTools.Method(typeof(Harmony_NonViolentNonLethal_Patch), nameof(WorkTagIsDisabledExceptNonLethal))
+            );
+        }
+
+        private static bool WorkTagIsDisabledExceptNonLethal(Pawn pawn, WorkTags workTags)
+        {
+            if (workTags == WorkTags.Violent && (pawn.equipment?.Primary?.def?.IsNonLethalWeapon() ?? false))
+            {
+                return false;
+            }
+            return pawn.WorkTagIsDisabled(workTags);
+        }
+    }
+
+    //Make non-lethal weapons useable by non-violent pawns (melee)
+    [HarmonyPatch]
+    class Harmony_NonViolentNonLethalMelee_Patch
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
             yield return AccessTools.Method(typeof(FloatMenuUtility), nameof(FloatMenuUtility.GetMeleeAttackAction));
         }
 
@@ -28,13 +53,42 @@ namespace CombatExtended.HarmonyCE
         {
             return instructions.MethodReplacer(
                 AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled)),
-                AccessTools.Method(typeof(Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch), nameof(WorkTagIsDisabledExceptNonLethal))
+                AccessTools.Method(typeof(Harmony_NonViolentNonLethalMelee_Patch), nameof(WorkTagIsDisabledExceptNonLethalMelee))
             );
         }
 
-        private static bool WorkTagIsDisabledExceptNonLethal(Pawn pawn, WorkTags workTags)
+        private static bool WorkTagIsDisabledExceptNonLethalMelee(Pawn pawn, WorkTags workTags)
         {
-            if (workTags == WorkTags.Violent && (pawn.equipment?.Primary?.def?.IsNonLethalWeapon() ?? false))
+            if (workTags == WorkTags.Violent && (pawn.equipment?.Primary?.def?.IsNonLethalMeleeWeapon() ?? false))
+            {
+                return false;
+            }
+            return pawn.WorkTagIsDisabled(workTags);
+        }
+    }
+
+    //Make non-lethal weapons useable by non-violent pawns (ranged)
+    [HarmonyPatch]
+    class Harmony_NonViolentNonLethalRanged_Patch
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(FloatMenuUtility), nameof(FloatMenuUtility.GetRangedAttackAction));
+            yield return AccessTools.Method(typeof(VerbTracker), "CreateVerbTargetCommand");
+        }
+
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return instructions.MethodReplacer(
+                AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled)),
+                AccessTools.Method(typeof(Harmony_NonViolentNonLethalRanged_Patch), nameof(WorkTagIsDisabledExceptNonLethalRanged))
+            );
+        }
+
+        private static bool WorkTagIsDisabledExceptNonLethalRanged(Pawn pawn, WorkTags workTags)
+        {
+            if (workTags == WorkTags.Violent && (pawn.equipment?.Primary?.def?.IsNonLethalRangedWeapon() ?? false))
             {
                 return false;
             }

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -1,0 +1,57 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended.HarmonyCE
+{
+    //Make non-lethal weapons useable by non-violent pawns
+    [HarmonyPatch]
+    class Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch
+    {
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(Pawn), nameof(Pawn.TryStartAttack));
+            yield return AccessTools.Method(typeof(VerbTracker), "CreateVerbTargetCommand");
+            yield return AccessTools.Method(typeof(FloatMenuUtility), nameof(FloatMenuUtility.GetRangedAttackAction));
+            yield return AccessTools.Method(typeof(FloatMenuUtility), nameof(FloatMenuUtility.GetMeleeAttackAction));
+        }
+
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            bool patchApplied = false;
+            List<CodeInstruction> instructionsArray = instructions.ToList();
+            for (int i = 0; i < instructions.Count(); i++)
+            {
+                if ((instructionsArray[i].opcode == OpCodes.Call || instructionsArray[i].opcode == OpCodes.Callvirt) && ReferenceEquals(instructionsArray[i].operand, AccessTools.Method(typeof(Pawn), nameof(Pawn.WorkTagIsDisabled))))
+                {
+                    instructionsArray[i].opcode = OpCodes.Call;
+                    instructionsArray[i].operand = AccessTools.Method(typeof(Harmony_AllowNonLethalWeaponsForNonViolentPawns_Patch), nameof(WorkTagIsDisabledExceptNonLethal));
+                    patchApplied = true;
+                    break;
+                }
+            }
+            if (!patchApplied)
+            {
+                Log.Error($"{MethodBase.GetCurrentMethod().DeclaringType} did not find opcode to apply transpiler patch.");
+            }
+            return instructionsArray;
+        }
+
+        private static bool WorkTagIsDisabledExceptNonLethal(Pawn pawn, WorkTags workTags)
+        {
+            if (workTags == WorkTags.Violent && pawn.equipment?.Primary?.def?.IsNonLethalWeapon() == true)
+            {
+                return false;
+            }
+            return pawn.WorkTagIsDisabled(workTags);
+        }
+    }
+}


### PR DESCRIPTION
## Additions
- Any weapon containing `CE_Nonlethal_Melee` or `CE_Nonlethal_Ranged` in its weaponTags can now be used by non-violent pawns.

## Notes
- I had to set the aiming stats to neverDisabled to prevent error messages, as non-violent pawns need these to use grenades and other ranged weapons that might be set to non-lethal later on. As far as I'm aware, this should not have any negative effects, it just means that non-violent pawns now have aiming accuracy displayed in their info window.