### PR TITLE
Remove unnecessary message logs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/HoldRecord.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/HoldRecord.cs
@@ -71,15 +71,11 @@ namespace CombatExtended
         /// </summary>
         public void ExposeData()
         {
-            Log.Message("Saving _def");
             Scribe_Defs.Look(ref _def, "ThingDef");
-            Log.Message("Saving count");
             Scribe_Values.Look(ref count, "count");
-            Log.Message("Saving pickedUp");
             Scribe_Values.Look(ref pickedUp, "pickedUp");
             if (!pickedUp)
             {
-                Log.Message("Saving tickOfPickedupJob");
                 Scribe_Values.Look(ref _tickJobIssued, "tickOfPickupJob");
             }
         }

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -128,7 +128,6 @@ namespace CombatExtended
         public void AddSlot(LoadoutSlot slot)
         {
         	LoadoutSlot old = _slots.FirstOrDefault(slot.isSameDef);
-            Log.Message(string.Concat("Adding ThingDef ", slot.thingDef == null ? "Null" : (string)slot.thingDef.LabelCap, " added, count: ", slot.count));
             if (old != null)
         		old.count += slot.count;
         	else


### PR DESCRIPTION
## Changes
- Remove log messages when adding items to a loadout, or when saving the game while colonists have inventory hold trackers.

## Reasoning
- These were likely added for for debugging purposes at some point, and should have been cleaned up before merging. In large colonies, these can cause the logger to hit its message limit quite easily, which is detrimental for playtesting or bug reports as any errors are suppressed until the log is manually cleared.