### PR TITLE
Exiled Dawn Tweaks

### DIFF
--- a/Patches/JDS Exiled Dawn/Ammo/Ammo_ExilePlasma.xml
+++ b/Patches/JDS Exiled Dawn/Ammo/Ammo_ExilePlasma.xml
@@ -92,7 +92,7 @@
 				<value>
 					<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base556x45mmNATOBullet">
 						<defName>Bullet_ExilePlasmaMid</defName>
-						<label>Median Density Plasma Bullet</label>
+						<label>Medium Density Plasma Bullet</label>
 						<graphicData>
 						  <texPath>Things/Misc/Plasma_Bullet</texPath>
 						  <graphicClass>Graphic_Single</graphicClass>

--- a/Patches/JDS Exiled Dawn/Ammo/Ammo_ExilePlasma.xml
+++ b/Patches/JDS Exiled Dawn/Ammo/Ammo_ExilePlasma.xml
@@ -73,8 +73,15 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						  <speed>100</speed>
-						  <damageDef>Flame_Secondary</damageDef>
-						  <damageAmountBase>7</damageAmountBase>
+						  <damageAmountBase>10</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Flame_Secondary</def>
+							  <amount>2</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>19</armorPenetrationSharp>
+						  <armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 						</projectile>
 					</ThingDef>
 				</value>
@@ -92,8 +99,15 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						  <speed>150</speed>
-						  <damageDef>Flame_Secondary</damageDef>
-						  <damageAmountBase>9</damageAmountBase>
+						  <damageAmountBase>12</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Flame_Secondary</def>
+							  <amount>2</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>26</armorPenetrationSharp>
+						  <armorPenetrationBlunt>4</armorPenetrationBlunt>
 						</projectile>
 					</ThingDef>
 				</value>
@@ -111,8 +125,15 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						  <speed>150</speed>
-						  <damageDef>Flame_Secondary</damageDef>
-						  <damageAmountBase>12</damageAmountBase>
+						  <damageAmountBase>17</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Flame_Secondary</def>
+							  <amount>3</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>30</armorPenetrationSharp>
+						  <armorPenetrationBlunt>9</armorPenetrationBlunt>
 						</projectile>
 					</ThingDef>
 				</value>
@@ -130,8 +151,15 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						  <speed>200</speed>
-						  <damageDef>Flame_Secondary</damageDef>
-						  <damageAmountBase>33</damageAmountBase>
+						  <damageAmountBase>24</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Flame_Secondary</def>
+							  <amount>4</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>41</armorPenetrationSharp>
+						  <armorPenetrationBlunt>23</armorPenetrationBlunt>
 						</projectile>
 					</ThingDef>
 				</value>

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Weapons_Melee.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Weapons_Melee.xml
@@ -43,7 +43,7 @@
 							<power>11</power>
 							<cooldownTime>1.18</cooldownTime>
 							<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
-							<armorPenetrationSharp>6.89</armorPenetrationSharp>
+							<armorPenetrationSharp>9.30</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -92,7 +92,7 @@
 							<power>25</power>
 							<cooldownTime>1.54</cooldownTime>
 							<armorPenetrationBlunt>1.238</armorPenetrationBlunt>
-							<armorPenetrationSharp>3.67</armorPenetrationSharp>
+							<armorPenetrationSharp>4.95</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -141,7 +141,7 @@
 							<power>26</power>
 							<cooldownTime>3.75</cooldownTime>
 							<armorPenetrationBlunt>2.592</armorPenetrationBlunt>
-							<armorPenetrationSharp>5.67</armorPenetrationSharp>
+							<armorPenetrationSharp>7.65</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -189,7 +189,7 @@
 							</capacities>
 							<power>18</power>
 							<cooldownTime>2.19</cooldownTime>
-							<armorPenetrationBlunt>7.2</armorPenetrationBlunt>
+							<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -238,7 +238,7 @@
 							<power>26</power>
 							<cooldownTime>1.23</cooldownTime>
 							<armorPenetrationBlunt>2.588</armorPenetrationBlunt>
-							<armorPenetrationSharp>9.59</armorPenetrationSharp>
+							<armorPenetrationSharp>12.95</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -287,7 +287,7 @@
 							<power>43</power>
 							<cooldownTime>2.51</cooldownTime>
 							<armorPenetrationBlunt>3.726</armorPenetrationBlunt>
-							<armorPenetrationSharp>8.28</armorPenetrationSharp>
+							<armorPenetrationSharp>11.18</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -336,7 +336,7 @@
 							<power>55</power>
 							<cooldownTime>2.03</cooldownTime>
 							<armorPenetrationBlunt>4.6</armorPenetrationBlunt>
-							<armorPenetrationSharp>6.82</armorPenetrationSharp>
+							<armorPenetrationSharp>9.207</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 					</tools>

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Weapons_Ranged.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Weapons_Ranged.xml
@@ -167,14 +167,15 @@
 					<defaultProjectile>Bullet_ExilePlasmaHeavy</defaultProjectile>
 					<warmupTime>1.1</warmupTime>
 					<range>55</range>
+					<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 					<burstShotCount>6</burstShotCount>
-					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
 					<soundCast>reforged_Plasma_rifle_shot</soundCast>
 					<soundCastTail>GunTail_Light</soundCastTail>
 					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
-					<magazineSize>20</magazineSize>
+					<magazineSize>40</magazineSize>
 					<reloadTime>4</reloadTime>
 					<ammoSet>AmmoSet_ExileRifle</ammoSet>
 				</AmmoUser>


### PR DESCRIPTION

## Changes

Switched the properties of the plasma weapons. Originally they were pure burn weapons in vanilla, but at some point they got changed to bullet. They now function pretty much as charge weapons with slightly improved conc. rounds (that burn instead of blasting) with better sharp penetraiton but much worse blunt.

The big plasma rifle also now consumes 2x rounds per shot and has twice the mag capacity, just to differentiate it a bit more from the standard version.

The melee weapon penetration has been buffed (1.35x sharp penetration, 2x blunt for the mace), both because the faciton heavily relies on the melee weapons to be effective, and because after testing, a lot of the weapons were way more expensive than I had originally thought and as such contribute a lot more to player wealth, and to help improve their usability.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
