### PR TITLE
Fix blazebulb error

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
@@ -21,14 +21,17 @@ namespace CombatExtended
         public override void TickLong()
         {
             base.TickLong();
-            float temperature = Position.GetTemperature(base.Map);
-            if (temperature > IgnitionTemp)
+            if (!Destroyed)
             {
-                float ignitionChance = 0.005f * Mathf.Pow((temperature - IgnitionTemp), 2);
-                float rand = UnityEngine.Random.value;
-                if(UnityEngine.Random.value < ignitionChance)
+                float temperature = Position.GetTemperature(base.Map);
+                if (temperature > IgnitionTemp)
                 {
-                    FireUtility.TryStartFireIn(Position, base.Map, 0.1f);
+                    float ignitionChance = 0.005f * Mathf.Pow((temperature - IgnitionTemp), 2);
+                    float rand = UnityEngine.Random.value;
+                    if (UnityEngine.Random.value < ignitionChance)
+                    {
+                        FireUtility.TryStartFireIn(Position, base.Map, 0.1f);
+                    }
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
@@ -21,8 +21,10 @@ namespace CombatExtended
         public override void TickLong()
         {
             base.TickLong();
-            if (!Destroyed)
+            if (Destroyed)
             {
+              return;
+            }
                 float temperature = Position.GetTemperature(base.Map);
                 if (temperature > IgnitionTemp)
                 {

--- a/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Plant_Blazebulb.cs
@@ -23,17 +23,16 @@ namespace CombatExtended
             base.TickLong();
             if (Destroyed)
             {
-              return;
+                return;
             }
-                float temperature = Position.GetTemperature(base.Map);
-                if (temperature > IgnitionTemp)
+            float temperature = Position.GetTemperature(base.Map);
+            if (temperature > IgnitionTemp)
+            {
+                float ignitionChance = 0.005f * Mathf.Pow((temperature - IgnitionTemp), 2);
+                float rand = UnityEngine.Random.value;
+                if (UnityEngine.Random.value < ignitionChance)
                 {
-                    float ignitionChance = 0.005f * Mathf.Pow((temperature - IgnitionTemp), 2);
-                    float rand = UnityEngine.Random.value;
-                    if (UnityEngine.Random.value < ignitionChance)
-                    {
-                        FireUtility.TryStartFireIn(Position, base.Map, 0.1f);
-                    }
+                    FireUtility.TryStartFireIn(Position, base.Map, 0.1f);
                 }
             }
         }


### PR DESCRIPTION
## Changes
- Fix "Got temperature for null map" error that pops up when blazebulb dies from environmental causes (cold snap, etc)