### PR TITLE
Fix Feral Shriker

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -174,10 +174,11 @@
 			<value>
 			  <projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Spore</damageDef>
-				<damageAmountBase>1</damageAmountBase>
-				<explosionRadius>1.5</explosionRadius>
+				<damageAmountBase>5</damageAmountBase>
+				<explosionRadius>3.2</explosionRadius>
 				<flyOverhead>True</flyOverhead>				
 				<speed>40</speed>
+				<gravityFactor>20</gravityFactor>
 				<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>				
 			  </projectile>
 			</value>


### PR DESCRIPTION
## Additions

Adds gravity factor to the Feral Shriker's attack so it can aim properly and slightly increases its radius (the spore won't do any damage because of the way it was implemented in the original mod).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
