### PR TITLE
Fix Eyes soaking high caliber hits

### DIFF
--- a/Defs/Bodies/BodyPartGroups.xml
+++ b/Defs/Bodies/BodyPartGroups.xml
@@ -7,6 +7,11 @@
   </BodyPartGroupDef>
 
   <BodyPartGroupDef>
+    <defName>OutsideSquishy</defName>
+    <label>outside squishy</label>
+  </BodyPartGroupDef>
+
+  <BodyPartGroupDef>
     <defName>LeftArm</defName>
     <label>left arm</label>
   </BodyPartGroupDef>

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -6,6 +6,50 @@
   <!-- ========== Add groups ========== -->
 
   <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left ear"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right ear"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
+
+  
+  
+  <Operation Class="PatchOperationAdd">
     <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
     <value>
       <li>LeftArm</li>

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartGroupDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartGroupDefOf.cs
@@ -13,5 +13,6 @@ namespace CombatExtended
     {
         public static BodyPartGroupDef CoveredByNaturalArmor;
         public static BodyPartGroupDef RightArm;
+	public static BodyPartGroupDef OutsideSquishy;
     }
 }

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -101,6 +101,55 @@ namespace CombatExtended.HarmonyCE
         }
     }
 
+    [StaticConstructorOnStartup]
+    [HarmonyPatch(typeof(DamageWorker_AddInjury), "CheckDuplicateDamageToOuterParts")]
+    static class Patch_CheckDuplicateDamageToOuterParts
+    {
+	static MethodInfo FinalizeAndAddInjury = null;
+
+	static Patch_CheckDuplicateDamageToOuterParts()
+	{
+	    FinalizeAndAddInjury = typeof(DamageWorker_AddInjury).GetMethod("FinalizeAndAddInjury",
+									    BindingFlags.Instance | BindingFlags.NonPublic,
+									    null,
+									    new Type[] {
+										typeof(Pawn),
+										typeof(Hediff_Injury),
+										typeof(DamageInfo),
+										typeof(DamageWorker.DamageResult) },
+									    null);
+	}
+	
+	[HarmonyPrefix]
+	static bool Prefix(DamageWorker_AddInjury __instance, DamageInfo dinfo, Pawn pawn, float totalDamage, DamageWorker.DamageResult result)
+	{
+	    var hitPart = dinfo.HitPart;
+	    if (hitPart.IsInGroup(CE_BodyPartGroupDefOf.OutsideSquishy))
+	    {
+		var parent = hitPart.parent;
+		if (parent != null)
+		{
+		    dinfo.SetHitPart(parent);
+                    if (pawn.health.hediffSet.GetPartHealth(parent) != 0f && parent.coverageAbs > 0f)
+		    {
+			Hediff_Injury hediff_Injury = (Hediff_Injury)HediffMaker.MakeHediff(HealthUtility.GetHediffDefFromDamage(dinfo.Def, pawn, parent), pawn, null);
+			hediff_Injury.Part = parent;
+			hediff_Injury.source = dinfo.Weapon;
+			hediff_Injury.sourceBodyPartGroup = dinfo.WeaponBodyPartGroup;
+			hediff_Injury.Severity = totalDamage;
+			if (hediff_Injury.Severity <= 0f)
+			{
+			    hediff_Injury.Severity = 1f;
+			}
+			FinalizeAndAddInjury.Invoke(__instance, new object[]{pawn, hediff_Injury, dinfo, result});
+		    }
+		}
+	    }
+	    
+	    return true;
+	}
+    }
+
     // Should work as long as ShouldReduceDamageToPreservePart exists
 
     [HarmonyPatch(typeof(DamageWorker_AddInjury), nameof(DamageWorker_AddInjury.ShouldReduceDamageToPreservePart))]


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
Adds a new body part group called `OutsideSquishy` to mark body parts which are outside their sibling (like the eyes, nose, and ears, relative to the skull).

## Changes

Describe adjustments to existing features made in this merge, e.g.
`OutsideSquishy` body parts will propagate overdamage to their sibling.

## Reasoning

Currently, high caliber (.50BMG or similar) projectiles regularly hit pawns in the head, destroying a single eye, ear, nose, or jaw, without causing further injury.  This fixes that problem.

## Alternatives

Dynamically detect when a body part is outside and damage should continue.  This is not trivial.
Always propagate damage.  This either over-applies damage, or fails on non-humanoid/irregular body definitions.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
