### PR TITLE
Fix Mech Stun resist

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -12,6 +12,76 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(StunHandler), "Notify_DamageApplied")]
     public static class Harmony_StunHandler_Notify_DamageApplied
     {
+	public static bool Prefix(StunHandler __instance,
+				  DamageInfo dinfo,
+				  bool affectedByEMP,
+				  int ___EMPAdaptedTicksLeft,
+				  int ___stunTicksLeft,
+				  bool ___stunFromEMP
+				  )
+	{
+
+	    Pawn pawn = __instance.parent as Pawn;
+	    if (pawn == null || pawn.Downed || pawn.Dead)
+	    {
+		return false;
+	    }
+	    float bodySize = pawn.BodySize;
+	    
+	    if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
+	    {
+		if (___EMPAdaptedTicksLeft > 0)
+		{
+		    int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+		    int newStunTicks = Mathf.RoundToInt(dinfo.Amount * 30);
+
+		    float stunResistChance = ((float) ___EMPAdaptedTicksLeft / (float) newStunAdaptedTicks) * 15;
+		    void reStun()
+		    {
+			if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
+			{
+			    ___stunTicksLeft = newStunTicks;
+			}
+			else
+			{
+			    __instance.StunFor_NewTmp(newStunTicks, dinfo.Instigator, true, true);
+			}
+			
+		    }
+		    
+		    if (UnityEngine.Random.value > stunResistChance)
+		    {
+			___EMPAdaptedTicksLeft += Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+			reStun();
+		    }
+		    else
+		    {
+			MoteMaker.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
+			int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
+			
+			if (adaptationReduction < ___EMPAdaptedTicksLeft) {
+			    ___EMPAdaptedTicksLeft -= adaptationReduction;
+			}
+			else
+			{
+			    float adaptationReductionRatio = (adaptationReduction - ___EMPAdaptedTicksLeft) / adaptationReduction;
+			    newStunAdaptedTicks = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
+			    newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
+			    reStun();
+			}
+		    }
+		    		    
+		}
+		else
+		{
+		    __instance.StunFor_NewTmp(Mathf.RoundToInt(dinfo.Amount * 30f), dinfo.Instigator, true, true);
+		    ___EMPAdaptedTicksLeft = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
+		    ___stunFromEMP = true;
+		    
+		}
+	    }
+	    return true;
+	}
         public static void Postfix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP)
         {
             if (dinfo.Def == DamageDefOf.EMP)


### PR DESCRIPTION

## Changes

Duration of mech stun resist scales with damage taken.
If the stun is resisted, the stun resistance duration is slightly decreased.
If a more-stunning hit lands while the target is still stunned, the stun duration increases.
Use a random chance for re-stunning.  As the stun-resist timer gets close to 0, they can get re-stunned early.

## References

Fixes #461

## Reasoning

The design goals are:
1. Adding new EMP/ion damage sources should never be a mistake
1. Stun locking mechs should be possible with concentrated fire
1. Such concentrated fire should terminate the mech fast enough to be usually moot
1. Some variability in how long between stuns
1. Mechs, especially more than a single mech, should still be dangerous


## Alternatives

Disable mech adaptation - breaks 5
Allow multiple hits before adaptation - breaks 5 and 1
Make stun chance constant and random - breaks 1

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
