### PR TITLE
Include permalink to dev snapshot download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Combat Extended
 Combat Extended completely overhauls combat. It adds completely new shooting and melee mechanics, an inventory system and rebalances the health system. **Requires a new save**
 
+# Development Version
+If you want the latest development snapshot, without building it yourself:  **https://combatextended.lp-programming.com/CombatExtended-latest.zip**
+**Do not download this repository if you aren't going to build it yourself!**
+It is automatically updated a few minutes after each PR is merged.  
+
 # Features
 ## Shooting
 **Projectile rebalance:**


### PR DESCRIPTION
## Additions

A permalink to the download of the latest dev snapshot, prominent in the project's README


## Reasoning

Keeping the assembly inline in the repository causes problems.  First because git can't well handle regularly-changing binary data.  Second because keeping it in sync with the source code is a challenge.  Third (related to the first), because it causes merge conflicts needlessly.

For the past few months, we've been automatically building dev snapshots out-of-tree, and including links to them automatically in PRs.  When PRs get merged, a new dev snapshot is created as well.  This adds a link to that dev snapshot.

## Alternatives

Continue as we have, which requires extra work on merging PRs, and leads to features sometimes getting missed for a release.

Create micro/pre-releases for each merge.  This would work, but is not automatic, and is not easy to permalink.
