### PR TITLE
Buffs/Adjustments to Royalty melee wepaons

### DIFF
--- a/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_BladelinkMelee.xml
@@ -12,9 +12,9 @@
 					<capacities>
 						<li>Poke</li>
 					</capacities>
-					<power>4</power>
-					<cooldownTime>1.5</cooldownTime>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<power>2</power>
+					<cooldownTime>1.36</cooldownTime>
+					<armorPenetrationBlunt>0.605</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -22,11 +22,11 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>34</power>
-					<cooldownTime>0.92</cooldownTime>
+					<power>38</power>
+					<cooldownTime>0.74</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>2.42</armorPenetrationBlunt>
-					<armorPenetrationSharp>9.68</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.485</armorPenetrationBlunt>
+					<armorPenetrationSharp>21.78</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -34,10 +34,10 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>13</power>					
-					<cooldownTime>0.71</cooldownTime>
+					<power>16</power>					
+					<cooldownTime>0.85</cooldownTime>
 					<armorPenetrationBlunt>1.173</armorPenetrationBlunt>
-					<armorPenetrationSharp>23.47</armorPenetrationSharp>
+					<armorPenetrationSharp>30.24</armorPenetrationSharp>
 				</li>					
 			</tools>
 		</value>
@@ -96,10 +96,10 @@
 					<capacities>
 						<li>Poke</li>
 					</capacities>
-					<power>6</power>
-					<cooldownTime>1.78</cooldownTime>
+					<power>4</power>
+					<cooldownTime>1.62</cooldownTime>
 					<chanceFactor>0.10</chanceFactor>
-					<armorPenetrationBlunt>1.000</armorPenetrationBlunt>
+					<armorPenetrationBlunt>1.21</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -107,15 +107,15 @@
 					<capacities>
 					<li>Blunt</li>
 					</capacities>
-					<power>45</power>
+					<power>49</power>
 					<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
 						<amount>8</amount>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2.5</cooldownTime>
-					<armorPenetrationBlunt>157.5</armorPenetrationBlunt>
+					<cooldownTime>2.24</cooldownTime>
+					<armorPenetrationBlunt>190.575</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					<chanceFactor>0.30</chanceFactor>
 				</li>	
@@ -170,9 +170,9 @@
 						<li>Poke</li>
 					</capacities>
 					<power>3</power>
-					<cooldownTime>1.69</cooldownTime>
+					<cooldownTime>1.53</cooldownTime>
 					<chanceFactor>0.10</chanceFactor>
-					<armorPenetrationBlunt>0.80</armorPenetrationBlunt>
+					<armorPenetrationBlunt>0.968</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -180,7 +180,7 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>45</power>
+					<power>51</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
@@ -188,10 +188,10 @@
 						<chance>0.3</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>0.91</cooldownTime>
-					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>3.20</armorPenetrationBlunt>
-					<armorPenetrationSharp>16</armorPenetrationSharp>
+					<cooldownTime>1.03</cooldownTime>
+					<chanceFactor>0.66</chanceFactor>
+					<armorPenetrationBlunt>5.576</armorPenetrationBlunt>
+					<armorPenetrationSharp>29.04</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -199,7 +199,7 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>20</power>
+					<power>26</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
@@ -207,9 +207,9 @@
 						<chance>0.2</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>0.99</cooldownTime>
-					<armorPenetrationBlunt>3.24</armorPenetrationBlunt>
-					<armorPenetrationSharp>32.4</armorPenetrationSharp>
+					<cooldownTime>0.96</cooldownTime>
+					<armorPenetrationBlunt>2.478</armorPenetrationBlunt>
+					<armorPenetrationSharp>38.72</armorPenetrationSharp>
 				</li>					
 			</tools>
 		</value>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -23,11 +23,11 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>17</power>
-					<cooldownTime>3.52</cooldownTime>
+					<power>22</power>
+					<cooldownTime>2.48</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.68</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.72</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 			</tools>
@@ -82,10 +82,10 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>16</power>
-					<cooldownTime>2.91</cooldownTime>
+					<power>28</power>
+					<cooldownTime>2.79</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>6.25</armorPenetrationBlunt>
+					<armorPenetrationBlunt>11.76</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>
@@ -170,11 +170,11 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>32</power>
-					<cooldownTime>0.92</cooldownTime>
+					<power>35</power>
+					<cooldownTime>0.83</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
-					<armorPenetrationBlunt>2.42</armorPenetrationBlunt>
-					<armorPenetrationSharp>9.68</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.88</armorPenetrationBlunt>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -182,10 +182,10 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>10</power>					
-					<cooldownTime>0.71</cooldownTime>
-					<armorPenetrationBlunt>1.173</armorPenetrationBlunt>
-					<armorPenetrationSharp>23.47</armorPenetrationSharp>
+					<power>16</power>					
+					<cooldownTime>0.94</cooldownTime>
+					<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+					<armorPenetrationSharp>25</armorPenetrationSharp>
 				</li>					
 			</tools>
 		</value>
@@ -344,7 +344,7 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>40</power>
+					<power>47</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
@@ -352,10 +352,10 @@
 						<chance>0.3</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2.06</cooldownTime>
-					<chanceFactor>0.30</chanceFactor>
-					<armorPenetrationBlunt>3.20</armorPenetrationBlunt>
-					<armorPenetrationSharp>16</armorPenetrationSharp>
+					<cooldownTime>1.17</cooldownTime>
+					<chanceFactor>0.66</chanceFactor>
+					<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
+					<armorPenetrationSharp>24</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -363,7 +363,7 @@
 					<capacities>
 					<li>Stab</li>
 					</capacities>
-					<power>17</power>
+					<power>25</power>
 					<extraMeleeDamages>
 					<li>
 						<def>Flame</def>
@@ -371,9 +371,9 @@
 						<chance>0.2</chance>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>0.99</cooldownTime>
-					<armorPenetrationBlunt>3.24</armorPenetrationBlunt>
-					<armorPenetrationSharp>32.4</armorPenetrationSharp>
+					<cooldownTime>1.05</cooldownTime>
+					<armorPenetrationBlunt>2.048</armorPenetrationBlunt>
+					<armorPenetrationSharp>32</armorPenetrationSharp>
 				</li>				
 			</tools>
 		</value>


### PR DESCRIPTION

## Changes

Increased the damage and penetration of monoswords.
Increased the damage and penetration of plasmaswords in general, though some attacks are now slightly slower. It is still overall more powerful however. Increased the chance to use the slash slightly.
Improved the warhammer to make it more comparable in performance to the maul. It's still slightly weaker/faster striking but shouldn't be a practically worse mace that stops from you using shields now.
Improved the handaxe, making it more comparable to a slightly weaker mace against armor, but stronger against unarmored targets where it can use slash damage.

Persona weapons now function as if all their strikes are 10% faster, including the damage and penetration that entails


## Reasoning

New weapon data here

https://docs.google.com/spreadsheets/d/1kE53Zjlb8GzLGl9bjYQYWOYgotIGULiyqpZi6uZlnbg/edit?usp=sharing

Currently, royalty melee weapons are lacking. The axe is unnessciarily weak given that it's functionally a mace with a sharpened edge, and the warhammer is extremely weak despite having a comparable that performs much better in the form of the CE maul and even being edged out by some working tools like the hammer from the vanilla expanded series. Both of these should recieve respective buffs to make them more relevant of weapons, and more consequentely, to make hostile raiders usnig them not a complete waste.

The ultratech melee in royalty have been overtly weak since release. Even though there have been some buffs, I believe they have been insufficent. Their damage rate has been fairly low against all but unarmored or very lightly armored targets, and when compared to contemporary guns, they perform extremely poorly. While it might not be a good idea to make them as lethal as the wraithblade currently stands, as is, they are limited weapons the player can only purchase or aquire from quests, and require trekking into melee range which is so much more difficult than shooting targets that it actually is generally considered entirely non-viable until you have power armor, and all of them are fragile, so due to the parry mechanic can easily be destroyed in an intense fight. And once you make it into said melee, 2/3s of them are completely pathetic in terms of damage output compared to just standing one tile away and getting perfect hits with any other gun.

While for real weapons, this is acceptable to an extent because well, we are basing them off real items, where these weapons are limited largely by the weilder's strength, for the ultratech melee this is unacceptable. These are not real weapons, and could potentially implement systems that overcome this handicap, and as such we are free to largely balance them from a mechanical standpoint rather than soley compare them to real life melee options. I also know for damn sure that any ultratech guns' patches are still going to allow them to shred targets way faster at close range than the melee weapons will, even post buffing of our melee weapons. We also had an example of a ultratech melee weapon prior to royalty's release (the wraithblade) and none of the royalty weapons in their current implementation come anywhere near close.

The further buffs to persona weapons are because they are proportionally rarer and more difficult to use (very few personabond weapons can be shared, it is possible for them to have negative traits etc), and to give the player an option closer to the upper cieling of melee that I consider the wraithblade to set.


## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
