### PR TITLE
Additional Vanilla Weapons Expanded patch work.

### DIFF
--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
@@ -44,12 +44,16 @@
     <advanced>true</advanced>
   </CombatExtended.AmmoCategoryDef>
   
-  <!-- ========== For Metal Gear Solid and Militaires Sans Frontieres ========== -->
-  
   <CombatExtended.AmmoCategoryDef>
     <defName>TranqNonLethal</defName>
     <label>tranquilizer</label>
     <description>Special round designed for non-lethal engagements of targets. Filled with fast-acting sedatives and tipped with a hypodermic needle.</description>
   </CombatExtended.AmmoCategoryDef>
-  
+
+  <CombatExtended.AmmoCategoryDef>
+    <defName>RubberBullet</defName>
+    <label>rubber bullet</label>
+    <description>Special round designed for non-lethal engagements of targets, intended to inflict painful but non-fatal injuries.</description>
+  </CombatExtended.AmmoCategoryDef>
+
 </Defs>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
@@ -56,4 +56,10 @@
     <description>Special round designed for non-lethal engagements of targets, intended to inflict painful but non-fatal injuries.</description>
   </CombatExtended.AmmoCategoryDef>
 
+  <CombatExtended.AmmoCategoryDef>
+    <defName>Taser</defName>
+    <label>taser</label>
+    <description>Special round designed for non-lethal engagements of targets, delivering an incapacitating electrical current.</description>
+  </CombatExtended.AmmoCategoryDef>
+
 </Defs>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
@@ -28,5 +28,12 @@
     <description>Filled with a smoke-producing agent. Explodes on impact to generate a thick smokescreen.</description>
 	<advanced>true</advanced>
   </CombatExtended.AmmoCategoryDef>	
-	
+
+   <CombatExtended.AmmoCategoryDef>
+    <defName>CNGas</defName>
+    <label>tear gas</label>
+    <description>Filled with a non-lethal chemical agent capable of causing pain, irritation, and temporary blindness.</description>
+	<advanced>true</advanced>
+  </CombatExtended.AmmoCategoryDef>	
+
 </Defs>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -10,6 +10,20 @@
     <hediffSolid>CrackBeanbag</hediffSolid>
   </DamageDef>
 
+	<DamageDef ParentName="CutBase">
+		<defName>Taser</defName>
+		<label>taser</label>
+		<deathMessage>{0} has been tasered to death.</deathMessage>
+		<hediff>MuscleSpasms</hediff>
+		<hediffSkin>TaserStab</hediffSkin>
+		<hediffSolid>TaserStab</hediffSolid>
+		<modExtensions>		
+		<li Class="CombatExtended.DamageDefExtensionCE">
+			<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>
+		</li>	
+		</modExtensions>					
+	</DamageDef>
+
   <DamageDef ParentName="Bullet">
     <defName>Fragment</defName>
     <label>fragment</label>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -430,6 +430,19 @@
     </comps>
   </HediffDef>
 
+	<HediffDef ParentName="Stab">
+		<defName>TaserStab</defName>
+		<label>puncture</label>
+		<labelNoun>a puncture wound from taser barbs</labelNoun>
+		<comps>
+		<li Class="CombatExtended.HediffCompProperties_Beanbag"/>
+		</comps>
+		<injuryProps>
+			<bleedRate>0.01</bleedRate>
+			<canMerge>false</canMerge>
+		</injuryProps>		
+	</HediffDef>
+
   <HediffDef ParentName="HediffBite">
     <defName>VenomousBite</defName>
     <label>venomous bite</label>
@@ -512,5 +525,7 @@
 			<destroyedOutLabel>Torn out</destroyedOutLabel>
 		</injuryProps>
 	</HediffDef>
+ 
+
  
 </Defs>

--- a/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
@@ -91,12 +91,18 @@
   	</value>
 	</Operation>
 
-	<!-- Beanbag inheritance -->
+	<!-- Beanbag / Taser inheritance -->
 
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/HediffDef[defName="Bruise"]</xpath>
 	  <attribute>Name</attribute>
 	  <value>Bruise</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/HediffDef[defName="Stab"]</xpath>
+	  <attribute>Name</attribute>
+	  <value>Stab</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAttributeSet">

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -541,7 +541,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
       <warmupTime>0.6</warmupTime>
-      <range>15</range>
+      <range>25</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
       <soundCast>Shot_HeavySMG</soundCast>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
@@ -9,10 +9,113 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+        <!-- === Ammo === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs</xpath>
+          <value>
+
+          <CombatExtended.AmmoSetDef>
+            <defName>AmmoSet_HeavyCrossbowBolt</defName>
+            <label>crossbow bolts</label>
+            <ammoTypes>
+              <Ammo_CrossbowBolt_Stone>Projectile_HeavyCrossbowBolt_Stone</Ammo_CrossbowBolt_Stone>
+              <Ammo_CrossbowBolt_Steel>Projectile_HeavyCrossbowBolt_Steel</Ammo_CrossbowBolt_Steel>
+              <Ammo_CrossbowBolt_Plasteel>Projectile_HeavyCrossbowBolt_Plasteel</Ammo_CrossbowBolt_Plasteel>
+              <Ammo_CrossbowBolt_Venom>Projectile_HeavyCrossbowBolt_Venom</Ammo_CrossbowBolt_Venom>
+              <Ammo_CrossbowBolt_Flame>Projectile_HeavyCrossbowBolt_Flame</Ammo_CrossbowBolt_Flame>      
+            </ammoTypes>
+          </CombatExtended.AmmoSetDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_HeavyCrossbowBolt_Stone</defName>
+            <label>crossbow bolt (stone)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>8</damageAmountBase>
+              <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>1.85</armorPenetrationSharp>			
+              <preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Stone</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_HeavyCrossbowBolt_Steel</defName>
+            <label>crossbow bolt (steel)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>12</damageAmountBase>
+              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>2.85</armorPenetrationSharp>
+              <speed>18</speed>			
+              <preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_HeavyCrossbowBolt_Plasteel</defName>
+            <label>crossbow bolt (plasteel)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>10</damageAmountBase>
+              <armorPenetrationBlunt>8.12</armorPenetrationBlunt>
+              <armorPenetrationSharp>4</armorPenetrationSharp>
+              <speed>20</speed>				
+              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_HeavyCrossbowBolt_Venom</defName>
+            <label>crossbow bolt (venom)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>ArrowVenom</damageDef>
+              <damageAmountBase>12</damageAmountBase>
+              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>2.5</armorPenetrationSharp>
+              <speed>18</speed>	
+              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+          
+          <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_HeavyCrossbowBolt_Flame</defName>
+            <label>crossbow bolt (flame)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>Flame</damageDef>
+              <damageAmountBase>5</damageAmountBase>
+              <armorPenetrationBlunt>3.28</armorPenetrationBlunt>
+              <armorPenetrationSharp>1.5</armorPenetrationSharp>
+              <speed>18</speed>	
+            </projectile>
+          </ThingDef>
+
+          </value>
+        </li>
+
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEM_Bow_HeavyCrossbow"]/tools</xpath>
-
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -38,14 +141,14 @@
             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
           </statBases>
           <costList>
-			  <WoodLog>60</WoodLog>
-			  <Steel>25</Steel>
-			  <ComponentIndustrial>1</ComponentIndustrial>
+            <WoodLog>60</WoodLog>
+            <Steel>25</Steel>
+            <ComponentIndustrial>1</ComponentIndustrial>
           </costList>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
+            <defaultProjectile>Projectile_HeavyCrossbowBolt_Steel</defaultProjectile>
             <warmupTime>1</warmupTime>
             <range>34</range>
             <soundCast>Bow_Large</soundCast>
@@ -53,7 +156,7 @@
           <AmmoUser>
             <magazineSize>1</magazineSize>
             <reloadTime>8</reloadTime>
-            <ammoSet>AmmoSet_CrossbowBolt</ammoSet>
+            <ammoSet>AmmoSet_HeavyCrossbowBolt</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -361,7 +361,7 @@
         <AmmoUser>
           <magazineSize>500</magazineSize>
           <reloadTime>9.2</reloadTime>
-          <ammoSet>Ammo_556x45mmNATO_FMJ</ammoSet>
+          <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
         </AmmoUser>
         <weaponTags Inherit="false">
           <li>TurretGun</li>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -348,7 +348,7 @@
           <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
           <warmupTime>2.3</warmupTime>
           <range>62</range>
-          <burstShotCount>300</burstShotCount>
+          <burstShotCount>50</burstShotCount>
           <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
           <soundCast>Shot_Minigun</soundCast>
           <soundCastTail>GunTail_Medium</soundCastTail>
@@ -363,9 +363,6 @@
           <reloadTime>9.2</reloadTime>
           <ammoSet>Ammo_556x45mmNATO_FMJ</ammoSet>
         </AmmoUser>
-        <FireModes>
-          <aimedBurstShotCount>150</aimedBurstShotCount>
-        </FireModes>
         <weaponTags Inherit="false">
           <li>TurretGun</li>
         </weaponTags>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -345,7 +345,7 @@
         <Properties>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
-          <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+          <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
           <warmupTime>2.3</warmupTime>
           <range>62</range>
           <burstShotCount>300</burstShotCount>
@@ -361,7 +361,7 @@
         <AmmoUser>
           <magazineSize>500</magazineSize>
           <reloadTime>9.2</reloadTime>
-          <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+          <ammoSet>Ammo_556x45mmNATO_FMJ</ammoSet>
         </AmmoUser>
         <FireModes>
           <aimedBurstShotCount>150</aimedBurstShotCount>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
+<Patch>
 <Operation Class="PatchOperationFindMod">
 	<mods>
 		<li>Vanilla Weapons Expanded - Frontier</li>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Weapons Expanded - Frontier</li>
+	</mods>
+	<match Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Weapons Expanded - Quickdraw</li>
+		</mods>
+		<match Class="PatchOperationAdd">
+            <xpath>Defs</xpath>
+            <value>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSetHR_41RimfireHR</defName>
+		<label>.41 Rimfire</label>
+		<ammoTypes>
+			<Ammo_41Rimfire_FMJ>Bullet_41RimfireHR_FMJ</Ammo_41Rimfire_FMJ>
+			<Ammo_41Rimfire_AP>Bullet_41RimfireHR_AP</Ammo_41Rimfire_AP>
+			<Ammo_41Rimfire_HP>Bullet_41RimfireHR_HP</Ammo_41Rimfire_HP>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base41RimfireBullet">
+		<defName>Bullet_41RimfireHR_FMJ</defName>
+		<label>.41 Rimfire bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>6</damageAmountBase>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bullet</def>
+				<amount>6</amount>
+				<chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base41RimfireBullet">
+		<defName>Bullet_41RimfireHR_AP</defName>
+		<label>.41 Rimfire bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>4</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bullet</def>
+				<amount>4</amount>
+				<chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base41RimfireBullet">
+		<defName>Bullet_41RimfireHR_HP</defName>
+		<label>.41 Rimfire bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bullet</def>
+				<amount>7</amount>
+				<chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+		</value>
+	    </match>
+	</match>
+</Operation>
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_AddonAmmo.xml
@@ -16,7 +16,7 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSetHR_41RimfireHR</defName>
+		<defName>AmmoSet_41RimfireHR</defName>
 		<label>.41 Rimfire</label>
 		<ammoTypes>
 			<Ammo_41Rimfire_FMJ>Bullet_41RimfireHR_FMJ</Ammo_41Rimfire_FMJ>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_Ammo.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Patch_HighRoller_Ammo.xml
@@ -1,0 +1,445 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Weapons Expanded - Frontier</li>
+		</mods>
+	<match Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_44MagnumHR</defName>
+		<label>.44 Magnum</label>
+		<ammoTypes>
+			<Ammo_44Magnum_FMJ>Bullet_44MagnumHR_FMJ</Ammo_44Magnum_FMJ>
+			<Ammo_44Magnum_AP>Bullet_44MagnumHR_AP</Ammo_44Magnum_AP>
+			<Ammo_44Magnum_HP>Bullet_44MagnumHR_HP</Ammo_44Magnum_HP>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base44MagnumBullet">
+		<defName>Bullet_44MagnumHR_FMJ</defName>
+		<label>.44 Magnum bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.280</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>15</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base44MagnumBullet">
+		<defName>Bullet_44MagnumHR_AP</defName>
+		<label>.44 Magnum bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.280</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+                  <def>Bullet</def>
+                  <amount>10</amount>
+                  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base44MagnumBullet">
+		<defName>Bullet_44MagnumHR_HP</defName>
+		<label>.44 Magnum bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.280</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+                  <def>Bullet</def>
+                  <amount>19</amount>
+                  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_763x25mmMauserHR</defName>
+		<label>7.63x25mm Mauser</label>
+		<ammoTypes>
+			<Ammo_763x25mmMauser_FMJ>Bullet_763x25mmMauserHR_FMJ</Ammo_763x25mmMauser_FMJ>
+			<Ammo_763x25mmMauser_AP>Bullet_763x25mmMauserHR_AP</Ammo_763x25mmMauser_AP>
+			<Ammo_763x25mmMauser_HP>Bullet_763x25mmMauserHR_HP</Ammo_763x25mmMauser_HP>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base763x25mmMauserBullet">
+		<defName>Bullet_763x25mmMauserHR_FMJ</defName>
+		<label>7.63mm Mauser bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>10</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base763x25mmMauserBullet">
+		<defName>Bullet_763x25mmMauserHR_AP</defName>
+		<label>7.63mm Mauser bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>7</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base763x25mmMauserBullet">
+		<defName>Bullet_763x25mmMauserHR_HP</defName>
+		<label>7.63mm Mauser bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>13</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_4570GovHR</defName>
+		<label>.45-70 Government</label>
+		<ammoTypes>
+			<Ammo_4570Gov_FMJ>Bullet_4570GovHR_FMJ</Ammo_4570Gov_FMJ>
+			<Ammo_4570Gov_AP>Bullet_4570GovHR_AP</Ammo_4570Gov_AP>
+			<Ammo_4570Gov_HP>Bullet_4570GovHR_HP</Ammo_4570Gov_HP>
+		    <Ammo_4570Gov_Incendiary>Bullet_4570GovHR_Incendiary</Ammo_4570Gov_Incendiary>
+			<Ammo_4570Gov_HE>Bullet_4570GovHR_HE</Ammo_4570Gov_HE>
+			<Ammo_4570Gov_Sabot>Bullet_4570GovHR_Sabot</Ammo_4570Gov_Sabot>					
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_FMJ</defName>
+		<label>.45-70 Government cartridge (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>20</damageAmountBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>20</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_AP</defName>
+		<label>.45-70 Government cartridge (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>13</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_HP</defName>
+		<label>.45-70 Government cartridge (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>25</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>25</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>			
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_Incendiary</defName>
+		<label>.45-70 bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>13</damageAmountBase>
+		  <armorPenetrationSharp>18</armorPenetrationSharp>
+		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>8</amount>
+				</li>
+				<li>
+				  <def>Bullet</def>
+				  <amount>13</amount>
+				  <chance>0.10</chance>
+				</li>				
+				<li>
+				  <def>Flame_Secondary</def>
+				  <amount>8</amount>
+				  <chance>0.10</chance>
+				</li>				
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_HE</defName>
+		<label>.45-70 bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>20</damageAmountBase>
+		  <armorPenetrationSharp>9</armorPenetrationSharp>
+		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>12</amount>
+				</li>
+				<li>
+				  <def>Bullet</def>
+				  <amount>20</amount>
+				  <chance>0.10</chance>
+				</li>
+				<li>
+				  <def>Bomb_Secondary</def>
+				  <amount>12</amount>
+				  <chance>0.10</chance>
+				</li>								
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base4570GovBullet">
+		<defName>Bullet_4570GovHR_Sabot</defName>
+		<label>.45-70 bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>31.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>60.68</armorPenetrationBlunt>
+		  <speed>128</speed>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>11</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>		  
+		</projectile>
+	  </ThingDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_12GaugeHR</defName>
+    <label>12 Gauge</label>
+    <ammoTypes>
+      <Ammo_12Gauge_Buck>Bullet_12GaugeHR_Buck</Ammo_12Gauge_Buck>
+      <Ammo_12Gauge_Slug>Bullet_12GaugeHR_Slug</Ammo_12Gauge_Slug>
+      <Ammo_12Gauge_Beanbag>Bullet_12Gauge_Beanbag</Ammo_12Gauge_Beanbag>
+      <Ammo_12Gauge_ElectroSlug>Bullet_12GaugeHR_ElectroSlug</Ammo_12Gauge_ElectroSlug>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+    <defName>Bullet_12GaugeHR_Buck</defName>
+    <label>buckshot pellet</label>
+    <graphicData>
+      <texPath>Things/Projectile/Shotgun_Pellet</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>8</damageAmountBase>
+      <pelletCount>9</pelletCount>
+      <armorPenetrationSharp>4</armorPenetrationSharp>
+      <armorPenetrationBlunt>4.52</armorPenetrationBlunt>
+      <spreadMult>17.8</spreadMult>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>9</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>      
+    </projectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+    <defName>Bullet_12GaugeHR_Slug</defName>
+    <label>shotgun slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_big</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>110</speed>
+      <damageAmountBase>28</damageAmountBase>
+      <armorPenetrationSharp>6</armorPenetrationSharp>
+      <armorPenetrationBlunt>85.2</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>28</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>      
+    </projectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+    <defName>Bullet_12GaugeHR_ElectroSlug</defName>
+    <label>EMP slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_big</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>30</speed>
+      <damageDef>EMP</damageDef>
+      <damageAmountBase>12</damageAmountBase>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <empShieldBreakChance>0.2</empShieldBreakChance>
+			<secondaryDamage>
+				<li>
+				  <def>EMP</def>
+				  <amount>12</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>      
+    </projectile>
+  </ThingDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_25ACPHR</defName>
+		<label>.25 ACP</label>
+		<ammoTypes>
+			<Ammo_25ACP_FMJ>Bullet_25ACPHR_FMJ</Ammo_25ACP_FMJ>
+			<Ammo_25ACP_AP>Bullet_25ACPHR_AP</Ammo_25ACP_AP>
+			<Ammo_25ACP_HP>Bullet_25ACPHR_HP</Ammo_25ACP_HP>			
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25ACPBullet">
+		<defName>Bullet_25ACPHR_FMJ</defName>
+		<label>.25 ACP bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>11</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25ACPBullet">
+		<defName>Bullet_25ACPHR_AP</defName>
+		<label>.25 ACP bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>7</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25ACPBullet">
+		<defName>Bullet_25ACPHR_HP</defName>
+		<label>.25 ACP bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				  <def>Bullet</def>
+				  <amount>15</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>            
+		</projectile>
+	</ThingDef>
+
+		</value>	
+	</match>
+</Operation>
+			  
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
@@ -74,7 +74,7 @@
             <recoilAmount>0.66</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_4570Gov_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_4570GovHR_FMJ</defaultProjectile>
             <burstShotCount>10</burstShotCount>
             <ticksBetweenBurstShots>9</ticksBetweenBurstShots>
             <warmupTime>2.1</warmupTime>
@@ -87,7 +87,7 @@
           <AmmoUser>
             <magazineSize>40</magazineSize>
             <reloadTime>7.8</reloadTime>
-            <ammoSet>AmmoSet_4570Gov</ammoSet>
+            <ammoSet>AmmoSet_4570GovHR</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>SuppressFire</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Quickdraw.xml
@@ -96,7 +96,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
-            <defaultProjectile>Bullet_41Rimfire_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_41RimfireHR_FMJ</defaultProjectile>
             <warmupTime>0.4</warmupTime>
             <range>8</range>
             <soundCast>Shot_Revolver</soundCast>
@@ -106,7 +106,7 @@
           <AmmoUser>
             <magazineSize>2</magazineSize>
             <reloadTime>1</reloadTime>
-            <ammoSet>AmmoSet_41Rimfire</ammoSet>
+            <ammoSet>AmmoSet_41RimfireHR</ammoSet>
             <reloadOneAtATime>true</reloadOneAtATime>
           </AmmoUser>
           <FireModes>
@@ -136,7 +136,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
-            <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+            <defaultProjectile>Bullet_12GaugeHR_Buck</defaultProjectile>
             <warmupTime>0.6</warmupTime>
             <range>16</range>
             <soundCast>Shot_Shotgun</soundCast>
@@ -146,7 +146,7 @@
           <AmmoUser>
             <magazineSize>5</magazineSize>
             <reloadTime>0.85</reloadTime>
-            <ammoSet>AmmoSet_12Gauge</ammoSet>
+            <ammoSet>AmmoSet_12GaugeHR</ammoSet>
             <reloadOneAtATime>true</reloadOneAtATime>
           </AmmoUser>
           <FireModes>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
@@ -114,7 +114,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_44MagnumHR_FMJ</defaultProjectile>
       <warmupTime>0.6</warmupTime>
       <range>12</range>
       <soundCast>Shot_Revolver</soundCast>
@@ -124,7 +124,7 @@
     <AmmoUser>
       <magazineSize>6</magazineSize>
       <reloadTime>5.1</reloadTime>
-      <ammoSet>AmmoSet_44Magnum</ammoSet>
+      <ammoSet>AmmoSet_44MagnumHR</ammoSet>
     </AmmoUser>
     <FireModes>
     <aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -153,7 +153,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_25ACP_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_25ACPHR_FMJ</defaultProjectile>
       <warmupTime>0.6</warmupTime>
       <range>12</range>
       <soundCast>Shot_Revolver</soundCast>
@@ -163,7 +163,7 @@
     <AmmoUser>
       <magazineSize>10</magazineSize>
       <reloadTime>1</reloadTime>
-      <ammoSet>AmmoSet_25ACP</ammoSet>
+      <ammoSet>AmmoSet_25ACPHR</ammoSet>
       <reloadOneAtATime>true</reloadOneAtATime>
     </AmmoUser>
     <FireModes>
@@ -193,7 +193,7 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_763x25mmMauser_FMJ</defaultProjectile>
+			<defaultProjectile>Bullet_763x25mmMauserHR_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>12</range>
       <soundCast>Shot_Autopistol</soundCast>
@@ -203,7 +203,7 @@
 		<AmmoUser>
 			<magazineSize>10</magazineSize>
 			<reloadTime>4.3</reloadTime>
-			<ammoSet>AmmoSet_763x25mmMauser</ammoSet>
+			<ammoSet>AmmoSet_763x25mmMauserHR</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -229,7 +229,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_4570Gov_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_4570GovHR_FMJ</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>64</range>
       <soundCast>Shot_SniperRifle</soundCast>
@@ -239,7 +239,7 @@
     <AmmoUser>
       <magazineSize>1</magazineSize>
       <reloadTime>2.2</reloadTime>
-      <ammoSet>AmmoSet_4570Gov</ammoSet>
+      <ammoSet>AmmoSet_4570GovHR</ammoSet>
     </AmmoUser>
     <FireModes>
       <aiAimMode>AimedShot</aiAimMode>
@@ -265,7 +265,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+      <defaultProjectile>Bullet_12GaugeHR_Buck</defaultProjectile>
       <warmupTime>0.6</warmupTime>
       <range>16</range>
       <soundCast>Shot_Shotgun</soundCast>
@@ -276,7 +276,7 @@
       <magazineSize>5</magazineSize>
       <reloadOneAtATime>true</reloadOneAtATime>
       <reloadTime>0.85</reloadTime>
-      <ammoSet>AmmoSet_12Gauge</ammoSet>
+      <ammoSet>AmmoSet_12GaugeHR</ammoSet>
     </AmmoUser>
     <FireModes />
     <weaponTags>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
@@ -162,7 +162,7 @@
     </Properties>
     <AmmoUser>
       <magazineSize>10</magazineSize>
-      <reloadTime>1</reloadTime>
+      <reloadTime>0.85</reloadTime>
       <ammoSet>AmmoSet_25ACPHR</ammoSet>
       <reloadOneAtATime>true</reloadOneAtATime>
     </AmmoUser>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
@@ -29,12 +29,13 @@
     <label>40x46mm grenade (CN)</label>
     <description>Low velocity grenade filled with a non-lethal chemical irritant, intended for crowd control.</description>
     <graphicData>
-      <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+      <texPath>Things/Ammo/GrenadeLauncher/GS50_SMK</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.37</MarketValue>
+      <MarketValue>5.37</MarketValue>
     </statBases>
+    <stackLimit>200</stackLimit>
     <ammoClass>CNGas</ammoClass>
 	<detonateProjectile>Bullet_40x46mmGrenade_CN</detonateProjectile>
   </ThingDef>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/40mmLessLethal.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs</xpath>
+        <value>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_40x46mmGrenadeNL</defName>
+    <label>40x46mm Grenades</label>
+    <ammoTypes>
+      <Ammo_40x46mmGrenade_CN>Bullet_40x46mmGrenade_CN</Ammo_40x46mmGrenade_CN>  
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="40x46mmGrenadeBase">
+    <defName>Ammo_40x46mmGrenade_CN</defName>
+    <label>40x46mm grenade (CN)</label>
+    <description>Low velocity grenade filled with a non-lethal chemical irritant, intended for crowd control.</description>
+    <graphicData>
+      <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>2.37</MarketValue>
+    </statBases>
+    <ammoClass>CNGas</ammoClass>
+	<detonateProjectile>Bullet_40x46mmGrenade_CN</detonateProjectile>
+  </ThingDef>
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef ParentName="Base40x46mmGrenadeBullet">
+    <defName>Bullet_40x46mmGrenade_CN</defName>
+    <label>40x46mm grenade (CN)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <explosionRadius>3.9</explosionRadius>
+      <damageDef>VWENL_TearGas</damageDef>
+      <postExplosionSpawnThingDef>VWENL_TearGasCloud</postExplosionSpawnThingDef>
+      <preExplosionSpawnChance>1</preExplosionSpawnChance>
+      <postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>
+    </projectile>
+  </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_40x46mmGrenade_CN</defName>
+    <label>make 40x46mm CN grenades x100</label>
+    <description>Craft 100 40x46mm CN grenades.</description>
+    <jobString>Making 40x46mm CN grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Neutroamine</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Neutroamine</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_40x46mmGrenade_CN>100</Ammo_40x46mmGrenade_CN>
+    </products>
+    <workAmount>9000</workAmount>
+  </RecipeDef>
+
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Toxic Grenade === -->
+        <!-- == Projectile == -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/thingClass</xpath>
+          <value>
+            <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/projectile</xpath>
+          <value>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>VWE_ToxicGas</damageDef>
+              <explosionRadius>3.9</explosionRadius>
+              <damageAmountBase>1</damageAmountBase>
+              <explosionDelay>100</explosionDelay>
+              <dropsCasings>true</dropsCasings>
+              <flyOverhead>false</flyOverhead>
+              <soundExplode>DispensePaste</soundExplode>
+              <postExplosionSpawnThingDef>VWENL_TearGasCloud</postExplosionSpawnThingDef>
+              <postExplosionSpawnChance>1</postExplosionSpawnChance>
+              <postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>
+              <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+              <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+            </projectile>
+          </value>
+        </li>
+
+        <!-- == Grenade == -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
+          <value>
+            <thingClass>CombatExtended.AmmoThing</thingClass>
+            <stackLimit>75</stackLimit>
+            <resourceReadoutPriority>First</resourceReadoutPriority>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAttributeSet">
+          <xpath>/Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
+          <attribute>Class</attribute>
+          <value>CombatExtended.AmmoDef</value>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VWE_TearGasGrenade</defName>
+          <statBases>
+            <Mass>1</Mass>
+            <MarketValue>2.25</MarketValue>
+            <SightsEfficiency>1</SightsEfficiency>
+            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <label>throw tear gas</label>
+            <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>VWENL_Projectile_TearGasGrenade</defaultProjectile>
+            <range>12</range>
+            <warmupTime>1.8</warmupTime>
+            <soundCast>ThrowGrenade</soundCast>
+            <noiseRadius>4</noiseRadius>
+            <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+            <onlyManualCast>true</onlyManualCast>
+            <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+            <targetParams>
+              <canTargetLocations>true</canTargetLocations>
+            </targetParams>
+          </Properties>
+          <weaponTags>
+            <li>CE_OneHandedWeapon</li>
+          </weaponTags>
+        </li>
+
+        <!-- == Recipe == -->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs</xpath>
+          <value>
+            <RecipeDef ParentName="GrenadeRecipeBase">
+              <defName>MakeVWENLTearGasGrenade</defName>
+              <label>make tear gas grenades x10</label>
+              <description>Craft 10 tear gas grenades.</description>
+              <jobString>Making tear gas grenades.</jobString>
+              <ingredients>
+                <li>
+                  <filter>
+                    <thingDefs>
+                      <li>Steel</li>
+                    </thingDefs>
+                  </filter>
+                  <count>10</count>
+                </li>
+                <li>
+                  <filter>
+                    <thingDefs>
+                      <li>Neutroamine</li>
+                    </thingDefs>
+                  </filter>
+                  <count>10</count>
+                </li>
+              </ingredients>
+              <fixedIngredientFilter>
+                <thingDefs>
+                  <li>Steel</li>
+                  <li>Neutroamine</li>
+                </thingDefs>
+              </fixedIngredientFilter>
+              <products>
+                <VWE_TearGasGrenade>10</VWE_TearGasGrenade>
+              </products>
+            </RecipeDef>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
@@ -10,8 +10,8 @@
 
         <!-- === Toxic Grenade === -->
         <!-- == Projectile == -->
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/thingClass</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]</xpath>
           <value>
             <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
           </value>
@@ -21,7 +21,7 @@
           <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/projectile</xpath>
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <damageDef>VWE_ToxicGas</damageDef>
+              <damageDef>VWENL_TearGas</damageDef>
               <explosionRadius>3.9</explosionRadius>
               <damageAmountBase>1</damageAmountBase>
               <explosionDelay>100</explosionDelay>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Baton === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/statBases</xpath>
+          <value>
+            <Bulk>2.75</Bulk>
+            <MeleeCounterParryBonus>0.9</MeleeCounterParryBonus>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]</xpath>
+          <value>
+            <equippedStatOffsets>
+              <MeleeCritChance>0.17</MeleeCritChance>
+              <MeleeParryChance>0.9</MeleeParryChance>
+              <MeleeDodgeChance>0.3</MeleeDodgeChance>
+            </equippedStatOffsets>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/weaponTags</xpath>
+          <value>
+            <li>CE_Sidearm_Melee</li>
+            <li>CE_OneHandedWeapon</li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>handle</label>
+                <capacities>
+                  <li>Poke</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>1.59</cooldownTime>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+              </li>            
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>9</power>
+                <extraMeleeDamages>
+                <li>
+                  <def>Stun</def>
+                  <amount>32</amount>
+                  <chance>0.4</chance>
+                </li>
+                </extraMeleeDamages>                
+                <cooldownTime>1.68</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetrationBlunt>3.375</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
@@ -53,14 +53,14 @@
               <li Class="CombatExtended.ToolCE">
                 <label>head</label>
                 <capacities>
-                  <li>Blunt</li>
+                  <li>Poke</li>
                 </capacities>
-                <power>9</power>
+                <power>5</power>
                 <extraMeleeDamages>
                 <li>
                   <def>Stun</def>
                   <amount>32</amount>
-                  <chance>0.4</chance>
+                  <chance>0.20</chance>
                 </li>
                 </extraMeleeDamages>                
                 <cooldownTime>1.68</cooldownTime>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -147,7 +147,7 @@
 	<Properties>
 		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+		<defaultProjectile>Bullet_43cal_NL</defaultProjectile>
 		<warmupTime>0.6</warmupTime>
 		<range>12</range>
 		<soundCast>VWENL_Shot_RubberBulletPistol</soundCast>
@@ -157,7 +157,7 @@
 	<AmmoUser>
 		<magazineSize>5</magazineSize>
 		<reloadTime>5.4</reloadTime>
-		<ammoSet>AmmoSet_45ACP</ammoSet>
+		<ammoSet>AmmoSet_43cal_NL</ammoSet>
 	</AmmoUser>
 	<FireModes>
 		<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -155,7 +155,7 @@
 		<muzzleFlashScale>9</muzzleFlashScale>
 	</Properties>
 	<AmmoUser>
-		<magazineSize>2</magazineSize>
+		<magazineSize>5</magazineSize>
 		<reloadTime>5.4</reloadTime>
 		<ammoSet>AmmoSet_45ACP</ammoSet>
 	</AmmoUser>
@@ -222,10 +222,10 @@
 		<Properties>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+			<defaultProjectile>Bullet_40x46mmGrenade_CN</defaultProjectile>
 			<warmupTime>1</warmupTime>
 			<range>40</range>
-			<soundCast>VWE_Shot_GrenadeLauncher</soundCast>
+			<soundCast>VWENL_Shot_GrenadeLauncher</soundCast>
 			<soundCastTail>GunTail_Medium</soundCastTail>			
 			<muzzleFlashScale>14</muzzleFlashScale>
 			<ai_IsBuildingDestroyer>True</ai_IsBuildingDestroyer>
@@ -236,8 +236,8 @@
 		</Properties>
 		<AmmoUser>
 			<magazineSize>1</magazineSize>
-			<reloadTime></reloadTime>
-			<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+			<reloadTime>2.2</reloadTime>
+			<ammoSet>AmmoSet_40x46mmGrenadeNL</ammoSet>
 		</AmmoUser>
 		<FireModes>
 			<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -102,7 +102,7 @@
 	<defName>VWE_Gun_Taser</defName>
 	<statBases>
 		<Mass>0.21</Mass>
-		<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		<RangedWeapon_Cooldown>0.98</RangedWeapon_Cooldown>
 		<SightsEfficiency>0.60</SightsEfficiency>
 		<ShotSpread>0.67</ShotSpread>
 		<SwayFactor>1.07</SwayFactor>
@@ -111,7 +111,7 @@
 	<Properties>
 		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+		<defaultProjectile>Bullet_Taser</defaultProjectile>
 		<warmupTime>0.6</warmupTime>
 		<range>7</range>
 		<soundCast>VWE_TaserShot_Electricity</soundCast>
@@ -121,7 +121,7 @@
 	<AmmoUser>
 		<magazineSize>2</magazineSize>
 		<reloadTime>5.4</reloadTime>
-		<ammoSet>AmmoSet_45ACP</ammoSet>
+		<ammoSet>AmmoSet_Taser</ammoSet>
 	</AmmoUser>
 	<FireModes>
 		<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Weapons Expanded - Non-Lethal</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+
+	<!-- === Tools === -->
+
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Gun_Taser" or defName="VWE_Gun_RubberBulletPistol"]/tools</xpath>
+		<value>
+		<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>grip</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+					<li>Poke</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+		</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName = "VWE_Gun_DartGun"]/tools</xpath>
+		<value>
+		<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>stock</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>5</power>
+				<cooldownTime>2.02</cooldownTime>
+				<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+					<li>Poke</li>
+				</capacities>
+				<power>8</power>
+				<cooldownTime>1.55</cooldownTime>
+				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+		</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Gun_TearGasLauncher"]/tools</xpath>
+		<value>
+		<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>barrel</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>10</power>
+				<cooldownTime>2.44</cooldownTime>
+				<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+		</tools>
+		</value>
+	</li>
+
+	<!-- ========== Taser ========== -->
+
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	<defName>VWE_Gun_Taser</defName>
+	<statBases>
+		<Mass>0.21</Mass>
+		<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		<SightsEfficiency>0.60</SightsEfficiency>
+		<ShotSpread>0.67</ShotSpread>
+		<SwayFactor>1.07</SwayFactor>
+		<Bulk>1.85</Bulk>
+	</statBases>
+	<Properties>
+		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		<hasStandardCommand>true</hasStandardCommand>
+		<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+		<warmupTime>0.6</warmupTime>
+		<range>7</range>
+		<soundCast>VWE_TaserShot_Electricity</soundCast>
+		<soundCastTail>GunTail_Heavy</soundCastTail>
+		<muzzleFlashScale>9</muzzleFlashScale>
+	</Properties>
+	<AmmoUser>
+		<magazineSize>2</magazineSize>
+		<reloadTime>5.4</reloadTime>
+		<ammoSet>AmmoSet_45ACP</ammoSet>
+	</AmmoUser>
+	<FireModes>
+		<aiUseBurstMode>FALSE</aiUseBurstMode>
+	</FireModes>
+	<weaponTags>
+		<li>NonLethal</li>
+		<li>CE_OneHandedWeapon</li>
+	</weaponTags>
+	</li>
+
+	<!-- ========== Rubber Bullet Pistol ========== -->
+
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	<defName>VWE_Gun_RubberBulletPistol</defName>
+	<statBases>
+		<Mass>1.11</Mass>
+		<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+		<SightsEfficiency>0.7</SightsEfficiency>
+		<ShotSpread>0.17</ShotSpread>
+		<SwayFactor>1.07</SwayFactor>
+		<Bulk>2.10</Bulk>
+	</statBases>
+	<Properties>
+		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		<hasStandardCommand>true</hasStandardCommand>
+		<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+		<warmupTime>0.6</warmupTime>
+		<range>12</range>
+		<soundCast>VWENL_Shot_RubberBulletPistol</soundCast>
+		<soundCastTail>GunTail_Light</soundCastTail>
+		<muzzleFlashScale>9</muzzleFlashScale>
+	</Properties>
+	<AmmoUser>
+		<magazineSize>2</magazineSize>
+		<reloadTime>5.4</reloadTime>
+		<ammoSet>AmmoSet_45ACP</ammoSet>
+	</AmmoUser>
+	<FireModes>
+		<aiUseBurstMode>FALSE</aiUseBurstMode>
+	</FireModes>
+	<weaponTags>
+		<li>NonLethal</li>
+		<li>CE_OneHandedWeapon</li>
+	</weaponTags>
+	</li>
+
+	<!-- ========== Dart Gun ========== -->
+
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	<defName>VWE_Gun_DartGun</defName>
+	<statBases>
+		<Mass>3</Mass>
+		<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+		<SightsEfficiency>2.6</SightsEfficiency>
+		<ShotSpread>0.21</ShotSpread>
+		<SwayFactor>1.33</SwayFactor>
+		<Bulk>10.03</Bulk>
+	</statBases>
+	<costList>
+      <Steel>60</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+	</costList>
+	<Properties>
+		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		<hasStandardCommand>true</hasStandardCommand>
+		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+		<warmupTime>1.1</warmupTime>
+		<range>55</range>
+        <soundCast>VWENL_Shot_DartGun</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+		<muzzleFlashScale>9</muzzleFlashScale>
+	</Properties>
+	<AmmoUser>
+		<magazineSize>1</magazineSize>
+		<reloadTime>2.4</reloadTime>
+		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+	</AmmoUser>
+	<FireModes>
+		<aiAimMode>AimedShot</aiAimMode>
+	</FireModes>
+	</li>
+
+	<!-- === Tear Gas Launcher === -->
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>VWE_Gun_TearGasLauncher</defName>
+		<statBases>
+			<Mass>5.35</Mass>
+			<Bulk>5.70</Bulk>
+			<SwayFactor>1.31</SwayFactor>
+			<ShotSpread>0.18</ShotSpread>
+			<SightsEfficiency>1</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+		</statBases>
+		<costList>
+			<Steel>65</Steel>
+			<ComponentIndustrial>3</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+			<warmupTime>1</warmupTime>
+			<range>40</range>
+			<soundCast>VWE_Shot_GrenadeLauncher</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>			
+			<muzzleFlashScale>14</muzzleFlashScale>
+			<ai_IsBuildingDestroyer>True</ai_IsBuildingDestroyer>
+			<ignorePartialLoSBlocker>True</ignorePartialLoSBlocker>
+			<targetParams>
+				<canTargetLocations>True</canTargetLocations>
+			</targetParams>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<reloadTime></reloadTime>
+			<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>AimedShot</aiAimMode>
+			<aiUseBurstMode>False</aiUseBurstMode>
+		</FireModes>
+		<weaponTags>
+			<li>NonLethal</li>
+		</weaponTags>
+
+	</li>
+
+		</operations>
+	</match>
+</Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -120,7 +120,7 @@
 	</Properties>
 	<AmmoUser>
 		<magazineSize>2</magazineSize>
-		<reloadTime>5.4</reloadTime>
+		<reloadTime>4.7</reloadTime>
 		<ammoSet>AmmoSet_Taser</ammoSet>
 	</AmmoUser>
 	<FireModes>
@@ -187,7 +187,7 @@
 	<Properties>
 		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+		<defaultProjectile>Bullet_DartRifle_NL</defaultProjectile>
 		<warmupTime>1.1</warmupTime>
 		<range>55</range>
         <soundCast>VWENL_Shot_DartGun</soundCast>
@@ -197,7 +197,7 @@
 	<AmmoUser>
 		<magazineSize>1</magazineSize>
 		<reloadTime>2.4</reloadTime>
-		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+		<ammoSet>AmmoSet_DartRifle_NonLethal</ammoSet>
 	</AmmoUser>
 	<FireModes>
 		<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/RubberBullet.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/RubberBullet.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs</xpath>
+        <value>
+
+	<ThingCategoryDef>
+		<defName>Ammo43cal</defName>
+		<label>.43 caliber</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_43cal_NL</defName>
+		<label>.43 caliber rubber bullet</label>
+		<ammoTypes>
+			<Ammo_43cal_NL>Bullet_43cal_NL</Ammo_43cal_NL>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+		<defName>Ammo_43cal_NL</defName>
+		<label>.43 caliber rubber bullet</label>
+    <description>Gas-powered pistol cartridge firing rubberized projectiles. Painful, but generally non-lethal.</description>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.09</MarketValue>
+		</statBases>
+		<ammoClass>RubberBullet</ammoClass>
+	</ThingDef>
+
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+		<defName>Bullet_43cal_NL</defName>
+		<label>rubber bullet</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Blunt</damageDef>
+			<damageAmountBase>5</damageAmountBase>
+			<secondaryDamage>
+				<li>
+				  <def>Beanbag</def>
+				  <amount>4</amount>
+				  <chance>0.10</chance>
+				</li>
+			</secondaryDamage>        
+			<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+      <speed>20</speed>
+      <dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_43cal_NL</defName>
+		<label>make .43 rubber bullet cartridges x200</label>
+		<description>Craft 200 .43 rubber bullet cartridges.</description>
+		<jobString>Making .43 rubber bullet cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>      
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+        <li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_43cal_NL>200</Ammo_43cal_NL>
+		</products>
+		<workAmount>1800</workAmount>
+	</RecipeDef>
+
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs</xpath>
+        <value>
+
+	<ThingCategoryDef>
+		<defName>AmmoTaser</defName>
+		<label>taser cartridge</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Taser</defName>
+		<label>taser cartridge</label>
+		<ammoTypes>
+			<Ammo_Taser>Bullet_Taser</Ammo_Taser>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
+		<defName>Ammo_Taser</defName>
+		<label>taser cartridge</label>
+		<description>A nitrogen powered cartridge, firing a pair of thin wires to deliver an incapacitating shock to foes.</description>    
+		<graphicData>
+			<texPath>Things/Ammo/PlasmaCell/Pistol</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.85</MarketValue>
+			<Mass>0.05</Mass>
+			<Bulk>0.05</Bulk>      
+		</statBases>
+		<ammoClass>ElectroSlug</ammoClass>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
+		<defName>Bullet_Taser</defName>
+		<label>taser prong</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>2</damageAmountBase>
+      <damageDef>Stab</damageDef>
+			<secondaryDamage>
+				<li>
+				  <def>Stun</def>
+				  <amount>32</amount>
+				  <chance>0.8</chance>
+				</li>
+			</secondaryDamage>                 
+			<armorPenetrationSharp>0.25</armorPenetrationSharp>
+			<armorPenetrationBlunt>3</armorPenetrationBlunt>
+			<speed>18</speed>
+			<dropsCasings>false</dropsCasings>      
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45ACP_FMJ</defName>
+		<label>make .45 ACP (FMJ) cartridge x500</label>
+		<description>Craft 500 .45 ACP (FMJ) cartridges.</description>
+		<jobString>Making .45 ACP (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Taser>500</Ammo_Taser>
+		</products>
+		<workAmount>2200</workAmount>
+	</RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_Taser</defName>
+    <label>make taser cartridge x50</label>
+    <description>Craft 50 taser cartridges.</description>
+    <jobString>Making taser cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>15</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>      
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+        <li>Chemfuel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+    	<Ammo_Taser>50</Ammo_Taser>
+    </products>
+    <workAmount>2400</workAmount>
+  </RecipeDef>
+
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
@@ -44,7 +44,7 @@
 			<Mass>0.05</Mass>
 			<Bulk>0.05</Bulk>      
 		</statBases>
-		<ammoClass>ElectroSlug</ammoClass>
+		<ammoClass>Taser</ammoClass>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -53,16 +53,9 @@
 		<defName>Bullet_Taser</defName>
 		<label>taser prong</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>2</damageAmountBase>
-      <damageDef>Stab</damageDef>
-			<secondaryDamage>
-				<li>
-				  <def>Stun</def>
-				  <amount>32</amount>
-				  <chance>0.8</chance>
-				</li>
-			</secondaryDamage>                 
-			<armorPenetrationSharp>0.25</armorPenetrationSharp>
+			<damageAmountBase>6</damageAmountBase>
+      		<damageDef>Taser</damageDef>               
+			<armorPenetrationSharp>0.65</armorPenetrationSharp>
 			<armorPenetrationBlunt>3</armorPenetrationBlunt>
 			<speed>18</speed>
 			<dropsCasings>false</dropsCasings>      
@@ -70,32 +63,6 @@
 	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
-
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_45ACP_FMJ</defName>
-		<label>make .45 ACP (FMJ) cartridge x500</label>
-		<description>Craft 500 .45 ACP (FMJ) cartridges.</description>
-		<jobString>Making .45 ACP (FMJ) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_Taser>500</Ammo_Taser>
-		</products>
-		<workAmount>2200</workAmount>
-	</RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_Taser</defName>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/TranquilizerDart.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/TranquilizerDart.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs</xpath>
+        <value>
+
+		<!-- ==================== AmmoSet ========================== -->
+
+		<CombatExtended.AmmoSetDef>
+			<defName>AmmoSet_DartRifle_NonLethal</defName>
+			<label>dart rifle</label>
+			<ammoTypes>
+				<Ammo_DartRifle_NL>Bullet_DartRifle_NL</Ammo_DartRifle_NL>
+			</ammoTypes>
+		</CombatExtended.AmmoSetDef>
+
+		<!-- ==================== Ammo ========================== -->	
+
+		<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+			<defName>Ammo_DartRifle_NL</defName>
+			<label>dart rifle cartridge</label>
+			<graphicData>
+				<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+				<graphicClass>Graphic_StackCount</graphicClass>
+			</graphicData>
+			<statBases>
+				<MarketValue>0.85</MarketValue>
+			</statBases>
+			<ammoClass>TranqNonLethal</ammoClass>
+			<cookOffProjectile>Bullet_DartRifle_NL</cookOffProjectile>
+		</ThingDef>
+
+		<!-- ================== Projectiles ================== -->
+
+		<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+			<defName>Bullet_DartRifle_NL</defName>
+			<label>tranquilizer dart</label>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>VWE_AnestheticDart</damageDef>
+				<damageAmountBase>2</damageAmountBase>
+				<armorPenetrationSharp>1.85</armorPenetrationSharp>
+				<armorPenetrationBlunt>12.85</armorPenetrationBlunt>
+				<speed>30</speed>
+			</projectile>
+		</ThingDef>
+
+		<!-- ==================== Recipes ========================== -->
+
+		<RecipeDef ParentName="AmmoRecipeBase">
+			<defName>MakeAmmo_DartRifle_NL</defName>
+			<label>make dart rifle cartridge x200</label>
+			<description>Craft 200 dart rifle cartridges.</description>
+			<jobString>Making dart rifle cartridges.</jobString>
+			<ingredients>
+				<li>
+					<filter>
+						<thingDefs>
+							<li>Steel</li>
+						</thingDefs>
+					</filter>
+					<count>18</count>
+				</li>
+				<li>
+					<filter>
+						<thingDefs>
+							<li>Neutroamine</li>
+						</thingDefs>
+					</filter>
+					<count>12</count>
+				</li>
+			</ingredients>
+			<fixedIngredientFilter>
+				<thingDefs>
+					<li>Steel</li>
+					<li>Neutroamine</li>
+				</thingDefs>
+			</fixedIngredientFilter>
+			<products>
+				<Ammo_DartRifle_NL>200</Ammo_DartRifle_NL>
+			</products>
+			<workAmount>3800</workAmount>
+		</RecipeDef>
+
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -78,30 +78,28 @@
   </li>
 
   <!-- ========== PDW ========== -->
-  <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
     <defName>VWE_Gun_PDW</defName>
     <statBases>
-      <WorkToMake>13000</WorkToMake>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.12</ShotSpread>
-      <SwayFactor>0.93</SwayFactor>
-      <Bulk>6.67</Bulk>
-      <Mass>2.6</Mass>
+      <Mass>2.60</Mass>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SightsEfficiency>1.</SightsEfficiency>
+      <ShotSpread>0.12</ShotSpread>
+      <SwayFactor>0.77</SwayFactor>
+      <Bulk>5.05</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>1.05</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>True</hasStandardCommand>
+      <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
       <warmupTime>0.4</warmupTime>
-      <range>15</range>
+      <range>25</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
       <soundCast>Shot_HeavySMG</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
-      <recoilPattern>Regular</recoilPattern>
-      <recoilAmount>1.14</recoilAmount>
     </Properties>
     <AmmoUser>
       <magazineSize>50</magazineSize>
@@ -109,14 +107,13 @@
       <ammoSet>AmmoSet_FN57x28mm</ammoSet>
     </AmmoUser>
     <FireModes>
-      <aiUseBurstMode>True</aiUseBurstMode>
-      <aiAimMode>AimedShot</aiAimMode>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
       <aimedBurstShotCount>3</aimedBurstShotCount>
     </FireModes>
     <weaponTags>
       <li>IndustrialGunAdvanced</li>
       <li>CE_Sidearm</li>
-      <li>CE_OneHandedWeapon</li>
     </weaponTags>
     <!-- Required research rework -->
     <researchPrerequisite>BlowbackOperation</researchPrerequisite>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
@@ -1,0 +1,236 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Weapons Expanded - Tribal</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+    <!-- Heavy Club -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_HeavyClub"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>4</power>
+            <cooldownTime>1.78</cooldownTime>
+            <armorPenetrationBlunt>1</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>head</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>11</power>
+            <cooldownTime>3.48</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>4</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_HeavyClub"]/statBases</xpath>
+      <value>
+            <Bulk>4</Bulk>
+            <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_HeavyClub"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.67</MeleeCritChance>
+          <MeleeParryChance>0.15</MeleeParryChance>
+          <MeleeDodgeChance>0.2</MeleeDodgeChance>	
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+    <!-- Light Club -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>4</power>
+            <cooldownTime>1.78</cooldownTime>
+            <armorPenetrationBlunt>1</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>head</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>11</power>
+            <cooldownTime>3.48</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>4</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]/statBases</xpath>
+      <value>
+            <Bulk>4</Bulk>
+            <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.67</MeleeCritChance>
+          <MeleeParryChance>0.15</MeleeParryChance>
+          <MeleeDodgeChance>0.2</MeleeDodgeChance>	
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]/weaponTags</xpath>
+      <value>
+        <li>CE_OneHandedWeapon</li>
+      </value>
+    </li>
+
+    <!-- === Tribal Axe === -->
+
+    <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/tools</xpath>
+        <value>
+        <tools>
+            <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+                <li>Poke</li>
+            </capacities>
+            <power>3</power>
+            <cooldownTime>1.59</cooldownTime>
+            <chanceFactor>0.10</chanceFactor>
+            <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+            <label>edge</label>
+            <capacities>
+                <li>Cut</li>
+            </capacities>
+            <power>17</power>
+            <cooldownTime>3.52</cooldownTime>
+            <chanceFactor>0.30</chanceFactor>
+            <armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.68</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+            </li>
+        </tools>
+        </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/statBases</xpath>
+        <value>
+        <Bulk>4</Bulk>
+        <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+        </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]</xpath>
+        <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.10</MeleeCritChance>
+          <MeleeParryChance>0.15</MeleeParryChance>
+          <MeleeDodgeChance>0.20</MeleeDodgeChance>
+        </equippedStatOffsets>  
+        </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/weaponTags</xpath>
+        <value>
+            <li>CE_OneHandedWeapon</li>
+        </value>
+    </li>
+
+    <!-- === Shiv === -->
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shiv"]/tools</xpath>
+		<value>
+        <tools>
+            <li Class="CombatExtended.ToolCE">
+                <label>handle</label>
+                <capacities>
+                    <li>Blunt</li>
+                </capacities>
+                <power>4</power>
+                <cooldownTime>1.2</cooldownTime>
+                <armorPenetration>0.071</armorPenetration>
+                <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+                <label>point</label>
+                <capacities>
+                    <li>Stab</li>
+                </capacities>
+                <power>9.5</power>
+                <cooldownTime>1.2</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetration>0.208</armorPenetration>
+                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+            </li>
+        </tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shiv"]/statBases</xpath>
+		<value>
+      		<Bulk>0.15</Bulk>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shiv"]</xpath>
+		<value>
+        <equippedStatOffsets>
+            <MeleeCritChance>0.1</MeleeCritChance>
+            <MeleeParryChance>0.1</MeleeParryChance>
+            <MeleeDodgeChance>0.05</MeleeDodgeChance>
+        </equippedStatOffsets>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shiv"]/weaponTags</xpath>
+		<value>
+            <li>CE_OneHandedWeapon</li>
+		</value>
+	</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
@@ -19,9 +19,9 @@
             <capacities>
               <li>Poke</li>
             </capacities>
-            <power>4</power>
-            <cooldownTime>1.78</cooldownTime>
-            <armorPenetrationBlunt>1</armorPenetrationBlunt>
+            <power>5</power>
+            <cooldownTime>1.93</cooldownTime>
+            <armorPenetrationBlunt>1.375</armorPenetrationBlunt>
             <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
           </li>
           <li Class="CombatExtended.ToolCE">
@@ -29,10 +29,10 @@
             <capacities>
               <li>Blunt</li>
             </capacities>
-            <power>11</power>
-            <cooldownTime>3.48</cooldownTime>
+            <power>14</power>
+            <cooldownTime>4.49</cooldownTime>
             <chanceFactor>1.33</chanceFactor>
-            <armorPenetrationBlunt>4</armorPenetrationBlunt>
+            <armorPenetrationBlunt>5.5</armorPenetrationBlunt>
             <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
           </li>
         </tools>
@@ -42,8 +42,8 @@
     <li Class="PatchOperationAdd">
       <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_HeavyClub"]/statBases</xpath>
       <value>
-            <Bulk>4</Bulk>
-            <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+            <Bulk>6</Bulk>
+            <MeleeCounterParryBonus>0.53</MeleeCounterParryBonus>
       </value>
     </li>
 
@@ -51,9 +51,9 @@
       <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_HeavyClub"]</xpath>
       <value>
         <equippedStatOffsets>
-          <MeleeCritChance>0.67</MeleeCritChance>
-          <MeleeParryChance>0.15</MeleeParryChance>
-          <MeleeDodgeChance>0.2</MeleeDodgeChance>	
+          <MeleeCritChance>1.38</MeleeCritChance>
+          <MeleeParryChance>0.4</MeleeParryChance>
+          <MeleeDodgeChance>0.37</MeleeDodgeChance>	
         </equippedStatOffsets>
       </value>
     </li>
@@ -79,10 +79,10 @@
             <capacities>
               <li>Blunt</li>
             </capacities>
-            <power>11</power>
-            <cooldownTime>3.48</cooldownTime>
+            <power>10</power>
+            <cooldownTime>3.01</cooldownTime>
             <chanceFactor>1.33</chanceFactor>
-            <armorPenetrationBlunt>4</armorPenetrationBlunt>
+            <armorPenetrationBlunt>3.75</armorPenetrationBlunt>
             <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
           </li>
         </tools>
@@ -92,8 +92,8 @@
     <li Class="PatchOperationAdd">
       <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]/statBases</xpath>
       <value>
-            <Bulk>4</Bulk>
-            <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+            <Bulk>3.75</Bulk>
+            <MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
       </value>
     </li>
 
@@ -101,9 +101,9 @@
       <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_LightClub"]</xpath>
       <value>
         <equippedStatOffsets>
-          <MeleeCritChance>0.67</MeleeCritChance>
-          <MeleeParryChance>0.15</MeleeParryChance>
-          <MeleeDodgeChance>0.2</MeleeDodgeChance>	
+          <MeleeCritChance>0.58</MeleeCritChance>
+          <MeleeParryChance>0.14</MeleeParryChance>
+          <MeleeDodgeChance>0.16</MeleeDodgeChance>	
         </equippedStatOffsets>
       </value>
     </li>
@@ -141,7 +141,7 @@
             <cooldownTime>3.52</cooldownTime>
             <chanceFactor>0.30</chanceFactor>
             <armorPenetrationBlunt>2.025</armorPenetrationBlunt>
-            <armorPenetrationSharp>0.68</armorPenetrationSharp>
+            <armorPenetrationSharp>0.28</armorPenetrationSharp>
             <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
             </li>
         </tools>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -54,11 +54,11 @@
           </graphicData>	
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>RangedStab</damageDef>
-            <damageAmountBase>10</damageAmountBase>
+            <damageAmountBase>7</damageAmountBase>
             <flyOverhead>false</flyOverhead>
             <speed>14</speed>
-            <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
-            <armorPenetrationSharp>0.76</armorPenetrationSharp>
+            <armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.26</armorPenetrationSharp>
             <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
             <preExplosionSpawnThingDef>VWE_Throwing_Shards</preExplosionSpawnThingDef>
           </projectile>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -305,6 +305,10 @@
 		</weaponTags>
 	</li>
 
+  <li Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]/recipeMaker</xpath>
+  </li>
+
   <li Class="PatchOperationAdd">
     <xpath>Defs</xpath>
     <value>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -1,0 +1,323 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Weapons Expanded - Tribal</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+    <!-- ========== Sling ========== -->
+    <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+      <defName>VWE_Sling</defName>
+      <statBases>
+        <SightsEfficiency>0.6</SightsEfficiency>
+        <ShotSpread>1</ShotSpread>
+        <SwayFactor>2</SwayFactor>
+        <Bulk>0.8</Bulk>
+        <RangedWeapon_Cooldown>3.2</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>True</hasStandardCommand>
+        <defaultProjectile>Projectile_SlingBullet_Stone</defaultProjectile>
+        <warmupTime>2.4</warmupTime>
+        <range>32</range>
+        <soundCast>Bow_Small</soundCast>
+        <muzzleFlashScale>9</muzzleFlashScale>
+      </Properties>
+      <AmmoUser>
+        <reloadTime>3.8</reloadTime>
+        <ammoSet>AmmoSet_SlingBullet</ammoSet>
+      </AmmoUser>
+      <FireModes>
+        <aiAimMode>AimedShot</aiAimMode>
+      </FireModes>
+    </li>
+
+    <li Class="PatchOperationRemove">
+      <xpath>/Defs/ThingDef[defName="VWE_Sling"]/tools</xpath>
+    </li>
+
+    <!-- === Throwing Shard === -->
+    <!-- == Projectile == -->
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VWE_FlyingShard"]/projectile</xpath>
+      <value>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+          <damageDef>RangedStab</damageDef>
+          <damageAmountBase>10</damageAmountBase>
+          <flyOverhead>false</flyOverhead>
+          <speed>14</speed>
+          <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+          <armorPenetrationSharp>0.76</armorPenetrationSharp>
+          <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
+          <preExplosionSpawnThingDef>VWE_Throwing_Shards</preExplosionSpawnThingDef>
+        </projectile>
+      </value>
+    </li>
+
+    <!-- == Weapon == -->
+    <li Class="PatchOperationAttributeSet">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+      <attribute>ParentName</attribute>
+      <value>BaseWeapon</value>
+    </li>
+    
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath> 
+      <value>
+        <thingCategories>
+          <li>WeaponsRanged</li>
+        </thingCategories>
+      </value>
+    </li>
+
+    <li Class="PatchOperationRemove">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/recipeMaker</xpath>
+    </li>
+
+    <li Class="PatchOperationRemove">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/costStuffCount</xpath>
+    </li>
+
+    <li Class="PatchOperationRemove">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/stuffCategories</xpath>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/graphicData</xpath>
+      <value>
+        <color>(105,105,105)</color>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+      <value>
+        <thingClass>CombatExtended.AmmoThing</thingClass>
+        <stackLimit>75</stackLimit>
+        <resourceReadoutPriority>First</resourceReadoutPriority>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAttributeSet">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+      <attribute>Class</attribute>
+      <value>CombatExtended.AmmoDef</value>
+    </li>
+
+    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+      <defName>VWE_Throwing_Shards</defName>
+      <statBases>
+        <SightsEfficiency>0.45</SightsEfficiency>
+        <Bulk>0.35</Bulk>
+        <Mass>0.15</Mass>
+        <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <label>Throw shard</label>
+        <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+        <hasStandardCommand>True</hasStandardCommand>
+        <defaultProjectile>VWE_FlyingShard</defaultProjectile>
+        <warmupTime>1</warmupTime>
+        <range>9</range>
+        <soundCast>ThrowGrenade</soundCast>
+          <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+      </Properties>
+      <weaponTags>
+        <li>CE_OneHandedWeapon</li>
+      </weaponTags>
+    </li>
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>point</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>14</power>
+            <cooldownTime>1.2</cooldownTime>
+            <chanceFactor>1.88</chanceFactor>
+            <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.76</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <!-- == Recipe == -->
+    <li Class="PatchOperationAdd">
+      <xpath>Defs</xpath>
+      <value>
+        <RecipeDef ParentName="GrenadeRecipeBase">
+          <defName>MakeVWEThrowingShard</defName>
+          <label>make throwing shards x10</label>
+          <description>Craft 10 throwing shards.</description>
+          <jobString>Making throwing shards.</jobString>
+          <workAmount>800</workAmount>
+          <ingredients>
+            <li>
+              <filter>
+              <stuffCategoriesToAllow>
+                <li>Metallic</li>
+                <li>Stony</li>
+              </stuffCategoriesToAllow>              
+              </filter>
+              <count>20</count>
+            </li>
+          </ingredients>
+          <fixedIngredientFilter>
+            <stuffCategoriesToAllow>
+              <li>Metallic</li>
+              <li>Stony</li>
+            </stuffCategoriesToAllow>   
+          </fixedIngredientFilter>
+          <products>
+            <VWE_Throwing_Shards>10</VWE_Throwing_Shards>
+          </products>
+          <recipeUsers>
+            <li>CraftingSpot</li>
+          </recipeUsers>
+        </RecipeDef>
+      </value>
+    </li>
+
+	<!-- ========== Fire Bomb ========== -->
+
+	<!-- Projectile -->
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VWE_Proj_FireBomb"]/projectile</xpath>
+		<value>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<explosionRadius>0.5</explosionRadius>
+				<damageDef>Flame</damageDef>
+				<damageAmountBase>10</damageAmountBase>
+				<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+				<preExplosionSpawnChance>1</preExplosionSpawnChance>
+				<speed>5</speed>
+				<ai_IsIncendiary>true</ai_IsIncendiary>
+			</projectile>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_Proj_FireBomb"]</xpath>
+		<value>
+			<thingClass>CombatExtended.Projectile_FireTrail</thingClass>
+		</value>
+	</li>
+
+	<!-- Grenade -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]</xpath>
+		<value>
+			<thingClass>CombatExtended.AmmoThing</thingClass>
+			<stackLimit>50</stackLimit>
+			<resourceReadoutPriority>First</resourceReadoutPriority>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]/comps</xpath>
+		<value>
+		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+			<damageAmountBase>1</damageAmountBase>
+			<explosiveDamageType>Flame</explosiveDamageType>
+			<explosiveRadius>0.5</explosiveRadius>
+				<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+				<preExplosionSpawnChance>1</preExplosionSpawnChance>
+		  </li>
+		</value>
+	</li>
+
+	<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>VWE_Weapon_FireBomb</defName>
+		<statBases>
+			<Mass>0.6</Mass>
+			<Bulk>1.8</Bulk>
+			<MarketValue>3</MarketValue>
+			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.65</SightsEfficiency>
+		</statBases>
+		<Properties>
+			<label>throw firebomb</label>
+			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<range>10</range>
+			<minRange>3</minRange>
+			<warmupTime>1.8</warmupTime>
+			<noiseRadius>4</noiseRadius>
+			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+			<soundCast>ThrowMolotovCocktail</soundCast>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<defaultProjectile>VWE_Proj_FireBomb</defaultProjectile>
+			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+		</Properties>
+		<weaponTags>
+			<li>CE_OneHandedWeapon</li>
+		</weaponTags>
+	</li>
+
+  <li Class="PatchOperationAdd">
+    <xpath>Defs</xpath>
+    <value>
+      <RecipeDef ParentName="GrenadeRecipeBase">
+        <defName>MakeFireBomb</defName>
+        <label>make fire bombs x10</label>
+        <description>Craft 10 fire bombs.</description>
+        <jobString>Making fire bombs.</jobString>
+        <workAmount>1200</workAmount>
+        <recipeUsers>
+          <li>CraftingSpot</li>
+        </recipeUsers>
+        <ingredients>
+          <li>
+            <filter>
+              <thingDefs>
+                <li>Cloth</li>
+              </thingDefs>
+            </filter>
+            <count>20</count>
+          </li>
+          <li>
+            <filter>
+              <thingDefs>
+                <li>Chemfuel</li>
+              </thingDefs>
+            </filter>
+            <count>20</count>
+          </li>
+        </ingredients>
+        <fixedIngredientFilter>
+          <thingDefs>
+            <li>Cloth</li>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+          <VWE_Weapon_FireBomb>10</VWE_Weapon_FireBomb>
+        </products>
+      </RecipeDef>
+    </value>
+  </li>
+
+ 		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -43,22 +43,40 @@
     <!-- === Throwing Shard === -->
     <!-- == Projectile == -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_FlyingShard"]/projectile</xpath>
+      <xpath>/Defs/ThingDef[defName="VWE_FlyingShard"]</xpath>
       <value>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-          <damageDef>RangedStab</damageDef>
-          <damageAmountBase>10</damageAmountBase>
-          <flyOverhead>false</flyOverhead>
-          <speed>14</speed>
-          <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
-          <armorPenetrationSharp>0.76</armorPenetrationSharp>
-          <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
-          <preExplosionSpawnThingDef>VWE_Throwing_Shards</preExplosionSpawnThingDef>
-        </projectile>
+        <ThingDef ParentName="BasePilumProjectile">
+          <defName>VWE_FlyingShard</defName>
+          <label>shard</label>
+          <graphicData>
+            <texPath>Things/Projectile/ShardThrown</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+          </graphicData>	
+          <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageDef>RangedStab</damageDef>
+            <damageAmountBase>10</damageAmountBase>
+            <flyOverhead>false</flyOverhead>
+            <speed>14</speed>
+            <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.76</armorPenetrationSharp>
+            <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
+            <preExplosionSpawnThingDef>VWE_Throwing_Shards</preExplosionSpawnThingDef>
+          </projectile>
+        </ThingDef>
       </value>
     </li>
 
     <!-- == Weapon == -->
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/graphicData</xpath>
+      <value>
+        <graphicData>
+          <texPath>Things/Projectile/ShardThrown</texPath>
+          <graphicClass>Graphic_Single</graphicClass>
+        </graphicData>  
+      </value>
+    </li>
+
     <li Class="PatchOperationAttributeSet">
       <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
       <attribute>ParentName</attribute>
@@ -84,13 +102,6 @@
 
     <li Class="PatchOperationRemove">
       <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/stuffCategories</xpath>
-    </li>
-
-    <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/graphicData</xpath>
-      <value>
-        <color>(105,105,105)</color>
-      </value>
     </li>
 
     <li Class="PatchOperationAdd">
@@ -136,16 +147,26 @@
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>1</power>
+            <cooldownTime>1.26</cooldownTime>
+            <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
             <label>point</label>
             <capacities>
-              <li>Blunt</li>
+              <li>Stab</li>
             </capacities>
-            <power>14</power>
-            <cooldownTime>1.2</cooldownTime>
-            <chanceFactor>1.88</chanceFactor>
-            <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
-            <armorPenetrationSharp>0.76</armorPenetrationSharp>
-            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+            <power>10</power>
+            <cooldownTime>1.26</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.36</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
           </li>
         </tools>
       </value>
@@ -215,6 +236,16 @@
 	</li>
 
 	<!-- Grenade -->
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]/graphicData</xpath>
+		<value>
+      <graphicData>
+        <texPath>Things/Projectile/FireBombThrown</texPath>
+        <graphicClass>Graphic_Single</graphicClass>
+      </graphicData> 
+		</value>
+	</li>
 
 	<li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="VWE_Weapon_FireBomb"]</xpath>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -269,30 +269,30 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>VWE_Gun_LightSMG</defName>
 					<statBases>
-						<WorkToMake>13000</WorkToMake>
 						<Mass>3.50</Mass>
-						<Bulk>4.45</Bulk>
-						<SwayFactor>2.65</SwayFactor>
-						<ShotSpread>0.12</ShotSpread>
-						<SightsEfficiency>0.70</SightsEfficiency>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.12</ShotSpread>
+						<SwayFactor>3.30</SwayFactor>
+						<Bulk>4.70</Bulk>
+						<WorkToMake>13000</WorkToMake>
 					</statBases>
 					<costList>
 						<Steel>30</Steel>
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.39</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-						<hasStandardCommand>True</hasStandardCommand>
+						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>25</range>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-						<warmupTime>0.6</warmupTime>
-						<range>20</range>
 						<soundCast>VWE_Shot_LightSMG</soundCast>
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>1.39</recoilAmount>
 					</Properties>
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
@@ -300,14 +300,14 @@
 						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
 					</AmmoUser>
 					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>Snapshot</aiAimMode>
-						<aiUseBurstMode>True</aiUseBurstMode>
 						<aimedBurstShotCount>3</aimedBurstShotCount>
 					</FireModes>
 					<weaponTags>
 						<li>IndustrialGunAdvanced</li>
-						<li>CE_Sidearm</li>
-						<li>CE_OneHandedWeapon</li>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>CE_SMG</li>
 					</weaponTags>
 				</li>
 
@@ -610,7 +610,7 @@
 						<magazineSize>7</magazineSize>
 						<reloadTime>0.85</reloadTime>
 						<ammoSet>AmmoSet_44-40Winchester</ammoSet>
-            <reloadOneAtATime>true</reloadOneAtATime>
+						<reloadOneAtATime>true</reloadOneAtATime>
 					</AmmoUser>
 					<FireModes>
 						<aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -252,6 +252,16 @@
         </li>
 
         <!-- == Weapon == -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/graphicData</xpath>
+          <value>
+            <graphicData>
+              <texPath>Things/Projectile/KnifeThrown</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>  
+          </value>
+        </li>
+
         <li Class="PatchOperationAttributeSet">
           <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
           <attribute>ParentName</attribute>
@@ -279,12 +289,6 @@
           <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/stuffCategories</xpath>
         </li>
 
-        <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/graphicData</xpath>
-          <value>
-            <color>(105,105,105)</color>
-          </value>
-        </li>
 
         <li Class="PatchOperationAdd">
           <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
@@ -329,16 +333,26 @@
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
+                <label>handle</label>
+                <capacities>
+                  <li>Poke</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
                 <label>point</label>
                 <capacities>
-                  <li>Blunt</li>
+                  <li>Stab</li>
                 </capacities>
-                <power>14</power>
-                <cooldownTime>1.2</cooldownTime>
-                <chanceFactor>1.88</chanceFactor>
-                <armorPenetrationBlunt>0.55</armorPenetrationBlunt>
-                <armorPenetrationSharp>0.76</armorPenetrationSharp>
-                <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+                <power>11</power>
+                <cooldownTime>1.26</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.42</armorPenetrationSharp>
+                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
               </li>
             </tools>
           </value>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -149,7 +149,7 @@
             <Mass>1.25</Mass>
             <Bulk>3.90</Bulk>
             <SwayFactor>1.22</SwayFactor>
-            <ShotSpread>0.12</ShotSpread>
+            <ShotSpread>0.36</ShotSpread>
             <SightsEfficiency>0.7</SightsEfficiency>
             <RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
           </statBases>
@@ -201,7 +201,7 @@
             <Mass>4.8</Mass>
             <Bulk>14.9</Bulk>
             <SwayFactor>1.92</SwayFactor>
-            <ShotSpread>0.10</ShotSpread>
+            <ShotSpread>0.30</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>
             <RangedWeapon_Cooldown>1.35</RangedWeapon_Cooldown>
           </statBases>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -222,9 +222,12 @@ Vanilla Furniture Expanded - Production	|
 Vanilla Furniture Expanded -  Security |
 Vanilla Vehicles Expanded	|
 Vanilla Weapons Expanded |
+Vanilla Weapons Expanded - Frontier	|
 Vanilla Weapons Expanded - Grenades |
 Vanilla Weapons Expanded - Heavy Weapons |
-Vanilla Weapons Expanded Quickdraw	|
+Vanilla Weapons Expanded - Non-Lethal	|
+Vanilla Weapons Expanded - Quickdraw	|
+Vanilla Weapons Expanded - Tribal	|
 Vanilla-Friendly Animal Surgery	|
 Vanilla-Friendly Weapon Expansion	|
 Vanilla Storytellers Expanded - Perry Persistent |


### PR DESCRIPTION
- Add High Roller variants of projectiles, with a 10% chance to double damage.
- Patch Vanilla Weapons Expanded - Tribal (Complete).
- Patch Vanilla Weapons Expanded - Non-lethal (Complete).
- Increases the range of some SMGs.
- Swaps VFE - Security sentry gun from 7.62mm NATO to 5.56mm NATO.
- Adds some additional ammo categories that I felt were generic enough to be useful in the base mod, like rubber bullets and tear gas. 
- Adds damageDefs and injury Hediffs for a tasers to the base mod, since it's may be useful.
- Increases heavy crossbow damage slightly by using stats for a slightly faster bolt.
Closes #617 