### PR TITLE
Patch AA Mature Fleshbeast + BodyDef

### DIFF
--- a/Patches/Alpha Animals/BodyDefs/AlphaAnimals_CE_Patch_Bodies.xml
+++ b/Patches/Alpha Animals/BodyDefs/AlphaAnimals_CE_Patch_Bodies.xml
@@ -1170,6 +1170,80 @@
 					</match>
 					</li>						
 
+			<!-- ====== Tentacled EyelessQuadruped ====== -->
+
+					<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+					</li>
+
+					<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+					</li>
+					
+					<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+					</li>
+
+					<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="AA_TentacledQuadrupedEyeless"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+					</li>				
+
 			<!-- ====== ManTrap or FlyTrap or Sentientplant ====== -->
 
 					<li Class="PatchOperationConditional">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MatureFleshbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MatureFleshbeast.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Alpha Animals</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Quadruped</bodyShape>
+				</li>
+				</value>
+			</li>
+
+			<!-- Remove the 'Swallow Whole' attack, since it doesn't work in CE and insta-kills instead. -->
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/thingClass</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/statBases</xpath>
+				<value>
+				<MeleeDodgeChance>0.01</MeleeDodgeChance>
+				<MeleeCritChance>0.23</MeleeCritChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>35</power>
+							<cooldownTime>2.56</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>9</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>25</power>
+							<cooldownTime>3.51</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<armorPenetrationBlunt>12</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>					
+					</tools>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Patches the AA Mature Fleshbeast and its bodyDef, which are currently unpatched. Removes AA's "swallowed whole" mechanic, because it's bugged with CE's knockdown mechanic for animals, usually resulting in an insta-kill by destroying the victim's neck.