### PR TITLE
Make CarryBulk & CarryWeight on apparel affected by item quality

### DIFF
--- a/Defs/Stats/Stats_Pawns_Inventory.xml
+++ b/Defs/Stats/Stats_Pawns_Inventory.xml
@@ -11,6 +11,15 @@
     <formatString>{0} kg</formatString>
     <parts>
       <li Class="StatPart_Bodysize" />
+      <li Class="StatPart_Quality">
+        <factorAwful>0.8</factorAwful>
+        <factorPoor>0.9</factorPoor>
+        <factorNormal>1</factorNormal>
+        <factorGood>1</factorGood>
+        <factorExcellent>1.05</factorExcellent>
+        <factorMasterwork>1.15</factorMasterwork>
+        <factorLegendary>1.25</factorLegendary>
+      </li>      
     </parts>
     <capacityFactors>
       <li>
@@ -31,6 +40,15 @@
     <displayPriorityInCategory>10</displayPriorityInCategory>
     <parts>
       <li Class="StatPart_Bodysize" />
+      <li Class="StatPart_Quality">
+        <factorAwful>0.8</factorAwful>
+        <factorPoor>0.9</factorPoor>
+        <factorNormal>1</factorNormal>
+        <factorGood>1</factorGood>
+        <factorExcellent>1.10</factorExcellent>
+        <factorMasterwork>1.30</factorMasterwork>
+        <factorLegendary>1.45</factorLegendary>
+      </li>      
     </parts>
   </StatDef>
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- The CarryWeight and CarryBulk stats added by apparel are now affected by the quality of the piece of apparel.  

## Reasoning
This makes higher quality loadbearing gear like packs and tactical rigs (and other apparel that adds these things) more valuable and desirable, whereas there was previously no practical justification for higher quality loadbearing gear having a higher market value.

## Alternatives

- Do not add quality affect, leaving it as it currently stands.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
