### PR TITLE
Fix moyo nail ammo

### DIFF
--- a/Patches/Moyo from the depth/Ammo/Ammo_Moyo.xml
+++ b/Patches/Moyo from the depth/Ammo/Ammo_Moyo.xml
@@ -348,9 +348,9 @@
 						<label>Abyssteel Nail</label>
 						<description>Machined nails made of abyssteel.</description>
 						<statBases>
-							<Mass>1.02</Mass>
-							<Bulk>2.87</Bulk>
-							<MarketValue>27.22</MarketValue>
+							<Mass>0.02</Mass>
+							<Bulk>0.01</Bulk>
+							<MarketValue>0.05</MarketValue>
 						</statBases>
 						<tradeTags>
 							<li>CE_AutoEnableTrade</li>


### PR DESCRIPTION

## Changes

Fixed the nail ammo's bulk/mass/cost, as it's current ones were way too high from what I copied the ammo from previously.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
