### PR TITLE
Fix two-handed check on optimize-apparel patch

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
+++ b/Source/CombatExtended/Harmony/Harmony_JobGiver_OptimizeApparel.cs
@@ -15,7 +15,8 @@ namespace CombatExtended.HarmonyCE
     {
         internal static bool Prefix(Pawn pawn, Apparel ap, ref float __result)
         {
-            if (ap is Apparel_Shield && (pawn?.equipment?.Primary?.def?.weaponTags?.Contains(Apparel_Shield.OneHandedTag) ?? false))
+            var hasOneHandedWeapon = pawn?.equipment?.Primary?.def?.weaponTags?.Contains(Apparel_Shield.OneHandedTag) ?? false;
+            if (ap is Apparel_Shield && pawn?.equipment?.Primary != null && !hasOneHandedWeapon)
             {
                 __result = -1000f;
                 return false;


### PR DESCRIPTION
## Changes
- #584 has a bug in it, causing all weapons without tags as well as one-handed weapons to prevent equipping a shield, rather than just two-handed weapons as intended. This change should fix it to work correctly in all cases.