### PR TITLE
Lasers ready

### DIFF
--- a/Source/CombatExtended/CombatExtended/Lasers/LaserBeamGraphicCE.cs
+++ b/Source/CombatExtended/CombatExtended/Lasers/LaserBeamGraphicCE.cs
@@ -7,6 +7,7 @@ using Verse;
 
 namespace CombatExtended.Lasers
 {
+    [StaticConstructorOnStartup]
     public class LaserBeamGraphicCE :Thing
     {
         public LaserBeamDefCE projDef;

--- a/Source/CombatExtended/CombatExtended/Lasers/LaserBeamGraphicCE.cs
+++ b/Source/CombatExtended/CombatExtended/Lasers/LaserBeamGraphicCE.cs
@@ -254,8 +254,14 @@ namespace CombatExtended.Lasers
             GenExplosion.DoExplosion(center, map2, explosionRadius, damageDef, launcher, damageAmount, 0f, soundExplode, equipmentDef, def, null, postExplosionSpawnThingDef, postExplosionSpawnChance, postExplosionSpawnThingCount, this.def.projectile.applyDamageToExplosionCellsNeighbors, preExplosionSpawnThingDef, this.def.projectile.preExplosionSpawnChance, this.def.projectile.preExplosionSpawnThingCount, this.def.projectile.explosionChanceToStartFire, this.def.projectile.explosionDamageFalloff);
         }
 
-        private static readonly Material BeamMat = MaterialPool.MatFrom("Other/OrbitalBeam", ShaderDatabase.MoteGlow, MapMaterialRenderQueues.OrbitalBeam);
-        private static readonly Material BeamEndMat = MaterialPool.MatFrom("Other/OrbitalBeamEnd", ShaderDatabase.MoteGlow, MapMaterialRenderQueues.OrbitalBeam);
-        private static readonly MaterialPropertyBlock MatPropertyBlock = new MaterialPropertyBlock();
+	static LaserBeamGraphicCE() {
+	     BeamMat = MaterialPool.MatFrom("Other/OrbitalBeam", ShaderDatabase.MoteGlow, MapMaterialRenderQueues.OrbitalBeam);
+	     BeamEndMat  = MaterialPool.MatFrom("Other/OrbitalBeamEnd", ShaderDatabase.MoteGlow, MapMaterialRenderQueues.OrbitalBeam);
+	     MatPropertyBlock = new MaterialPropertyBlock();
+	}
+	
+        private static Material BeamMat;
+        private static Material BeamEndMat;
+        private static MaterialPropertyBlock MatPropertyBlock;
     }
 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -390,10 +390,12 @@ namespace CombatExtended
         }
         #endregion
 
-        public virtual void RayCast(Thing launcher, VerbProperties verbProps, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, float spreadDegrees = 0f, Thing equipment = null) {
-            const float magicLaserDamageConstant = 341.6478229576042f;
-	    const float aperatureSize = 0.03f;
-            ProjectilePropertiesCE pprops = def.projectile as ProjectilePropertiesCE;
+	public virtual void RayCast(Thing launcher, VerbProperties verbProps, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, float spreadDegrees = 0f, float aperatureSize = 0.03f, Thing equipment = null) {
+
+	    float magicSpreadFactor = Mathf.Sin(0.06f / 2 * Mathf.Deg2Rad) + aperatureSize;
+            float magicLaserDamageConstant = 1 / (magicSpreadFactor * magicSpreadFactor * 3.14159f);
+
+	    ProjectilePropertiesCE pprops = def.projectile as ProjectilePropertiesCE;
             shotRotation = Mathf.Deg2Rad * shotRotation + (float)(3.14159/2.0f);
             Vector3 direction = new Vector3(Mathf.Cos(shotRotation) * Mathf.Cos(shotAngle), Mathf.Sin(shotAngle), Mathf.Sin(shotRotation) * Mathf.Cos(shotAngle));
             Vector3 origin3 = new Vector3(origin.x, shotHeight, origin.y);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -413,7 +413,10 @@ namespace CombatExtended
 	    var it_bounds = CE_Utility.GetBoundsFor(intendedTarget);
             for (int i=1; i < verbProps.range; i++) {
                 float spreadArea = (i * spreadRadius + 0.01f) * (i * spreadRadius + 0.01f) * 3.14159f;
-                lbce.DamageModifier = 1 / (magicLaserDamageConstant * spreadArea);
+		if (pprops.damageFalloff)
+		{
+		  lbce.DamageModifier = 1 / (magicLaserDamageConstant * spreadArea);
+		}
                 
                 Vector3 tp = ray.GetPoint(i);
                 if (tp.y > CollisionVertical.WallCollisionHeight) {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -390,12 +390,12 @@ namespace CombatExtended
         }
         #endregion
 
-	public virtual void RayCast(Thing launcher, VerbProperties verbProps, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, float spreadDegrees = 0f, float aperatureSize = 0.03f, Thing equipment = null) {
+        public virtual void RayCast(Thing launcher, VerbProperties verbProps, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, float spreadDegrees = 0f, float aperatureSize = 0.03f, Thing equipment = null) {
 
-	    float magicSpreadFactor = Mathf.Sin(0.06f / 2 * Mathf.Deg2Rad) + aperatureSize;
+            float magicSpreadFactor = Mathf.Sin(0.06f / 2 * Mathf.Deg2Rad) + aperatureSize;
             float magicLaserDamageConstant = 1 / (magicSpreadFactor * magicSpreadFactor * 3.14159f);
 
-	    ProjectilePropertiesCE pprops = def.projectile as ProjectilePropertiesCE;
+            ProjectilePropertiesCE pprops = def.projectile as ProjectilePropertiesCE;
             shotRotation = Mathf.Deg2Rad * shotRotation + (float)(3.14159/2.0f);
             Vector3 direction = new Vector3(Mathf.Cos(shotRotation) * Mathf.Cos(shotAngle), Mathf.Sin(shotAngle), Mathf.Sin(shotRotation) * Mathf.Cos(shotAngle));
             Vector3 origin3 = new Vector3(origin.x, shotHeight, origin.y);
@@ -413,13 +413,13 @@ namespace CombatExtended
 
             LaserGunDef defWeapon = equipmentDef as LaserGunDef;
             Vector3 muzzle = ray.GetPoint( (defWeapon == null ? 0.9f : defWeapon.barrelLength) );
-	    var it_bounds = CE_Utility.GetBoundsFor(intendedTarget);
+            var it_bounds = CE_Utility.GetBoundsFor(intendedTarget);
             for (int i=1; i < verbProps.range; i++) {
                 float spreadArea = (i * spreadRadius + aperatureSize) * (i * spreadRadius + aperatureSize) * 3.14159f;
-		if (pprops.damageFalloff)
-		{
-		  lbce.DamageModifier = 1 / (magicLaserDamageConstant * spreadArea);
-		}
+                if (pprops.damageFalloff)
+                {
+                  lbce.DamageModifier = 1 / (magicLaserDamageConstant * spreadArea);
+                }
                 
                 Vector3 tp = ray.GetPoint(i);
                 if (tp.y > CollisionVertical.WallCollisionHeight) {
@@ -872,20 +872,20 @@ namespace CombatExtended
                 ambientSustainer.Maintain();
             }
 
-	    if (def.HasModExtension<TrailerProjectileExtension>())
-	    {
-		var trailer = def.GetModExtension<TrailerProjectileExtension>();
-		if (trailer != null)
-		{
-		    if (ticksToImpact % trailer.trailerMoteInterval == 0)
-		    {
-			for (int i = 0; i < trailer.motesThrown; i++)
+            if (def.HasModExtension<TrailerProjectileExtension>())
+            {
+                var trailer = def.GetModExtension<TrailerProjectileExtension>();
+                if (trailer != null)
+                {
+                    if (ticksToImpact % trailer.trailerMoteInterval == 0)
+                    {
+                        for (int i = 0; i < trailer.motesThrown; i++)
                             {
                                 TrailThrower.ThrowSmoke(DrawPos, trailer.trailMoteSize, Map, trailer.trailMoteDef);
                             }
-		    }
-		}
-	    }
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -976,15 +976,15 @@ namespace CombatExtended
 
         protected virtual void Impact(Thing hitThing)
         {
-	    if (def.HasModExtension<EffectProjectileExtension>())
-	    {
-		def.GetModExtension<EffectProjectileExtension>()?.ThrowMote(ExactPosition,
-									    Map,
-									    def.projectile.damageDef.explosionCellMote,
-									    def.projectile.damageDef.explosionColorCenter,
-									    def.projectile.damageDef.soundExplosion,
-									    hitThing);
-	    }
+            if (def.HasModExtension<EffectProjectileExtension>())
+            {
+                def.GetModExtension<EffectProjectileExtension>()?.ThrowMote(ExactPosition,
+                                                                            Map,
+                                                                            def.projectile.damageDef.explosionCellMote,
+                                                                            def.projectile.damageDef.explosionColorCenter,
+                                                                            def.projectile.damageDef.soundExplosion,
+                                                                            hitThing);
+            }
             var ignoredThings = new List<Thing>();
 
             //Spawn things from preExplosionSpawnThingDef != null

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -391,7 +391,8 @@ namespace CombatExtended
         #endregion
 
         public virtual void RayCast(Thing launcher, VerbProperties verbProps, Vector2 origin, float shotAngle, float shotRotation, float shotHeight = 0f, float shotSpeed = -1f, float spreadDegrees = 0f, Thing equipment = null) {
-            const float magicLaserDamageConstant = 1789.255934470907f;
+            const float magicLaserDamageConstant = 341.6478229576042f;
+	    const float aperatureSize = 0.03f;
             ProjectilePropertiesCE pprops = def.projectile as ProjectilePropertiesCE;
             shotRotation = Mathf.Deg2Rad * shotRotation + (float)(3.14159/2.0f);
             Vector3 direction = new Vector3(Mathf.Cos(shotRotation) * Mathf.Cos(shotAngle), Mathf.Sin(shotAngle), Mathf.Sin(shotRotation) * Mathf.Cos(shotAngle));
@@ -412,7 +413,7 @@ namespace CombatExtended
             Vector3 muzzle = ray.GetPoint( (defWeapon == null ? 0.9f : defWeapon.barrelLength) );
 	    var it_bounds = CE_Utility.GetBoundsFor(intendedTarget);
             for (int i=1; i < verbProps.range; i++) {
-                float spreadArea = (i * spreadRadius + 0.01f) * (i * spreadRadius + 0.01f) * 3.14159f;
+                float spreadArea = (i * spreadRadius + aperatureSize) * (i * spreadRadius + aperatureSize) * 3.14159f;
 		if (pprops.damageFalloff)
 		{
 		  lbce.DamageModifier = 1 / (magicLaserDamageConstant * spreadArea);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -19,6 +19,7 @@ namespace CombatExtended
         public string casingMoteDefname = "Mote_EmptyCasing";
         public float gravityFactor = 1;
         public bool isInstant = false;
+        public bool damageFalloff = true; // Damage falloff for *instant* projectiles.
         public float armorPenetrationSharp;
         public float armorPenetrationBlunt;
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -597,7 +597,8 @@ namespace CombatExtended
             if (Projectile.projectile is ProjectilePropertiesCE pprop) {
                 instant = pprop.isInstant;
                 spreadDegrees = (EquipmentSource?.GetStatValue(StatDef.Named("ShotSpread")) ?? 0) * pprop.spreadMult;
-		aperatureSize = (EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize")) ?? 0.03f);
+		aperatureSize = 0.03f; //(EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize"))? ?? 0.03f);
+		
             }
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -592,10 +592,12 @@ namespace CombatExtended
             bool instant = false;
 
             float spreadDegrees = 0;
+	    float aperatureSize = 0;
 
             if (Projectile.projectile is ProjectilePropertiesCE pprop) {
                 instant = pprop.isInstant;
                 spreadDegrees = (EquipmentSource?.GetStatValue(StatDef.Named("ShotSpread")) ?? 0) * pprop.spreadMult;
+		aperatureSize = (EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize")) ?? 0.03f);
             }
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);
@@ -627,6 +629,7 @@ namespace CombatExtended
                                        shotHeight,
                                        ShotSpeed,
                                        spreadDegrees,
+				       aperatureSize,
                                        EquipmentSource);
 
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -309,7 +309,7 @@ namespace CombatExtended
                     }
                     targetHeight = VerbPropsCE.ignorePartialLoSBlocker ? 0 : targetRange.Average;
                 }
-                if (projectilePropsCE.isInstant && projectilePropsCE.damageFalloff) {
+                if (projectilePropsCE.isInstant) {
 		    angleRadians += Mathf.Atan2(targetHeight - ShotHeight, (newTargetLoc - sourceLoc).magnitude);
                 }
                 else {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -597,8 +597,7 @@ namespace CombatExtended
             if (Projectile.projectile is ProjectilePropertiesCE pprop) {
                 instant = pprop.isInstant;
                 spreadDegrees = (EquipmentSource?.GetStatValue(StatDef.Named("ShotSpread")) ?? 0) * pprop.spreadMult;
-		aperatureSize = 0.03f; //(EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize"))? ?? 0.03f);
-		
+                aperatureSize = 0.03f; //(EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize"))? ?? 0.03f);
             }
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);
@@ -630,7 +629,7 @@ namespace CombatExtended
                                        shotHeight,
                                        ShotSpeed,
                                        spreadDegrees,
-				       aperatureSize,
+                                       aperatureSize,
                                        EquipmentSource);
 
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -592,7 +592,7 @@ namespace CombatExtended
             bool instant = false;
 
             float spreadDegrees = 0;
-	    float aperatureSize = 0;
+            float aperatureSize = 0;
 
             if (Projectile.projectile is ProjectilePropertiesCE pprop) {
                 instant = pprop.isInstant;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -309,7 +309,7 @@ namespace CombatExtended
                     }
                     targetHeight = VerbPropsCE.ignorePartialLoSBlocker ? 0 : targetRange.Average;
                 }
-                if (projectilePropsCE.isInstant) {
+                if (projectilePropsCE.isInstant && projectilePropsCE.damageFalloff) {
 		    angleRadians += Mathf.Atan2(targetHeight - ShotHeight, (newTargetLoc - sourceLoc).magnitude);
                 }
                 else {
@@ -320,7 +320,7 @@ namespace CombatExtended
             // ----------------------------------- STEP 4: Mechanical variation
 
             // Get shotvariation, in angle Vector2 RADIANS.
-            Vector2 spreadVec = projectilePropsCE.isInstant? new Vector2(0,0) : report.GetRandSpreadVec() ;
+            Vector2 spreadVec = (projectilePropsCE.isInstant && projectilePropsCE.damageFalloff)? new Vector2(0,0) : report.GetRandSpreadVec() ;
             // ----------------------------------- STEP 5: Finalization
 
             var w = (newTargetLoc - sourceLoc);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -597,7 +597,7 @@ namespace CombatExtended
             if (Projectile.projectile is ProjectilePropertiesCE pprop) {
                 instant = pprop.isInstant;
                 spreadDegrees = (EquipmentSource?.GetStatValue(StatDef.Named("ShotSpread")) ?? 0) * pprop.spreadMult;
-                aperatureSize = 0.03f; //(EquipmentSource?.GetStatValue(StatDef.Named("AperatureSize"))? ?? 0.03f);
+                aperatureSize = 0.03f;
             }
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);


### PR DESCRIPTION

## Changes

Toggling damageFalloff property on `ProjectilePropertiesCE` disables damage falloff for lasers and re-enables shots deviating


## Reasoning

Coilguns have 0 damage falloff, but shouldn't fire from dead-center for every shot.

## Alternatives

Move to a new property to control shot spread vs shot variance. - Can't be done in time for this release, will be needed to support instant-projectile "scatter guns".

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
