### PR TITLE
Fix error when unloading items during a save/load cycle

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
@@ -21,7 +21,13 @@ namespace CombatExtended
 		
 		private int amountToDrop;
 
-        public override bool TryMakePreToilReservations(bool errorOnFailed)
+		public override void ExposeData()
+		{
+			base.ExposeData();
+			Scribe_Values.Look(ref amountToDrop, "amountToDrop", -1, false);
+		}
+
+		public override bool TryMakePreToilReservations(bool errorOnFailed)
         {
             return true;
         }


### PR DESCRIPTION
## Changes
- Fixes the `<PawnName> tried to place hauled thing in cell but is not hauling anything.` when pawns try to finish a caravan unloading job that had been started before the save file was loaded.
