### PR TITLE
'Anty The war ant' Apparel patch error fix

### DIFF
--- a/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
+++ b/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
@@ -112,9 +112,7 @@
 			<!--Composite Helmet-->
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="AT_AP_Head_A" or
-				defName="AT_AP_Head_B"
-				]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_Head_A"]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
@@ -122,27 +120,21 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AT_AP_Head_A" or
-				defName="AT_AP_Head_B"
-				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_Head_A"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AT_AP_Head_A" or
-				defName="AT_AP_Head_B"
-				]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_Head_A"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AT_AP_Head_A" or
-				defName="AT_AP_Head_B"
-				]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_Head_A"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
@@ -220,9 +212,6 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="AT_AP_Flakvest"]/equippedStatOffsets/MoveSpeed</xpath>
-			</li>
 			
 			<!--Flak Plate-->
 			
@@ -262,16 +251,12 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="AT_AP_Additionalarmorplate_A"]/equippedStatOffsets/MoveSpeed</xpath>
-			</li>
 			
 			<!--Cloaks-->
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="AT_AP_CO_A" or
-				defName="AT_AP_CO_B" or
-				defName="AT_AP_SH_A"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_SH_A" or
+				defName="AT_AP_CO_A"]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
@@ -279,22 +264,22 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AT_AP_CO_A" or
-				defName="AT_AP_CO_B" or
-				defName="AT_AP_SH_A"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_SH_A" or
+				defName="AT_AP_CO_A"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AT_AP_CO_A" or
-				defName="AT_AP_CO_B" or
-				defName="AT_AP_SH_A"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AT_AP_SH_A" or
+				defName="AT_AP_CO_A"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
 				</value>
 			</li>
+			
+			<!--power-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="AT_AP_Power_A"]/statBases/Mass</xpath>


### PR DESCRIPTION
## Changes
-'Anty The war ant' Apparel patch error fix
-Composite Helmet
-Flak Vest
-Flak Plate
-Cloaks

## Reasoning
-With the recent update, the xml configuration of the Apparel has been changed.
Some of the existing patches did not work.

## Testing
Check tests you have performed:
- [o] Game runs without errors
- [o] (For compatibility patches) ...with and without patched mod loaded
- [o] Playtested a colony (3 days in game time)