### PR TITLE
Prevent Map 'cross-talk'

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -451,7 +451,7 @@ namespace CombatExtended
         {
             if (ShouldThrowMote)
             {
-                MoteMaker.ThrowText(Position.ToVector3Shifted(), Find.CurrentMap, "CE_OutOfAmmo".Translate() + "!");
+                MoteMaker.ThrowText(Position.ToVector3Shifted(), Map, "CE_OutOfAmmo".Translate() + "!");
             }
             if (IsEquippedGun && CompInventory != null && (Wielder.CurJob == null || Wielder.CurJob.def != JobDefOf.Hunt)) CompInventory.SwitchToNextViableWeapon();
         }
@@ -524,7 +524,7 @@ namespace CombatExtended
             }
             CurMagCount = newMagCount;
             if (turret != null) turret.SetReloading(false);
-            if (parent.def.soundInteract != null) parent.def.soundInteract.PlayOneShot(new TargetInfo(Position, Find.CurrentMap, false));
+            if (parent.def.soundInteract != null) parent.def.soundInteract.PlayOneShot(new TargetInfo(Position, Map, false));
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -41,7 +41,7 @@ namespace CombatExtended
             var fragPerTick = Mathf.CeilToInt((float)fragToSpawn / TicksToSpawnAllFrag);
             var fragSpawnedInTick = 0;
 
-            while (fragToSpawn > 0)
+            while (fragToSpawn > 0 && map != null)
             {
                 var projectile = (ProjectileCE)ThingMaker.MakeThing(frag.thingDef);
                 GenSpawn.Spawn(projectile, cell, map);

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_TakeAndEquip.cs
@@ -176,7 +176,7 @@ namespace CombatExtended
                 return null;
             }
 
-            if (!pawn.Faction.IsPlayer && FindBattleWorthyEnemyPawnsCount(Find.CurrentMap, pawn) > 25)
+            if (!pawn.Faction.IsPlayer && FindBattleWorthyEnemyPawnsCount(pawn.Map, pawn) > 25)
             {
                 return null;
             }

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -102,6 +102,9 @@ namespace CombatExtended
 
         private bool TryDetonate(float stackCountScale = 1)
         {
+            if (Map == null)
+                return false;
+
             CompExplosiveCE comp = this.TryGetComp<CompExplosiveCE>();
             var detProps = AmmoDef?.detonateProjectile?.projectile;
 
@@ -133,7 +136,7 @@ namespace CombatExtended
 
         private bool TryLaunchCookOffProjectile()
         {
-            if (AmmoDef == null || AmmoDef.cookOffProjectile == null) return false;
+            if (AmmoDef == null || AmmoDef.cookOffProjectile == null || Map == null) return false;
 
             // Spawn projectile if enabled
             if (!Controller.settings.RealisticCookOff)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -435,10 +435,11 @@ namespace CombatExtended
                         sound = verb.SoundHitPawn();
                     }
                 }
-                sound?.PlayOneShot(new TargetInfo(caster.Position, caster.Map));
+                // Held, because the caster may have died and despawned
+                sound?.PlayOneShot(new TargetInfo(caster.PositionHeld, caster.MapHeld));
             }
             // Register with parry tracker
-            ParryTracker tracker = defender.Map?.GetComponent<ParryTracker>();
+            ParryTracker tracker = defender.MapHeld?.GetComponent<ParryTracker>();
             if (tracker == null)
             {
                 Log.Error("CE failed to find ParryTracker to register pawn " + defender.ToString());


### PR DESCRIPTION
## Changes

- Various long-standing bugs related to sounds from all maps playing on the map the player is looking at
- In essence: Find.CurrentMap -> Map

## References

- No prior issues, I believe?

## Reasoning

- Bugs came up during BattleRoyale unit testing all the time:
- - Fragment routines run after Map is destroyed, throwing errors: Tried to spawn thing Fragment_Small80726, but the map provided does not exist.
- - Reload sounds are heard in CurrentMap (rather than in Map, where they should be)
- - Reload text is thrown in CurrentMap (rather than in Map)
- - Ammo explosions can start in destroyed Map
- - Melee parries threw errors after a riposte causing the attacker to die

## To test:

- Run CombatExtended current build on BattleRoyale and notice that every map has reload sounds
- Run this PR and notice no reload sounds

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors (with fewer errors)
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
- - [x] Playtested intense melee battles through BattleRoyale in Dev mode
