### PR TITLE
Update LetterTracker.cs

### DIFF
--- a/Source/CombatExtended/CombatExtended/LetterTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LetterTracker.cs
@@ -15,7 +15,11 @@ namespace CombatExtended
         {
             base.MapComponentTick();
 
-            if (!_sentMechWarning && GenDate.DaysPassed >= Faction.OfMechanoids.def.earliestRaidDays * 0.75f)
+            if (Find.TickManager.TicksGame % 2000 == 0  //Only test once every 33.33 seconds
+                && Faction.OfMechanoids != null         //Accounts for '#646 Exception spam with Remove Spacer Stuff (Continued)'
+                && !_sentMechWarning
+                && GenDate.DaysPassed >= Faction.OfMechanoids.def.earliestRaidDays * 0.75f
+                && Find.AnyPlayerHomeMap != null)       //Accounts for the player not having a home
             {
                 var suggestingPawn = Find.AnyPlayerHomeMap.mapPawns.FreeColonistsSpawnedCount != 0
                     ? Find.AnyPlayerHomeMap.mapPawns.FreeColonistsSpawned.RandomElement()


### PR DESCRIPTION
## Additions

Nullcheck for mechanoid faction (in case it's removed)
Letter check is performed only every 33.33 seconds, like other letters, instead of every tick (60 times per second)

## References

Links to the associated issues, e.g.
- Closes #646
- Needed towards a better letter system (using GameComponent - as these systems use since the latest RW version - instead of MapComponent)

## Reasoning

Simplest fix is a nullcheck (direct error)
More complete fix might break saves if the MapComponent isn't handled correctly (which I'm not sure how to do so far)

## Alternatives

Make the MapComponent a GameComponent and errorhandle that MapComponent not existing anymore in player saves

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
- - [ ] Playtested with the mod in question (although it's obvious that the nullcheck should fix the issue)