### PR TITLE
Tweak Spartan Foundry

### DIFF
--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
@@ -43,7 +43,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>21.85</ArmorRating_Sharp>
+					<ArmorRating_Sharp>28</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -97,7 +97,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -150,7 +150,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16.67</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -202,7 +202,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>27.41</ArmorRating_Sharp>
+					<ArmorRating_Sharp>32</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -253,7 +253,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -306,7 +306,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20.74</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -359,7 +359,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20.74</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -466,7 +466,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>19.44</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -520,7 +520,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15.74</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -574,7 +574,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18.52</ArmorRating_Sharp>
+					<ArmorRating_Sharp>19</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -629,7 +629,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>19.44</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
@@ -96,13 +96,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>61</ArmorRating_Blunt>
+					<ArmorRating_Blunt>65</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -201,13 +201,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>32</ArmorRating_Sharp>
+					<ArmorRating_Sharp>28</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>80</ArmorRating_Blunt>
+					<ArmorRating_Blunt>91</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -305,13 +305,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>24</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>54</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -358,13 +358,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>24</ArmorRating_Sharp>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>63</ArmorRating_Blunt>
+					<ArmorRating_Blunt>55</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
@@ -188,7 +188,7 @@
 						<CarryBulk>16</CarryBulk>
 						<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.5</ToxicSensitivity>
-						<RangedWeapon_Cooldown>-0.3</RangedWeapon_Cooldown>
+						<ReloadSpeed>-0.3</ReloadSpeed>
 					</equippedStatOffsets>
 				</value>
 			</li>

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
@@ -7,7 +7,6 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-			<!-- Using Combat Extended's vanilla Power Armor patch as a base -->
 			<!-- ==================================== Powered Assault Armor =====================================-->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/MaxHitPoints</xpath>
@@ -43,13 +42,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>28</ArmorRating_Sharp>
+					<ArmorRating_Sharp>26</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>55</ArmorRating_Blunt>
+					<ArmorRating_Blunt>59</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -103,7 +102,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>75</ArmorRating_Blunt>
+					<ArmorRating_Blunt>61</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -156,7 +155,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -208,7 +207,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>78</ArmorRating_Blunt>
+					<ArmorRating_Blunt>80</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -259,7 +258,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>46</ArmorRating_Blunt>
+					<ArmorRating_Blunt>50</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -312,7 +311,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -365,7 +364,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>56</ArmorRating_Blunt>
+					<ArmorRating_Blunt>63</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -472,7 +471,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>55</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -526,7 +525,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>36</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -580,7 +579,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>85</ArmorRating_Blunt>
+					<ArmorRating_Blunt>52</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -635,7 +634,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>65</ArmorRating_Blunt>
+					<ArmorRating_Blunt>55</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
@@ -201,13 +201,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>50</ArmorRating_Blunt>
+					<ArmorRating_Blunt>71</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -315,7 +315,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
@@ -38,7 +38,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>17.6</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -149,7 +149,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14.08</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -202,7 +202,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>17.6</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -422,7 +422,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>17.92</ArmorRating_Sharp>
+					<ArmorRating_Sharp>21</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -588,7 +588,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14.72</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -645,7 +645,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>12.8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
@@ -7,7 +7,6 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-			<!-- Using Combat Extended's vanilla Power Armor Helmet patch as a base -->
 			<!-- ==================================== Powered Assault Armor Helmet =====================================-->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/MaxHitPoints</xpath>
@@ -44,7 +43,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>46</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -100,7 +99,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>74</ArmorRating_Blunt>
+					<ArmorRating_Blunt>44</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -155,7 +154,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>25</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -208,7 +207,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>38</ArmorRating_Blunt>
+					<ArmorRating_Blunt>50</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -372,7 +371,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -428,7 +427,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>58</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -538,7 +537,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>46</ArmorRating_Blunt>
+					<ArmorRating_Blunt>36</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -594,7 +593,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>66</ArmorRating_Blunt>
+					<ArmorRating_Blunt>44</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -651,7 +650,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>33</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
## Changes

Tweaked the values of Spartan foundry armor to better reflect it's place as uncraftable (with one exception), end-game armor that doesn't have prestige variants.

## Reasoning

Made a list as follows with vanilla stats:

### Armor
recon 92% -> 16mm
marine 106% -> 20mm
cataphract 120% -> 28mm
### Helmets
recon 92% -> 12mm
marine 106% -> 16mm
cataphract 120% -> 22mm

and then placed the spartan foundry armor as seemed appropriate by their armor values compared to the above values, with preference for multiples of 2 and exclusively using whole numbers. This then gave me the following list: 

### Armor:
powered assault 118% -> 28mm +
engineer 108% -> 22mm +
explorer 90% -> 18mm ++
grenadier 148% -> 32mm --
commando 108% -> 22mm +
hazard 112% -> 24mm +
diplomat 112% -> 24mm +
defender 108% -> 22mm +
scout 105% -> 20mm +
samurai 85% -> 16mm +
shock 100% -> 19mm +
recon 105% -> 20mm +

### Helmets:
powered assault 110% -> 20mm +
engineer 100% -> 16mm +
explorer 88% -> 14mm ++
grenadier 110% -> 20mm +
commando 100% -> 16mm +
hazard 100% -> 16mm +
diplomat 100% -> 16mm +
defender 112% -> 21mm +
scout 100% -> 16mm +
samurai 100% -> 16mm +
shock 100% -> 16mm +
recon 80% -> 12mm ++

The +/- reflects armor whether the stats are higher/lower than the appropriate value at the curve between the vanilla armors. Most of these can be justified as rounding up to a multiple of 2 to make the armor slightly stronger considering it is uncraftable (or requires an AI core).

The exceptions are:
- An all-round buff to explorer to make it between recon and marine armor so it is more viable as it's buffs to farming and animal husbandry aren't particularly impressive.
- A heavy nerf to the chest armor of grenadier armor, which still puts it at 32mm but now at least it's not as insanely strong as its vanilla counterpart.
- A buff to the recon helmet so it's not weaker than actual marine armor.
