### PR TITLE
Tweaks to Vanilla Armor Expanded spacer armor.

### DIFF
--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -141,12 +141,11 @@
 				</li>
 
 				<!-- === Siegebreaker Helmet === -->
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Mass</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases</xpath>
 					<value>
-						<Bulk>10</Bulk>
-						<WornBulk>2.5</WornBulk>
-						<Mass>9</Mass>
+						<Bulk>6</Bulk>
+						<WornBulk>2</WornBulk>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -139,14 +139,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>20.8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>20.4</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>48</ArmorRating_Blunt>
+						<ArmorRating_Blunt>50</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -158,16 +158,22 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/Flammability</xpath>
+					<value>
+						<Flammability>0</Flammability>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
-							<PsychicSensitivity>-0.3</PsychicSensitivity>
+							<PsychicSensitivity>-0.2</PsychicSensitivity>
 							<AimingAccuracy>0.3</AimingAccuracy>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
 							<CarryWeight>5.4</CarryWeight>
 							<CarryBulk>1</CarryBulk>
 							<SmokeSensitivity>-1</SmokeSensitivity>
-							<PainShockThreshold>0.05</PainShockThreshold>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -176,10 +182,11 @@
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>55</Plasteel>
+							<Plasteel>40</Plasteel>
 							<DevilstrandCloth>20</DevilstrandCloth>
-							<Hyperweave>5</Hyperweave>
-							<ComponentSpacer>3</ComponentSpacer>
+							<Hyperweave>10</Hyperweave>
+							<Uranium>10</Uranium>
+							<ComponentSpacer>2</ComponentSpacer>
 						</costList>
 					</value>
 				</li>
@@ -197,7 +204,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Mass</xpath>
 					<value>
-						<Bulk>120</Bulk>
+						<Bulk>100</Bulk>
 						<WornBulk>20</WornBulk>
 						<Mass>80</Mass>
 					</value>
@@ -225,14 +232,20 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/Flammability</xpath>
+					<value>
+						<Flammability>0</Flammability>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
-							<CarryWeight>100</CarryWeight>
+							<CarryWeight>80</CarryWeight>
 							<CarryBulk>20</CarryBulk>
 							<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
-							<PainShockThreshold>0.05</PainShockThreshold>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -245,16 +258,19 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
+				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>50</DevilstrandCloth>
-						<Hyperweave>10</Hyperweave>
+						<costList>
+							<Plasteel>140</Plasteel>
+							<DevilstrandCloth>40</DevilstrandCloth>
+							<Hyperweave>20</Hyperweave>
+							<Uranium>100</Uranium>
+							<ComponentSpacer>8</ComponentSpacer>
+						</costList>
 					</value>
 				</li>
-
 			</operations>
 		</match>
 	</Operation>
-
 </Patch>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -32,6 +32,13 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/Flammability</xpath>
+					<value>
+						<Flammability>0</Flammability>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>190</MaxHitPoints> <!-- Same health as recon power armor helmet. -->
@@ -91,6 +98,13 @@
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>30</ArmorRating_Blunt> <!-- Blunt armor is based off it being 12mm RHA worth of sharp armor. -->
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/Flammability</xpath>
+					<value>
+						<Flammability>0</Flammability>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -184,8 +184,6 @@
 							<PsychicSensitivity>-0.2</PsychicSensitivity>
 							<AimingAccuracy>0.3</AimingAccuracy>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
-							<CarryWeight>5.4</CarryWeight>
-							<CarryBulk>1</CarryBulk>
 							<SmokeSensitivity>-1</SmokeSensitivity>
 						</equippedStatOffsets>
 					</value>
@@ -196,9 +194,8 @@
 					<value>
 						<costList>
 							<Plasteel>40</Plasteel>
-							<DevilstrandCloth>20</DevilstrandCloth>
-							<Hyperweave>10</Hyperweave>
-							<Uranium>10</Uranium>
+							<DevilstrandCloth>25</DevilstrandCloth>
+							<Hyperweave>5</Hyperweave>
 							<ComponentSpacer>2</ComponentSpacer>
 						</costList>
 					</value>
@@ -276,8 +273,8 @@
 					<value>
 						<costList>
 							<Plasteel>140</Plasteel>
-							<DevilstrandCloth>40</DevilstrandCloth>
-							<Hyperweave>20</Hyperweave>
+							<DevilstrandCloth>50</DevilstrandCloth>
+							<Hyperweave>10</Hyperweave>
 							<Uranium>100</Uranium>
 							<ComponentSpacer>8</ComponentSpacer>
 						</costList>


### PR DESCRIPTION
## Changes

- Made trooper and siegebreaker power armor and helmet inflammable;
- Kept siegebreaker power armor armor values the same, however it now costs a bit less plasteel, doubled the cost of uranium and replaced the industrial components in the recipe with advanced components;
- Siegebreaker power armor carry weight reduced, decreased bulk of the armor;
- Removed siegebreaker power armor's and helmet's pain shock threshold offset;
- Minor tweaks to siegebreaker power armor helmet's armor values;
- Removed siegebreaker power armor helmet's carry bulk and carry weight stat offsets, reduced the helmet's weight, bulk and worn bulk;
- Decreased siegebreaker power armor helmet's plasteel and advanced component recipe cost and increased its devilstrand recipe cost.

## Reasoning

- Set flammability of trooper and siegebreaker power armor to 0 for consistency with other power armors;
- The siegebreaker power armor recipe having less plasteel cost is made up with the hyperweave cost to achieve the same blunt armor as cataphract power armor, but less sharp armor. The doubled cost of uranium, the increased advanced component cost and a bit of the plasteel cost can be attributed to the stat offsets and the advanced shield belt;
- Siegebreaker power armor vanilla movespeed penalty is larger than cataphract power armor's, bulk decrease is to make it in-line with cataphract armor;
- There's not much reason for power armor to have it;
- Siegebreaker power armor helmet's sharp armor is now 20.4mm RHA (22/28*26=20.4) and blunt armor is the same as cataphract's power armor helmet's to make it more understandable with siegebreaker power armor's stats;
- Tried to make the bulk, mass and worn bulk of the helmet similar to cataphract's, however because of that, I decided the helmet no longer needs the carry bulk and carry weight stat offsets;
- Modified to make the recipe cost of the helmet match siegebreaker power armor's (120/3=40 plasteel, 50/2=25 devilstrand, 10/2=5 hyperweave) the same way how cataphract power armor helmet's recipe matches cataphract power armor's. The dvanced components can be attributed to the helmet's stat offsets.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
