### PR TITLE
Actual fix for fragments/cookoff

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -41,7 +41,7 @@ namespace CombatExtended
             var fragPerTick = Mathf.CeilToInt((float)fragToSpawn / TicksToSpawnAllFrag);
             var fragSpawnedInTick = 0;
 
-            while (fragToSpawn > 0 && map != null)
+            while (fragToSpawn > 0 && Find.Maps.IndexOf(map) >= 0)
             {
                 var projectile = (ProjectileCE)ThingMaker.MakeThing(frag.thingDef);
                 GenSpawn.Spawn(projectile, cell, map);

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -102,7 +102,7 @@ namespace CombatExtended
 
         private bool TryDetonate(float stackCountScale = 1)
         {
-            if (Map == null)
+            if (Find.Maps.IndexOf(Map) < 0)
                 return false;
 
             CompExplosiveCE comp = this.TryGetComp<CompExplosiveCE>();
@@ -136,7 +136,7 @@ namespace CombatExtended
 
         private bool TryLaunchCookOffProjectile()
         {
-            if (AmmoDef == null || AmmoDef.cookOffProjectile == null || Map == null) return false;
+            if (AmmoDef == null || AmmoDef.cookOffProjectile == null || Find.Maps.IndexOf(Map) < 0) return false;
 
             // Spawn projectile if enabled
             if (!Controller.settings.RealisticCookOff)


### PR DESCRIPTION
Apparently "Map == null" doesn't account for maps that aren't active anymore but which still exist in memory.

## Changes

- Instead of Map == null now checks that Find.Maps.IndexOf(Map) >= 0

## References

- Fix to #651 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [] Playtested a colony (specify how long)
- - [x] Playtested 'Battle Royale All PawnKinds' with and without fix. Without the fix, there are occasional errors of fragments spawning in null maps (still).
