### PR TITLE
Nullcheck to fix NPE on ammosets for guns without ammosets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
@@ -118,7 +118,7 @@ namespace CombatExtended
             foreach (ThingDef gun in guns)
             {
                 // make sure the gun has ammo defined...
-                if (gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Count <= 0)
+                if (gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet == null || gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Count <= 0)
                     continue;
                 generic = new LoadoutGenericDef();
                 generic.defName = "GenericAmmo-" + gun.defName;


### PR DESCRIPTION
Adds a nullcheck for ammosets to generic loadout generating so guns without ammosets don't break loadout generation. 

Personally I think this is a poor fix to an issue that exists through other systems that aren't designed well enough, but... this works.

Why did you choose to implement things this way, e.g.
- It was easy lol

Describe alternative implementations you have considered, e.g.
- Taking out a large amount of time to improve the systems that allow this problem to exist in the first place

Check tests you have performed:
- [x ] Compiles without warnings
- [x ] Game runs without errors
- [ x] (For compatibility patches) ...with and without patched mod loaded
- [x ] Playtested a colony (about 20 seconds to see if the issue fixed and what it touches works)
