### PR TITLE
Vanilla animal tweak

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -262,10 +262,10 @@
 		<value>
 			<MoveSpeed>5.5</MoveSpeed>
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
-			<MeleeCritChance>0.52</MeleeCritChance>
+			<MeleeCritChance>0.57</MeleeCritChance>
 			<MeleeParryChance>0.27</MeleeParryChance>
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.28</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
@@ -278,10 +278,10 @@
 					<capacities>
 						<li>Poke</li>
 					</capacities>
-					<power>24</power>
-					<cooldownTime>3.17</cooldownTime>
+					<power>28</power>
+					<cooldownTime>2.67</cooldownTime>
 					<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>horn</label>
@@ -289,9 +289,9 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>24</power>
-					<cooldownTime>3.17</cooldownTime>
+					<cooldownTime>2.37</cooldownTime>
 					<linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
@@ -308,11 +308,11 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>19</power>
+					<power>20</power>
 					<cooldownTime>2.95</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8.5</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -328,7 +328,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Rhinoceros"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>2.3</baseHealthScale>
+			<baseHealthScale>2.4</baseHealthScale>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -8,7 +8,7 @@
 		<value>
 			<MoveSpeed>5</MoveSpeed>
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
-			<MeleeCritChance>0.27</MeleeCritChance>
+			<MeleeCritChance>0.33</MeleeCritChance>
 			<MeleeParryChance>0.20</MeleeParryChance>
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -23,7 +23,7 @@
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/statBases</xpath>
 		<value>
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
-			<MeleeCritChance>0.19</MeleeCritChance>
+			<MeleeCritChance>0.3</MeleeCritChance>
 			<MeleeParryChance>0.11</MeleeParryChance>
 		</value>
 	</Operation>
@@ -35,14 +35,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.15</baseBodySize>
+			<baseBodySize>1.3</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>1.3</baseHealthScale>
+			<baseHealthScale>1.5</baseHealthScale>
 		</value>
 	</Operation>
 
@@ -71,8 +71,8 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>1.41</cooldownTime>
+					<power>22</power>
+					<cooldownTime>1.3</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -82,16 +82,16 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.15</armorPenetrationSharp>
-					<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.28</armorPenetrationSharp>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>1.41</cooldownTime>
+					<power>22</power>
+					<cooldownTime>1.3</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -101,15 +101,15 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.15</armorPenetrationSharp>
-					<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.28</armorPenetrationSharp>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>31</power>
-					<cooldownTime>2.05</cooldownTime>
+					<power>33</power>
+					<cooldownTime>2.0</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -119,8 +119,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.85</armorPenetrationSharp>
-					<armorPenetrationBlunt>8.450</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>9.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -142,9 +142,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bear_Polar"]/statBases</xpath>
 		<value>
-			<MoveSpeed>4.0</MoveSpeed>
+			<MoveSpeed>4.2</MoveSpeed>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
-			<MeleeCritChance>0.18</MeleeCritChance>
+			<MeleeCritChance>0.38</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
 		</value>
 	</Operation>
@@ -158,7 +158,7 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>21</power>
+					<power>24</power>
 					<cooldownTime>1.32</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -169,16 +169,16 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.12</armorPenetrationSharp>
-					<armorPenetrationBlunt>3.375</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.32</armorPenetrationSharp>
+					<armorPenetrationBlunt>6.75</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>1.32</cooldownTime>
+					<power>24</power>
+					<cooldownTime>1.3</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -188,14 +188,14 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.12</armorPenetrationSharp>
-					<armorPenetrationBlunt>3.375</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.32</armorPenetrationSharp>
+					<armorPenetrationBlunt>6.75</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>32</power>
+					<power>36</power>
 					<cooldownTime>1.68</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -206,15 +206,15 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.79</armorPenetrationSharp>
-					<armorPenetrationBlunt>7.84</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.75</armorPenetrationSharp>
+					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>10</power>
+					<power>12</power>
 					<cooldownTime>2.44</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
@@ -227,14 +227,14 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bear_Polar"]/race</xpath>
 		<value>
-			<baseBodySize>1.55</baseBodySize>
+			<baseBodySize>1.75</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bear_Polar"]/race</xpath>
 		<value>
-			<baseHealthScale>1.75</baseHealthScale>
+			<baseHealthScale>2</baseHealthScale>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -35,7 +35,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.3</baseBodySize>
+			<baseBodySize>1.33</baseBodySize>
 		</value>
 	</Operation>
 
@@ -56,7 +56,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[@Name="BearBase"]/combatPower</xpath>
 		<value>
-			<combatPower>150</combatPower>
+			<combatPower>140</combatPower>
 		</value>
 	</Operation>
 
@@ -82,7 +82,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.28</armorPenetrationSharp>
+					<armorPenetrationSharp>0.3</armorPenetrationSharp>
 					<armorPenetrationBlunt>5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -101,7 +101,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.28</armorPenetrationSharp>
+					<armorPenetrationSharp>0.3</armorPenetrationSharp>
 					<armorPenetrationBlunt>5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -169,8 +169,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.32</armorPenetrationSharp>
-					<armorPenetrationBlunt>6.75</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.45</armorPenetrationSharp>
+					<armorPenetrationBlunt>7</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
@@ -188,8 +188,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.32</armorPenetrationSharp>
-					<armorPenetrationBlunt>6.75</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.45</armorPenetrationSharp>
+					<armorPenetrationBlunt>7</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
@@ -206,7 +206,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>1.75</armorPenetrationSharp>
+					<armorPenetrationSharp>1.8</armorPenetrationSharp>
 					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">

--- a/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
@@ -15,8 +15,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.23</MeleeDodgeChance>
-			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeDodgeChance>0.36</MeleeDodgeChance>
+			<MeleeCritChance>0.16</MeleeCritChance>
 			<MeleeParryChance>0.06</MeleeParryChance>
 		</value>
 	</Operation>
@@ -30,8 +30,8 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>7</power>
-					<cooldownTime>0.97</cooldownTime>
+					<power>10</power>
+					<cooldownTime>0.9</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -41,7 +41,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.09</armorPenetrationSharp>
+					<armorPenetrationSharp>0.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.423</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -49,8 +49,8 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>7</power>
-					<cooldownTime>0.97</cooldownTime>
+					<power>10</power>
+					<cooldownTime>0.84</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -60,14 +60,14 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.09</armorPenetrationSharp>
+					<armorPenetrationSharp>0.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.423</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>14</power>
+					<power>18</power>
 					<cooldownTime>1.35</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -78,8 +78,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.25</armorPenetrationSharp>
-					<armorPenetrationBlunt>1.35</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -99,14 +99,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>0.85</baseBodySize>
+			<baseBodySize>0.9</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>0.8</baseHealthScale>
+			<baseHealthScale>0.9</baseHealthScale>
 		</value>
 	</Operation>
 
@@ -131,7 +131,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Lynx"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.29</MeleeDodgeChance>
+			<MeleeDodgeChance>0.36</MeleeDodgeChance>
 			<MeleeCritChance>0.07</MeleeCritChance>
 			<MeleeParryChance>0.05</MeleeParryChance>
 		</value>
@@ -222,7 +222,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Lynx"]/combatPower</xpath>
 		<value>
-			<combatPower>60</combatPower>
+			<combatPower>50</combatPower>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -105,7 +105,7 @@
 					<power>6</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.01</armorPenetrationSharp>
+					<armorPenetrationSharp>0.04</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -152,7 +152,7 @@
 		<xpath>Defs/ThingDef[defName="Cow"]/statBases</xpath>
 		<value>
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
-			<MeleeCritChance>0.13</MeleeCritChance>
+			<MeleeCritChance>0.27</MeleeCritChance>
 			<MeleeParryChance>0.18</MeleeParryChance>
 		</value>
 	</Operation>
@@ -175,24 +175,24 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>6</power>
+					<power>16</power>
 					<cooldownTime>2.12</cooldownTime>
 					<chanceFactor>0.2</chanceFactor>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>2</armorPenetrationBlunt>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>horns</label>
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>19</power>
-					<cooldownTime>2.12</cooldownTime>
+					<power>21</power>
+					<cooldownTime>2.0</cooldownTime>
 					<chanceFactor>0.65</chanceFactor>
 					<restrictedGender>Male</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
-					<armorPenetrationBlunt>2</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -403,7 +403,7 @@
 		<value>
 			<MoveSpeed>5.6</MoveSpeed>
 			<MeleeDodgeChance>0.11</MeleeDodgeChance>
-			<MeleeCritChance>0.37</MeleeCritChance>
+			<MeleeCritChance>0.4</MeleeCritChance>
 			<MeleeParryChance>0.22</MeleeParryChance>
 		</value>
 	</Operation>
@@ -417,12 +417,23 @@
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>20</power>
-					<cooldownTime>3.09</cooldownTime>
+					<power>23</power>
+					<cooldownTime>2.18</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationSharp>0.12</armorPenetrationSharp>					
+					<armorPenetrationSharp>0.45</armorPenetrationSharp>					
 					<armorPenetrationBlunt>9</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>18</power>
+					<cooldownTime>2.02</cooldownTime>
+					<chanceFactor>0.2</chanceFactor>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -896,7 +907,7 @@
 					<restrictedGender>Female</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>horns</label>
@@ -907,7 +918,7 @@
 					<cooldownTime>2.05</cooldownTime>
 					<restrictedGender>Male</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -7,11 +7,11 @@
 		<xpath>Defs/ThingDef[defName="Elephant"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>5</MoveSpeed>
-			<MeleeDodgeChance>0.08</MeleeDodgeChance>
-			<MeleeCritChance>0.79</MeleeCritChance>
+			<MeleeDodgeChance>0.1</MeleeDodgeChance>
+			<MeleeCritChance>0.88</MeleeCritChance>
 			<MeleeParryChance>0.51</MeleeParryChance>
-			<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
+			<ArmorRating_Blunt>0.205</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
@@ -31,29 +31,29 @@
 						<li>Poke</li>
 					</capacities>
 					<power>67</power>
-					<cooldownTime>3.57</cooldownTime>
+					<cooldownTime>3.37</cooldownTime>
 					<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>31.226</armorPenetrationBlunt>	
+					<armorPenetrationBlunt>40.226</armorPenetrationBlunt>	
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>left foot</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>31</power>
-					<cooldownTime>2.57</cooldownTime>
+					<power>33</power>
+					<cooldownTime>2.37</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>12.960</armorPenetrationBlunt>	
+					<armorPenetrationBlunt>25.960</armorPenetrationBlunt>	
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right foot</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>31</power>
-					<cooldownTime>2.57</cooldownTime>
+					<power>33</power>
+					<cooldownTime>2.37</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>12.960</armorPenetrationBlunt>	
+					<armorPenetrationBlunt>25.960</armorPenetrationBlunt>	
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -61,10 +61,10 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>55</power>
-					<cooldownTime>3.99</cooldownTime>
+					<cooldownTime>3.69</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>25</armorPenetrationBlunt>	
+					<armorPenetrationBlunt>36</armorPenetrationBlunt>	
 				</li>
 			</tools>
 		</value>
@@ -106,22 +106,22 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>59</power>
-					<cooldownTime>2.44</cooldownTime>
+					<power>56</power>
+					<cooldownTime>2.34</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.7</armorPenetrationSharp>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>59</power>
-					<cooldownTime>2.44</cooldownTime>
+					<power>56</power>
+					<cooldownTime>2.34</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.7</armorPenetrationSharp>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.25</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -129,10 +129,10 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>24</power>
-					<cooldownTime>3.17</cooldownTime>
+					<cooldownTime>3.07</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -206,40 +206,40 @@
 					<power>46</power>
 					<cooldownTime>2.52</cooldownTime>
 					<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.54</armorPenetrationSharp>
-					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+					<armorPenetrationSharp>3</armorPenetrationSharp>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>horn</label>
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>42</power>
+					<power>41</power>
 					<cooldownTime>2.52</cooldownTime>
 					<chanceFactor>0.65</chanceFactor>
 					<linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
-					<armorPenetrationSharp>8</armorPenetrationSharp>
-					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+					<armorPenetrationSharp>10</armorPenetrationSharp>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>left foot</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>2.33</cooldownTime>
+					<power>22</power>
+					<cooldownTime>2.13</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+					<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right foot</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>2.33</cooldownTime>
+					<power>22</power>
+					<cooldownTime>2.13</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>8.640</armorPenetrationBlunt>
+					<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
@@ -248,7 +248,7 @@
 					<power>19</power>
 					<cooldownTime>1.62</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
+					<armorPenetrationSharp>0.09</armorPenetrationSharp>
 					<armorPenetrationBlunt>2.016</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -260,7 +260,7 @@
 					<cooldownTime>2.52</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -18,7 +18,7 @@
 		<xpath>Defs/ThingDef[defName="Megascarab"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>4.7</MoveSpeed>
-			<MeleeDodgeChance>0.14</MeleeDodgeChance>
+			<MeleeDodgeChance>0.21</MeleeDodgeChance>
 			<MeleeCritChance>0.02</MeleeCritChance>
 		</value>
 	</Operation>
@@ -34,7 +34,7 @@
 					<power>9</power>
 					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.1</armorPenetrationSharp>
+					<armorPenetrationSharp>0.24</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -100,11 +100,21 @@
 					<capacities>
 						<li>Cut</li>
 					</capacities>
-					<power>20</power>
+					<power>21</power>
 					<cooldownTime>1.78</cooldownTime>
 					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.14</armorPenetrationSharp>
-					<armorPenetrationBlunt>1</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.36</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+				</li>
+				  <li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.78</cooldownTime>
+					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+					<armorPenetrationSharp>1.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -124,7 +134,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spelopede"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>6</ArmorRating_Blunt>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -156,7 +166,7 @@
 		<value>
 			<MoveSpeed>4.5</MoveSpeed>
 			<MeleeDodgeChance>0.07</MeleeDodgeChance>
-			<MeleeCritChance>0.25</MeleeCritChance>
+			<MeleeCritChance>0.31</MeleeCritChance>
 			<MeleeParryChance>0.17</MeleeParryChance>
 		</value>
 	</Operation>
@@ -182,8 +192,8 @@
 					<power>43</power>
 					<cooldownTime>2.48</cooldownTime>
 					<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.5</armorPenetrationSharp>
-					<armorPenetrationBlunt>3.750</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -204,7 +214,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megaspider"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -331,7 +331,7 @@
 					<restrictedGender>Female</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>antlers</label>
@@ -342,8 +342,8 @@
 					<cooldownTime>1.66</cooldownTime>
 					<restrictedGender>Male</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.750</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.24</armorPenetrationSharp>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -454,7 +454,7 @@
 					<restrictedGender>Female</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>antlers</label>
@@ -465,8 +465,8 @@
 					<cooldownTime>1.66</cooldownTime>
 					<restrictedGender>Male</restrictedGender>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.750</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.16</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -507,8 +507,8 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WildBoar"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>4.0</MoveSpeed>
-			<MeleeDodgeChance>0.12</MeleeDodgeChance>
+			<MoveSpeed>4.2</MoveSpeed>
+			<MeleeDodgeChance>0.21</MeleeDodgeChance>
 			<MeleeCritChance>0.08</MeleeCritChance>
 			<MeleeParryChance>0.07</MeleeParryChance>
 		</value>
@@ -526,19 +526,19 @@
 					<power>11</power>
 					<cooldownTime>1.89</cooldownTime>
 					<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.01</armorPenetrationSharp>
-					<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.09</armorPenetrationSharp>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>tusk</label>
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>4</power>
+					<power>7</power>
 					<cooldownTime>1.41</cooldownTime>
 					<chanceFactor>0.65</chanceFactor>
 					<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.1</armorPenetrationSharp>
+					<armorPenetrationSharp>0.18</armorPenetrationSharp>
 					<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -548,7 +548,7 @@
 					<power>8</power>
 					<cooldownTime>1.57</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0.02</armorPenetrationSharp>					
+					<armorPenetrationSharp>0.05</armorPenetrationSharp>					
 					<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -611,7 +611,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Tortoise"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>10</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -41,7 +41,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.05</armorPenetrationSharp>
+					<armorPenetrationSharp>0.07</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.225</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
@@ -62,7 +62,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Cobra"]/combatPower</xpath>
 		<value>
-			<combatPower>140</combatPower>
+			<combatPower>70</combatPower>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -76,7 +76,7 @@
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>23</power>
+					<power>24</power>
 					<cooldownTime>1.46</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
@@ -88,8 +88,8 @@
 						</extraMeleeDamages>
 					</surpriseAttack>
 					<chanceFactor>2</chanceFactor>
-					<armorPenetrationSharp>0.8</armorPenetrationSharp>
-					<armorPenetrationBlunt>5.063</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.6</armorPenetrationSharp>
+					<armorPenetrationBlunt>8.863</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -169,7 +169,7 @@
 						</extraMeleeDamages>
 					</surpriseAttack>
 					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.05</armorPenetrationSharp>
+					<armorPenetrationSharp>0.07</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
@@ -188,7 +188,7 @@
 						</extraMeleeDamages>
 					</surpriseAttack>
 					<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.05</armorPenetrationSharp>
+					<armorPenetrationSharp>0.07</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
@@ -205,7 +205,7 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>0.43</armorPenetrationSharp>
+					<armorPenetrationSharp>0.55</armorPenetrationSharp>
 					<armorPenetrationBlunt>4.225</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
## Additions

Tweaks to make most large predators and herbivores more dangerous, also tweaked the stats of some animals be less nonsensical.

## Reasoning

Because a bear would easily lose to a random person with a jacket and knife, because leather jackets apparently makes you impervious to bear attacks somehow. This tweak only buffs animals very slightly, so nonsense like the above could still happen.
Pretty much all animals are so terrible at fighting at a degree that is far beyond my comprehension. Why?

## Alternatives
If this PR is merged, I'll take a look at patches for modded animals as well.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
