### PR TITLE
Rework EMP Stun Handling

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -15,27 +15,27 @@ namespace CombatExtended.HarmonyCE
     {
         /* STUN_TIME_DAMAGE_RATIO : How long a stun is based on the damage applied
          * ADAPTATION_TIME_RATIO : How long adaptation lasts, based on stun time
-         * FLAT_ADAPTATION_TIME_REDUCTION_RATIO : The adaptation reduction based on damage, scaled to the adaptation time based on damage. 
+         * FLAT_ADAPTATION_TIME_REDUCTION_RATIO : The adaptation reduction based on damage, scaled to the adaptation time based on damage.
+         * STUN_REDUCTION_DAMAGE_THRESHOLD : Intended to make it harder to restun enemies with weapons that have a large ratio of DPS to hit damage. Essentially, it uses the time based
+         * decay of adaptation to allow certain weapons to bypass the stun reduction because the adaptation decays enough by the time another hit lands. 
          *
          * Because the adaptation time ratio only has an effect on the speed that adaptation decays over time, the only affect changing it has is on how much less damage is required
          * to cause an enemy to be stunned again over a certain period of time.
-         * The amount of hits to restun an enemy is (1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
-         * The amount of DPS needed to re-stun an enemy before the stun wears off is damageperhit*(1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
-         * 1/(damageperhit*(1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)) / DPS) is the ratio of time they spend stunned 
-         * The amount of damage to re-stun an entity instantly after it's stun wears off is ADAPTATION_TIME_RATIO / FLAT_ADAPTATION_TIME_REDUCTION_RATIO / STUN_TIME_DAMAGE_RATIO
-         * when not factoring in adaptation decay over time.
-         *
-         * NOTE : Something possible to do if high DPS low DPH weapons are too strong is to apply a penalty if the hit isn't significantly higher than the adaptation time
+         * Assumption: Adaptation reduces at a rate of 60 per second
+         * The amount of hits to restun an enemy is 1/(FLAT_ADAPTATION_TIME_REDUCTION_RATIO/ADAPTATION_TIME_RATIO) assuming no adaptation decay
+         * The amount of damage needed to re-stun an enemy is damageperhit*1/(FLAT_ADAPTATION_TIME_REDUCTION_RATIO/ADAPTATION_TIME_RATIO) assuming no adaptation decay
+         * TODO : Figure out how long it takes to re-stun an enemy at -60 adaptation per second at some DPS
+         * TODO : Use above to figure out what exactly the ratio is where permastunning becomes possible
          */
 
         // 
         private const float STUN_TIME_DAMAGE_RATIO = 15f; // The scaling factor of stuns based on damage
         private const float ADAPTATION_TIME_RATIO = STUN_TIME_DAMAGE_RATIO * 3; // Adaptation time based on stun time
         private const float FLAT_ADAPTATION_TIME_REDUCTION_RATIO = ADAPTATION_TIME_RATIO / 8; // Scaling of adaptation reduction
-        private const float REDUCTION_MULTIPLIER_WHILE_STUNNED = 0.8f;
-        private const float BUILDING_DEFAULT_BODYSIZE = 2f;
+        private const float REDUCTION_MULTIPLIER_WHILE_STUNNED = 1f; // NOTE : Effectively not doing anything until i figure out something 
+        private const float BUILDING_DEFAULT_BODYSIZE = 2f; // i.e turrets 
 
-        public static bool Prefix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP, int ___EMPAdaptedTicksLeft, int ___stunTicksLeft, bool ___stunFromEMP)
+        public static bool Prefix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP, ref int ___EMPAdaptedTicksLeft, ref int ___stunTicksLeft, ref bool ___stunFromEMP)
         {
             float bodysize = BUILDING_DEFAULT_BODYSIZE;
             if (__instance.parent is Pawn)
@@ -45,29 +45,24 @@ namespace CombatExtended.HarmonyCE
                 bodysize = p.BodySize;
             }
 
-            Type t = typeof(StunHandler);
-            FieldInfo EMPAdaptedTicksLeft = t.GetField("EMPAdaptedTicksLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            FieldInfo StunTicksLeft = t.GetField("stunTicksLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            FieldInfo StunFromEMP = t.GetField("stunFromEMP", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            
-            float multiplier = bodysize / Mathf.Pow(bodysize, 2); // Multiplier based on bodysize, smaller for larger creatures
+            float multiplier = 1/bodysize; // Multiplier based on bodysize, smaller for larger creatures
             if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
             {
                 if(___EMPAdaptedTicksLeft > 0)
                 {
                     
                     if (___stunTicksLeft > 0) 
-                    { EMPAdaptedTicksLeft.SetValue(__instance, ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * REDUCTION_MULTIPLIER_WHILE_STUNNED * multiplier)); }
+                    { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * REDUCTION_MULTIPLIER_WHILE_STUNNED * multiplier); }
                     else 
-                    { EMPAdaptedTicksLeft.SetValue(__instance, ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * multiplier)); }
+                    { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * multiplier); }
                     
                     
                     if(___EMPAdaptedTicksLeft < 0)
                     {
                         float stun_time = Mathf.Abs(___EMPAdaptedTicksLeft / (ADAPTATION_TIME_RATIO / STUN_TIME_DAMAGE_RATIO));
                         __instance.StunFor_NewTmp((int)(stun_time), dinfo.Instigator, true, true);
-                        EMPAdaptedTicksLeft.SetValue(__instance, (int)(stun_time * ADAPTATION_TIME_RATIO));
-                        StunFromEMP.SetValue(__instance, true);
+                        ___EMPAdaptedTicksLeft = (int)(stun_time * (ADAPTATION_TIME_RATIO / STUN_TIME_DAMAGE_RATIO));
+                        ___stunFromEMP = true;
                         return false;
                     }
                     MoteMaker.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
@@ -75,8 +70,8 @@ namespace CombatExtended.HarmonyCE
                 else
                 {
                     __instance.StunFor_NewTmp((int)(dinfo.Amount * STUN_TIME_DAMAGE_RATIO * multiplier), dinfo.Instigator, true, true);
-                    EMPAdaptedTicksLeft.SetValue(__instance, (int)(dinfo.Amount * ADAPTATION_TIME_RATIO));
-                    StunFromEMP.SetValue(__instance, true);
+                    ___EMPAdaptedTicksLeft = (int)(dinfo.Amount * ADAPTATION_TIME_RATIO);
+                    ___stunFromEMP = true;
                 }
             }
             return false; 
@@ -95,4 +90,3 @@ namespace CombatExtended.HarmonyCE
         }
     }
 }
-

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -12,33 +12,68 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(StunHandler), "Notify_DamageApplied")]
     public static class Harmony_StunHandler_Notify_DamageApplied
     {
-        private const int FLAT_ADAPTATION_TIME_REDUCTION = 2;
-        private const float ADAPTATION_TIME_MULTIPLIER = 0.75f;
-        private const float LOGARITHM_BASE = 6f;
+        /* STUN_TIME_DAMAGE_RATIO : How long a stun is based on the damage applied
+         * ADAPTATION_TIME_RATIO : How long adaptation lasts, based on stun time
+         * FLAT_ADAPTATION_TIME_REDUCTION_RATIO : The adaptation reduction based on damage, scaled to the adaptation time based on damage. 
+         *
+         * Because the adaptation reduction is scaled based on the adaptation gain, the amount of hits to reduce adaptation to 0 remains constant in regards to how
+         * much adaptation time is applied by damage. i.e if the FATRR is untouched, it will always take e.g 6 hits to reduce adaptation to 0 regardless of if adaptation time
+         * is 5 seconds or a million years.
+         * So because the adaptation time ratio only has an effect on the speed that adaptation decays over time, the only affect changing it has is on how much less damage is required
+         * to cause an enemy to be stunned again over a certain period of time.
+         * The amount of hits to restun an enemy is (1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
+         * The amount of DPS needed to re-stun an enemy before the stun wears off is damageperhit*(1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
+         * 1/(damageperhit*(1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)) / DPS) is the ratio of time they spend stunned 
+         * The amount of damage to re-stun an entity instantly after it's stun wears off is ADAPTATION_TIME_RATIO / FLAT_ADAPTATION_TIME_REDUCTION_RATIO / STUN_TIME_DAMAGE_RATIO
+         * when not factoring in adaptation decay over time.
+         *
+         * NOTE : Something possible to do if high DPS low DPH weapons are too strong is to apply a penalty if the hit isn't significantly higher than the adaptation time
+         */
+
+        // 
+        private const float STUN_TIME_DAMAGE_RATIO = 1f; // The scaling factor of stuns based on damage
+        private const float ADAPTATION_TIME_RATIO = STUN_TIME_DAMAGE_RATIO * 3; // Adaptation time based on stun time
+        private const float FLAT_ADAPTATION_TIME_REDUCTION_RATIO = ADAPTATION_TIME_RATIO / 8; // Scaling of adaptation reduction based adaptation time based on damage.
+        private const float REDUCTION_MULTIPLIER_WHILE_STUNNED = 0.8f;
+        private const float BUILDING_DEFAULT_BODYSIZE = 2f;
 
         public static bool Prefix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP, int ___EMPAdaptedTicksLeft, int ___stunTicksLeft, bool ___stunFromEMP)
         {
-            // This is purely logic for things that are adapted to make it easier to re-stun them. It doesn't do anything if they're not stunned, and it doesn't directly stun them.
-            // Whenever an EMP hit is taken the adaptation is reduced by a certain amount based on the damage of the hit, clamped to a certain value so it always takes more than 1 hit to restun.
-            Pawn p = null;
+            float bodysize = BUILDING_DEFAULT_BODYSIZE;
             if (__instance.parent is Pawn)
             {
-                p = (Pawn)__instance.parent;
+                Pawn p = (Pawn)__instance.parent;
                 if (p.Downed || p.Dead) { return false; }
+                bodysize = p.BodySize;
             }
 
-            if (___EMPAdaptedTicksLeft > 0 && ___stunTicksLeft == 0 && dinfo.Def == DamageDefOf.EMP && affectedByEMP)
+            float multiplier = bodysize / Mathf.Pow(bodysize, 2); // Multiplier based on bodysize, smaller for larger creatures
+            if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
             {
-                if (p != null)
+                if(___EMPAdaptedTicksLeft > 0)
                 {
-                    // TODO : Add the projectile damage into this calculation, making it reduce this multiplier by some factor based on the damage
-                    float new_mult = Mathf.Clamp(ADAPTATION_TIME_MULTIPLIER + 0.25f * Mathf.Log(p.BodySize, LOGARITHM_BASE), 0, 1);
-                    ___EMPAdaptedTicksLeft = (int)((float)___EMPAdaptedTicksLeft * new_mult);
+
+                    if (___stunTicksLeft > 0) { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * REDUCTION_MULTIPLIER_WHILE_STUNNED * multiplier); }
+                    else { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * multiplier); }
+                    
+                    if(___EMPAdaptedTicksLeft < 0)
+                    {
+                        float stun_time = Mathf.Abs(___EMPAdaptedTicksLeft / (ADAPTATION_TIME_RATIO / STUN_TIME_DAMAGE_RATIO));
+                        __instance.StunFor_NewTmp((int)(stun_time), dinfo.Instigator, true, true);
+                        ___EMPAdaptedTicksLeft = (int)(stun_time * ADAPTATION_TIME_RATIO);
+                        ___stunFromEMP = true;
+                        return false;
+                    }
+                    MoteMaker.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
                 }
-                else { ___EMPAdaptedTicksLeft = (int)((float)___EMPAdaptedTicksLeft * ADAPTATION_TIME_MULTIPLIER); }// Casting removes the decimal so it always rounds down for positive values
-                if (___EMPAdaptedTicksLeft > FLAT_ADAPTATION_TIME_REDUCTION) { ___EMPAdaptedTicksLeft -= FLAT_ADAPTATION_TIME_REDUCTION; }
+                else
+                {
+                    __instance.StunFor_NewTmp((int)(dinfo.Amount * STUN_TIME_DAMAGE_RATIO * multiplier), dinfo.Instigator, true, true);
+                    ___EMPAdaptedTicksLeft = (int)(dinfo.Amount * ADAPTATION_TIME_RATIO * multiplier);
+                    ___stunFromEMP = true;
+                }
             }
-            return true;
+            return false; 
         }
 	
         public static void Postfix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP)

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,82 +12,41 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(StunHandler), "Notify_DamageApplied")]
     public static class Harmony_StunHandler_Notify_DamageApplied
     {
-	public static bool Prefix(StunHandler __instance,
-				  DamageInfo dinfo,
-				  bool affectedByEMP,
-				  int ___EMPAdaptedTicksLeft,
-				  int ___stunTicksLeft,
-				  bool ___stunFromEMP
-				  )
-	{
+        private const int FLAT_ADAPTATION_TIME_REDUCTION = 2;
+        private const float ADAPTATION_TIME_MULTIPLIER = 0.75f;
+        private const float LOGARITHM_BASE = 6f;
 
-	    Pawn pawn = __instance.parent as Pawn;
-	    if (pawn == null || pawn.Downed || pawn.Dead)
-	    {
-		return false;
-	    }
-	    float bodySize = pawn.BodySize;
-	    
-	    if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
-	    {
-		if (___EMPAdaptedTicksLeft > 0)
-		{
-		    int newStunAdaptedTicks = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-		    int newStunTicks = Mathf.RoundToInt(dinfo.Amount * 30);
+        public static bool Prefix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP, int ___EMPAdaptedTicksLeft, int ___stunTicksLeft, bool ___stunFromEMP)
+        {
+            // This is purely logic for things that are adapted to make it easier to re-stun them. It doesn't do anything if they're not stunned, and it doesn't directly stun them.
+            // Whenever an EMP hit is taken the adaptation is reduced by a certain amount based on the damage of the hit, clamped to a certain value so it always takes more than 1 hit to restun.
+            Pawn p = null;
+            if (__instance.parent is Pawn)
+            {
+                p = (Pawn)__instance.parent;
+                if (p.Downed || p.Dead) { return false; }
+            }
 
-		    float stunResistChance = ((float) ___EMPAdaptedTicksLeft / (float) newStunAdaptedTicks) * 15;
-		    void reStun()
-		    {
-			if (___stunTicksLeft > 0 && newStunTicks > ___stunTicksLeft)
-			{
-			    ___stunTicksLeft = newStunTicks;
-			}
-			else
-			{
-			    __instance.StunFor_NewTmp(newStunTicks, dinfo.Instigator, true, true);
-			}
-			
-		    }
-		    
-		    if (UnityEngine.Random.value > stunResistChance)
-		    {
-			___EMPAdaptedTicksLeft += Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-			reStun();
-		    }
-		    else
-		    {
-			MoteMaker.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
-			int adaptationReduction = Mathf.RoundToInt(Mathf.Sqrt(dinfo.Amount * 45));
-			
-			if (adaptationReduction < ___EMPAdaptedTicksLeft) {
-			    ___EMPAdaptedTicksLeft -= adaptationReduction;
-			}
-			else
-			{
-			    float adaptationReductionRatio = (adaptationReduction - ___EMPAdaptedTicksLeft) / adaptationReduction;
-			    newStunAdaptedTicks = Mathf.RoundToInt(newStunAdaptedTicks * adaptationReductionRatio);
-			    newStunTicks = Mathf.RoundToInt(newStunTicks * adaptationReductionRatio);
-			    reStun();
-			}
-		    }
-		    		    
-		}
-		else
-		{
-		    __instance.StunFor_NewTmp(Mathf.RoundToInt(dinfo.Amount * 30f), dinfo.Instigator, true, true);
-		    ___EMPAdaptedTicksLeft = Mathf.RoundToInt(dinfo.Amount * 45 * bodySize);
-		    ___stunFromEMP = true;
-		    
-		}
-	    }
-	    return true;
-	}
+            if (___EMPAdaptedTicksLeft > 0 && ___stunTicksLeft == 0 && dinfo.Def == DamageDefOf.EMP && affectedByEMP)
+            {
+                if (p != null)
+                {
+                    // TODO : Add the projectile damage into this calculation, making it reduce this multiplier by some factor based on the damage
+                    float new_mult = Mathf.Clamp(ADAPTATION_TIME_MULTIPLIER + 0.25f * Mathf.Log(p.BodySize, LOGARITHM_BASE), 0, 1);
+                    ___EMPAdaptedTicksLeft = (int)((float)___EMPAdaptedTicksLeft * new_mult);
+                }
+                else { ___EMPAdaptedTicksLeft = (int)((float)___EMPAdaptedTicksLeft * ADAPTATION_TIME_MULTIPLIER); }// Casting removes the decimal so it always rounds down for positive values
+                if (___EMPAdaptedTicksLeft > FLAT_ADAPTATION_TIME_REDUCTION) { ___EMPAdaptedTicksLeft -= FLAT_ADAPTATION_TIME_REDUCTION; }
+            }
+            return true;
+        }
+	
         public static void Postfix(StunHandler __instance, DamageInfo dinfo, bool affectedByEMP)
         {
             if (dinfo.Def == DamageDefOf.EMP)
             {
                 var dmgAmount = dinfo.Amount;
-                if (!affectedByEMP) dmgAmount = Mathf.RoundToInt(dmgAmount * 0.25f);
+                if (!affectedByEMP) { dmgAmount = Mathf.RoundToInt(dmgAmount * 0.25f); }
                 var newDinfo = new DamageInfo(CE_DamageDefOf.Electrical, dmgAmount, 9999, // Hack to avoid double-armor application (EMP damage reduced -> proportional electric damage reduced again)
                     dinfo.Angle, dinfo.Instigator, dinfo.HitPart, dinfo.Weapon, dinfo.Category);
                 __instance.parent.TakeDamage(newDinfo);
@@ -95,3 +54,4 @@ namespace CombatExtended.HarmonyCE
         }
     }
 }
+

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using RimWorld;
 using Verse;
@@ -16,10 +17,7 @@ namespace CombatExtended.HarmonyCE
          * ADAPTATION_TIME_RATIO : How long adaptation lasts, based on stun time
          * FLAT_ADAPTATION_TIME_REDUCTION_RATIO : The adaptation reduction based on damage, scaled to the adaptation time based on damage. 
          *
-         * Because the adaptation reduction is scaled based on the adaptation gain, the amount of hits to reduce adaptation to 0 remains constant in regards to how
-         * much adaptation time is applied by damage. i.e if the FATRR is untouched, it will always take e.g 6 hits to reduce adaptation to 0 regardless of if adaptation time
-         * is 5 seconds or a million years.
-         * So because the adaptation time ratio only has an effect on the speed that adaptation decays over time, the only affect changing it has is on how much less damage is required
+         * Because the adaptation time ratio only has an effect on the speed that adaptation decays over time, the only affect changing it has is on how much less damage is required
          * to cause an enemy to be stunned again over a certain period of time.
          * The amount of hits to restun an enemy is (1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
          * The amount of DPS needed to re-stun an enemy before the stun wears off is damageperhit*(1/FLAT_ADAPTATION_TIME_REDUCTION_RATIO)
@@ -31,9 +29,9 @@ namespace CombatExtended.HarmonyCE
          */
 
         // 
-        private const float STUN_TIME_DAMAGE_RATIO = 1f; // The scaling factor of stuns based on damage
+        private const float STUN_TIME_DAMAGE_RATIO = 15f; // The scaling factor of stuns based on damage
         private const float ADAPTATION_TIME_RATIO = STUN_TIME_DAMAGE_RATIO * 3; // Adaptation time based on stun time
-        private const float FLAT_ADAPTATION_TIME_REDUCTION_RATIO = ADAPTATION_TIME_RATIO / 8; // Scaling of adaptation reduction based adaptation time based on damage.
+        private const float FLAT_ADAPTATION_TIME_REDUCTION_RATIO = ADAPTATION_TIME_RATIO / 8; // Scaling of adaptation reduction
         private const float REDUCTION_MULTIPLIER_WHILE_STUNNED = 0.8f;
         private const float BUILDING_DEFAULT_BODYSIZE = 2f;
 
@@ -47,21 +45,29 @@ namespace CombatExtended.HarmonyCE
                 bodysize = p.BodySize;
             }
 
+            Type t = typeof(StunHandler);
+            FieldInfo EMPAdaptedTicksLeft = t.GetField("EMPAdaptedTicksLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            FieldInfo StunTicksLeft = t.GetField("stunTicksLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            FieldInfo StunFromEMP = t.GetField("stunFromEMP", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            
             float multiplier = bodysize / Mathf.Pow(bodysize, 2); // Multiplier based on bodysize, smaller for larger creatures
             if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
             {
                 if(___EMPAdaptedTicksLeft > 0)
                 {
-
-                    if (___stunTicksLeft > 0) { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * REDUCTION_MULTIPLIER_WHILE_STUNNED * multiplier); }
-                    else { ___EMPAdaptedTicksLeft = ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * multiplier); }
+                    
+                    if (___stunTicksLeft > 0) 
+                    { EMPAdaptedTicksLeft.SetValue(__instance, ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * REDUCTION_MULTIPLIER_WHILE_STUNNED * multiplier)); }
+                    else 
+                    { EMPAdaptedTicksLeft.SetValue(__instance, ___EMPAdaptedTicksLeft - (int)(dinfo.Amount * FLAT_ADAPTATION_TIME_REDUCTION_RATIO * multiplier)); }
+                    
                     
                     if(___EMPAdaptedTicksLeft < 0)
                     {
                         float stun_time = Mathf.Abs(___EMPAdaptedTicksLeft / (ADAPTATION_TIME_RATIO / STUN_TIME_DAMAGE_RATIO));
                         __instance.StunFor_NewTmp((int)(stun_time), dinfo.Instigator, true, true);
-                        ___EMPAdaptedTicksLeft = (int)(stun_time * ADAPTATION_TIME_RATIO);
-                        ___stunFromEMP = true;
+                        EMPAdaptedTicksLeft.SetValue(__instance, (int)(stun_time * ADAPTATION_TIME_RATIO));
+                        StunFromEMP.SetValue(__instance, true);
                         return false;
                     }
                     MoteMaker.ThrowText(new Vector3((float)__instance.parent.Position.x + 1f, (float)__instance.parent.Position.y, (float)__instance.parent.Position.z + 1f), __instance.parent.Map, "Adapted".Translate(), Color.white, -1f);
@@ -69,8 +75,8 @@ namespace CombatExtended.HarmonyCE
                 else
                 {
                     __instance.StunFor_NewTmp((int)(dinfo.Amount * STUN_TIME_DAMAGE_RATIO * multiplier), dinfo.Instigator, true, true);
-                    ___EMPAdaptedTicksLeft = (int)(dinfo.Amount * ADAPTATION_TIME_RATIO * multiplier);
-                    ___stunFromEMP = true;
+                    EMPAdaptedTicksLeft.SetValue(__instance, (int)(dinfo.Amount * ADAPTATION_TIME_RATIO));
+                    StunFromEMP.SetValue(__instance, true);
                 }
             }
             return false; 


### PR DESCRIPTION
Fixes buildings (Turrets, Mech Shields) being unstunnable Closes #643 
Fixes "Adapted" appearing twice

Reworks stun handling by adding new equations that determine stun time, along with variables that affect how different factors are scaled. Makes it fairly easy to understand and modify. Removes random chance to stun and makes it deterministic, allowing harder hitting projectiles to re-stun enemies. 

Needs to be playtested. 

Why did you choose to implement things this way, e.g.
I thought it could use cleaning up, and have a bit more flexibility. 

Describe alternative implementations you have considered, e.g.
None. 

Check tests you have performed:
- [x ] Compiles without warnings
- [x ] Game runs without errors
- [] Playtested a colony
