### PR TITLE
Fix #643 - EMP Stunning turrets

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -22,11 +22,15 @@ namespace CombatExtended.HarmonyCE
 	{
 
 	    Pawn pawn = __instance.parent as Pawn;
-	    if (pawn == null || pawn.Downed || pawn.Dead)
+            float bodySize = 1.0f;
+	    if (pawn != null)
 	    {
-		return false;
+                if (pawn.Downed || pawn.Dead)
+                {
+                    return false;
+                }
+		bodySize = pawn.BodySize;
 	    }
-	    float bodySize = pawn.BodySize;
 	    
 	    if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
 	    {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
EMP damage stuns turrets.

## Changes

Check if the stun target is a pawn.  If it is, and it's dead or downed, return early.  Otherwise get it's body size.
If it *isn't* a pawn, use 1.0 as the default, instead of returning early.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #643 

## Reasoning

Turrets, and possibly other EMP-affected things, are not pawns.  So casting them to `Pawn` is `null`.  The previous version jumped out if the stun target was not a pawn, leading to the unstunnable turret bug.


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
