### PR TITLE
Update bayonet and muskets

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -30,5 +30,7 @@
 		<li>HC.GiantRace</li>
 		<li>neronix17.fr.compilation</li>
 		<li>VanillaExpanded.VWEFT</li>
+    		<li>oskarpotocki.vanillafactionsexpanded.medievalmodule</li>
+    		<li>vanillaexpanded.vwe</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
+++ b/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
@@ -118,6 +118,10 @@
 			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
+		<tradeTags>
+			<li>CE_AutoEnableCrafting_FueledSmithy</li>
+			<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+		</tradeTags>
 		<statBases>
 			<MarketValue>0.35</MarketValue>
 			<MaxHitPoints>450</MaxHitPoints>
@@ -136,6 +140,10 @@
 		<graphicClass>Graphic_Single</graphicClass>
 		<drawSize>2</drawSize>
 	</graphicData>
+	<tradeTags>
+		<li>CE_AutoEnableCrafting_FueledSmithy</li>
+		<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+	</tradeTags>
 	<statBases>
 		<MarketValue>0.5</MarketValue>
 		<Mass>16</Mass>
@@ -166,11 +174,11 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
-			<pelletCount>8</pelletCount>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>16</armorPenetrationBlunt>
-			<spreadMult>21.5</spreadMult>
+			<damageAmountBase>10</damageAmountBase>
+			<pelletCount>10</pelletCount>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>12</armorPenetrationBlunt>
+			<spreadMult>22.5</spreadMult>
 			<speed>64</speed>
 		</projectile>
 	</ThingDef>

--- a/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
+++ b/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
@@ -72,7 +72,7 @@
 				<capacities>
 				<li>Stab</li>
 				</capacities>
-				<power>6</power>
+				<power>18</power>
 				<cooldownTime>1.49</cooldownTime>
 				<armorPenetrationBlunt>2.16</armorPenetrationBlunt>
 				<armorPenetrationSharp>1.44</armorPenetrationSharp>				  

--- a/Patches/Vanilla Factions Expanded - Medieval/PawnKindDefs/Patch_Musketman.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/PawnKindDefs/Patch_Musketman.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+					<mods>
+						<li>Vanilla Factions Expanded - Medieval</li>
+					</mods>
+		<match Class="PatchOperationFindMod">
+					<mods>
+						<li>Vanilla Weapons Expanded</li>
+					</mods>
+					
+			<match Class="PatchOperationSequence">
+				<operations>
+              
+	<!-- ========== Give ammo to musketeer ========== -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Musketeer"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>8</min>
+                <max>10</max>
+              </primaryMagazineCount>
+              <forcedSidearm>
+                <sidearmMoney>
+                  <min>120</min>
+                  <max>250</max>
+                </sidearmMoney>
+                <weaponTags>
+	<li>NeolithicMeleeBasic</li>
+	<li>MedievalMeleeDecent</li>	
+                </weaponTags>
+              </forcedSidearm>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Musketeer"]</xpath>
+          <value>
+            <apparelRequired>
+                <li>Apparel_TribalBackpack</li>
+            </apparelRequired>
+          </value>
+        </li>
+
+				</operations>
+			</match>					
+		</match>			
+	</Operation>
+
+</Patch>
+


### PR DESCRIPTION
## Additions
Tweaked bayonet damage.
Make cannonballs makable at the smithy.

!!!!IMPORTANT!!!!
Added ammo to Medieval Musketman.
This will only work if Combat Extended is loaded after both Vanilla weapons expanded AND Vanilla Faction Expanded: Medieval!!!!!!
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
