### PR TITLE
Set melee targeting to Vanilla

### DIFF
--- a/Source/CombatExtended/CombatExtended/CollisionVertical.cs
+++ b/Source/CombatExtended/CombatExtended/CollisionVertical.cs
@@ -128,9 +128,10 @@ namespace CombatExtended
             return BodyPartHeight.Top;
         }
 
+        /* Alistaire: Part of code that targets Bottom too often
         public BodyPartHeight GetRandWeightedBodyHeightBelow(float threshold)
         {
             return GetCollisionBodyHeight(Rand.Range(Min, threshold));
-        }
+        }*/
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -249,7 +249,8 @@ namespace CombatExtended
             Vector3 direction = (target.Thing.Position - CasterPawn.Position).ToVector3();
             DamageDef def = damDef;
             //END 1:1 COPY
-            BodyPartHeight bodyRegion = GetBodyPartHeightFor(target);   //Custom // Add check for body height
+            BodyPartHeight bodyRegion = BodyPartHeight.Undefined; //Alistaire: The GetBodyPartHeightFor code is completely broken and targets Bottom some 90% of the time! Therefore easiest fix to set to Vanilla (Undefined)
+                                                                  //GetBodyPartHeightFor(target);   //Custom // Add check for body height
             //START 1:1 COPY
             DamageInfo damageInfo = new DamageInfo(def, damAmount, armorPenetration, -1f, caster, null, source, DamageInfo.SourceCategory.ThingOrUnknown, null); //Alteration
 
@@ -450,6 +451,9 @@ namespace CombatExtended
             }
         }
 
+        /*
+         *  Alistaire: Code targets Bottom about 90% of the time, therefore commented out
+         *  
         /// <summary>
         /// Selects a random BodyPartHeight out of the ones our CasterPawn can hit, depending on our body size vs the target's. So a rabbit can hit top height of another rabbit, but not of a human.
         /// </summary>
@@ -464,7 +468,7 @@ namespace CombatExtended
             BodyPartHeight maxHeight = targetHeight.GetRandWeightedBodyHeightBelow(casterReach);
             BodyPartHeight height = (BodyPartHeight)Rand.RangeInclusive(1, (int)maxHeight);
             return height;
-        }
+        }*/
 
         // unmodified
         private SoundDef SoundHitPawn()


### PR DESCRIPTION
CE version targeted bottom about 90% of the time because of poor randomization code - see #642 for proper calculation of random chance

## Changes

- Reverted melee BodyPartHeight to Undefined (e.g Vanilla randomizes part appropriately)

## References

- Closes #642

## Reasoning

- More in-depth approaches change the Verb, which throws new errors that can't really be fixed if we want to do it appropriately (lock out certain Tools when they can't hit something)
- Current approach is quickest fix which immediately makes melee viable

## Alternatives

- In-depth implementation that takes into account actual heights, WITHOUT!! locking out tools based on their height

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
