### PR TITLE
NewRatkinPlus patch stuff

### DIFF
--- a/Patches/NewRatkinPlus/Ammo/RKBallistaBolt.xml
+++ b/Patches/NewRatkinPlus/Ammo/RKBallistaBolt.xml
@@ -183,7 +183,9 @@
     </products>
 	<recipeUsers>
 	  <li>FueledSmithy</li>
-	  <li>ElectricSmithy</li>	
+	  <li>ElectricSmithy</li>
+	  <li>RK_FueledSmithy</li>
+	  <li>RK_ElectricSmithy</li>	
 	</recipeUsers>
   </RecipeDef>
 
@@ -222,7 +224,9 @@
     </products>
 		<recipeUsers>
 		  <li>FueledSmithy</li>
-		  <li>ElectricSmithy</li>	
+		  <li>ElectricSmithy</li>
+		  <li>RK_FueledSmithy</li>
+		  <li>RK_ElectricSmithy</li>	
 		</recipeUsers>
   </RecipeDef>
 
@@ -269,7 +273,9 @@
     </products>
 		<recipeUsers>
 		  <li>FueledSmithy</li>
-		  <li>ElectricSmithy</li>	
+		  <li>ElectricSmithy</li>
+		  <li>RK_FueledSmithy</li>
+		  <li>RK_ElectricSmithy</li>	
 		</recipeUsers>
   </RecipeDef>
 

--- a/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
+++ b/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+			<mods>
+				<li>NewRatkinPlus</li>
+			</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>	
+	
+    <ThingCategoryDef>
+      <defName>Ammo_RKCannonShell</defName>
+      <label>Ratkin Cannon Balls</label>
+      <parent>AmmoMedieval</parent>
+    </ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_RKCannonBall</defName>
+		<label>Cannon Ball</label>
+		<ammoTypes>
+			<Ammo_RKCannonBall>Projectile_RKCannonBall</Ammo_RKCannonBall>	
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+	
+   <ThingDef Name="AmmoRKCannonBall" ParentName="AmmoBase" Abstract="True">
+    <description>Simple solid shot, designed for ratkin cannons.</description>
+    <statBases>
+      <Mass>13.6</Mass>
+      <Bulk>8.31</Bulk>
+      <Flammability>1</Flammability>
+    </statBases>
+    <thingCategories>
+      <li>Ammo_RKCannonShell</li>
+    </thingCategories>
+    <stackLimit>25</stackLimit>
+    <techLevel>Medieval</techLevel>	
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRKCannonBall">
+    <defName>Ammo_RKCannonBall</defName>
+    <label>Cannon Ball</label>
+    <graphicData>
+			<texPath>Things/Item/Resource/Big_mouse</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+			<drawSize>(0.6,0.6)</drawSize>
+    </graphicData>
+    <statBases>
+      <MarketValue>54.7</MarketValue>
+    </statBases>
+    <ammoClass>CannonBall</ammoClass>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef ParentName="BaseProjectileNeolithic" Name="BaseProjectileRKCannon" Abstract="true">
+		<thingClass>CombatExtended.BulletCE</thingClass>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>45</speed>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="BaseProjectileRKCannon">
+		<defName>Projectile_RKCannonBall</defName>
+		<label>Cannon Ball</label>
+		<graphicData>
+			<texPath>Things/Projectile/Big_mouse</texPath>
+			<drawSize>(0.6,0.6)</drawSize>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>			
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>337</damageAmountBase>
+			<armorPenetrationBlunt>17856.08</armorPenetrationBlunt>
+			<armorPenetrationSharp>8</armorPenetrationSharp>	
+		</projectile>
+	</ThingDef>
+	
+	<!-- ==================== Recipes ========================== -->
+
+    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+    <defName>MakeRKCannonBall</defName>
+    <label>make Cannon 5 Balls</label>
+    <description>Craft Cannon Ball x5.</description>
+    <jobString>Making Cannon Ball.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>138</count>
+      </li>
+    </ingredients>
+    <workAmount>13800</workAmount>	
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_RKCannonBall>5</Ammo_RKCannonBall>
+    </products>
+	<recipeUsers>
+	  <li>FueledSmithy</li>
+	  <li>ElectricSmithy</li>	
+	</recipeUsers>
+    </RecipeDef>
+
+
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
+++ b/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
@@ -111,7 +111,9 @@
     </products>
 	<recipeUsers>
 	  <li>FueledSmithy</li>
-	  <li>ElectricSmithy</li>	
+	  <li>ElectricSmithy</li>
+	  <li>RK_FueledSmithy</li>
+	  <li>RK_ElectricSmithy</li>	
 	</recipeUsers>
     </RecipeDef>
 

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -38,6 +38,29 @@
 					defName="RK_SantaRobe"					
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 			</li>
+			
+			<!-- ========== Gaurden Uniform =========== -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_GaurdenUniform"]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<WornBulk>6</WornBulk>	
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_GaurdenUniform"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>					
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_GaurdenUniform"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>2</ArmorRating_Blunt>			
+				</value>
+			</li>
 		
 			<!-- ========== Winter Robe =========== -->
 			<li Class="PatchOperationAdd">
@@ -66,6 +89,30 @@
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>	
+				</value>
+			</li>
+			
+			<!-- ========== White Coat =========== -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_WhiteCoat"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>4</WornBulk>	
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_WhiteCoat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>	
+					<ArmorRating_Electric>0.60</ArmorRating_Electric>					
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_WhiteCoat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>			
 				</value>
 			</li>
 			
@@ -231,14 +278,14 @@
 			</li>
 			<!-- ========== Combat Mask =========== -->
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RK_Mask"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases</xpath>
 				<value>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RK_Mask"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/equippedStatOffsets</xpath>
 				<value>
 					<PsychicSensitivity>-0.1</PsychicSensitivity>
 					<AimingAccuracy>0.1</AimingAccuracy>
@@ -246,16 +293,16 @@
 				</value>
 			</li>
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="RK_Mask"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/StuffEffectMultiplierArmor</xpath>
 			</li>			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RK_Mask"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>13</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RK_Mask"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="RK_Mask" or defName="RK_MaskB"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>
@@ -306,6 +353,84 @@
 				<value>
 					<AimingAccuracy>-0.4</AimingAccuracy>
 					<MeleeHitChance>-2</MeleeHitChance>				
+				</value>
+			</li>
+			
+			<!-- ========== Shields =========== -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases</xpath>
+				<value>
+					<Bulk>7</Bulk>
+					<WornBulk>4</WornBulk>					
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.2</ArmorRating_Sharp>						
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.75</ArmorRating_Blunt>						
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_WoodenShield"]/equippedStatOffsets</xpath>
+				<value>
+				  <ReloadSpeed>-0.2</ReloadSpeed>
+				  <MeleeHitChance>-1</MeleeHitChance>
+				  <ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
+				  <AimingAccuracy>-0.08</AimingAccuracy>
+				  <Suppressability>-0.25</Suppressability>
+				  <MeleeCritChance>-0.05</MeleeCritChance>
+				  <MeleeParryChance>1.0</MeleeParryChance>			
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/Mass</xpath>
+				<value>
+					<Mass>8</Mass>
+					<Bulk>14</Bulk>
+					<WornBulk>8</WornBulk>					
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>						
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>						
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>						
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/equippedStatOffsets</xpath>
+				<value>
+				  <ReloadSpeed>-0.2</ReloadSpeed>
+				  <MeleeHitChance>-1</MeleeHitChance>
+				  <ShootingAccuracyPawn>-0.30</ShootingAccuracyPawn>
+				  <AimingAccuracy>-0.16</AimingAccuracy>
+				  <Suppressability>-0.25</Suppressability>
+				  <MeleeCritChance>-0.05</MeleeCritChance>
+				  <MeleeParryChance>1.0</MeleeParryChance>			
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>					
 				</value>
 			</li>
 			<!-- ========== Add proper tags to loadbearing gear. =========== -->

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -215,27 +215,40 @@
 					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>						
 				</value>
 			</li>
-			<!-- ========== Order Uniform =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_BulletProofHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>6</Bulk>
-					<WornBulk>1</WornBulk>					
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>						
+				</value>
+			</li>
+			<!-- ========== Order Uniform =========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/Mass</xpath>
+				<value>
+					<Bulk>16</Bulk>
+					<WornBulk>10</WornBulk>
+					<Mass>10</Mass>
 				</value>
 			</li>	
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>						
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>						
 				</value>
 			</li>
-			<li Class="PatchOperationRemove">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>5.75</ArmorRating_Sharp>						
+				</value>
 			</li>
 
-			<li Class="PatchOperationRemove">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RK_OrderUniform"]/statBases/ArmorRating_Blunt</xpath>
-			</li>			
+				<value>
+					<ArmorRating_Blunt>7.875</ArmorRating_Blunt>						
+				</value>
+			</li>		
 			<!-- ========== Battlesuit =========== -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RK_BattleSuit"]/statBases</xpath>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -441,11 +441,15 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="RK_HeavyShield"]/stuffCategories/li[.="Metallic"]</xpath>
+				<xpath>Defs/ThingDef[defName="RK_HeavyShield" or defName="RK_WoodenShield"]/apparel/layers</xpath>
 				<value>
-					<li>Steeled</li>					
+					<layers>
+						<li>Shield</li>
+					</layers>
 				</value>
 			</li>
+			
+			
 			<!-- ========== Add proper tags to loadbearing gear. =========== -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
@@ -82,10 +82,9 @@
 					<SightsEfficiency>1</SightsEfficiency>
 					<ShotSpread>0.04</ShotSpread>
 					<SwayFactor>0.96</SwayFactor>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.13</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Projectile_RKBallistaBolt</defaultProjectile>
@@ -145,6 +144,10 @@
 				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/statBases/AccuracyLong</xpath>
 			</li>
 			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/costList/Chemfuel</xpath>
+			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
@@ -189,23 +192,22 @@
 					<Mass>20</Mass>
 					<Bulk>20</Bulk>	
 					<SightsEfficiency>1</SightsEfficiency>
-					<ShotSpread>0.12</ShotSpread>
+					<ShotSpread>0.26</ShotSpread>
 					<SwayFactor>1.55</SwayFactor>
-					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>3</RangedWeapon_Cooldown>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.13</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Projectile_RKCannonBall</defaultProjectile>
 					<warmupTime>4.9</warmupTime>
-					<range>50</range>
+					<range>75</range>
 					<soundCast>RKCannonShot</soundCast>
 					<muzzleFlashScale>12</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>16</reloadTime>
+					<reloadTime>14</reloadTime>
 					<ammoSet>AmmoSet_RKCannonBall</ammoSet>
 				</AmmoUser>
 				<FireModes>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
@@ -7,147 +7,222 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-			  <!-- ========== Ratkin Ballista ========== -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="RK_BaseArtilleryBuilding"]</xpath>
-					<value>
-						<ThingDef Name="RK_BaseArtilleryBuilding" ParentName="BuildingBase" Abstract="True">
-							<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-							<graphicData>
-								<texPath>Things/Building/Security/Ballista_Base</texPath>
-								<shaderType>CutoutComplex</shaderType>
-								<graphicClass>Graphic_Single</graphicClass>
-								<drawSize>(2,2)</drawSize>
-								<damageData>
-									<rect>(0.38,0.2,0.56375,0.8)</rect>
-									<cornerTL>Damage/Corner</cornerTL>
-								</damageData>
-								<shadowData>
-									<offset>(-0.13,-0.87,-0.1)</offset>
-									<volume>(0.5,0.4,1.05)</volume>
-								</shadowData>
-							</graphicData>
-							<minifiedDef>MinifiedThing</minifiedDef>
-							<altitudeLayer>Building</altitudeLayer>
-							<hasInteractionCell>True</hasInteractionCell>
-							<interactionCellOffset>(0,0,-1)</interactionCellOffset>
-							<stealable>false</stealable>
-							<size>(3,2)</size>
-							<passability>PassThroughOnly</passability>
-							<pathCost>50</pathCost>
-							<fillPercent>0.75</fillPercent>
-							<thingCategories>
-								<li>BuildingsSecurity</li>
-							</thingCategories>
-							<stuffCategories>
-								<li>Woody</li>
-							</stuffCategories>
-							<tickerType>Normal</tickerType>
-							<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-							<designationCategory>Security</designationCategory>
-							<costStuffCount>240</costStuffCount>
-							<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
-							<costList>
-								<Steel>80</Steel>
-								<ComponentIndustrial>1</ComponentIndustrial>
-							</costList>
-							<comps>
-								<li Class="CompProperties_Forbiddable"/>
-								<li Class="CompProperties_Mannable">
-									<manWorkType>Violent</manWorkType>
-								</li>
-							</comps>
-							<statBases>
-								<MaxHitPoints>180</MaxHitPoints>
-								<Flammability>0.7</Flammability>
-								<WorkToBuild>1900</WorkToBuild>
-								<Mass>30</Mass>
-								<Beauty>-20</Beauty>
-								<AccuracyTouch>0.9</AccuracyTouch>
-								<AccuracyShort>0.8</AccuracyShort>
-								<AccuracyMedium>0.75</AccuracyMedium>
-								<AccuracyLong>0.70</AccuracyLong>
-								<RangedWeapon_Cooldown>0.1</RangedWeapon_Cooldown>
-							</statBases>
-							<building>
-								<turretBurstWarmupTime>3.0</turretBurstWarmupTime>
-								<turretBurstCooldownTime>7.0</turretBurstCooldownTime>
-								<buildingTags>
-									<li>RK_Artillery</li>
-								</buildingTags>
-							</building>
-							<placeWorkers>
-								<!-- <li>PlaceWorker_NotUnderRoof</li> -->
-								<li>PlaceWorker_TurretTop</li>
-							</placeWorkers>
-							<uiIconScale>1</uiIconScale>
-							<researchPrerequisites>
-								<li>Ballista</li>
-							</researchPrerequisites>
-						</ThingDef>
-					</value>
-				</li>
+			<!-- ========== Ratkin Ballista ========== -->
+			  
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/inspectorTabs</xpath>
+			</li>
 			
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RK_Turret_Ballista_Strait"]</xpath>
-					<value>
-					  <ThingDef ParentName="BaseTurretGun">
-						<defName>RK_Turret_Ballista_Strait</defName>
-						<label>ballista</label>
-						<graphicData>
-						  <texPath>Things/Building/Security/Ballista_Turret</texPath>
-						  <graphicClass>Graphic_Single</graphicClass>
-						</graphicData>
-						<description>It is a machine that fires large arrows. It is designed to be easy to operate by Ratkin.</description>
-						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-						<statBases>
-						  <Flammability>1.0</Flammability>
-						  <WorkToMake>31500</WorkToMake>
-						  <Mass>16.5</Mass>
-						  <Bulk>20</Bulk>	
-						  <MarketValue>2000</MarketValue>
-						  <SightsEfficiency>1</SightsEfficiency>
-						  <ShotSpread>0.04</ShotSpread>
-						  <SwayFactor>0.96</SwayFactor>
-						  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						</statBases>
-						<verbs>
-						  <li Class="CombatExtended.VerbPropertiesCE">
-							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-							<hasStandardCommand>true</hasStandardCommand>
-							<defaultProjectile>Projectile_RKBallistaBolt</defaultProjectile>
-							<warmupTime>1.4</warmupTime>
-							<range>44</range>
-							<soundCast>BallistaShot</soundCast>
-							<recoilPattern>Mounted</recoilPattern>
-						  </li>
-						</verbs>
-						<comps>
-							<li>
-								<compClass>CompEquippable</compClass>
-							</li>					
-						  <li Class="CombatExtended.CompProperties_AmmoUser">
-							<magazineSize>1</magazineSize>
-							<reloadTime>8</reloadTime>
-							<ammoSet>AmmoSet_RKBallistaBolt</ammoSet>
-						  </li>
-						  <li Class="CombatExtended.CompProperties_FireModes">
-							<aiAimMode>AimedShot</aiAimMode>
-						  </li>
-						</comps>
-					  </ThingDef>					
-					</value>
-				</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/statBases/AccuracyTouch</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/statBases/AccuracyShort</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/statBases/AccuracyMedium</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/statBases/AccuracyLong</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/building</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/comps/li[@Class="CompProperties_ChangeableProjectile"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/statBases/AccuracyTouch</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/statBases/AccuracyShort</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/statBases/AccuracyMedium</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon"]/statBases/AccuracyLong</xpath>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "RK_Turret_Ballista_Strait"]</xpath>
+				<value>
+				<statBases/>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RK_Turret_Ballista_Strait</defName>
+				<statBases>
+					<Mass>16.5</Mass>
+					<Bulk>20</Bulk>	
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>0.96</SwayFactor>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.13</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_RKBallistaBolt</defaultProjectile>
+					<warmupTime>2.1</warmupTime>
+					<range>44</range>
+					<soundCast>BallistaShot</soundCast>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>8</reloadTime>
+					<ammoSet>AmmoSet_RKBallistaBolt</ammoSet>
+				</AmmoUser>
+				<FireModes>
+				</FireModes>
+				<weaponTags>
+					<li>TurretGun</li>
+				</weaponTags>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="BallistaBolt_Normal"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="BallistaBolt_AP"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="BallistaBolt_Heavy"]</xpath>
+			</li>	
+			
+			<!-- ========== Ratkin Cannon ========== -->
+			  
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/inspectorTabs</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/statBases/AccuracyTouch</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/statBases/AccuracyShort</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/statBases/AccuracyMedium</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/statBases/AccuracyLong</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryBuilding_Cannon"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/building</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/comps/li[@Class="CompProperties_ChangeableProjectile"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/statBases/AccuracyTouch</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/statBases/AccuracyShort</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/statBases/AccuracyMedium</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name = "RK_BaseArtilleryWeapon_Cannon"]/statBases/AccuracyLong</xpath>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "RK_Turret_Cannon_Strait"]</xpath>
+				<value>
+				<statBases/>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RK_Turret_Cannon_Strait</defName>
+				<statBases>
+					<Mass>20</Mass>
+					<Bulk>20</Bulk>	
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.12</ShotSpread>
+					<SwayFactor>1.55</SwayFactor>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.13</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Projectile_RKCannonBall</defaultProjectile>
+					<warmupTime>4.9</warmupTime>
+					<range>50</range>
+					<soundCast>BallistaShot</soundCast>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>16</reloadTime>
+					<ammoSet>AmmoSet_RKCannonBall</ammoSet>
+				</AmmoUser>
+				<FireModes>
+				</FireModes>
+				<weaponTags>
+					<li>TurretGun</li>
+				</weaponTags>
+			</li>
+			  
+
 				
 			<!-- Bolts -->
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="BallistaBolt_Normal"]</xpath>
+					<xpath>Defs/ThingDef[defName="Bullet_Big_mouse"]</xpath>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="BallistaBolt_AP"]</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="BallistaBolt_Heavy"]</xpath>
+					<xpath>Defs/ThingDef[defName="Big_mouse"]</xpath>
 				</li>				
 			
 		</operations>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Buildings_Security.xml
@@ -200,7 +200,7 @@
 					<defaultProjectile>Projectile_RKCannonBall</defaultProjectile>
 					<warmupTime>4.9</warmupTime>
 					<range>50</range>
-					<soundCast>BallistaShot</soundCast>
+					<soundCast>RKCannonShot</soundCast>
 					<muzzleFlashScale>12</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
@@ -557,11 +557,12 @@
 			  </tools>
 			</value>
 		  </li>
-		  <li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="RK_HeavyLance"]/statBases</xpath>
+		  <li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="RK_HeavyLance"]/statBases/Mass</xpath>
 			<value>
 			  <MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
 			  <Bulk>7</Bulk>
+			  <Mass>5</Mass>
 			</value>
 		  </li>
 		  <li Class="PatchOperationReplace">
@@ -574,6 +575,12 @@
 			  </equippedStatOffsets>
 			</value>
 		  </li>
+		  <li Class="PatchOperationReplace">
+		  	<xpath>/Defs/ThingDef[defName="RK_HeavyLance"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+				  <li>Metallic_Weapon</li>
+				</value>
+		    </li>
 
 		  <!-- Gunlances (Normal & Spread) -->
 			<li Class="PatchOperationReplace">
@@ -618,11 +625,12 @@
 				</tools>
 			</value>
 		    </li>
-		    <li Class="PatchOperationAdd">
-		  	<xpath>/Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/statBases</xpath>
+		    <li Class="PatchOperationReplace">
+		  	<xpath>/Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/statBases/Mass</xpath>
 				<value>
 				  <MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
 				  <Bulk>7</Bulk>
+				  <Mass>8</Mass>
 				</value>
 		    </li>
 		    <li Class="PatchOperationReplace">
@@ -633,6 +641,12 @@
 					<MeleeParryChance>0.98</MeleeParryChance>
 					<MeleeDodgeChance>0.8</MeleeDodgeChance>
 				  </equippedStatOffsets>
+				</value>
+		    </li>
+			<li Class="PatchOperationReplace">
+		  	<xpath>/Defs/ThingDef[defName="RK_Gunlance_NormalType" or defName="RK_Gunlance_SpreadType"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+				  <li>Metallic_Weapon</li>
 				</value>
 		    </li>
 

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_MeleeWeapons.xml
@@ -649,6 +649,77 @@
 				  <li>Metallic_Weapon</li>
 				</value>
 		    </li>
+			
+			<!-- ========== Patch StrawberryBeer ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>2.22</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>neck</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>3.33</cooldownTime>
+							<armorPenetrationBlunt>0.150</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>0.33</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.1</MeleeCritChance>
+						<MeleeParryChance>0.33</MeleeParryChance>
+						<MeleeDodgeChance>0.07</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+				<success>Always</success>
+				<operations>
+					<li Class="PatchOperationTest">
+						<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]/weaponTags</xpath>
+						<success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]</xpath>
+						<value>
+							<weaponTags />
+						</value>
+					</li>
+				</operations>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RK_StrawberryBeer"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
 
 		</operations>
 		</match>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -94,7 +94,7 @@
 			  <defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
 			  <warmupTime>1</warmupTime>
 			  <range>26</range>
-			  <soundCast>Bow_Large</soundCast>
+			  <soundCast>Bow_Small</soundCast>
 			</Properties>
 			<costList>
 				<WoodLog>40</WoodLog>
@@ -216,7 +216,7 @@
 			  <defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
 			  <warmupTime>1.1</warmupTime>
 			  <range>55</range>
-			  <soundCast>FlechetteRifle</soundCast>
+			  <soundCast>Rifle</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>
@@ -262,7 +262,7 @@
 			  <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 			  <warmupTime>0.6</warmupTime>
 			  <range>16</range>
-			  <soundCast>Shot_BoltActionRifle</soundCast>
+			  <soundCast>FlechetteRifle</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>
@@ -301,7 +301,7 @@
 			  <defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
 			  <range>68</range>
-			  <soundCast>Shot_BoltActionRifle</soundCast>
+			  <soundCast>Rifle</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -9,7 +9,7 @@
 
 		<!-- ========== Melee Tools - Rifles ========== -->
 		  <li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="RK_Rifle" or defName="RK_SniperRifle" or defName="RK_FlechetteRifle" or defName="RK_FlechetteSniperRifle"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="RK_Rifle" or defName="RK_SniperRifle" or defName="RK_FlechetteRifle" or defName="RK_FlechetteSniperRifle" or defName="RK_Rifle_line"]/tools</xpath>
 			<value>
 			  <tools>
 				<li Class="CombatExtended.ToolCE">
@@ -208,7 +208,7 @@
 			<costList>
 				<WoodLog>30</WoodLog>
 				<Steel>55</Steel>
-				<ComponentIndustrial>3</ComponentIndustrial>
+				<ComponentIndustrial>1</ComponentIndustrial>
 			</costList>
 			<Properties>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -216,7 +216,7 @@
 			  <defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
 			  <warmupTime>1.1</warmupTime>
 			  <range>55</range>
-			  <soundCast>Shot_BoltActionRifle</soundCast>
+			  <soundCast>FlechetteRifle</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>
@@ -238,6 +238,45 @@
 				<li>CE_AI_Rifle</li>
 			</weaponTags>
 		  </li>
+		  
+		  <!-- ========== Shotgun ========== -->
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>RK_Rifle_line</defName>
+			<statBases>
+			  <Mass>3.30</Mass>
+			  <RangedWeapon_Cooldown>1.00</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.14</ShotSpread>
+			  <SwayFactor>1.22</SwayFactor>
+			  <Bulk>9</Bulk>
+			  <WorkToMake>9500</WorkToMake>
+			</statBases>
+			<costList>
+			  <Steel>45</Steel>
+			  <WoodLog>10</WoodLog>
+			  <ComponentIndustrial>1</ComponentIndustrial>
+			</costList>
+			<Properties>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+			  <warmupTime>0.6</warmupTime>
+			  <range>16</range>
+			  <soundCast>Shot_BoltActionRifle</soundCast>
+			  <soundCastTail>GunTail_Heavy</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>5</magazineSize>
+			  <reloadOneAtATime>true</reloadOneAtATime>
+			  <reloadTime>0.85</reloadTime>
+			  <ammoSet>AmmoSet_12Gauge</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			</FireModes>
+			<weaponTags>
+			</weaponTags>
+		  </li>
 
 		  <!-- ========== Sniper Rifle ========== -->
 		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -254,7 +293,7 @@
 			<costList>
 				<WoodLog>30</WoodLog>
 				<Steel>70</Steel>
-				<ComponentIndustrial>5</ComponentIndustrial>
+				<ComponentIndustrial>2</ComponentIndustrial>
 			</costList>
 			<Properties>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
@@ -23,8 +23,24 @@
 		</operations>
 		</li>
 		
+		<li Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationTest">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin_Su"]/comps</xpath>
+			<success>Invert</success>
+			</li>
+			<li Class="PatchOperationAdd">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin_Su"]</xpath>
+			<value>
+				<comps />
+			</value>
+			</li>
+		</operations>
+		</li>
+		
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
 			<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Humanoid</bodyShape>
@@ -34,21 +50,21 @@
 
 		<!-- Melee Tool & Basestats Defs -->
 		<li Class="PatchOperationAdd">
-		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/statBases</xpath>
+		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/statBases</xpath>
 			  <value>
 				<MeleeCritChance>0.95</MeleeCritChance>
 				<MeleeParryChance>1</MeleeParryChance>
 			  </value>
 		</li>
 		<li Class="PatchOperationReplace">
-		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/statBases/MeleeDodgeChance</xpath>
+		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/statBases/MeleeDodgeChance</xpath>
 			  <value>
 				<MeleeDodgeChance>1.05</MeleeDodgeChance>
 			  </value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/tools</xpath> 
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/tools</xpath> 
 			<value>
 				<tools>
 				  <li Class="CombatExtended.ToolCE">
@@ -103,7 +119,7 @@
 
 		<!-- Adding Inventory Support-->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]</xpath>
 			<value>
 			<inspectorTabs>
 				<li>CombatExtended.ITab_Inventory</li>
@@ -112,14 +128,14 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/comps</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
 			<value>
 				<li Class="CombatExtended.CompProperties_Inventory" />
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/comps</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/comps</xpath>
 			<value>
 				<li>
 				  <compClass>CombatExtended.CompPawnGizmo</compClass>
@@ -130,15 +146,15 @@
 
 		<!-- Tweak weaponList -->
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/alienRace/raceRestriction/weaponList/li[text()="RK_LongSword"]</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/alienRace/raceRestriction/weaponList/li[.="RK_LongSword"]</xpath>
 		</li>
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/alienRace/raceRestriction/weaponList/li[text()="RK_FlechetteRifle"]</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/alienRace/raceRestriction/weaponList/li[.="RK_FlechetteRifle"]</xpath>
 		</li>
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/alienRace/raceRestriction/weaponList/li[text()="RK_FlechetteSniperRifle"]</xpath>
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin" or defName="Ratkin_Su"]/alienRace/raceRestriction/weaponList/li[.="RK_FlechetteSniperRifle"]</xpath>
 		</li>
 
 		</operations>


### PR DESCRIPTION
## Additions

Added appropirate stats for a lot of new content items. Added race stuff for the subject subrace.

## Changes

Reduced the weight on a few weapons to prevent massive overweight problems for ratkin knights. Gave guardner and order armor back their innate protection since they are specifically combat armors. Moreso for order armor which actually takes up the middle slot, blocking you out of other armor options.

Changed the ballistia patch to not be so intrusive. Also it was broken as well for some reason, so that's fixed.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
