### PR TITLE
Windows of Leadership patch

### DIFF
--- a/Patches/Colony Leadership/WarriorLeadership.xml
+++ b/Patches/Colony Leadership/WarriorLeadership.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Colony Leadership</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leader2"]/stages/li[1]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+         							<TradePriceImprovement>+0.05</TradePriceImprovement>
+       							<NegotiationAbility>+0.05</NegotiationAbility>
+       							<MoveSpeed>+0.10</MoveSpeed>
+       							<MeleeHitChance>+0.05</MeleeHitChance>
+             							<MedicalTendQualityOffset>+0.05</MedicalTendQualityOffset>
+							<Suppressability>-0.12</Suppressability>
+          						</statOffsets>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leader2"]/stages/li[1]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+       						<TradePriceImprovement>+0.10</TradePriceImprovement>
+       						<NegotiationAbility>+0.10</NegotiationAbility>
+          						<MoveSpeed>+0.20</MoveSpeed>      
+      						<MeleeHitChance>+0.15</MeleeHitChance>      
+      						<MedicalTendQualityOffset>+0.10</MedicalTendQualityOffset>
+						<Suppressability>-0.25</Suppressability>
+          						</statOffsets>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leader2"]/stages/li[1]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+         						<TradePriceImprovement>+0.15</TradePriceImprovement>  
+       						<NegotiationAbility>+0.15</NegotiationAbility>       
+             						<MoveSpeed>+0.3</MoveSpeed>         
+         						<MeleeHitChance>+0.30</MeleeHitChance>      
+         						<MedicalTendQualityOffset>+0.2</MedicalTendQualityOffset>
+						<Suppressability>-0.4</Suppressability>
+          						</statOffsets>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leaderAura2"]/stages/li[1]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+          							<MoveSpeed>+0.10</MoveSpeed>
+		  					<MeleeHitChance>+0.05</MeleeHitChance>
+		  					<MeleeWeapon_CooldownMultiplier>0.96</MeleeWeapon_CooldownMultiplier>
+		  					<MedicalTendQualityOffset>+0.05</MedicalTendQualityOffset>
+							<Suppressability>-0.1</Suppressability>
+      							<ShootingAccuracyPawn>0.1</ShootingAccuracyPawn>
+          						</statOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leaderAura2"]/stages/li[2]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+          							<MoveSpeed>+0.20</MoveSpeed>
+		  					<MeleeHitChance>+0.15</MeleeHitChance>
+		  					<MeleeWeapon_CooldownMultiplier>0.92</MeleeWeapon_CooldownMultiplier>
+		  					<MedicalTendQualityOffset>+0.1</MedicalTendQualityOffset>
+							<Suppressability>-0.2</Suppressability>
+      							<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
+          						</statOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/HediffDef[defName="leaderAura2"]/stages/li[3]/statOffsets</xpath>
+					<value>
+          						<statOffsets>
+          							<MoveSpeed>+0.30</MoveSpeed>
+		  					<MeleeHitChance>+0.25</MeleeHitChance>
+		  					<MeleeWeapon_CooldownMultiplier>0.87</MeleeWeapon_CooldownMultiplier>
+		  					<MedicalTendQualityOffset>+0.15</MedicalTendQualityOffset>
+							<Suppressability>-0.35</Suppressability>
+      							<ShootingAccuracyPawn>0.35</ShootingAccuracyPawn>
+          						</statOffsets>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/JPT Open The Windows/Openvindows.xml
+++ b/Patches/JPT Open The Windows/Openvindows.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>[JPT] Open The Windows</li>
+		</mods>
+		
+		<match Class="PatchOperationSequence">
+			<success></success>
+			<operations>
+
+		<!-- -->
+      		<li Class="PatchOperationReplace">
+        		<xpath>Defs/ThingDef[@Name = "WindowBase"]/fillPercent</xpath>
+        		<value>
+    			<fillPercent>0.6</fillPercent>
+        		</value>
+      		</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/JPT Open The Windows/Openvindows.xml
+++ b/Patches/JPT Open The Windows/Openvindows.xml
@@ -6,7 +6,6 @@
 		</mods>
 		
 		<match Class="PatchOperationSequence">
-			<success></success>
 			<operations>
 
 		<!-- -->


### PR DESCRIPTION
## Additions
Makes Open the windows compatible.
Improvements to Colony leadership, make the stat buffs from warrior type leaders compatible with CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
