### PR TITLE
Hard Armor damage changes

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -220,10 +220,6 @@ namespace CombatExtended
             newPenAmount -= partDensity;    // Factor partDensity only after damage calculations
 
             // Apply damage to armor
-            var fullDeflect = armorAmount > penAmount * 2f;
-            var armorDamagePen = penAmount * 2f - armorAmount;
-            var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
-            var armorDmgAmount = dmgAmount * armorDmgMult;
             if (armor != null)
             {
                 var isSoftArmor = armor.Stuff != null && armor.Stuff.stuffProps.categories.Any(s => softStuffs.Contains(s));
@@ -239,6 +235,10 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
+                    var fullDeflect = armorAmount > penAmount * 2f;
+                    var armorDamagePen = penAmount * 2f - armorAmount;
+                    var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
+                    var armorDmgAmount = dmgAmount * armorDmgMult;
                     var armorDamage = Mathf.Max(0, armorDmgAmount);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -220,6 +220,10 @@ namespace CombatExtended
             newPenAmount -= partDensity;    // Factor partDensity only after damage calculations
 
             // Apply damage to armor
+            var fullDeflect = armorAmount > penAmount * 2f;
+            var armorDamagePen = penAmount * 2f - armorAmount;
+            var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
+            var armorDmgAmount = dmgAmount * armorDmgMult;
             if (armor != null)
             {
                 var isSoftArmor = armor.Stuff != null && armor.Stuff.stuffProps.categories.Any(s => softStuffs.Contains(s));
@@ -235,7 +239,7 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-                    var armorDamage = Mathf.Max(1, newDmgAmount);
+                    var armorDamage = Mathf.Max(0, armorDmgAmount);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }


### PR DESCRIPTION

## Changes

Changed damage dealt to hard armor to scale off of (2 x penetration - armor)/penetration (capped to 1) for the purposes of dealing damage to hard armor, thus requring armor to have double the protection compared to the incoming penetration in order to completely mitigate it. Reduced the minimum damage hard armor can potentially take to 0, meaning comparably very low penetration attacks can no longer damage armor.

## Reasoning

Currently, armor only takes damage equal to the amount of damage that is delivered through it, with a minimum of 1. Many high durability pieces of armor thus are able to absorb insane amounts of punishment, easily outliving the pawns wearing it by a factor of 5 or more.

Not only does this make hardened armors, especially some lategame options such as power armor extremely durable, capable of absorbing a ton of punishment over their lifetime, it also makes it very easy to loot working sets of said armor, even off of corpses since 50 damage from their 400+ pool of HP isn't particuarly significant.

## Alternatives

One option would be to generally reduce the HP of many high HP items, however I feel this requires a lot more overall work.

Rather than increasing the effective penetration and adding addtional calculations to do so, we could just apply a flat increase, but this would only really benefit high power weapons that are already dealing okay damage to said armor, without improving the large number of weapons that are close to penetrating but still deal only 1 damage.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors : not tested
- [ ] Playtested a colony (specify how long)
