### PR TITLE
Fix Armor Penetration for Alpha Ships and SOS2's Ship Weapons

### DIFF
--- a/Patches/Alpha Ships/Patch_AlphaShips_DamageDefs.xml
+++ b/Patches/Alpha Ships/Patch_AlphaShips_DamageDefs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Alpha Ships</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[
+				defName="AS_ShipBioSmall"
+			]/defaultArmorPenetration</xpath>
+			<value>
+				<defaultArmorPenetration>200</defaultArmorPenetration>
+			</value>
+		</li>
+			
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/Save Our Ship 2/Patch_DamageDefs_SOS2.xml
+++ b/Patches/Save Our Ship 2/Patch_DamageDefs_SOS2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Save Our Ship 2</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[
+				defName="ShipLaserSmall" or
+				defName="ShipPlasmaSmall" or
+				defName="BombKinetic" or
+				defName="ShipLaserTwo" or
+				defName="BombKineticLarge" or
+				defName="ShipPlasmaLarge"
+			]/defaultArmorPenetration</xpath>
+			<value>
+				<defaultArmorPenetration>200</defaultArmorPenetration>
+			</value>
+		</li>
+			
+		</operations>
+		</match>
+	</Operation>
+	
+</Patch>

--- a/Patches/Save Our Ship 2/Patch_DamageDefs_SOS2.xml
+++ b/Patches/Save Our Ship 2/Patch_DamageDefs_SOS2.xml
@@ -10,15 +10,24 @@
 		
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/DamageDef[
-				defName="ShipLaserSmall" or
 				defName="ShipPlasmaSmall" or
-				defName="BombKinetic" or
+				defName="BombKinetic"
+			]/defaultArmorPenetration</xpath>
+			<value>
+				<defaultArmorPenetration>150</defaultArmorPenetration>
+			</value>
+		</li>
+		
+		<!-- Small lasers do low damage and are unlikely to kill -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[
+				defName="ShipLaserSmall" or
 				defName="ShipLaserTwo" or
 				defName="BombKineticLarge" or
 				defName="ShipPlasmaLarge"
 			]/defaultArmorPenetration</xpath>
 			<value>
-				<defaultArmorPenetration>200</defaultArmorPenetration>
+				<defaultArmorPenetration>500</defaultArmorPenetration>
 			</value>
 		</li>
 			


### PR DESCRIPTION
## Additions

Adds a patch that changes the default AP of Alpha Ships and SOS2's ship mounted weapons to 200 MPa (originally 0.1 MPa)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (few minutes)
