### PR TITLE
increase ogron armor to feral mail level

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -35,14 +35,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Mutant_Ogron"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Mutant_Ogron"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Races/Race_Ogrons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Races/Race_Ogrons.xml
@@ -42,7 +42,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Mutant_Ogron"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 			


### PR DESCRIPTION
Ogron armor was initially 1.5 sharp and 0.5 blunt, probably a leftover from the old armor system. Since the different ogron classes (hellmaker, gutcher, orgenaut) use the same race_ogron armor, I decided to only up the armor to 8 sharp and 8 blunt, which is what the current feral mail armor is. Hopefully it'll give the ogrons enough survivability while not making it too tanky given its health pool.

## Additions

Describe new functionality added by your code, e.g.
- Buffs Ogrons 

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased ogron armor to 8 sharp and 8 blunt, the armor level used for feral mail

## Reasoning

Why did you choose to implement things this way, e.g.
- Ogrons were easy to down due to lack of armor (1.5 sharp and 0.5 blunt currently)
- increases ogron survivability 
- Easy to implement

## Testing

Check tests you have performed:
- [x ] Compiles without warnings
- [ x] Game runs without errors
- [x ] (For compatibility patches) ...with and without patched mod loaded
- [x ] Playtested a colony (specify how long)
