### PR TITLE
PA tier cost rebalance

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -230,7 +230,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>80</Plasteel>
+      <Plasteel>60</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
   </Operation>
@@ -311,7 +311,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>60</Plasteel>
+      <Plasteel>50</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -75,7 +75,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SimpleHelmet"]/costStuffCount</xpath>
     <value>
-      <costStuffCount>50</costStuffCount>
+      <costStuffCount>25</costStuffCount>
     </value>
   </Operation>
 
@@ -186,6 +186,13 @@
       <Flammability>0</Flammability>
     </value>
   </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>4.8</Mass>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/MaxHitPoints</xpath>
@@ -223,7 +230,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>45</Plasteel>
+      <Plasteel>80</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
   </Operation>
@@ -260,6 +267,13 @@
       <Flammability>0</Flammability>
     </value>
   </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>3.6</Mass>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/MaxHitPoints</xpath>
@@ -294,12 +308,14 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList</xpath>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList/Plasteel</xpath>
     <value>
+      <Plasteel>60</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
     </value>
   </Operation>
+
 
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/apparel/layers</xpath>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -137,6 +137,15 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<!-- Reduce Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_PlateArmor"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>105</costStuffCount>
+		</value>
+	</Operation>
 
 	<!-- ========== Armor vest ========== -->
 
@@ -447,6 +456,22 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<!-- Increase Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>225</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>40</Uranium>
+		</value>
+	</Operation>
 
 	<!-- ========== Recon armor ========== -->
 
@@ -517,6 +542,22 @@
 		<value>
 			<li>Hands</li>
 			<li>Feet</li>
+		</value>
+	</Operation>
+	
+	<!-- Increase Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>180</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>20</Uranium>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -462,7 +462,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>225</Plasteel>
+			<Plasteel>180</Plasteel>
 		</value>
 	</Operation>
 	
@@ -550,7 +550,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>180</Plasteel>
+			<Plasteel>140</Plasteel>
 		</value>
 	</Operation>
 	

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
@@ -14,7 +14,7 @@
 				<xpath>Defs/ThingDef[@Name="JDSExiledChestPlate(AR)ArmorBase" or 
 				@Name="JDSExiledChestPlateArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>9.6</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -22,7 +22,7 @@
 				<xpath>Defs/ThingDef[@Name="JDSExiledChestPlate(AR)ArmorBase" or 
 				@Name="JDSExiledChestPlateArmorBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -155,7 +155,7 @@
 				</value>
 			</li>
 			
-			<!--Plate Gambeson-->
+			<!--Plate Gambeson : Stronger in vanilla but costs less. No idea why.-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledPlateGambesonARArmorBase" or 
@@ -204,12 +204,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--King Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKingArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -237,12 +237,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Knight Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKnightArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -270,12 +270,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Knight Captain Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKnightCaptainArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -303,7 +303,20 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Price Change-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Colored_King_Armor" or
+				defName="Colored_Knight_Armor" or
+				defName="Colored_Knight_Captain"
+				]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<!--Scholar Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledScholarArmorBase"]/statBases/ArmorRating_Sharp</xpath>
@@ -333,6 +346,18 @@
 				<value>
 					<CarryBulk>10</CarryBulk>
 					<CarryWeight>60</CarryWeight>
+				</value>
+			</li>
+			
+			<!--Price Change-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Colored_Scholar_Armor"
+				]/costList/Steel</xpath>
+				<value>
+					<Plasteel>120</Plasteel>
+					<Steel>250</Steel>
+					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
@@ -311,7 +311,7 @@
 				defName="Colored_Knight_Captain"
 				]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>240</Plasteel>
+					<Plasteel>190</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -355,8 +355,8 @@
 				<xpath>Defs/ThingDef[defName="Colored_Scholar_Armor"
 				]/costList/Steel</xpath>
 				<value>
-					<Plasteel>120</Plasteel>
-					<Steel>250</Steel>
+					<Plasteel>100</Plasteel>
+					<Steel>200</Steel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -300,7 +300,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>240</Moyo_Abyssteel>
+					<Moyo_Abyssteel>190</Moyo_Abyssteel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
@@ -363,7 +363,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>80</Moyo_Abyssteel>
+					<Moyo_Abyssteel>60</Moyo_Abyssteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -433,7 +433,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>190</Moyo_Abyssteel>
+					<Moyo_Abyssteel>150</Moyo_Abyssteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -490,7 +490,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>65</Moyo_Abyssteel>
+					<Moyo_Abyssteel>50</Moyo_Abyssteel>
 					<DevilstrandCloth>15</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -297,9 +297,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>240</Moyo_Abyssteel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
@@ -359,9 +360,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>80</Moyo_Abyssteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -428,9 +430,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>190</Moyo_Abyssteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -484,9 +487,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>65</Moyo_Abyssteel>
 					<DevilstrandCloth>15</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -142,6 +142,13 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GDsuit"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>325</Moyo_Abyssteel>
+				</value>
+			</li>
+			
 			<!--Royal Guard Helmet-->
 			
 			<li Class="PatchOperationAdd">
@@ -196,6 +203,14 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>115</Moyo_Abyssteel>
+					<Hyperweave>10</Hyperweave>
+				</value>
+			</li>
+			
 			<!--Royal Guard Light Armor-->
 			
 			<li Class="PatchOperationAdd">
@@ -243,6 +258,13 @@
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
 					<MoveSpeed>0.1</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GSsuit"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>190</Moyo_Abyssteel>
 				</value>
 			</li>
 			
@@ -297,6 +319,14 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>
 					<AimingAccuracy>0.10</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>100</Moyo_Abyssteel>
+					<Hyperweave>10</Hyperweave>
 				</value>
 			</li>
 			

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -145,7 +145,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_GDsuit"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>325</Moyo_Abyssteel>
+					<Moyo_Abyssteel>260</Moyo_Abyssteel>
 				</value>
 			</li>
 			
@@ -206,7 +206,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>115</Moyo_Abyssteel>
+					<Moyo_Abyssteel>90</Moyo_Abyssteel>
 					<Hyperweave>10</Hyperweave>
 				</value>
 			</li>
@@ -264,7 +264,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_GSsuit"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>190</Moyo_Abyssteel>
+					<Moyo_Abyssteel>150</Moyo_Abyssteel>
 				</value>
 			</li>
 			
@@ -325,7 +325,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
-					<Moyo_Abyssteel>100</Moyo_Abyssteel>
+					<Moyo_Abyssteel>80</Moyo_Abyssteel>
 					<Hyperweave>10</Hyperweave>
 				</value>
 			</li>

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -253,9 +253,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>75</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -256,7 +256,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>75</Plasteel>
+					<Plasteel>60</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -55,7 +55,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>70</Plasteel>
+						<Plasteel>55</Plasteel>
 					</value>
 				</li>
 				
@@ -110,7 +110,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>200</Plasteel>
+						<Plasteel>160</Plasteel>
 					</value>
 				</li>
 

--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -52,6 +52,13 @@
 					</value>
 				</li>
 				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>70</Plasteel>
+					</value>
+				</li>
+				
 				<!-- Deliberately omitted WearingGasMask ApparelHediffExtension, as we assume the T-45b Helmet is more comfortable than real-life gas masks -->
 				
 				<!-- ========== T-45b armor ========== -->
@@ -97,6 +104,13 @@
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases</xpath>
 					<value>
 						<ArmorRating_Electric>0.05</ArmorRating_Electric>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>200</Plasteel>
 					</value>
 				</li>
 

--- a/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -58,7 +58,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>255</Plasteel>
+						<Plasteel>180</Plasteel>
 						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
@@ -118,7 +118,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>90</Plasteel>
+						<Plasteel>70</Plasteel>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
@@ -183,7 +183,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>225</Plasteel>
+						<Plasteel>180</Plasteel>
 						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
@@ -243,7 +243,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>80</Plasteel>
+						<Plasteel>60</Plasteel>
 						<DevilstrandCloth>20</DevilstrandCloth>
 					</value>
 				</li>
@@ -305,7 +305,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>180</Plasteel>
+						<Plasteel>140</Plasteel>
 						<DevilstrandCloth>50</DevilstrandCloth>
 					</value>
 				</li>
@@ -365,7 +365,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>60</Plasteel>
+						<Plasteel>50</Plasteel>
 						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>

--- a/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -55,9 +55,10 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>255</Plasteel>
 						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
@@ -101,7 +102,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/Mass</xpath>
 					<value>
-						<Mass>1.6</Mass>
+						<Mass>5.2</Mass>
 					</value>
 				</li>
 				<!-- equippedStatOffsets -->
@@ -117,7 +118,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>45</Plasteel>
+						<Plasteel>90</Plasteel>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
@@ -179,10 +180,11 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>50</DevilstrandCloth>
+						<Plasteel>225</Plasteel>
+						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
 				<!-- apparel -->
@@ -225,7 +227,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/Mass</xpath>
 					<value>
-						<Mass>1.2</Mass>
+						<Mass>4.8</Mass>
 					</value>
 				</li>
 				<!-- equippedStatOffsets -->
@@ -238,9 +240,10 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>80</Plasteel>
 						<DevilstrandCloth>20</DevilstrandCloth>
 					</value>
 				</li>
@@ -299,10 +302,11 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>45</DevilstrandCloth>
+						<Plasteel>180</Plasteel>
+						<DevilstrandCloth>50</DevilstrandCloth>
 					</value>
 				</li>
 				<!-- apparel -->
@@ -358,9 +362,10 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>60</Plasteel>
 						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
@@ -384,6 +384,14 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RB_RegularInfantrySuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<!--Regular Army Helmet, 10mm Power Armor-->
 			
 			<li Class="PatchOperationAdd">
@@ -416,6 +424,14 @@
 					<AimingAccuracy>0.15</AimingAccuracy>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>100</Plasteel>
+					<DevilstrandCloth>25</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
@@ -387,7 +387,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RB_RegularInfantrySuit"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>240</Plasteel>
+					<Plasteel>190</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -430,7 +430,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>100</Plasteel>
+					<Plasteel>80</Plasteel>
 					<DevilstrandCloth>25</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
@@ -48,7 +48,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>240</Plasteel>
+					<Plasteel>190</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
@@ -13,18 +13,26 @@
 		<operations>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/Mass</xpath>
 				<value>
-					<ArmorRating_Sharp>20.50</ArmorRating_Sharp>
+					<Mass>50</Mass>
 					<Bulk>100</Bulk>
 					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>21</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.45</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>38</ArmorRating_Blunt>
+					<ArmorRating_Blunt>47.25</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -32,8 +40,16 @@
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-					<CarryWeight>60</CarryWeight>
+					<CarryWeight>85</CarryWeight>
 					<CarryBulk>20</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
@@ -39,7 +39,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>85</Plasteel>
+					<Plasteel>70</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
@@ -15,7 +15,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18.85</ArmorRating_Sharp>
+					<ArmorRating_Sharp>19</ArmorRating_Sharp>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
@@ -24,7 +24,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>42.75</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -33,6 +33,14 @@
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 					<AimingAccuracy>0.10</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>85</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -75,7 +75,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>100</Plasteel>
+					<Plasteel>80</Plasteel>
 					<DevilstrandCloth>35</DevilstrandCloth>
 				</value>
 			</li>
@@ -83,7 +83,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Steel</xpath>
 				<value>
-					<Steel>160</Steel>
+					<Steel>130</Steel>
 				</value>
 			</li>
 
@@ -138,7 +138,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>30</Plasteel>
+					<Plasteel>25</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
@@ -166,7 +166,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>225</Plasteel>
+					<Plasteel>180</Plasteel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
@@ -236,7 +236,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>75</Plasteel>
+					<Plasteel>60</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -278,7 +278,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>150</Plasteel>
+					<Plasteel>120</Plasteel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
@@ -333,7 +333,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>45</Plasteel>
+					<Plasteel>35</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
@@ -382,7 +382,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>280</Plasteel>
+					<Plasteel>225</Plasteel>
 					<DevilstrandCloth>60</DevilstrandCloth>
 				</value>
 			</li>
@@ -390,7 +390,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Uranium</xpath>
 				<value>
-					<Uranium>90</Uranium>
+					<Uranium>70</Uranium>
 				</value>
 			</li>
 			
@@ -486,8 +486,8 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>90</Plasteel>
-					<Uranium>20</Uranium>
+					<Plasteel>70</Plasteel>
+					<Uranium>15</Uranium>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -542,7 +542,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>220</Plasteel>
+					<Plasteel>175</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -587,7 +587,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>70</Plasteel>
+					<Plasteel>55</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -640,7 +640,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>200</Plasteel>
+					<Plasteel>160</Plasteel>
 					<DevilstrandCloth>75</DevilstrandCloth>
 				</value>
 			</li>
@@ -701,7 +701,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>75</Plasteel>
+					<Plasteel>60</Plasteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -761,7 +761,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>180</Plasteel>
+					<Plasteel>145</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -769,7 +769,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Uranium</xpath>
 				<value>
-					<Uranium>80</Uranium>
+					<Uranium>65</Uranium>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
@@ -819,7 +819,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>60</Plasteel>
+					<Plasteel>50</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
@@ -827,7 +827,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Uranium</xpath>
 				<value>
-					<Uranium>30</Uranium>
+					<Uranium>25</Uranium>
 				</value>
 			</li>
 			
@@ -874,7 +874,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>180</Plasteel>
+					<Plasteel>145</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -882,7 +882,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Uranium</xpath>
 				<value>
-					<Uranium>140</Uranium>
+					<Uranium>110</Uranium>
 				</value>
 			</li>
 			
@@ -937,7 +937,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>80</Plasteel>
+					<Plasteel>65</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -61,28 +61,36 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>17</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>38</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList</xpath>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>100</Plasteel>
 					<DevilstrandCloth>35</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Steel</xpath>
+				<value>
+					<Steel>160</Steel>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>60</CarryWeight>
+					<CarryWeight>45</CarryWeight>
 					<CarryBulk>15</CarryBulk>
 				</value>
 			</li>
@@ -109,14 +117,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -124,6 +132,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>30</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -138,13 +154,23 @@
 			
 			<!-- ========== Drop Suit =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/Mass</xpath>
 				<value>
+					<Mass>60</Mass>
 					<Bulk>90</Bulk>
-					<WornBulk>12</WornBulk>
+					<WornBulk>18</WornBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>225</Plasteel>
+					<DevilstrandCloth>40</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -156,7 +182,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>15</CarryWeight>
+					<CarryWeight>90</CarryWeight>
 					<CarryBulk>8</CarryBulk>
 				</value>
 			</li>
@@ -164,23 +190,24 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>17</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>51</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<!-- ========== Dropsuit Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/Mass</xpath>
 				<value>
 					<Bulk>5</Bulk>
+					<Mass>5</Mass>
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
@@ -188,14 +215,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>42</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -203,6 +230,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>75</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -217,11 +252,12 @@
 			
 			<!-- ========== Nervesuit =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>80</Bulk>
-					<WornBulk>8</WornBulk>
+					<Bulk>75</Bulk>
+					<Mass>20</Mass>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
@@ -234,22 +270,30 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>10</CarryWeight>
-					<CarryBulk>5</CarryBulk>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>150</Plasteel>
+					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>23</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>	
 			
@@ -274,7 +318,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -283,6 +327,14 @@
 				<value>
 					<Suppressability>-0.25</Suppressability>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>45</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -296,39 +348,52 @@
 			</li>
 			
 			<!-- ========== Assault Armor =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases</xpath>
-				<value>
-					<Bulk>120</Bulk>
-					<WornBulk>20</WornBulk>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>60</Mass>
+					<Mass>100</Mass>
+					<Bulk>120</Bulk>
+					<WornBulk>30</WornBulk>
 				</value>
 			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Sharp>28</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>58.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>70</ArmorRating_Blunt>
 				</value>
-			</li>			
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
-					<CarryBulk>10</CarryBulk>
+					<CarryWeight>95</CarryWeight>
+					<CarryBulk>5</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>280</Plasteel>
+					<DevilstrandCloth>60</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>90</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -390,23 +455,24 @@
 			
 			<!-- ========== Assault Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>8</Bulk>
-					<WornBulk>2</WornBulk>
+					<Mass>10</Mass>
+					<Bulk>20</Bulk>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>25</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>62.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -414,6 +480,15 @@
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>90</Plasteel>
+					<Uranium>20</Uranium>
+					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -427,18 +502,13 @@
 			</li>
 			
 			<!-- ========== Fire Support Armor =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases</xpath>
-				<value>
-					<Bulk>80</Bulk>
-					<WornBulk>15</WornBulk>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>55</Mass>
+					<Mass>70</Mass>
+					<Bulk>80</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -450,16 +520,33 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 				</value>
 			</li>			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>90</CarryWeight>
-					<CarryBulk>40</CarryBulk>
+					<CarryWeight>120</CarryWeight>
+					<CarryBulk>50</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/equippedStatOffsets/AimingDelayFactor</xpath>
+				<value>
+					<AimingDelayFactor>-0.25</AimingDelayFactor>
+					<ReloadSpeed>0.5</ReloadSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>220</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -468,12 +555,13 @@
 				</value>
 			</li>
 			<!-- ========== Fire Support Helmet =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases</xpath>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>7</Bulk>
-					<WornBulk>1.5</WornBulk>
+					<WornBulk>5</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -485,7 +573,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -493,6 +581,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>70</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -507,23 +603,18 @@
 			
 			<!-- ========== Reflactor Carapace =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases</xpath>
-				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>15</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>50</Mass>
+					<Mass>60</Mass>
+					<Bulk>100</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -535,14 +626,29 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>42</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
+					<CarryWeight>100</CarryWeight>
 					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>200</Plasteel>
+					<DevilstrandCloth>75</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>60</Uranium>
 				</value>
 			</li>
 
@@ -556,17 +662,18 @@
 
 			<!-- ========== Reflactor Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1.1</WornBulk>
+					<Mass>5.2</Mass>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -578,7 +685,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -588,6 +695,21 @@
 					<equippedStatOffsets>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</equippedStatOffsets>	
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>75</Plasteel>
+					<DevilstrandCloth>30</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>20</Uranium>
 				</value>
 			</li>
 			
@@ -602,23 +724,18 @@
 			
 			<!-- ========== Hazard Carapace =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases</xpath>
-				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>18</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/Mass</xpath>
 				<value>
-					<Mass>55</Mass>
+					<Mass>65</Mass>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -630,14 +747,29 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Heat</xpath>
 				<value>
-					<ArmorRating_Heat>1.4</ArmorRating_Heat>
+					<ArmorRating_Heat>1</ArmorRating_Heat>
+					<ArmorRating_Electric>1</ArmorRating_Electric>
 				</value>
 			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>45</CarryWeight>
+					<CarryWeight>90</CarryWeight>
 					<CarryBulk>25</CarryBulk>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>180</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>80</Uranium>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
@@ -650,23 +782,24 @@
 
 			<!-- ========== Hazard Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1.0</WornBulk>
+					<Mass>6</Mass>
+					<Bulk>6</Bulk>
+					<WornBulk>1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>19</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>31.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -683,6 +816,21 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>60</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>30</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/apparel/layers</xpath>
 				<value>
@@ -694,44 +842,50 @@
 
 			<!-- ========== CQ Armor =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases</xpath>
-				<value>
-					<Bulk>65</Bulk>
-					<WornBulk>12</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>30</Mass>
+					<Mass>60</Mass>
+					<Bulk>65</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.7</ArmorRating_Heat>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 					<CarryBulk>20</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>180</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>140</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -739,6 +893,7 @@
 					<li>Feet</li>
 				</value>
 			</li>
+			
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
@@ -751,29 +906,24 @@
 
 			<!-- ========== CQ Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>5</Bulk>
-					<WornBulk>1.0</WornBulk>
+					<WornBulk>1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.85</ArmorRating_Heat>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -781,6 +931,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>80</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -44,10 +44,11 @@
 			</li>	
 		
 			<!-- ========== Riot Armor =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>40</Bulk>
+					<Bulk>100</Bulk>
+					<Mass>60</Mass>
 					<WornBulk>10</WornBulk>
 				</value>
 			</li>
@@ -55,7 +56,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>5</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 				</value>
 			</li>
 
@@ -71,20 +72,30 @@
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>28</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.75</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/costList/Foerum</xpath>
+				<value>
+					<Foerum>240</Foerum>
+					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
 
 			<!-- ========== Riot Helmet =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
@@ -94,13 +105,29 @@
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.70</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>37.15</ArmorRating_Blunt>
+					<ArmorRating_Blunt>26</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/costList/Foerum</xpath>
+				<value>
+					<Foerum>90</Foerum>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -114,19 +141,20 @@
 			</li>
 		
 			<!-- ========== Marksman Armor =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>20</Bulk>
-					<WornBulk>3</WornBulk>
+					<Mass>15</Mass>
+					<Bulk>40</Bulk>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>5</CarryWeight>
-					<CarryBulk>4</CarryBulk>
+					<CarryWeight>20</CarryWeight>
+					<CarryBulk>15</CarryBulk>
 				</value>
 			</li>
 
@@ -141,14 +169,15 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -165,13 +194,21 @@
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-0.75</SmokeSensitivity>
 				</value>
 			</li>
 			
@@ -186,18 +223,18 @@
 
 			<!-- ========== Unity Guard Armor =========== -->
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>10</Bulk>
+					<Bulk>15</Bulk>
 					<WornBulk>5</WornBulk>
+					<Mass>11</Mass>
 				</value>
 			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>4</CarryWeight>
-					<CarryBulk>5</CarryBulk>
+					<CarryBulk>10</CarryBulk>
 				</value>
 			</li>
 
@@ -212,13 +249,14 @@
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 		
@@ -234,14 +272,15 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -86,7 +86,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/costList/Foerum</xpath>
 				<value>
-					<Foerum>240</Foerum>
+					<Foerum>190</Foerum>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -126,7 +126,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/costList/Foerum</xpath>
 				<value>
-					<Foerum>90</Foerum>
+					<Foerum>70</Foerum>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -93,13 +93,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -110,7 +110,13 @@
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
-			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>46</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>		
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/apparel/layers</xpath>
 				<value>
@@ -182,13 +188,13 @@
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/statBases</xpath>
 				<value>
 					<Bulk>110</Bulk>
-					<WornBulk>18</WornBulk>					
+					<WornBulk>25</WornBulk>					
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/Mass</xpath>
 				<value>
-					<Mass>60</Mass>		
+					<Mass>75</Mass>		
 				</value>
 			</li>					
 			<li Class="PatchOperationAdd">
@@ -199,22 +205,29 @@
 					<ToxicSensitivity>-0.45</ToxicSensitivity>
 			</value>
 		    </li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>104</Plasteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
-			</li>			
+			</li>		
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Steel</xpath>
+				<value>
+					<Steel>256</Steel>
+				</value>
+			</li>	
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -113,7 +113,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>46</Plasteel>
+					<Plasteel>36</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>		
@@ -208,14 +208,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>104</Plasteel>
+					<Plasteel>83</Plasteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>		
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Steel</xpath>
 				<value>
-					<Steel>256</Steel>
+					<Steel>204</Steel>
 				</value>
 			</li>	
 			<li Class="PatchOperationReplace">

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -104,7 +104,7 @@
     <li Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>80</Plasteel>
+      <Plasteel>65</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
    </li>
@@ -136,7 +136,7 @@
 		<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList/Plasteel</xpath>
 		<value>
-		  <Plasteel>285</Plasteel>
+		  <Plasteel>230</Plasteel>
 		  <DevilstrandCloth>20</DevilstrandCloth>
 		</value>
 	   </li>

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -104,7 +104,7 @@
     <li Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>50</Plasteel>
+      <Plasteel>80</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
    </li>
@@ -133,12 +133,13 @@
 		</li>
 			
 	<!--  Heavy EVA Suit -->
-		<li Class="PatchOperationAdd">
-		      <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList</xpath>
-		      <value>
-			 <DevilstrandCloth>50</DevilstrandCloth>
-		      </value>
-		</li>
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList/Plasteel</xpath>
+		<value>
+		  <Plasteel>285</Plasteel>
+		  <DevilstrandCloth>20</DevilstrandCloth>
+		</value>
+	   </li>
 			
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/ArmorRating_Sharp</xpath>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -83,7 +83,7 @@
 				defName="HAR_XO_AM_a"
 				]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>70</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
@@ -98,9 +98,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AM_a"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AM_a"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>200</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -130,7 +131,7 @@
 				defName="HAR_XO_AM_b"
 				]/statBases/Mass</xpath>
 				<value>
-					<Mass>35</Mass>
+					<Mass>25</Mass>
 				</value>
 			</li>
 			
@@ -139,7 +140,7 @@
 				defName="HAR_XO_AM_b"
 				]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>55</CarryWeight>
+					<CarryWeight>45</CarryWeight>
 					<CarryBulk>12</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
@@ -154,10 +155,11 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AM_b"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AM_b"]/costList/Plasteel</xpath>
 				<value>
-					<DevilstrandCloth>30</DevilstrandCloth>
+					<Plasteel>160</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 					<ComponentSpacer>1</ComponentSpacer>
 				</value>
 			</li>
@@ -250,9 +252,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>90</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -277,10 +280,11 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AH_g"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AH_g"]/costList/Plasteel</xpath>
 				<value>
-					<DevilstrandCloth>15</DevilstrandCloth>
+					<Plasteel>50</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -101,7 +101,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="HAR_XO_AM_a"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>200</Plasteel>
+					<Plasteel>160</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -158,7 +158,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="HAR_XO_AM_b"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>160</Plasteel>
+					<Plasteel>130</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 					<ComponentSpacer>1</ComponentSpacer>
 				</value>
@@ -255,7 +255,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>90</Plasteel>
+					<Plasteel>70</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -283,7 +283,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="HAR_XO_AH_g"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>50</Plasteel>
+					<Plasteel>40</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
@@ -78,7 +78,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorCataphractBase"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>315</Plasteel>
+			<Plasteel>250</Plasteel>
 		</value>
 	</Operation>
 	
@@ -284,7 +284,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocust"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>220</Plasteel>
+			<Plasteel>180</Plasteel>
 		</value>
 	</Operation>
 	
@@ -293,21 +293,21 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorReconPrestige"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>200</Plasteel>
+			<Plasteel>150</Plasteel>
 		</value>
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorMarinePrestige"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>245</Plasteel>
+			<Plasteel>190</Plasteel>
 		</value>
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPrestige"]/costList/Plasteel</xpath>
 		<value>
-			<Plasteel>335</Plasteel>
+			<Plasteel>260</Plasteel>
 		</value>
 	</Operation>
 

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
@@ -74,6 +74,20 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorCataphractBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>315</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorCataphractBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>80</Uranium>
+		</value>
+	</Operation>
 
 
     <!-- Grenadier armor -->
@@ -266,7 +280,36 @@
             <JumpRange>30</JumpRange>
         </value>
     </Operation>
-
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocust"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>220</Plasteel>
+		</value>
+	</Operation>
+	
+	<!-- ========== Prestige Armor ========== -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorReconPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>200</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorMarinePrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>245</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>335</Plasteel>
+		</value>
+	</Operation>
 
 </Patch>
 

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -150,6 +150,13 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>6.6</Mass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/statBases/MaxHitPoints</xpath>
     <value>
       <MaxHitPoints>260</MaxHitPoints>
@@ -182,10 +189,11 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/costList</xpath>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/costList/Plasteel</xpath>
     <value>
-      <DevilstrandCloth>30</DevilstrandCloth>
+      <Plasteel>110</Plasteel>
+      <DevilstrandCloth>25</DevilstrandCloth>
     </value>
   </Operation>
 
@@ -197,6 +205,29 @@
       <li>MiddleHead</li>
     </value>
   </Operation>
+  
+	<!-- ========== Prestige Armor ========== -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetReconPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>70</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorMarineHelmetPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>90</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>120</Plasteel>
+		</value>
+	</Operation>
 
 </Patch>
 


### PR DESCRIPTION

## Changes

Increased power armor tier apparel production costs. Generally increased helmet mass a bit.
Increased the avalibility of money for elite mercs so they can still reasonably get said armor
Tweaked some of the existing patches.
Re-did a lot of the rimsenal armor specifics to more closely match some of the vanilla attributes, as well as fix some instances where the armors had practically vanilla mass/boosting stats.
Reduction in plate and simple helmet costs.

## Reasoning

Currently, power armor provides, proportionally for its raw resource cost, significantly more protection, coverage and passive benefits than any other options. While it's reasonable for higher tech items to make more efficent use of your resources and provide higher protection levels to justify the tech investment, power armor apparels have an extreme disparity in their cost vs effectiveness as armor. Not only is power armor extremely strong, but it is also easiy the most cost efficent.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (17h 20min)
