### PR TITLE
Add new bodyshapes.

### DIFF
--- a/Defs/Bodies/BodyShapes.xml
+++ b/Defs/Bodies/BodyShapes.xml
@@ -8,7 +8,7 @@
 	<CombatExtended.BodyShapeDef>
 		<defName>Humanoid</defName>
 		<width>0.25</width>
-		<widthLaying>1</widthLaying>
+		<widthLaying>0.5</widthLaying>
 		<height>1</height>
 		<heightLaying>0.3</heightLaying>
 	</CombatExtended.BodyShapeDef>
@@ -32,9 +32,9 @@
 	<CombatExtended.BodyShapeDef>
 		<defName>QuadrupedTall</defName>
 		<width>1</width>
-		<widthLaying>1</widthLaying>
+		<widthLaying>0.5</widthLaying>
 		<height>1</height>
-		<heightLaying>0.25</heightLaying>
+		<heightLaying>0.4</heightLaying>
 	</CombatExtended.BodyShapeDef>
 
 	<CombatExtended.BodyShapeDef>
@@ -63,8 +63,8 @@
 
 	<CombatExtended.BodyShapeDef>
 		<defName>Plane</defName>
-		<width>1.25</width>
-		<widthLaying>1.25</widthLaying>
+		<width>0.7</width>
+		<widthLaying>0.7</widthLaying>
 		<height>1</height>
 		<heightLaying>1</heightLaying>
 	</CombatExtended.BodyShapeDef>

--- a/Defs/Bodies/BodyShapes.xml
+++ b/Defs/Bodies/BodyShapes.xml
@@ -30,6 +30,14 @@
 	</CombatExtended.BodyShapeDef>
 
 	<CombatExtended.BodyShapeDef>
+		<defName>QuadrupedTall</defName>
+		<width>1</width>
+		<widthLaying>1</widthLaying>
+		<height>1</height>
+		<heightLaying>0.25</heightLaying>
+	</CombatExtended.BodyShapeDef>
+
+	<CombatExtended.BodyShapeDef>
 		<defName>Serpentine</defName>
 		<width>1</width>
 		<widthLaying>1</widthLaying>
@@ -44,7 +52,8 @@
 		<height>0.75</height>
 		<heightLaying>0.5</heightLaying>
 	</CombatExtended.BodyShapeDef>
-	
+
+
 	<CombatExtended.BodyShapeDef>
 		<defName>Vehicle</defName>
 		<width>1</width>
@@ -54,11 +63,12 @@
 	</CombatExtended.BodyShapeDef>
 
 	<CombatExtended.BodyShapeDef>
-		<defName>Winged</defName>
+		<defName>Plane</defName>
 		<width>1.25</width>
 		<widthLaying>1.25</widthLaying>
 		<height>1</height>
 		<heightLaying>1</heightLaying>
 	</CombatExtended.BodyShapeDef>
+
 
 </Defs>

--- a/Defs/Bodies/BodyShapes.xml
+++ b/Defs/Bodies/BodyShapes.xml
@@ -53,7 +53,6 @@
 		<heightLaying>0.5</heightLaying>
 	</CombatExtended.BodyShapeDef>
 
-
 	<CombatExtended.BodyShapeDef>
 		<defName>Vehicle</defName>
 		<width>1</width>

--- a/Defs/Bodies/BodyShapes.xml
+++ b/Defs/Bodies/BodyShapes.xml
@@ -53,4 +53,12 @@
 		<heightLaying>1</heightLaying>
 	</CombatExtended.BodyShapeDef>
 
+	<CombatExtended.BodyShapeDef>
+		<defName>Winged</defName>
+		<width>1.25</width>
+		<widthLaying>1.25</widthLaying>
+		<height>1</height>
+		<heightLaying>1</heightLaying>
+	</CombatExtended.BodyShapeDef>
+
 </Defs>


### PR DESCRIPTION
- Adds a wider `Plane` bodyshape for aircraft, which does not change when laying.
- Adds a taller `QuadrupedTall` bodyshape, intended for tripod-like creatures that walk on especially tall, spindly legs.

Per my conversation with @Alicecomma, 'width' is actually a radius rather than straight distance or diameter--this would explain why humans measured 3+ meters wide when laying (they had widthlaying = height, and they are about 1.6m tall). I've adjusted some values accordingly.