### PR TITLE
Suppression is now caused by most projectiles (except for electrical and flame), modified pawn reaction to suppression.

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -121,15 +121,28 @@
 
   <StatDef>
     <defName>AverageSharpArmor</defName>
-    <label>armor coverage</label>
-    <description>The average value of armor coverage across this person's body. Higher values will make them more confident against low-penetration projectiles.</description>
-    <workerClass>CombatExtended.StatWorker_ArmorCoverage</workerClass>
+    <label>armor coverage (sharp)</label>
+    <description>The average value of sharp armor coverage across this person's body. Higher values will make them more confident against low-penetration projectiles.</description>
+    <workerClass>CombatExtended.StatWorker_ArmorCoverageSharp</workerClass>
     <category>PawnCombat</category>
     <displayPriorityInCategory>55</displayPriorityInCategory>
     <defaultBaseValue>0</defaultBaseValue>
     <minValue>0</minValue>
     <toStringStyle>FloatMaxTwo</toStringStyle>
     <formatString>{0} mm RHA</formatString>
+  </StatDef>
+
+  <StatDef>
+    <defName>AverageBluntArmor</defName>
+    <label>armor coverage (blunt)</label>
+    <description>The average value of blunt armor coverage across this person's body. Higher values will make them more confident against low-penetration explosions.</description>
+    <workerClass>CombatExtended.StatWorker_ArmorCoverageBlunt</workerClass>
+    <category>PawnCombat</category>
+    <displayPriorityInCategory>54</displayPriorityInCategory>
+    <defaultBaseValue>0</defaultBaseValue>
+    <minValue>0</minValue>
+    <toStringStyle>FloatMaxTwo</toStringStyle>
+    <formatString>{0} MPa</formatString>
   </StatDef>
 
   <!-- ================================== Melee =======================================-->

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_DamageDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_DamageDefOf.cs
@@ -13,6 +13,5 @@ namespace CombatExtended
     {
         public static DamageDef Electrical;
         public static DamageDef Flame_Secondary;
-        public static DamageDef Thermobaric;
     }
 }

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_DamageDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_DamageDefOf.cs
@@ -13,5 +13,6 @@ namespace CombatExtended
     {
         public static DamageDef Electrical;
         public static DamageDef Flame_Secondary;
+        public static DamageDef Thermobaric;
     }
 }

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
@@ -35,6 +35,7 @@ namespace CombatExtended
         public static StatDef BodyPartSharpArmor;
         public static StatDef BodyPartBluntArmor;
         public static StatDef AverageSharpArmor;
+        public static StatDef AverageBluntArmor;
 
         public static StatDef SmokeSensitivity;
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -835,18 +835,18 @@ namespace CombatExtended
                         ((damageArmorCategory == CE_DamageArmorCategoryDefOf.Blunt) ?
                             ((!propsCE.damageFalloff || propsCE.explosionRadius == 0) ?
                                 Mathf.Max(def.projectile.GetDamageAmount(1) * 0.3f, propsCE.armorPenetrationBlunt) :
-                                Mathf.Lerp(Mathf.Max(def.projectile.GetDamageAmount(1) * 0.3f, propsCE.armorPenetrationBlunt), 0.6f, Mathf.Pow(pawn.Position.DistanceTo(Position) / propsCE.explosionRadius, 0.55f)) //This is basically a condensed version of ExplosionCE.GetArmorPenetrationAtCE. Any changes to GetArmorPenetrationAtCE should be also applied
+                                Mathf.Lerp(Mathf.Max(def.projectile.GetDamageAmount(1) * 0.3f, propsCE.armorPenetrationBlunt), 0.6f, Mathf.Pow(pawn.Position.DistanceTo(Position) / propsCE.explosionRadius, 0.55f)) //This is basically a condensed version of ExplosionCE.GetArmorPenetrationAtCE. Any changes to GetArmorPenetrationAtCE should be also applied to this.
                             ) :
                             propsCE.armorPenetrationSharp
                         )
                     ) : 0f
                 );
                 float armorMod = ((propsCE.damageDef.GetModExtension<DamageDefExtensionCE>() ?? new DamageDefExtensionCE()).isAmbientDamage ?
-                    (1 - Mathf.Clamp(pawn.GetStatValue(damageArmorCategory.armorRatingStat)*(pawn.RaceProps.IsFlesh && (damageArmorCategory == CE_DamageArmorCategoryDefOf.Electric) ? 0.25f : 1), 0, 1)) : //Hardcoded fleshy pawn electric damage resistance of 75%
+                    (1 - Mathf.Clamp(pawn.GetStatValue(damageArmorCategory.armorRatingStat)*(pawn.RaceProps.IsFlesh && (damageArmorCategory == CE_DamageArmorCategoryDefOf.Electric) ? 0.25f : 1), 0, 1)) : //Hardcoded fleshy pawn electric damage resistance of 75% (EMP grenades and Ion projectiles only deal 25% damage).
                     (penetrationAmount <= 0 ? 0 : 1 - Mathf.Clamp(pawn.GetStatValue((damageArmorCategory == CE_DamageArmorCategoryDefOf.Blunt) ? CE_StatDefOf.AverageBluntArmor : CE_StatDefOf.AverageSharpArmor) * 0.5f / penetrationAmount, 0, 1))
                 );
                 suppressionAmount *= armorMod;
-                compSuppressable.AddSuppression(suppressionAmount, OriginIV3);
+                compSuppressable.AddSuppression(suppressionAmount, OriginIV3, (propsCE.explosionRadius > 0) ? true : false);
             }
         }
         #region Tick/Draw

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -828,9 +828,15 @@ namespace CombatExtended
             {
                 suppressionAmount = def.projectile.GetDamageAmount(1);
                 var propsCE = def.projectile as ProjectilePropertiesCE;
+                var penetrationAmount = (propsCE != null ? ((propsCE.explosionRadius > 0) && ((def.projectile.damageDef == DamageDefOf.Bomb) || (def.projectile.damageDef == CE_DamageDefOf.Thermobaric)) ? def.projectile.GetDamageAmount(0.3f) : propsCE.armorPenetrationSharp) : 0f);
+                suppressionAmount *= (propsCE.explosionRadius > 0 ? 4 : 1);
+                var armorMod = penetrationAmount <= 0 ? 0 : 1 - Mathf.Clamp(pawn.GetStatValue(propsCE?.armorPenetrationSharp > 0 ? CE_StatDefOf.AverageSharpArmor : CE_StatDefOf.AverageBluntArmor) * 0.5f / penetrationAmount, 0, 1);
+                suppressionAmount *= armorMod;
+                /*suppressionAmount = def.projectile.GetDamageAmount(1);
+                var propsCE = def.projectile as ProjectilePropertiesCE;
                 var penetrationAmount = propsCE?.armorPenetrationSharp ?? 0f;
                 var armorMod = penetrationAmount <= 0 ? 0 : 1 - Mathf.Clamp(pawn.GetStatValue(CE_StatDefOf.AverageSharpArmor) * 0.5f / penetrationAmount, 0, 1);
-                suppressionAmount *= armorMod;
+                suppressionAmount *= armorMod;*/
                 compSuppressable.AddSuppression(suppressionAmount, OriginIV3);
             }
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -828,9 +828,9 @@ namespace CombatExtended
             {
                 suppressionAmount = def.projectile.GetDamageAmount(1);
                 var propsCE = def.projectile as ProjectilePropertiesCE;
-                var penetrationAmount = (propsCE != null ? ((propsCE.explosionRadius > 0) && ((def.projectile.damageDef == DamageDefOf.Bomb) || (def.projectile.damageDef == CE_DamageDefOf.Thermobaric)) ? def.projectile.GetDamageAmount(0.3f) : propsCE.armorPenetrationSharp) : 0f);
-                suppressionAmount *= (propsCE.explosionRadius > 0 ? 4 : 1);
-                var armorMod = penetrationAmount <= 0 ? 0 : 1 - Mathf.Clamp(pawn.GetStatValue(propsCE?.armorPenetrationSharp > 0 ? CE_StatDefOf.AverageSharpArmor : CE_StatDefOf.AverageBluntArmor) * 0.5f / penetrationAmount, 0, 1);
+                var bluntArmorRatingStat = def.projectile.damageDef.armorCategory.armorRatingStat == StatDefOf.ArmorRating_Blunt;
+                var penetrationAmount = propsCE != null ? (bluntArmorRatingStat ? def.projectile.GetDamageAmount(0.3f) : propsCE.armorPenetrationSharp) : 0f; // You could say this is a dirty way to get the penetration of an explosion, but it's either this or hard-coding every DamageDef into here.
+                var armorMod = penetrationAmount <= 0 ? 0 : 1 - Mathf.Clamp(pawn.GetStatValue(bluntArmorRatingStat ? CE_StatDefOf.AverageSharpArmor : CE_StatDefOf.AverageBluntArmor) * 0.5f / penetrationAmount, 0, 1);
                 suppressionAmount *= armorMod;
                 /*suppressionAmount = def.projectile.GetDamageAmount(1);
                 var propsCE = def.projectile as ProjectilePropertiesCE;

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverageBlunt.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverageBlunt.cs
@@ -4,7 +4,7 @@ using Verse;
 
 namespace CombatExtended
 {
-    public class StatWorker_ArmorCoverage : StatWorker
+    public class StatWorker_ArmorCoverageBlunt : StatWorker
     {
         public override bool ShouldShowFor(StatRequest req)
         {
@@ -20,11 +20,11 @@ namespace CombatExtended
             foreach (var apparel in pawn.apparel.WornApparel)
             {
                 var coverage = apparel.def.apparel.HumanBodyCoverage;
-                weightedArmor += apparel.GetStatValue(StatDefOf.ArmorRating_Sharp) * coverage;
+                weightedArmor += apparel.GetStatValue(StatDefOf.ArmorRating_Blunt) * coverage;
                 totalCoverage += coverage;
             }
 
-            return totalCoverage > 0 ? weightedArmor / totalCoverage : 0;
+            return totalCoverage > 0 ? weightedArmor /*/ totalCoverage*/ : 0; // Why? I'd be more scared to be dressed only in power armor than with power armor and a helmet
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
@@ -37,7 +37,7 @@ namespace CombatExtended
                 stringBuilder.AppendLine();
                 foreach (var apparel in pawn.apparel.WornApparel)
                 {
-                    stringBuilder.AppendLine($"{apparel.LabelCap}: {apparel.GetStatValue(StatDefOf.ArmorRating_Sharp)} x {apparel.def.apparel.HumanBodyCoverage.ToStringPercent()}");
+                    stringBuilder.AppendLine($"{apparel.LabelCap}: {apparel.GetStatValue(StatDefOf.ArmorRating_Blunt)} x {apparel.def.apparel.HumanBodyCoverage.ToStringPercent()}");
                 }
 
                 stringBuilder.AppendLine();

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverageSharp.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverageSharp.cs
@@ -1,0 +1,49 @@
+﻿using System.Text;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended
+{
+    public class StatWorker_ArmorCoverageSharp : StatWorker
+    {
+        public override bool ShouldShowFor(StatRequest req)
+        {
+            return req.HasThing && (req.Thing as Pawn)?.apparel != null;
+        }
+
+        public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
+        {
+            var weightedArmor = 0f;
+            var totalCoverage = 0f;
+
+            var pawn = (Pawn)req.Thing;
+            foreach (var apparel in pawn.apparel.WornApparel)
+            {
+                var coverage = apparel.def.apparel.HumanBodyCoverage;
+                weightedArmor += apparel.GetStatValue(StatDefOf.ArmorRating_Sharp) * coverage;
+                totalCoverage += coverage;
+            }
+
+            return totalCoverage > 0 ? weightedArmor /*/ totalCoverage*/ : 0; // Why? I'd be more scared to be dressed only in power armor than with power armor and a helmet
+        }
+
+        public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
+        {
+            var stringBuilder = new StringBuilder(base.GetExplanationUnfinalized(req, numberSense));
+
+            var pawn = (Pawn)req.Thing;
+            if (pawn.apparel.WornApparelCount > 0)
+            {
+                stringBuilder.AppendLine();
+                foreach (var apparel in pawn.apparel.WornApparel)
+                {
+                    stringBuilder.AppendLine($"{apparel.LabelCap}: {apparel.GetStatValue(StatDefOf.ArmorRating_Sharp)} x {apparel.def.apparel.HumanBodyCoverage.ToStringPercent()}");
+                }
+
+                stringBuilder.AppendLine();
+            }
+
+            return stringBuilder.ToString().Trim();
+        }
+    }
+}


### PR DESCRIPTION
What started out as trying to give explosions suppression turned into any projectile/explosion being able to apply suppression to pawns, as well as pawns acting "smarter" when being suppressed by explosions.

## Additions

1. Added an average blunt armor coverage stat.

## Changes

2. Renamed the existing average armor coverage stat to average sharp armor coverage;
3. Removed the final division from the stat worker code of average sharp armor coverage;
4. Modified how suppression is applied, now any projectile (except those which's main damage is electric-or-fire-based) can apply suppression (this means that explosive projectiles apply suppression on impact, too);
5. Pawns seek out cover if they're being suppressed more than they can handle, but aren't over-suppressed or aren't being targeted by explosives. If they are over-suppressed, if they aren't running for cover, they hunker down, if they are, they instead hunker down after taking cover.

## Reasoning

1. Average blunt armor coverage stat is used in negating suppression from explosions and other blunt projectiles;
2. The rename is a part of the addition of average blunt armor coverage;
3. The final division was causing naked pawns wearing only one armor piece to have more average armor than they actually have;
4. Many projectiles which used damage defs that did not check against average coverage of sharp armor did not deal any suppression unless the target was completely naked. The reason for flame and electric damage projectiles not dealing suppression is because I did not want to add average heat and electric armor stats, normal and electrical burns already deal a lot of pain and being set on fire already makes fleshy pawns panic;
5. Many players don't enjoy their pawns hunkering down when a stickbomb lands too close as the player is unable to control their pawn to save them from their death. This change to suppression reactions should make pawns smart**er** by not hunkering down when an explosive lands at their feet.

## Testing

Check tests you have performed:
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony;
- Did minor testing (tested suppression build up and reaction to different projectiles for player-controlled and hostile pawns).
