### PR TITLE
Patch [FF] Bushi!

### DIFF
--- a/Patches/FF Bushi!/Headgear_Bushi.xml
+++ b/Patches/FF Bushi!/Headgear_Bushi.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[FF]Bushi!</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+		<!-- === Masks === -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[
+			defName="FFApparel_Samurai_mask_of_perseverance" or
+			defName="FFApparel_Samurai_mask_of_Destruction" or
+			defName="FFApparel_Samurai_mask_of_Communicating"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/FF Bushi!/Melee_Bushi.xml
+++ b/Patches/FF Bushi!/Melee_Bushi.xml
@@ -1,0 +1,211 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>[FF]Bushi!</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+	<!-- === One-handed Tags === -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_Wakizashi" or defName="MeleeWeapon_Tanto"]/weaponTags</xpath>
+		<value>
+			<li>CE_OneHandedWeapon</li>
+		</value>
+	</li>
+
+	<!-- === Katana === -->
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Katana"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>3</power>
+					<cooldownTime>1.33</cooldownTime>
+					<chanceFactor>0.10</chanceFactor>
+					<armorPenetrationBlunt>0.936</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>15</power>
+					<cooldownTime>1.33</cooldownTime>
+					<chanceFactor>0.60</chanceFactor>
+					<armorPenetrationBlunt>0.936</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.08</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>31</power>
+					<cooldownTime>1.28</cooldownTime>
+					<chanceFactor>0.30</chanceFactor>
+					<armorPenetrationBlunt>2.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.65</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Katana"]/statBases</xpath>
+		<value>
+      		<Bulk>7.85</Bulk>
+      		<MeleeCounterParryBonus>1.38</MeleeCounterParryBonus>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Katana"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.85</MeleeCritChance>
+				<MeleeParryChance>0.69</MeleeParryChance>
+				<MeleeDodgeChance>0.37</MeleeDodgeChance>	
+			</equippedStatOffsets>
+		</value>
+	</li> 
+
+	<!-- === Wakizashi === -->
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Wakizashi"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>1.18</cooldownTime>
+					<chanceFactor>0.10</chanceFactor>
+					<armorPenetrationBlunt>0.339</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>24</power>
+					<cooldownTime>1.18</cooldownTime>
+					<chanceFactor>0.60</chanceFactor>
+					<armorPenetrationBlunt>0.339</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.4</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>17</power>
+					<cooldownTime>1.05</cooldownTime>
+					<chanceFactor>0.30</chanceFactor>
+					<armorPenetrationBlunt>0.717</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.36</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Wakizashi"]/statBases</xpath>
+		<value>
+      		<Bulk>6.4</Bulk>
+      		<MeleeCounterParryBonus>0.43</MeleeCounterParryBonus>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Wakizashi"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.60</MeleeCritChance>
+				<MeleeParryChance>0.43</MeleeParryChance>
+				<MeleeDodgeChance>0.16</MeleeDodgeChance>	
+			</equippedStatOffsets>
+		</value>
+	</li> 
+
+	<!-- === Tanto === -->
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Tanto"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>0.97</cooldownTime>
+					<chanceFactor>0.10</chanceFactor>
+					<armorPenetrationBlunt>0.259</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>0.97</cooldownTime>
+					<chanceFactor>0.60</chanceFactor>
+					<armorPenetrationBlunt>0.259</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.48</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.05</cooldownTime>
+					<chanceFactor>0.30</chanceFactor>
+					<armorPenetrationBlunt>0.304</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.28</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Tanto"]/statBases</xpath>
+		<value>
+      		<Bulk>4.2</Bulk>
+      		<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Tanto"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.93</MeleeCritChance>
+				<MeleeParryChance>0.38</MeleeParryChance>
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>	
+			</equippedStatOffsets>
+		</value>
+	</li> 
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/FF Bushi!/Melee_Bushi.xml
+++ b/Patches/FF Bushi!/Melee_Bushi.xml
@@ -41,7 +41,7 @@
 					<cooldownTime>1.33</cooldownTime>
 					<chanceFactor>0.60</chanceFactor>
 					<armorPenetrationBlunt>0.936</armorPenetrationBlunt>
-					<armorPenetrationSharp>2.08</armorPenetrationSharp>
+					<armorPenetrationSharp>1.88</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -14,6 +14,7 @@ Mod |
 [CP] Rimmu-Nation - Weapons	|
 [CP] Spec Ops - The Line	|
 [CP] The DOOM Kit - Classic	|
+[FF] Bushi!	|
 [HLX] Rimworld: UNSC Armoury |
 [HLX] ReGrowth - Mutated Animals Pack |
 [HLX] Ultratech: Altered Carbon - Armoury


### PR DESCRIPTION
Mod adds three melee weapons and three masks. The weapons are generally somewhat lighter, shorter version of existing weapons.
- Katana is derived from a longsword. Somewhat shorter and lighter giving it faster attacks, but inferior stabbing damage.
- Wakizashi is a lighter gladius, giving it good stabbing but mediocre cutting. 
- Tanto is a longer, lighter knife.