### PR TITLE
Patch Pawnbold Race

### DIFF
--- a/Patches/Pawnbold Race/Body_Pawnbold.xml
+++ b/Patches/Pawnbold Race/Body_Pawnbold.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Pawnbold Race</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+    <!-- ==================== Pawnbold Body ==================== -->
+
+    <!-- ========== Add groups ========== -->
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left ear"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right ear"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+      <value>
+        <li>OutsideSquishy</li>
+      </value>
+    </li>
+    
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
+      <value>
+        <li>LeftArm</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
+      <value>
+        <li>RightArm</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+      <value>
+        <li>LeftShoulder</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+      <value>
+        <li>RightShoulder</li>
+      </value>
+    </li>
+
+    <!-- ========== Add armor coverage (for pawns with non-zero armor that use Pawnbold_Body body) ========== -->
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/BodyDef[defName = "Pawnbold_Body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+      <value>
+        <li>CoveredByNaturalArmor</li>
+      </value>
+    </li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>
+

--- a/Patches/Pawnbold Race/PawnKinds_Misc.xml
+++ b/Patches/Pawnbold Race/PawnKinds_Misc.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Pawnbold Race</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to bowman ========== -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/PawnKindDef[defName="Pawnbold_Archer" or defName="Pawnbold_Hunter" or defName="Pawnbold_HeavyArcher" or defName="Pawnbold_ChiefRanged"]</xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>14</min>
+              <max>26</max>
+            </primaryMagazineCount>
+            <forcedSidearm>
+              <sidearmMoney>
+                <min>150</min>
+                <max>350</max>
+              </sidearmMoney>
+              <weaponTags>
+                <li>NeolithicMeleeBasic</li>
+              </weaponTags>
+            </forcedSidearm>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Pawnbold Race/Race_Pawnbold.xml
+++ b/Patches/Pawnbold Race/Race_Pawnbold.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Pawnbold Race</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+				<success>Always</success>
+				<operations>
+					<li Class="PatchOperationTest">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]/comps</xpath>
+						<success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</li>
+				</operations>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]/race/baseBodySize</xpath>
+				<value>
+					<baseBodySize>0.6</baseBodySize>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]/statBases</xpath>
+				<value>
+					<CarryWeight>18</CarryWeight>
+					<CarryBulk>15</CarryBulk>
+					<MeleeDodgeChance>1.1</MeleeDodgeChance>
+					<MeleeCritChance>0.4</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.01</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.57</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.57</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.46</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+				
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Pawnbold Race/Race_Pawnbold.xml
+++ b/Patches/Pawnbold Race/Race_Pawnbold.xml
@@ -42,8 +42,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Pawnbold_bold"]/statBases</xpath>
 				<value>
-					<CarryWeight>18</CarryWeight>
-					<CarryBulk>15</CarryBulk>
+					<CarryWeight>40</CarryWeight>
+					<CarryBulk>20</CarryBulk>
 					<MeleeDodgeChance>1.1</MeleeDodgeChance>
 					<MeleeCritChance>0.4</MeleeCritChance>
 					<MeleeParryChance>0.5</MeleeParryChance>

--- a/Patches/Pawnbold Race/Scenarios_Misc.xml
+++ b/Patches/Pawnbold Race/Scenarios_Misc.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Pawnbold Race</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Starting Things ========== -->
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ScenarioDef[defName="PawnboldLostTribe"]/scenario/parts</xpath>
+        <value>
+          <li Class="ScenPart_StartingThing_Defined">
+            <def>StartingThing_Defined</def>
+            <thingDef>Ammo_Arrow_Stone</thingDef>
+            <count>100</count>
+          </li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath> /Defs/ScenarioDef[defName="PawnboldLostTribe"]/scenario/parts/li[thingDef="Pila" and @Class="ScenPart_StartingThing_Defined"]</xpath>
+        <value>
+          <count>10</count>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -162,6 +162,7 @@ Not Only Just a Cannon  |
 Orassans	|
 Outer Rim - Tatooine    |
 Palm Cats   |
+Pawnbold Race   |
 Penguin	|
 Polarisbloc - Security Force	|
 Prestige Specialist Armours	|


### PR DESCRIPTION
## Additions
Patches the Pawnbold race, scenario, pawnkinds, and body.

## References
- Closes #722 

## Reasoning
- Pawnbold race is patched using the same stats as the existing O21 Kobold race, as the base versions are already largely identical.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (15 minutes)
