### PR TITLE
Tweaks to Rim of Magic items/equipment

### DIFF
--- a/Patches/A Rimworld of Magic/Patch_Apparel.xml
+++ b/Patches/A Rimworld of Magic/Patch_Apparel.xml
@@ -8,19 +8,202 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 		
+			<!-- Cloaks : Vanilla cape is 4mm, so we use a general of that as a base and modify based on the original's stat -->
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[
 				defName="TM_MaestersCloak" or
-				defName="DemonLordCloak" or
-				defName="DarkRobe" or
-				defName="ArchMageRobe"
+				defName="DemonLordCloak"
 				]/statBases</xpath>
 				<value>
 					<Bulk>10</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_MaestersCloak"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="DemonLordCloak"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!-- Robes : Take up middle so we'll add a little extra protection to compensate. Should still generally be inferior to the armor combo unless we're using super-fabric though-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="DarkRobe" or
+				defName="ArchMageRobe" or
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases</xpath>
+				<value>
+					<Bulk>20</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="DarkRobe"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="DarkRobe"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="DarkRobe"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>7</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>9</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_DreamcatcherBuckskin"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- Hats -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="TM_WizardHat" or
+				defName="ArcaneHood"
+				]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="TM_WizardHat"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="ArcaneHood"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="HoodOfMadness"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="HoodOfMadness"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="HoodOfMadness"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="HoodOfMadness"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!--Armors-->
 
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[
@@ -45,41 +228,44 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RoyalArmor"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>30</Bulk>
-					<WornBulk>4.5</WornBulk>
-					<Mass>4.5</Mass>
+					<Bulk>100</Bulk>
+					<WornBulk>10</WornBulk>
+					<Mass>15</Mass>
 				</value>
 			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RoyalArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AncientMail"]/statBases/Mass</xpath>
+				<value>
+					<Bulk>60</Bulk>
+					<WornBulk>7.5</WornBulk>
+					<Mass>7.5</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="AncientMail"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="AncientMail"]/statBases</xpath>
-				<value>
-					<Bulk>10</Bulk>
-					<WornBulk>5</WornBulk>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="AncientMail"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
+			<!--<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="AncientMail"]/stuffCategories</xpath>
 				<value>
 					<stuffCategories>
 						<li>Steeled</li>
 					</stuffCategories>
 				</value>
-			</li>
+			</li>-->
 			
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="AncientMail"]/equippedStatOffsets/MoveSpeed</xpath>
@@ -96,7 +282,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RoyalHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -130,7 +316,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ParagonHelm"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -173,7 +359,7 @@
 				<xpath>Defs/ThingDef[@Name="TM_ArtifactBase"]/statBases</xpath>
 				<value>
 					<Bulk>0.35</Bulk>
-					<WornBulk>0.1</WornBulk>
+					<WornBulk>0</WornBulk>
 				</value>
 			</li>
 			

--- a/Patches/A Rimworld of Magic/Patch_Melee.xml
+++ b/Patches/A Rimworld of Magic/Patch_Melee.xml
@@ -20,9 +20,9 @@
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
-						<power>6</power>
-						<cooldownTime>1.31</cooldownTime>
-						<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+						<power>7</power>
+						<cooldownTime>2.24</cooldownTime>
+						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
 					  </li>
 					  <li Class="CombatExtended.ToolCE">
@@ -30,11 +30,11 @@
 						<capacities>
 						  <li>Cut</li>
 						</capacities>
-						<power>24</power>
-						<cooldownTime>1.8</cooldownTime>
+						<power>59</power>
+						<cooldownTime>4.71</cooldownTime>
 						<chanceFactor>1.165</chanceFactor>
-						<armorPenetrationBlunt>8.1</armorPenetrationBlunt>
-						<armorPenetrationSharp>1.62</armorPenetrationSharp>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.25</armorPenetrationSharp>
 						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 					  </li>
 					  <li Class="CombatExtended.ToolCE">
@@ -42,11 +42,11 @@
 						<capacities>
 						  <li>Stab</li>
 						</capacities>
-						<power>22</power>
-						<cooldownTime>1.16</cooldownTime>
+						<power>23</power>
+						<cooldownTime>1.87</cooldownTime>
 						<chanceFactor>1.165</chanceFactor>
-						<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
-						<armorPenetrationSharp>2.03</armorPenetrationSharp>
+						<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.4</armorPenetrationSharp>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					  </li>
 					</tools>
@@ -84,9 +84,9 @@
 							<capacities>
 								<li>Poke</li>
 							</capacities>
-							<power>8</power>
-							<cooldownTime>1.44</cooldownTime>
-							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+							<power>2</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -94,10 +94,10 @@
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>27</power>
-							<cooldownTime>1.44</cooldownTime>
-							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.48</armorPenetrationSharp>
+							<power>15</power>
+							<cooldownTime>0.88</cooldownTime>
+							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.85</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -106,10 +106,9 @@
 								<li>Cut</li>
 							</capacities>
 							<power>20</power>
-							<cooldownTime>1.34</cooldownTime>
-							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.956</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.43</armorPenetrationSharp>
+							<cooldownTime>0.83</cooldownTime>
+							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -135,6 +134,29 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationSequence">
+			<success>Always</success>
+			<operations>
+				<li Class="PatchOperationTest">
+				<xpath>Defs/ThingDef[defName="TM_ElephantTusk"]/weaponTags</xpath>
+				<success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_ElephantTusk"]</xpath>
+				<value>
+					<weaponTags />
+				</value>
+				</li>
+			</operations>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_ElephantTusk"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+			
 			
 			
 			<li Class="PatchOperationReplace">
@@ -146,9 +168,9 @@
 							<capacities>
 								<li>Poke</li>
 							</capacities>
-							<power>8</power>
-							<cooldownTime>0.5</cooldownTime>
-							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+							<power>2</power>
+							<cooldownTime>1.5</cooldownTime>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -156,10 +178,10 @@
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>32</power>
-							<cooldownTime>1.44</cooldownTime>
-							<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.48</armorPenetrationSharp>
+							<power>16</power>
+							<cooldownTime>0.94</cooldownTime>
+							<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+							<armorPenetrationSharp>15.06</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -167,11 +189,11 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>25</power>
-							<cooldownTime>1.34</cooldownTime>
+							<power>35</power>
+							<cooldownTime>0.83</cooldownTime>
 							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.956</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.43</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+							<armorPenetrationSharp>9</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -194,6 +216,29 @@
 						<MeleeParryChance>0.5</MeleeParryChance>
 						<MeleeDodgeChance>0.4</MeleeDodgeChance>	
 					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationSequence">
+			<success>Always</success>
+			<operations>
+				<li Class="PatchOperationTest">
+				<xpath>Defs/ThingDef[defName="TM_ThrumboSaber"]/weaponTags</xpath>
+				<success>Invert</success>
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_ThrumboSaber"]</xpath>
+				<value>
+					<weaponTags />
+				</value>
+				</li>
+			</operations>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_ThrumboSaber"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
 				</value>
 			</li>
 			
@@ -227,11 +272,11 @@
 					<capacities>
 					  <li>Cut</li>
 					</capacities>
-					<power>48</power>
-					<cooldownTime>3.4</cooldownTime>
+					<power>59</power>
+					<cooldownTime>4.71</cooldownTime>
 					<chanceFactor>1.165</chanceFactor>
-					<armorPenetrationBlunt>10.4</armorPenetrationBlunt>
-					<armorPenetrationSharp>3.6</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					<armorPenetrationSharp>16.13</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				  </li>
 				  <li Class="CombatExtended.ToolCE">
@@ -239,11 +284,11 @@
 					<capacities>
 					  <li>Stab</li>
 					</capacities>
-					<power>41</power>
-					<cooldownTime>1.8</cooldownTime>
+					<power>20</power>
+					<cooldownTime>1.87</cooldownTime>
 					<chanceFactor>1.165</chanceFactor>
-					<armorPenetrationBlunt>2.3</armorPenetrationBlunt>
-					<armorPenetrationSharp>4.4</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>18</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 				  </li>
 				</tools>
@@ -273,11 +318,11 @@
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>18</power>
-							<cooldownTime>1.69</cooldownTime>
+							<power>25</power>
+							<cooldownTime>0.94</cooldownTime>
 							<chanceFactor>0.60</chanceFactor>
-							<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
-							<armorPenetrationSharp>1.6</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.048</armorPenetrationBlunt>
+							<armorPenetrationSharp>32</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -285,11 +330,11 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>36</power>
-							<cooldownTime>1.56</cooldownTime>
+							<power>47</power>
+							<cooldownTime>0.83</cooldownTime>
 							<chanceFactor>0.30</chanceFactor>
-							<armorPenetrationBlunt>2.592</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.58</armorPenetrationSharp>
+							<armorPenetrationBlunt>4.608</armorPenetrationBlunt>
+							<armorPenetrationSharp>24</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -325,9 +370,9 @@
 							<capacities>
 								<li>Poke</li>
 							</capacities>
-							<power>1</power>
-							<cooldownTime>.93</cooldownTime>
-							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							<power>2</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -335,10 +380,10 @@
 							<capacities>
 							  <li>Stab</li>
 							</capacities>
-							<power>12</power>
-							<cooldownTime>.93</cooldownTime>
-							<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.32</armorPenetrationSharp>
+							<power>13</power>
+							<cooldownTime>.88</cooldownTime>
+							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
+							<armorPenetrationSharp>8.44</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -346,11 +391,11 @@
 							<capacities>
 							  <li>Cut</li>
 							</capacities>
-							<power>10</power>
-							<cooldownTime>0.78</cooldownTime>
+							<power>19</power>
+							<cooldownTime>0.83</cooldownTime>
 							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.42</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 					</tools>

--- a/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -301,12 +301,15 @@
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/ThingDef[defName="Projectile_BlazingPower"]</xpath>
 			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="TM_DefenderStaff" or defName="TM_BlazingPowerStaff"]/verbs/li[verbClass="TorannMagic.Weapon.Verb_BlazingPower"]</xpath>
+			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs</xpath>
 				<value>
 					  <ThingDef ParentName="Base6x24mmChargedBullet" Class="AbilityUser.ProjectileDef_Ability">
-						<!--<thingClass>TorannMagic.Weapon.Projectile_BlazingPower</thingClass>-->
 						<defName>Projectile_BlazingPower</defName>
 						<label>blazing power</label>
 						<graphicData>
@@ -386,6 +389,7 @@
 			</li>
 			
 			
+			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>TM_ElephantBow</defName>
 				<statBases>
@@ -451,7 +455,7 @@
 				  <soundCast>TM_ThrumBow</soundCast>
 				</Properties>
 				<AmmoUser>
-				  <ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+				  <ammoSet>AmmoSet_GreatArrowRoMThrumbo</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>
@@ -478,6 +482,125 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<!-- ==================== AmmoSets ========================== -->
+					
+				  <CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_GreatArrowRoMThrumbo</defName>
+					<label>great arrows</label>
+					<ammoTypes>
+					  <Ammo_GreatArrow_Stone>Projectile_GreatArrowRoMThrumbo_Stone</Ammo_GreatArrow_Stone>
+					  <Ammo_GreatArrow_Steel>Projectile_GreatArrowRoMThrumbo_Steel</Ammo_GreatArrow_Steel>
+					  <Ammo_GreatArrow_Plasteel>Projectile_GreatArrowRoMThrumbo_Plasteel</Ammo_GreatArrow_Plasteel>
+					  <Ammo_GreatArrow_Venom>Projectile_GreatArrowRoMThrumbo_Venom</Ammo_GreatArrow_Venom>
+					  <Ammo_GreatArrow_Flame>Projectile_GreatArrowRoMThrumbo_Flame</Ammo_GreatArrow_Flame>
+					</ammoTypes>
+				  </CombatExtended.AmmoSetDef>
+					
+					<!-- ================== Projectiles ================== -->
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+						<defName>Projectile_GreatArrowRoMThrumbo_Stone</defName>
+						<label>great arrow (stone)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>33</speed>
+							<damageAmountBase>28</damageAmountBase> <!--Artifically reduced from 33-->
+							<armorPenetrationBlunt>14.98</armorPenetrationBlunt>
+							<armorPenetrationSharp>4</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- All values are halved from original great arrow -->
+							<preExplosionSpawnThingDef>Ammo_GreatArrow_Stone</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+						<defName>Projectile_GreatArrowRoMThrumbo_Steel</defName>
+						<label>great arrow (steel)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>36</speed>
+							<damageAmountBase>20</damageAmountBase>
+							<armorPenetrationBlunt>21.06</armorPenetrationBlunt>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.3</preExplosionSpawnChance>
+							<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+						<defName>Projectile_GreatArrowRoMThrumbo_Plasteel</defName>
+						<label>great arrow (plasteel)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>37</speed>
+							<damageAmountBase>15</damageAmountBase>
+							<armorPenetrationBlunt>19.26</armorPenetrationBlunt>
+							<armorPenetrationSharp>12</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.375</preExplosionSpawnChance>
+							<preExplosionSpawnThingDef>Ammo_GreatArrow_Plasteel</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+						<defName>Projectile_GreatArrowRoMThrumbo_Venom</defName>
+						<label>great arrow (venom)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<speed>36</speed>
+							<damageDef>Arrow</damageDef>
+							<damageAmountBase>14</damageAmountBase>
+							<secondaryDamage>
+								<li>
+								<def>ArrowVenom</def>
+								<amount>6</amount>
+								</li>
+							</secondaryDamage>			
+							<armorPenetrationBlunt>21.06</armorPenetrationBlunt>
+							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<preExplosionSpawnChance>0.3</preExplosionSpawnChance>
+							<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+						<defName>Projectile_GreatArrowRoMThrumbo_Flame</defName>
+						<label>great arrow (flame)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>36</speed>
+					  <damageDef>Arrow</damageDef>
+					  <damageAmountBase>6</damageAmountBase>
+					  <armorPenetrationBlunt>10.54</armorPenetrationBlunt>
+					  <armorPenetrationSharp>4</armorPenetrationSharp>
+					  <secondaryDamage>
+						<li>
+						  <def>Flame</def>
+						  <amount>1</amount>
+						  <chance>0.33</chance>
+						</li>
+					  </secondaryDamage>
+					</projectile>
+					</ThingDef>
+					
+				</value>
+			</li>
 			
 		</operations>
 		</match>

--- a/Patches/A Rimworld of Magic/Patch_Stuff.xml
+++ b/Patches/A Rimworld of Magic/Patch_Stuff.xml
@@ -8,6 +8,7 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 		
+			<!--Demonscale-->
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/stuffProps/categories</xpath>
@@ -17,14 +18,171 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases/SharpDamageMultiplier</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/stuffProps/statFactors</xpath>
+				<value>
+					<MeleePenetrationFactor>1.5</MeleePenetrationFactor>
+					<Mass>0.75</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>1.75</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Electric>0.20</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>3.5</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.35</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases/StuffPower_Armor_Harmony</xpath>
+				<value>
+					<StuffPower_Armor_Harmony>0.15</StuffPower_Armor_Harmony>
+				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="TM_Demonscale"]/statBases</xpath>
 				<value>
 					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+			
+			<!--Arcalleum-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/stuffProps/statFactors</xpath>
+				<value>
+					<MeleePenetrationFactor>1.3</MeleePenetrationFactor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>1.1</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Electric>0.20</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>3.25</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.20</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases/StuffPower_Armor_Harmony</xpath>
+				<value>
+					<StuffPower_Armor_Harmony>0.12</StuffPower_Armor_Harmony>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases/SharpDamageMultiplier</xpath>
+				<value>
+					<SharpDamageMultiplier>0.75</SharpDamageMultiplier>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="TM_Arcalleum"]/statBases</xpath>
+				<value>
+					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+			
+			<!--Manaweave-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Manaweave"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Electric>0.08</StuffPower_Armor_Electric>
+					<Bulk>0.3</Bulk>
+					<WornBulk>0.3</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Manaweave"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Manaweave"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.08</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Manaweave"]/statBases/StuffPower_Armor_Harmony</xpath>
+				<value>
+					<StuffPower_Armor_Harmony>0.025</StuffPower_Armor_Harmony>
+				</value>
+			</li>
+			
+			<!--Demonhide-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonhide"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.95</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Electric>0.08</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonhide"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.3</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonhide"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.08</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="TM_Demonhide"]/statBases/StuffPower_Armor_Harmony</xpath>
+				<value>
+					<StuffPower_Armor_Harmony>0.06</StuffPower_Armor_Harmony>
 				</value>
 			</li>
 			


### PR DESCRIPTION
## Additions

Added special greatbow ammoset for thrumbo bow

## Changes

Improved the defensive specs of some of the more expensive gear, gave most the robes decent cloth thickness, adjusted the stats on materials to more closely match CE statting

## Reasoning

Many of the apparels had very low stuffable rates for their cost/investment, and the robes in particular take up both middle and outer, so a bit of extra thickness dosen't really  break anything and makes them a bit more usable. A few of the stuffs were either too weak or too strong for the difficulty of aquiring them + their market value.

The thrumbo gear and composite item bade from two pieces of them, as well as some of the more expensive armor, were buffed since thrumbo gear is strictly limited by thrumbo appearances, and by the time you can make them, you can also easily duplicate literally any makable item at the same bench for its original cost, even without the tech (i.e. you can buy a single charge rifle and some ammo for it, and magically fabricate duplicates out of plasteel/steel/components)

## Alternatives

In terms of buffing the weapons, I did also consider giving them some form of secondary magical damage that would allow them to generally bypass armor, but given how generally disliked that is on AP-I, for example, I opted against it.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (19h)
