### PR TITLE
Updated PsiTech patch, modified descriptions of electric and heat armor.

### DIFF
--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -22,7 +22,7 @@
   <StatDef ParentName="ArmorRatingBase">
     <defName>ArmorRating_Electric</defName>
     <label>Armor - Electric </label>
-    <description>The chance to affect electricity-related damage like EMP pulses and burns.\n\nUpon taking damage, first this armor rating is reduced by the attack's armor penetration value. The remaining armor forms a percentage reduction of damage.</description>
+    <description>Percentage-based reduction to damage from electricity-related damage sources such as EMP pulses and EMP-tipped projectiles.\n\nHaving a value of 100% and above makes the wearer immune to all electrical damage.</description>
 	<displayPriorityInCategory>39</displayPriorityInCategory>
     <parts>
       <li Class="StatPart_Stuff">

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -188,7 +188,7 @@
       <WorkToMake>31500</WorkToMake>
       <Mass>16.5</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
     </statBases>
     <description>M240B medium machine gun mounted on a tripod.</description>
     <costList>
@@ -223,7 +223,7 @@
       <WorkToMake>50500</WorkToMake>
       <Mass>88</Mass>
       <Bulk>100</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
     </statBases>
     <description>KPV heavy machine gun mounted on a tripod.</description>
     <costList>
@@ -257,7 +257,7 @@
       <WorkToMake>33500</WorkToMake>
       <Mass>16</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
     </statBases>
     <description>Lightweight automatic grenade launcher.</description>
     <costList>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -188,6 +188,7 @@
       <WorkToMake>31500</WorkToMake>
       <Mass>16.5</Mass>
       <Bulk>20</Bulk>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>M240B medium machine gun mounted on a tripod.</description>
     <costList>
@@ -222,6 +223,7 @@
       <WorkToMake>50500</WorkToMake>
       <Mass>88</Mass>
       <Bulk>100</Bulk>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>KPV heavy machine gun mounted on a tripod.</description>
     <costList>
@@ -255,6 +257,7 @@
       <WorkToMake>33500</WorkToMake>
       <Mass>16</Mass>
       <Bulk>20</Bulk>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>Lightweight automatic grenade launcher.</description>
     <costList>
@@ -290,6 +293,7 @@
       <WorkToBuild>79500</WorkToBuild>
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>Old school anti-aircraft cannon. Ineffective against modern aviation but still popular on rimworlds for use against entrenched enemies and vehicles.</description>
     <costList>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -188,7 +188,7 @@
       <WorkToMake>31500</WorkToMake>
       <Mass>16.5</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>M240B medium machine gun mounted on a tripod.</description>
     <costList>
@@ -223,7 +223,7 @@
       <WorkToMake>50500</WorkToMake>
       <Mass>88</Mass>
       <Bulk>100</Bulk>
-      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>KPV heavy machine gun mounted on a tripod.</description>
     <costList>
@@ -257,7 +257,7 @@
       <WorkToMake>33500</WorkToMake>
       <Mass>16</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>3</ShootingAccuracyTurret>
+      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>Lightweight automatic grenade launcher.</description>
     <costList>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -188,7 +188,6 @@
       <WorkToMake>31500</WorkToMake>
       <Mass>16.5</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>M240B medium machine gun mounted on a tripod.</description>
     <costList>
@@ -223,7 +222,6 @@
       <WorkToMake>50500</WorkToMake>
       <Mass>88</Mass>
       <Bulk>100</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>KPV heavy machine gun mounted on a tripod.</description>
     <costList>
@@ -257,7 +255,6 @@
       <WorkToMake>33500</WorkToMake>
       <Mass>16</Mass>
       <Bulk>20</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>Lightweight automatic grenade launcher.</description>
     <costList>
@@ -293,7 +290,6 @@
       <WorkToBuild>79500</WorkToBuild>
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>
-      <ShootingAccuracyTurret>4</ShootingAccuracyTurret>
     </statBases>
     <description>Old school anti-aircraft cannon. Ineffective against modern aviation but still popular on rimworlds for use against entrenched enemies and vehicles.</description>
     <costList>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -112,7 +112,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName = "ArmorRating_Heat"]/description</xpath>
 		<value>
-			<description>The chance to affect temperature-related damage like burns.\n\nUpon taking damage, first this armor rating is reduced by the attack's armor penetration value. The remaining armor forms a percentage reduction of damage.</description>
+			<description>Percentage-based reduction to damage from extreme heat damage sources such as fires and incendiary explosions.\n\nHaving a value of 100% and above makes the wearer immune to all flame damage.</description>
 		</value>
 	</Operation>
 

--- a/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
+++ b/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
@@ -14,7 +14,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Psion_Penitent"]/weaponMoney</xpath>
+					<xpath>Defs/PawnKindDef[defName="Psion_Penitent"]/weaponMoney</xpath>
 					<value>
 						<weaponMoney>80~150</weaponMoney>
 					</value>
@@ -44,12 +44,6 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Uninitiated"]/combatPower</xpath>
-					<value>
-						<combatPower>50</combatPower>
-					</value>
-				</li>
 
 				<!-- ==== Psion_Initiate ==== -->
 				<li Class="PatchOperationAddModExtension">
@@ -58,7 +52,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>4</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -83,7 +77,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>4</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -98,12 +92,6 @@
 								</li>
 							</sidearms>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Acolyte"]/weaponMoney</xpath>
-					<value>
-						<weaponMoney>300~800</weaponMoney>
 					</value>
 				</li>
 
@@ -131,10 +119,18 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Ascendant"]/combatPower</xpath>
+
+				<!-- ==== Forcing every elite tier psion to have a tactical vest for bulk reasons ==== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="Psion_Commando" or defName="Psion_Warrior" or defName="Psion_Conduit" or defName="Psion_Transcendent"]</xpath>
 					<value>
-						<combatPower>160</combatPower>
+						<specificApparelRequirements>
+							<li>
+								<bodyPartGroup>Shoulders</bodyPartGroup>
+								<apparelLayer>Webbing</apparelLayer>
+								<requiredTag>IndustrialMilitaryBasic</requiredTag>
+							</li>
+						</specificApparelRequirements>
 					</value>
 				</li>
 
@@ -145,7 +141,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>6</max>
 							</primaryMagazineCount>
 							<shieldMoney>
 								<min>200</min>
@@ -166,15 +162,13 @@
 										<li>CE_Sidearm_Melee</li>
 										<li>CE_Sidearm</li>
 									</weaponTags>
+									<magazineCount>
+										<min>0</min>
+										<max>2</max>
+									</magazineCount>
 								</li>
 							</sidearms>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Commando"]</xpath>
-					<value>
-						<combatPower>380</combatPower>
 					</value>
 				</li>
 
@@ -185,7 +179,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>6</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -202,12 +196,6 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Warrior"]</xpath>
-					<value>
-						<combatPower>340</combatPower>
-					</value>
-				</li>
 
 				<!-- ==== Psion_Conduit ==== -->
 				<li Class="PatchOperationAddModExtension">
@@ -216,7 +204,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>6</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -233,10 +221,35 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Conduit"]</xpath>
+
+				<!-- ==== Psion_Transcendent ==== -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[defName="Psion_Transcendent"]</xpath>
 					<value>
-						<combatPower>320</combatPower>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>2</min>
+								<max>6</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>999999</min>
+								<max>999999</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>OutlanderShield</li>
+							</shieldTags>
+							<shieldChance>1</shieldChance>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>999999</min>
+									<max>999999</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>CE_Sidearm_Melee</li>
+									<li>CE_Sidearm</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
 					</value>
 				</li>
 			</operations>


### PR DESCRIPTION
## Additions

- Patched new transcendant pawn kind of PsiTech mod (https://steamcommunity.com/sharedfiles/filedetails/?id=2078892294).

## Changes

- Every PsiTech's faction's pawn kind combat power patches removed, only left the penitent's;
- PsiTech's acolyte pawn kind's weapon money patch removed;
- Pawns from PsiTech's faction carry either more or less ammunition;
- PsiTech's faction's elite tier pawns forced to wear a tactical vest;
- Descriptions of electric and heat armor changed.

## Reasoning

- New unpatched PsiTech content;
- Combat Extended for the most part only changes the combat power of tribal pawn kinds. That is why only the penitent's combat power patch stayed;
- They carry at most 3 spare magazines and 1 at minimum, don't wear any real armor, use a simple gun, so the weapon money patch wasn't really necessary;
- More ammunition to make higher tier pawns more of a threat and less ammunition to lower tier pawn to make them less of a threat;
- Often elite tier pawns didn't spawn with any bulk-bearing apparel, so they would spawn with none-to-minimum ammunition;
- Description of these armor stats didn't describe with how they actually work in CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony (specify how long).
