### PR TITLE
Rakkle patch update

### DIFF
--- a/Patches/Rakkle the Rattlesnake/ThingDefs_Misc/Rakkle_Apparel.xml
+++ b/Patches/Rakkle the Rattlesnake/ThingDefs_Misc/Rakkle_Apparel.xml
@@ -15,9 +15,7 @@
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[
-				defName="RS_ChestWrap" or
-				defName="RS_Thermostat" or
-				defName="RS_Obedience_Terminal"
+				defName="RS_ChestWrap"
 				]/statBases</xpath>
 				<value>
 					<Bulk>0.5</Bulk>

--- a/Patches/Rakkle the Rattlesnake/ThingDefs_Races/AlienRace_Rakklelike.xml
+++ b/Patches/Rakkle the Rattlesnake/ThingDefs_Races/AlienRace_Rakklelike.xml
@@ -79,17 +79,6 @@
 							<armorPenetrationBlunt>0.456</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<label>venom fangs</label>
-							<capacities>
-								<li>ToxicBite</li>
-							</capacities>
-							<power>7</power>
-							<cooldownTime>1.4</cooldownTime>
-							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>1.52</armorPenetrationSharp>
-							<armorPenetrationBlunt>2.278</armorPenetrationBlunt>
-						</li>
-						<li Class="CombatExtended.ToolCE">
 							<label>snake tail</label>
 							<capacities>
 								<li>Blunt</li>
@@ -99,10 +88,40 @@
 							<linkedBodyPartsGroup>tail</linkedBodyPartsGroup>
 							<armorPenetrationBlunt>1.094</armorPenetrationBlunt>
 						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>fangs</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.4</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.52</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.278</armorPenetrationBlunt>
+						</li>
 					</tools>
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="Hediff_VenomGlands"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>venom fangs</label>
+							<capacities>
+								<li>ToxicBite</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.4</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>1.52</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.278</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
 
 			
 			<!--Venom immunity to make social fights less lethal-->


### PR DESCRIPTION

## Changes

Moved venom bite to the venom gland 'implant' to be consistent with the vanilla implementation. Slightly reduced regular bite damage to account for melee skil scaling. Removed redundant bulk/worn bulk stats from apparel that has been turned into implants.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
