### PR TITLE
PsiTech patch update

### DIFF
--- a/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
+++ b/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
@@ -14,7 +14,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[defName="Psion_Penitent"]/weaponMoney</xpath>
+					<xpath>Defs/PawnKindDef[defName="Psion_Penitent"]/weaponMoney</xpath>
 					<value>
 						<weaponMoney>80~150</weaponMoney>
 					</value>
@@ -44,12 +44,6 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Uninitiated"]/combatPower</xpath>
-					<value>
-						<combatPower>50</combatPower>
-					</value>
-				</li>
 
 				<!-- ==== Psion_Initiate ==== -->
 				<li Class="PatchOperationAddModExtension">
@@ -58,7 +52,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>4</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -83,7 +77,7 @@
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>4</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
@@ -98,12 +92,6 @@
 								</li>
 							</sidearms>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Acolyte"]/weaponMoney</xpath>
-					<value>
-						<weaponMoney>300~800</weaponMoney>
 					</value>
 				</li>
 
@@ -131,10 +119,18 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="Psion_Ascendant"]/combatPower</xpath>
+
+				<!-- ==== Every elite tier pawn is forced to wear a tactical vest for bulk capacity ==== -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="Psion_Commando" or defName="Psion_Warrior" or defName="Psion_Conduit" or defName="Psion_Transcendent"]</xpath>
 					<value>
-						<combatPower>160</combatPower>
+						<specificApparelRequirements>
+							<li>
+								<bodyPartGroup>Shoulders</bodyPartGroup>
+								<apparelLayer>Webbing</apparelLayer>
+								<requiredTag>IndustrialMilitaryBasic</requiredTag>
+							</li>
+						</specificApparelRequirements>
 					</value>
 				</li>
 
@@ -144,7 +140,7 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>2</min>
+								<min>3</min>
 								<max>5</max>
 							</primaryMagazineCount>
 							<shieldMoney>
@@ -159,22 +155,15 @@
 								<li>
 									<generateChance>0.8</generateChance>
 									<sidearmMoney>
-										<min>30</min>
+										<min>60</min>
 										<max>360</max>
 									</sidearmMoney>
 									<weaponTags>
 										<li>CE_Sidearm_Melee</li>
-										<li>CE_Sidearm</li>
 									</weaponTags>
 								</li>
 							</sidearms>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Commando"]</xpath>
-					<value>
-						<combatPower>380</combatPower>
 					</value>
 				</li>
 
@@ -184,14 +173,14 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>2</min>
+								<min>3</min>
 								<max>5</max>
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
 									<generateChance>0.8</generateChance>
 									<sidearmMoney>
-										<min>30</min>
+										<min>120</min>
 										<max>720</max>
 									</sidearmMoney>
 									<weaponTags>
@@ -202,12 +191,6 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Warrior"]</xpath>
-					<value>
-						<combatPower>340</combatPower>
-					</value>
-				</li>
 
 				<!-- ==== Psion_Conduit ==== -->
 				<li Class="PatchOperationAddModExtension">
@@ -215,7 +198,7 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>2</min>
+								<min>3</min>
 								<max>5</max>
 							</primaryMagazineCount>
 							<sidearms>
@@ -233,10 +216,51 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/PawnKindDef[defName="Psion_Conduit"]</xpath>
+
+				<!-- ==== Psion_Transcendent ==== -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[defName="Psion_Transcendent"]</xpath>
 					<value>
-						<combatPower>320</combatPower>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>3</min>
+								<max>6</max>
+							</primaryMagazineCount>
+							<shieldMoney>
+								<min>999999</min>
+								<max>999999</max>
+							</shieldMoney>
+							<shieldTags>
+								<li>OutlanderShield</li>
+							</shieldTags>
+							<shieldChance>1</shieldChance>
+							<sidearms>
+								<li>
+									<generateChance>1</generateChance>
+									<sidearmMoney>
+										<min>999999</min>
+										<max>999999</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm</li>
+									</weaponTags>
+									<magazineCount>
+										<min>0</min>
+										<max>3</max>
+									</magazineCount>
+								</li>
+								<li>
+									<generateChance>1</generateChance>
+									<sidearmMoney>
+										<min>999999</min>
+										<max>999999</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+							</sidearms>
+						</li>
 					</value>
 				</li>
 			</operations>

--- a/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
+++ b/Patches/PsiTech/PawnKindDefs/PawnKinds_PsiTech.xml
@@ -45,34 +45,9 @@
 					</value>
 				</li>
 
-				<!-- ==== Psion_Initiate ==== -->
+				<!-- ==== Psion_Initiate and Psion_Acolyte ==== -->
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/PawnKindDef[defName="Psion_Initiate"]</xpath>
-					<value>
-						<li Class="CombatExtended.LoadoutPropertiesExtension">
-							<primaryMagazineCount>
-								<min>2</min>
-								<max>4</max>
-							</primaryMagazineCount>
-							<sidearms>
-								<li>
-									<generateChance>0.6</generateChance>
-									<sidearmMoney>
-										<min>20</min>
-										<max>180</max>
-									</sidearmMoney>
-									<weaponTags>
-										<li>CE_Sidearm_Melee</li>
-									</weaponTags>
-								</li>
-							</sidearms>
-						</li>
-					</value>
-				</li>
-
-				<!-- ==== Psion_Acolyte ==== -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/PawnKindDef[defName="Psion_Acolyte"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="Psion_Initiate" or defName="Psion_Acolyte"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
@@ -106,7 +81,7 @@
 							</primaryMagazineCount>
 							<sidearms>
 								<li>
-									<generateChance>0.6</generateChance>
+									<generateChance>0.7</generateChance>
 									<sidearmMoney>
 										<min>20</min>
 										<max>180</max>


### PR DESCRIPTION
## Additions

1. Patch for Transcendant pawn kind;

## Changes

2. Removal of most pawn kind combat power patches, only left penitent's;
3. Removal of acolyte pawn kind weapon money nerf patch;
4. Magazine amount changes for most pawn kinds: lower tier pawn kinds have less ammo, higher tier pawn kinds have more;
5. Elite tier pawn kinds always spawn with tactical vests;
6. Doubled sidearm money for commando pawn kind from 30 to 60;
7. Quadrupled sidearm money for warrior pawn kind from 30 to 120.

## Reasoning

1. New mod content;
2. Recent combat power changes in the main mod as well as Combat Extended for the most part only changes combat power for tribal pawn kinds;
3. Does not provide much change, that's also one patch operation less;
4. Lower tier pawn magazine amount is the same of mercenary gunners, higher tier - similar to elite tier mercenaries;
5. Lack of bulk capacity made elite tier pawns spawn with either none or little ammo;
6. Max sidearm money is two times as much of a conduit pawn's;
7. Max sidearm money is four times as much of a conduit pawn's.

## Links
PsiTech mod links:
- Steam Workshop: https://steamcommunity.com/sharedfiles/filedetails/?id=2078892294
- Ludeon Forums: https://ludeon.com/forums/index.php?topic=51887.0

## Testing

Check tests you have performed:
- [ ] Compiles without warnings;
- [x] Game runs without errors;
- [x] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony.
