### PR TITLE
Fix surgery on outside-squishy parts causing damage to containing part.

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -124,7 +124,7 @@ namespace CombatExtended.HarmonyCE
 	static bool Prefix(DamageWorker_AddInjury __instance, DamageInfo dinfo, Pawn pawn, float totalDamage, DamageWorker.DamageResult result)
 	{
 	    var hitPart = dinfo.HitPart;
-	    if (hitPart.IsInGroup(CE_BodyPartGroupDefOf.OutsideSquishy))
+	    if (dinfo.Def != DamageDefOf.SurgicalCut && dinfo.Def != DamageDefOf.ExecutionCut && hitPart.IsInGroup(CE_BodyPartGroupDefOf.OutsideSquishy))
 	    {
 		var parent = hitPart.parent;
 		if (parent != null)

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -129,14 +129,21 @@ namespace CombatExtended.HarmonyCE
 		var parent = hitPart.parent;
 		if (parent != null)
 		{
+                    float hitPartHealth = pawn.health.hediffSet.GetPartHealth(hitPart);
+                    if (hitPartHealth >= totalDamage)
+                    {
+                        return true;
+                    }
+
 		    dinfo.SetHitPart(parent);
-                    if (pawn.health.hediffSet.GetPartHealth(parent) != 0f && parent.coverageAbs > 0f)
+                    float parentPartHealth = pawn.health.hediffSet.GetPartHealth(parent);
+                    if (parentPartHealth != 0f && parent.coverageAbs > 0f)
 		    {
 			Hediff_Injury hediff_Injury = (Hediff_Injury)HediffMaker.MakeHediff(HealthUtility.GetHediffDefFromDamage(dinfo.Def, pawn, parent), pawn, null);
 			hediff_Injury.Part = parent;
 			hediff_Injury.source = dinfo.Weapon;
 			hediff_Injury.sourceBodyPartGroup = dinfo.WeaponBodyPartGroup;
-			hediff_Injury.Severity = totalDamage;
+			hediff_Injury.Severity = totalDamage - (hitPartHealth * hitPartHealth / totalDamage);
 			if (hediff_Injury.Severity <= 0f)
 			{
 			    hediff_Injury.Severity = 1f;

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -25,6 +25,8 @@ namespace CombatExtended.HarmonyCE
             {
                 if (pawn.Spawned) LessonAutoActivator.TeachOpportunity(CE_ConceptDefOf.CE_ArmorSystem, OpportunityType.Critical);   // Inform the player about armor deflection
             }
+            Patch_CheckDuplicateDamageToOuterParts.lastHitPartHealth = pawn.health.hediffSet.GetPartHealth(newDinfo.HitPart);
+            
             dinfo = newDinfo;
         }
 
@@ -105,6 +107,7 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(DamageWorker_AddInjury), "CheckDuplicateDamageToOuterParts")]
     static class Patch_CheckDuplicateDamageToOuterParts
     {
+        public static float lastHitPartHealth = 0;
 	static MethodInfo FinalizeAndAddInjury = null;
 
 	static Patch_CheckDuplicateDamageToOuterParts()

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -130,7 +130,8 @@ namespace CombatExtended.HarmonyCE
 		if (parent != null)
 		{
                     float hitPartHealth = pawn.health.hediffSet.GetPartHealth(hitPart);
-                    if (hitPartHealth >= totalDamage)
+                    float hitPartMaxHealth = hitPart.def.GetMaxHealth(pawn);
+                    if (hitPartHealth > 0)
                     {
                         return true;
                     }
@@ -143,7 +144,7 @@ namespace CombatExtended.HarmonyCE
 			hediff_Injury.Part = parent;
 			hediff_Injury.source = dinfo.Weapon;
 			hediff_Injury.sourceBodyPartGroup = dinfo.WeaponBodyPartGroup;
-			hediff_Injury.Severity = totalDamage - (hitPartHealth * hitPartHealth / totalDamage);
+			hediff_Injury.Severity = totalDamage - (hitPartMaxHealth * hitPartMaxHealth / totalDamage);
 			if (hediff_Injury.Severity <= 0f)
 			{
 			    hediff_Injury.Severity = 1f;

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -132,9 +132,8 @@ namespace CombatExtended.HarmonyCE
 		var parent = hitPart.parent;
 		if (parent != null)
 		{
-                    float hitPartHealth = pawn.health.hediffSet.GetPartHealth(hitPart);
-                    float hitPartMaxHealth = hitPart.def.GetMaxHealth(pawn);
-                    if (hitPartHealth > 0)
+                    float hitPartHealth = lastHitPartHealth;
+                    if (hitPartHealth > totalDamage)
                     {
                         return true;
                     }
@@ -147,7 +146,7 @@ namespace CombatExtended.HarmonyCE
 			hediff_Injury.Part = parent;
 			hediff_Injury.source = dinfo.Weapon;
 			hediff_Injury.sourceBodyPartGroup = dinfo.WeaponBodyPartGroup;
-			hediff_Injury.Severity = totalDamage - (hitPartMaxHealth * hitPartMaxHealth / totalDamage);
+			hediff_Injury.Severity = totalDamage - (hitPartHealth * hitPartHealth / totalDamage);
 			if (hediff_Injury.Severity <= 0f)
 			{
 			    hediff_Injury.Severity = 1f;


### PR DESCRIPTION
## Changes

Only allow damage to propagate to siblings of squishy body parts when the damage type is not surgical or execution cut.

## References

Links to the associated issues or other related pull requests, e.g.
- Fixes #712 

## Reasoning

Surgical removal works by inflicting massive damage on the targeted body part.  This damage needs to not propagate.

## Alternatives

Calculate the exact damage needed to remove the part.  That is likely to be hard to do, given the possibility of mods which change how much damage the parts take.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
