### PR TITLE
Charge ammo tweak

### DIFF
--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -103,7 +103,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>12</armorPenetrationSharp>
-      <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+      <armorPenetrationBlunt>21.4</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -119,7 +119,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>24</armorPenetrationSharp>
-      <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+      <armorPenetrationBlunt>21.4</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -135,7 +135,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>18</armorPenetrationSharp>
-      <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+      <armorPenetrationBlunt>21.4</armorPenetrationBlunt>
       <empShieldBreakChance>1</empShieldBreakChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -103,7 +103,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>15</armorPenetrationSharp>
-      <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>32</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -119,7 +119,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>32</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -135,7 +135,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>22.5</armorPenetrationSharp>
-      <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>32</armorPenetrationBlunt>
       <empShieldBreakChance>0.2</empShieldBreakChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -103,7 +103,7 @@
           <amount>6</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>16</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -120,7 +120,7 @@
           <amount>2</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>32</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -137,7 +137,7 @@
           <amount>9</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>22.5</armorPenetrationSharp>
+      <armorPenetrationSharp>24</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
       <empShieldBreakChance>0.2</empShieldBreakChance>
     </projectile>


### PR DESCRIPTION
## Changes

Buffed the blunt penetration of smaller caliber charge bullets, increased sharp pen of larger charge rounds.

## Reasoning
Let's be honest here, Charge has never being that good and with the recent changes made blunt penetration even more important. It is going to get severely outcompeted. This tweak is meant to help charge weaponry a little.

Lasers suffer from this as well, so I'll tweak it when i find them as well.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
