### PR TITLE
Helmet and Plate armour cost tweak

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -11,14 +11,14 @@
         <stuffCategories>
             <li>Steeled</li>
         </stuffCategories>
-        <costStuffCount>50</costStuffCount>
+        <costStuffCount>65</costStuffCount>
         <statBases>
             <WorkToMake>8000</WorkToMake>
             <MaxHitPoints>120</MaxHitPoints>
             <Mass>3.5</Mass>
             <Bulk>5</Bulk>
             <WornBulk>1</WornBulk>
-            <StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+            <StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
             <StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
             <StuffEffectMultiplierInsulation_Heat>0</StuffEffectMultiplierInsulation_Heat>
             <EquipDelay>4</EquipDelay>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -72,13 +72,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_SimpleHelmet"]/costStuffCount</xpath>
-    <value>
-      <costStuffCount>40</costStuffCount>
-    </value>
-  </Operation>
-
   <!-- ========== Advanced Helmet ========== -->
 
   <Operation Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -75,7 +75,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SimpleHelmet"]/costStuffCount</xpath>
     <value>
-      <costStuffCount>25</costStuffCount>
+      <costStuffCount>40</costStuffCount>
     </value>
   </Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -137,15 +137,6 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
-	
-	<!-- Reduce Cost -->
-	
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_PlateArmor"]/costStuffCount</xpath>
-		<value>
-			<costStuffCount>105</costStuffCount>
-		</value>
-	</Operation>
 
 	<!-- ========== Armor vest ========== -->
 


### PR DESCRIPTION
Power armour price increase is a good move but I'm not sure why simple helmet and plate armour are getting price reductions? They aren't underpowered and do not need it at all , simple helmet is now OP compared to the composite helmet.
A small quantity of plasteel is very easy to acquire compared to devil strand and plasteel simple helmet is superior in everyway over composite helmet.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
