### PR TITLE
Missing Tweaks and fixes for Halo Weapon pack

### DIFF
--- a/Patches/Halo Ammo/5x23mmCaseless.xml
+++ b/Patches/Halo Ammo/5x23mmCaseless.xml
@@ -99,7 +99,6 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
-			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 
@@ -110,7 +109,6 @@
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
-			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 
@@ -121,7 +119,6 @@
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
-			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
  
@@ -132,7 +129,6 @@
 		  <damageAmountBase>8</damageAmountBase>
 		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>28.5</armorPenetrationBlunt>
-		  <dropsCasings>true</dropsCasings>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
@@ -149,7 +145,6 @@
 		  <damageAmountBase>12</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>28.5</armorPenetrationBlunt>
-		  <dropsCasings>true</dropsCasings>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -166,7 +161,6 @@
 		  <damageAmountBase>6</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.58</armorPenetrationBlunt>
-		  <dropsCasings>true</dropsCasings>
 		  <speed>246</speed>
 		</projectile>
 	  </ThingDef>

--- a/Patches/Halo Ammo/5x23mmCaseless.xml
+++ b/Patches/Halo Ammo/5x23mmCaseless.xml
@@ -99,6 +99,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
+			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
 
@@ -109,6 +110,7 @@
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
+			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
 
@@ -119,6 +121,7 @@
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>24.5</armorPenetrationBlunt>
+			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
  
@@ -135,6 +138,7 @@
 			  	<amount>4</amount>
 				</li>
 		  </secondaryDamage>
+		  <dropsCasings>false</dropsCasings>
 		</projectile>
 	  </ThingDef>
 	  
@@ -151,6 +155,7 @@
 			  	<amount>7</amount>
 				</li>
 		  </secondaryDamage>
+		  <dropsCasings>false</dropsCasings>
 		</projectile>
 	  </ThingDef>
 
@@ -162,6 +167,7 @@
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.58</armorPenetrationBlunt>
 		  <speed>246</speed>
+		  <dropsCasings>false</dropsCasings>
 		</projectile>
 	  </ThingDef>
 

--- a/Patches/Halo Ammo/9.5x40mm.xml
+++ b/Patches/Halo Ammo/9.5x40mm.xml
@@ -12,8 +12,8 @@
 
 
 	<ThingCategoryDef>
-		<defName>Ammo95x40mm</defName>
-		<label>9.5x40mm</label>
+		<defName>Ammo95X40mmUNSC</defName>
+		<label>9.5X40mm UNSC</label>
 		<parent>AmmoRifles</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
 	</ThingCategoryDef>
@@ -21,207 +21,219 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_95x40mm</defName>
-		<label>9.5x40mm</label>
+		<defName>AmmoSet_95X40mmUNSC</defName>
+		<label>9.5X40mm UNSC</label>
 		<ammoTypes>
-			<Ammo_95x40mm_FMJ>Bullet_95x40mm_FMJ</Ammo_95x40mm_FMJ>
-			<Ammo_95x40mm_AP>Bullet_95x40mm_AP</Ammo_95x40mm_AP>
-			<Ammo_95x40mm_HP>Bullet_95x40mm_HP</Ammo_95x40mm_HP>
-			<Ammo_95x40mm_Incendiary>Bullet_95x40mm_Incendiary</Ammo_95x40mm_Incendiary>
-			<Ammo_95x40mm_HE>Bullet_95x40mm_HE</Ammo_95x40mm_HE>
-			<Ammo_95x40mm_Sabot>Bullet_95x40mm_Sabot</Ammo_95x40mm_Sabot>				
+			<Ammo_95X40mmUNSC_FMJ>Bullet_95X40mmUNSC_FMJ</Ammo_95X40mmUNSC_FMJ>
+			<Ammo_95X40mmUNSC_AP>Bullet_95X40mmUNSC_AP</Ammo_95X40mmUNSC_AP>
+			<Ammo_95X40mmUNSC_HP>Bullet_95X40mmUNSC_HP</Ammo_95X40mmUNSC_HP>
+			<Ammo_95X40mmUNSC_Incendiary>Bullet_95X40mmUNSC_Incendiary</Ammo_95X40mmUNSC_Incendiary>
+			<Ammo_95X40mmUNSC_HE>Bullet_95X40mmUNSC_HE</Ammo_95X40mmUNSC_HE>
+			<Ammo_95X40mmUNSC_Sabot>Bullet_95X40mmUNSC_Sabot</Ammo_95X40mmUNSC_Sabot>				
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="95x40mmBase" ParentName="SmallAmmoBase" Abstract="True">
-		<description>A high-velocity rifle round, used in machine guns and battle rifles.</description>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="95X40mmUNSCBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>A relatively rare large diameter rifle catridge, advanced propellents allow it to be shortened consideraly without any loss of power. It is currently only used by UNSC battlerifles.</description>
 		<statBases>
-			<Mass>0.022</Mass>
-			<Bulk>0.03</Bulk>
+			<Mass>0.024</Mass>
+			<Bulk>0.02</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
 			<li>CE_AutoEnableCrafting</li>
 		</tradeTags>
 		<thingCategories>
-			<li>Ammo95x40mm</li>
+			<li>Ammo95X40mmUNSC</li>
 		</thingCategories>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_FMJ</defName>
-		<label>9.5x40mm cartridge (FMJ)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+		<defName>Ammo_95X40mmUNSC_FMJ</defName>
+		<label>9.5X40mm UNSC cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_FMJ</cookOffProjectile>
+		<generateAllowChance>0.4</generateAllowChance>
+		<cookOffProjectile>Bullet_95X40mmUNSC_FMJ</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_AP</defName>
-		<label>9.5x40mm cartridge (AP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+		<defName>Ammo_95X40mmUNSC_AP</defName>
+		<label>9.5X40mm UNSC cartridge (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_AP</cookOffProjectile>
+		<generateAllowChance>0.4</generateAllowChance>
+		<cookOffProjectile>Bullet_95X40mmUNSC_AP</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_HP</defName>
-		<label>9.5x40mm cartridge (HP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+		<defName>Ammo_95X40mmUNSC_HP</defName>
+		<label>9.5X40mm UNSC cartridge (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.1</MarketValue>
+			<MarketValue>0.12</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_HP</cookOffProjectile>
-	</ThingDef>
-		
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_Incendiary</defName>
-		<label>9.5x40mm cartridge (AP-I)</label>
-		<graphicData>
-		<texPath>Things/Ammo/Rifle/Incendiary</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-		<MarketValue>0.14</MarketValue>
-		</statBases>
-		<ammoClass>IncendiaryAP</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_Incendiary</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_HE</defName>
-		<label>9.5x40mm cartridge (HE)</label>
-		<graphicData>
-		<texPath>Things/Ammo/Rifle/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-		<MarketValue>0.2</MarketValue>
-		</statBases>
-		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_HE</cookOffProjectile>
+		<generateAllowChance>0.1</generateAllowChance>
+		<cookOffProjectile>Bullet_95X40mmUNSC_HP</cookOffProjectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmBase">
-		<defName>Ammo_95x40mm_Sabot</defName>
-		<label>9.5x40mm cartridge (Sabot)</label>
-		<graphicData>
-		<texPath>Things/Ammo/Rifle/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-		<MarketValue>0.11</MarketValue>
-		<Mass>0.017</Mass>
-		</statBases>
-		<ammoClass>Sabot</ammoClass>
-		<cookOffProjectile>Bullet_95x40mm_Sabot</cookOffProjectile>
-	</ThingDef>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+    <defName>Ammo_95X40mmUNSC_Incendiary</defName>
+    <label>9.5X40mm UNSC cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.17</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+	<generateAllowChance>0.2</generateAllowChance>
+    <cookOffProjectile>Bullet_95X40mmUNSC_Incendiary</cookOffProjectile>
+  </ThingDef>
 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+    <defName>Ammo_95X40mmUNSC_HE</defName>
+    <label>9.5X40mm UNSC cartridge (HEDP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.23</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+	<generateAllowChance>0.2</generateAllowChance>
+    <cookOffProjectile>Bullet_95X40mmUNSC_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
+    <defName>Ammo_95X40mmUNSC_Sabot</defName>
+    <label>9.5X40mm UNSC cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.13</MarketValue>
+	  <Mass>0.02</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+	<generateAllowChance>0.2</generateAllowChance>
+    <cookOffProjectile>Bullet_95X40mmUNSC_Sabot</cookOffProjectile>
+  </ThingDef>
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_FMJ</defName>
-		<label>9.5mm bullet (FMJ)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Base95X40mmUNSCBullet" ParentName="BaseBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>194</speed>
-			<damageAmountBase>23</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
-			<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
+			<damageDef>Bullet</damageDef>
+			<speed>196</speed>
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_AP</defName>
-		<label>9.5mm bullet (AP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_FMJ</defName>
+		<label>9.5mm UNSC bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>194</speed>
-			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
-			<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
+			<damageAmountBase>24</damageAmountBase>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_HP</defName>
-		<label>9.5mm bullet (HP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_AP</defName>
+		<label>9.5mm UNSC bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>194</speed>
-			<damageAmountBase>29</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>26</armorPenetrationSharp>
+			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_Incendiary</defName>
-		<label>9.5mm bullet (AP-I)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_HP</defName>
+		<label>9.5mm UNSC bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<speed>194</speed>
-		<damageAmountBase>14</damageAmountBase>
-		<armorPenetrationSharp>16</armorPenetrationSharp>
-		<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
-		<secondaryDamage>
+			<damageAmountBase>24</damageAmountBase>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_Incendiary</defName>
+		<label>9.5mm UNSC bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>17</damageAmountBase>
+		  <armorPenetrationSharp>26</armorPenetrationSharp>
+		  <armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+		  <secondaryDamage>
 				<li>
-				<def>Flame_Secondary</def>
-				<amount>9</amount>
+			  	<def>Flame_Secondary</def>
+			  	<amount>7</amount>
 				</li>
-		</secondaryDamage>
+		  </secondaryDamage>
 		</projectile>
-	</ThingDef>
-	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_HE</defName>
-		<label>9.5mm bullet (HE)</label>
+	  </ThingDef>
+	  
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_HE</defName>
+		<label>9.5mm UNSC bullet (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<speed>194</speed>
-		<damageAmountBase>23</damageAmountBase>
-		<armorPenetrationSharp>8</armorPenetrationSharp>
-		<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
-		<secondaryDamage>
+		  <damageAmountBase>24</damageAmountBase>
+		  <armorPenetrationSharp>13</armorPenetrationSharp>
+		  <armorPenetrationBlunt>79.72</armorPenetrationBlunt>
+		  <secondaryDamage>
 				<li>
-				<def>Bomb_Secondary</def>
-				<amount>14</amount>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>13</amount>
 				</li>
-		</secondaryDamage>
+		  </secondaryDamage>
 		</projectile>
-	</ThingDef>
+	  </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>Bullet_95x40mm_Sabot</defName>
-		<label>9.5mm bullet (Sabot)</label>
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
+		<defName>Bullet_95X40mmUNSC_Sabot</defName>
+		<label>9.5mm UNSC bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>11</damageAmountBase>
-		<armorPenetrationSharp>25</armorPenetrationSharp>
-		<armorPenetrationBlunt>86.28</armorPenetrationBlunt>
-		<speed>291</speed>
+		  <damageAmountBase>12</damageAmountBase>
+		  <armorPenetrationSharp>35</armorPenetrationSharp>
+		  <armorPenetrationBlunt>99.28</armorPenetrationBlunt>
+		  <speed>278</speed>
 		</projectile>
-	</ThingDef>
+	  </ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_FMJ</defName>
-		<label>make 9.5x40mm (FMJ) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (FMJ) cartridges.</description>
-		<jobString>Making 9.5x40mm (FMJ) cartridges.</jobString>
+	<RecipeDef ParentName="UNAmmoRecipeBase">
+		<defName>MakeAmmo_95X40mmUNSC_FMJ</defName>
+		<label>make 9.5X40mm UNSC (FMJ) cartridge x500</label>
+		<description>Craft 500 9.5X40mm UNSC (FMJ) cartridges.</description>
+		<jobString>Making 9.5X40mm UNSC (FMJ) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -229,7 +241,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>24</count>
+				<count>29</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -238,16 +250,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95x40mm_FMJ>500</Ammo_95x40mm_FMJ>
+			<Ammo_95X40mmUNSC_FMJ>500</Ammo_95X40mmUNSC_FMJ>
 		</products>
-		<workAmount>2400</workAmount>		
+	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_AP</defName>
-		<label>make 9.5x40mm (AP) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (AP) cartridges.</description>
-		<jobString>Making 9.5x40mm (AP) cartridges.</jobString>
+	<RecipeDef ParentName="UNAmmoRecipeBase">
+		<defName>MakeAmmo_95X40mmUNSC_AP</defName>
+		<label>make 9.5X40mm UNSC (AP) cartridge x500</label>
+		<description>Craft 500 9.5X40mm UNSC (AP) cartridges.</description>
+		<jobString>Making 9.5X40mm UNSC (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -255,7 +267,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>24</count>
+				<count>29</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,16 +276,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95x40mm_AP>500</Ammo_95x40mm_AP>
+			<Ammo_95X40mmUNSC_AP>500</Ammo_95X40mmUNSC_AP>
 		</products>
-		<workAmount>2400</workAmount>		
+	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_HP</defName>
-		<label>make 9.5x40mm (HP) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (HP) cartridges.</description>
-		<jobString>Making 9.5x40mm (HP) cartridges.</jobString>
+	<RecipeDef ParentName="UNAmmoRecipeBase">
+		<defName>MakeAmmo_95X40mmUNSC_HP</defName>
+		<label>make 9.5X40mm UNSC (HP) cartridge x500</label>
+		<description>Craft 500 9.5X40mm UNSC (HP) cartridges.</description>
+		<jobString>Making 9.5X40mm UNSC (HP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -281,7 +293,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>24</count>
+				<count>29</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -290,124 +302,124 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95x40mm_HP>500</Ammo_95x40mm_HP>
+			<Ammo_95X40mmUNSC_HP>500</Ammo_95X40mmUNSC_HP>
 		</products>
-		<workAmount>2400</workAmount>		
+	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
-	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_Incendiary</defName>
-		<label>make 9.5x40mm (AP-I) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (AP-I) cartridges.</description>
-		<jobString>Making 9.5x40mm (AP-I) cartridges.</jobString>
-		<ingredients>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-			</filter>
-			<count>24</count>
-		</li>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Prometheum</li>
-			</thingDefs>
-			</filter>
-			<count>3</count>
-		</li>
-		</ingredients>
-		<fixedIngredientFilter>
-		<thingDefs>
-			<li>Steel</li>
-			<li>Prometheum</li>
-		</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-		<Ammo_95x40mm_Incendiary>500</Ammo_95x40mm_Incendiary>
-		</products>
-		<workAmount>3600</workAmount>
-	</RecipeDef>
-	
-	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_HE</defName>
-		<label>make 9.5x40mm (HE) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (HE) cartridges.</description>
-		<jobString>Making 9.5x40mm (HE) cartridges.</jobString>
-		<ingredients>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-			</filter>
-			<count>24</count>
-		</li>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>FSX</li>
-			</thingDefs>
-			</filter>
-			<count>5</count>
-		</li>
-		</ingredients>
-		<fixedIngredientFilter>
-		<thingDefs>
-			<li>Steel</li>
-			<li>FSX</li>
-		</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-		<Ammo_95x40mm_HE>500</Ammo_95x40mm_HE>
-		</products>
-		<workAmount>4400</workAmount>
-	</RecipeDef>
-	
-	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_95x40mm_Sabot</defName>
-		<label>make 9.5x40mm (Sabot) cartridge x500</label>
-		<description>Craft 500 9.5x40mm (Sabot) cartridges.</description>
-		<jobString>Making 9.5x40mm (Sabot) cartridges.</jobString>
-		<ingredients>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-			</filter>
-			<count>14</count>
-		</li>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Uranium</li>
-			</thingDefs>
-			</filter>
-			<count>3</count>
-		</li>
-		<li>
-			<filter>
-			<thingDefs>
-				<li>Chemfuel</li>
-			</thingDefs>
-			</filter>
-			<count>3</count>
-		</li>		  
-		</ingredients>
-		<fixedIngredientFilter>
-		<thingDefs>
-			<li>Steel</li>
-			<li>Uranium</li>
-			<li>Chemfuel</li>		
-		</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-		<Ammo_95x40mm_Sabot>500</Ammo_95x40mm_Sabot>
-		</products>
-		<workAmount>3200</workAmount>
-	</RecipeDef>
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_95X40mmUNSC_Incendiary</defName>
+    <label>make 9.5X40mm UNSC (AP-I) cartridge x500</label>
+    <description>Craft 500 9.5X40mm UNSC (AP-I) cartridges.</description>
+    <jobString>Making 9.5X40mm UNSC (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_95X40mmUNSC_Incendiary>500</Ammo_95X40mmUNSC_Incendiary>
+    </products>
+    <workAmount>6900</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_95X40mmUNSC_HE</defName>
+    <label>make 9.5X40mm UNSC (HEDP) cartridge x500</label>
+    <description>Craft 500 9.5X40mm UNSC (HEDP) cartridges.</description>
+    <jobString>Making 9.5X40mm UNSC (HEDP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_95X40mmUNSC_HE>500</Ammo_95X40mmUNSC_HE>
+    </products>
+    <workAmount>6900</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_95X40mmUNSC_Sabot</defName>
+    <label>make 9.5X40mm UNSC (Sabot) cartridge x500</label>
+    <description>Craft 500 9.5X40mm UNSC (Sabot) cartridges.</description>
+    <jobString>Making 9.5X40mm UNSC (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_95X40mmUNSC_Sabot>500</Ammo_95X40mmUNSC_Sabot>
+    </products>
+    <workAmount>5000</workAmount>
+  </RecipeDef>
       
 
       </value>

--- a/Patches/Halo Ammo/9.5x40mm.xml
+++ b/Patches/Halo Ammo/9.5x40mm.xml
@@ -12,8 +12,8 @@
 
 
 	<ThingCategoryDef>
-		<defName>Ammo95X40mmUNSC</defName>
-		<label>9.5X40mm UNSC</label>
+		<defName>Ammo95x40mmUNSC</defName>
+		<label>9.5x40mm UNSC</label>
 		<parent>AmmoRifles</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
 	</ThingCategoryDef>
@@ -21,21 +21,21 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_95X40mmUNSC</defName>
-		<label>9.5X40mm UNSC</label>
+		<defName>AmmoSet_95x40mmUNSC</defName>
+		<label>9.5x40mm UNSC</label>
 		<ammoTypes>
-			<Ammo_95X40mmUNSC_FMJ>Bullet_95X40mmUNSC_FMJ</Ammo_95X40mmUNSC_FMJ>
-			<Ammo_95X40mmUNSC_AP>Bullet_95X40mmUNSC_AP</Ammo_95X40mmUNSC_AP>
-			<Ammo_95X40mmUNSC_HP>Bullet_95X40mmUNSC_HP</Ammo_95X40mmUNSC_HP>
-			<Ammo_95X40mmUNSC_Incendiary>Bullet_95X40mmUNSC_Incendiary</Ammo_95X40mmUNSC_Incendiary>
-			<Ammo_95X40mmUNSC_HE>Bullet_95X40mmUNSC_HE</Ammo_95X40mmUNSC_HE>
-			<Ammo_95X40mmUNSC_Sabot>Bullet_95X40mmUNSC_Sabot</Ammo_95X40mmUNSC_Sabot>				
+			<Ammo_95x40mmUNSC_FMJ>Bullet_95x40mmUNSC_FMJ</Ammo_95x40mmUNSC_FMJ>
+			<Ammo_95x40mmUNSC_AP>Bullet_95x40mmUNSC_AP</Ammo_95x40mmUNSC_AP>
+			<Ammo_95x40mmUNSC_HP>Bullet_95x40mmUNSC_HP</Ammo_95x40mmUNSC_HP>
+			<Ammo_95x40mmUNSC_Incendiary>Bullet_95x40mmUNSC_Incendiary</Ammo_95x40mmUNSC_Incendiary>
+			<Ammo_95x40mmUNSC_HE>Bullet_95x40mmUNSC_HE</Ammo_95x40mmUNSC_HE>
+			<Ammo_95x40mmUNSC_Sabot>Bullet_95x40mmUNSC_Sabot</Ammo_95x40mmUNSC_Sabot>				
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="95X40mmUNSCBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="95x40mmUNSCBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>A relatively rare large diameter rifle catridge, advanced propellents allow it to be shortened consideraly without any loss of power. It is currently only used by UNSC battlerifles.</description>
 		<statBases>
 			<Mass>0.024</Mass>
@@ -46,13 +46,13 @@
 			<li>CE_AutoEnableCrafting</li>
 		</tradeTags>
 		<thingCategories>
-			<li>Ammo95X40mmUNSC</li>
+			<li>Ammo95x40mmUNSC</li>
 		</thingCategories>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-		<defName>Ammo_95X40mmUNSC_FMJ</defName>
-		<label>9.5X40mm UNSC cartridge (FMJ)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+		<defName>Ammo_95x40mmUNSC_FMJ</defName>
+		<label>9.5x40mm UNSC cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -62,12 +62,12 @@
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<generateAllowChance>0.4</generateAllowChance>
-		<cookOffProjectile>Bullet_95X40mmUNSC_FMJ</cookOffProjectile>
+		<cookOffProjectile>Bullet_95x40mmUNSC_FMJ</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-		<defName>Ammo_95X40mmUNSC_AP</defName>
-		<label>9.5X40mm UNSC cartridge (AP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+		<defName>Ammo_95x40mmUNSC_AP</defName>
+		<label>9.5x40mm UNSC cartridge (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -77,12 +77,12 @@
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<generateAllowChance>0.4</generateAllowChance>
-		<cookOffProjectile>Bullet_95X40mmUNSC_AP</cookOffProjectile>
+		<cookOffProjectile>Bullet_95x40mmUNSC_AP</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-		<defName>Ammo_95X40mmUNSC_HP</defName>
-		<label>9.5X40mm UNSC cartridge (HP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+		<defName>Ammo_95x40mmUNSC_HP</defName>
+		<label>9.5x40mm UNSC cartridge (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -92,12 +92,12 @@
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
 		<generateAllowChance>0.1</generateAllowChance>
-		<cookOffProjectile>Bullet_95X40mmUNSC_HP</cookOffProjectile>
+		<cookOffProjectile>Bullet_95x40mmUNSC_HP</cookOffProjectile>
 	</ThingDef>
 	
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-    <defName>Ammo_95X40mmUNSC_Incendiary</defName>
-    <label>9.5X40mm UNSC cartridge (AP-I)</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+    <defName>Ammo_95x40mmUNSC_Incendiary</defName>
+    <label>9.5x40mm UNSC cartridge (AP-I)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/Incendiary</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -107,12 +107,12 @@
     </statBases>
     <ammoClass>IncendiaryAP</ammoClass>
 	<generateAllowChance>0.2</generateAllowChance>
-    <cookOffProjectile>Bullet_95X40mmUNSC_Incendiary</cookOffProjectile>
+    <cookOffProjectile>Bullet_95x40mmUNSC_Incendiary</cookOffProjectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-    <defName>Ammo_95X40mmUNSC_HE</defName>
-    <label>9.5X40mm UNSC cartridge (HEDP)</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+    <defName>Ammo_95x40mmUNSC_HE</defName>
+    <label>9.5x40mm UNSC cartridge (HEDP)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -122,12 +122,12 @@
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
 	<generateAllowChance>0.2</generateAllowChance>
-    <cookOffProjectile>Bullet_95X40mmUNSC_HE</cookOffProjectile>
+    <cookOffProjectile>Bullet_95x40mmUNSC_HE</cookOffProjectile>
   </ThingDef>
  
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95X40mmUNSCBase">
-    <defName>Ammo_95X40mmUNSC_Sabot</defName>
-    <label>9.5X40mm UNSC cartridge (Sabot)</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="95x40mmUNSCBase">
+    <defName>Ammo_95x40mmUNSC_Sabot</defName>
+    <label>9.5x40mm UNSC cartridge (Sabot)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/Sabot</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -138,61 +138,53 @@
     </statBases>
     <ammoClass>Sabot</ammoClass>
 	<generateAllowChance>0.2</generateAllowChance>
-    <cookOffProjectile>Bullet_95X40mmUNSC_Sabot</cookOffProjectile>
+    <cookOffProjectile>Bullet_95x40mmUNSC_Sabot</cookOffProjectile>
   </ThingDef>
 	<!-- ================== Projectiles ================== -->
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base95X40mmUNSCBullet" ParentName="BaseBullet" Abstract="true">
-		<graphicData>
-			<texPath>Things/Projectile/Bullet_Small</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<speed>196</speed>
-			<dropsCasings>true</dropsCasings>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_FMJ</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_FMJ</defName>
 		<label>9.5mm UNSC bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+			<speed>196</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_AP</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_AP</defName>
 		<label>9.5mm UNSC bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+			<speed>196</speed>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_HP</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_HP</defName>
 		<label>9.5mm UNSC bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>6.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+			<speed>196</speed>
 		</projectile>
 	</ThingDef>
 
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_Incendiary</defName>
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_Incendiary</defName>
 		<label>9.5mm UNSC bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>26</armorPenetrationSharp>
 		  <armorPenetrationBlunt>80.72</armorPenetrationBlunt>
+		  <speed>196</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
@@ -202,13 +194,14 @@
 		</projectile>
 	  </ThingDef>
 	  
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_HE</defName>
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_HE</defName>
 		<label>9.5mm UNSC bullet (HEDP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>24</damageAmountBase>
 		  <armorPenetrationSharp>13</armorPenetrationSharp>
 		  <armorPenetrationBlunt>79.72</armorPenetrationBlunt>
+		  <speed>196</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -218,8 +211,8 @@
 		</projectile>
 	  </ThingDef>
 
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base95X40mmUNSCBullet">
-		<defName>Bullet_95X40mmUNSC_Sabot</defName>
+	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>Bullet_95x40mmUNSC_Sabot</defName>
 		<label>9.5mm UNSC bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>11</damageAmountBase>
@@ -232,10 +225,10 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="UNAmmoRecipeBase">
-		<defName>MakeAmmo_95X40mmUNSC_FMJ</defName>
-		<label>make 9.5X40mm UNSC (FMJ) cartridge x500</label>
-		<description>Craft 500 9.5X40mm UNSC (FMJ) cartridges.</description>
-		<jobString>Making 9.5X40mm UNSC (FMJ) cartridges.</jobString>
+		<defName>MakeAmmo_95x40mmUNSC_FMJ</defName>
+		<label>make 9.5x40mm UNSC (FMJ) cartridge x500</label>
+		<description>Craft 500 9.5x40mm UNSC (FMJ) cartridges.</description>
+		<jobString>Making 9.5x40mm UNSC (FMJ) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -252,16 +245,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95X40mmUNSC_FMJ>500</Ammo_95X40mmUNSC_FMJ>
+			<Ammo_95x40mmUNSC_FMJ>500</Ammo_95x40mmUNSC_FMJ>
 		</products>
 	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="UNAmmoRecipeBase">
-		<defName>MakeAmmo_95X40mmUNSC_AP</defName>
-		<label>make 9.5X40mm UNSC (AP) cartridge x500</label>
-		<description>Craft 500 9.5X40mm UNSC (AP) cartridges.</description>
-		<jobString>Making 9.5X40mm UNSC (AP) cartridges.</jobString>
+		<defName>MakeAmmo_95x40mmUNSC_AP</defName>
+		<label>make 9.5x40mm UNSC (AP) cartridge x500</label>
+		<description>Craft 500 9.5x40mm UNSC (AP) cartridges.</description>
+		<jobString>Making 9.5x40mm UNSC (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -278,16 +271,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95X40mmUNSC_AP>500</Ammo_95X40mmUNSC_AP>
+			<Ammo_95x40mmUNSC_AP>500</Ammo_95x40mmUNSC_AP>
 		</products>
 	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="UNAmmoRecipeBase">
-		<defName>MakeAmmo_95X40mmUNSC_HP</defName>
-		<label>make 9.5X40mm UNSC (HP) cartridge x500</label>
-		<description>Craft 500 9.5X40mm UNSC (HP) cartridges.</description>
-		<jobString>Making 9.5X40mm UNSC (HP) cartridges.</jobString>
+		<defName>MakeAmmo_95x40mmUNSC_HP</defName>
+		<label>make 9.5x40mm UNSC (HP) cartridge x500</label>
+		<description>Craft 500 9.5x40mm UNSC (HP) cartridges.</description>
+		<jobString>Making 9.5x40mm UNSC (HP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -304,16 +297,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_95X40mmUNSC_HP>500</Ammo_95X40mmUNSC_HP>
+			<Ammo_95x40mmUNSC_HP>500</Ammo_95x40mmUNSC_HP>
 		</products>
 	<workAmount>5000</workAmount>		
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_95X40mmUNSC_Incendiary</defName>
-    <label>make 9.5X40mm UNSC (AP-I) cartridge x500</label>
-    <description>Craft 500 9.5X40mm UNSC (AP-I) cartridges.</description>
-    <jobString>Making 9.5X40mm UNSC (AP-I) cartridges.</jobString>
+    <defName>MakeAmmo_95x40mmUNSC_Incendiary</defName>
+    <label>make 9.5x40mm UNSC (AP-I) cartridge x500</label>
+    <description>Craft 500 9.5x40mm UNSC (AP-I) cartridges.</description>
+    <jobString>Making 9.5x40mm UNSC (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -339,16 +332,16 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_95X40mmUNSC_Incendiary>500</Ammo_95X40mmUNSC_Incendiary>
+      <Ammo_95x40mmUNSC_Incendiary>500</Ammo_95x40mmUNSC_Incendiary>
     </products>
     <workAmount>6900</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_95X40mmUNSC_HE</defName>
-    <label>make 9.5X40mm UNSC (HEDP) cartridge x500</label>
-    <description>Craft 500 9.5X40mm UNSC (HEDP) cartridges.</description>
-    <jobString>Making 9.5X40mm UNSC (HEDP) cartridges.</jobString>
+    <defName>MakeAmmo_95x40mmUNSC_HE</defName>
+    <label>make 9.5x40mm UNSC (HEDP) cartridge x500</label>
+    <description>Craft 500 9.5x40mm UNSC (HEDP) cartridges.</description>
+    <jobString>Making 9.5x40mm UNSC (HEDP) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -374,16 +367,16 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_95X40mmUNSC_HE>500</Ammo_95X40mmUNSC_HE>
+      <Ammo_95x40mmUNSC_HE>500</Ammo_95x40mmUNSC_HE>
     </products>
     <workAmount>6900</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_95X40mmUNSC_Sabot</defName>
-    <label>make 9.5X40mm UNSC (Sabot) cartridge x500</label>
-    <description>Craft 500 9.5X40mm UNSC (Sabot) cartridges.</description>
-    <jobString>Making 9.5X40mm UNSC (Sabot) cartridges.</jobString>
+    <defName>MakeAmmo_95x40mmUNSC_Sabot</defName>
+    <label>make 9.5x40mm UNSC (Sabot) cartridge x500</label>
+    <description>Craft 500 9.5x40mm UNSC (Sabot) cartridges.</description>
+    <jobString>Making 9.5x40mm UNSC (Sabot) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -418,7 +411,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_95X40mmUNSC_Sabot>500</Ammo_95X40mmUNSC_Sabot>
+      <Ammo_95x40mmUNSC_Sabot>500</Ammo_95x40mmUNSC_Sabot>
     </products>
     <workAmount>5000</workAmount>
   </RecipeDef>

--- a/Patches/Halo Ammo/9.5x40mm.xml
+++ b/Patches/Halo Ammo/9.5x40mm.xml
@@ -142,6 +142,8 @@
   </ThingDef>
 	<!-- ================== Projectiles ================== -->
 
+	<!-- ================== Projectiles ================== -->
+
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Base95X40mmUNSCBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Small</texPath>
@@ -158,7 +160,7 @@
 		<defName>Bullet_95X40mmUNSC_FMJ</defName>
 		<label>9.5mm UNSC bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>24</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		</projectile>
@@ -168,7 +170,7 @@
 		<defName>Bullet_95X40mmUNSC_AP</defName>
 		<label>9.5mm UNSC bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		</projectile>
@@ -178,7 +180,7 @@
 		<defName>Bullet_95X40mmUNSC_HP</defName>
 		<label>9.5mm UNSC bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>24</damageAmountBase>
+			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>6.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		</projectile>
@@ -188,7 +190,7 @@
 		<defName>Bullet_95X40mmUNSC_Incendiary</defName>
 		<label>9.5mm UNSC bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>17</damageAmountBase>
+		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>26</armorPenetrationSharp>
 		  <armorPenetrationBlunt>80.72</armorPenetrationBlunt>
 		  <secondaryDamage>
@@ -220,7 +222,7 @@
 		<defName>Bullet_95X40mmUNSC_Sabot</defName>
 		<label>9.5mm UNSC bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>12</damageAmountBase>
+		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>35</armorPenetrationSharp>
 		  <armorPenetrationBlunt>99.28</armorPenetrationBlunt>
 		  <speed>278</speed>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -134,7 +134,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>W-AV_M6_G-NR</defName>
 				<statBases>
-      					<WorkToMake>100000</WorkToMake>
+      		<WorkToMake>100000</WorkToMake>
 					<Mass>19.07</Mass>
 					<Bulk>18.00</Bulk>
 					<SwayFactor>2</SwayFactor>
@@ -143,10 +143,10 @@
 					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 				</statBases>
 				<costList>
-					<Steel>100</Steel>
-      					<Chemfuel>60</Chemfuel>
-      					<Plasteel>100</Plasteel>
-					<ComponentSpacer>5</ComponentSpacer>
+				<Steel>100</Steel>
+          <Chemfuel>60</Chemfuel>
+          <Plasteel>100</Plasteel>
+				  <ComponentSpacer>5</ComponentSpacer>
 				</costList>
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -358,7 +358,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
-      <defaultProjectile>Bullet_95x40mm_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_95X40mmUNSC_FMJ</defaultProjectile>
       <burstShotCount>3</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
       <warmupTime>1.1</warmupTime>
@@ -376,7 +376,7 @@
     <AmmoUser>
       <magazineSize>36</magazineSize>
       <reloadTime>3.5</reloadTime>
-      <ammoSet>AmmoSet_95x40mm</ammoSet>
+      <ammoSet>AmmoSet_95X40mmUNSC</ammoSet>
     </AmmoUser>
     <FireModes>
       <aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -134,6 +134,7 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>W-AV_M6_G-NR</defName>
 				<statBases>
+      					<WorkToMake>100000</WorkToMake>
 					<Mass>19.07</Mass>
 					<Bulk>18.00</Bulk>
 					<SwayFactor>2</SwayFactor>
@@ -141,19 +142,25 @@
 					<SightsEfficiency>2.25</SightsEfficiency>
 					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 				</statBases>
+				<costList>
+					<Steel>100</Steel>
+      					<Chemfuel>60</Chemfuel>
+      					<Plasteel>100</Plasteel>
+					<ComponentSpacer>5</ComponentSpacer>
+				</costList>
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>True</hasStandardCommand>
 					<defaultProjectile>Bullet_Laser_SpartanLaserInf</defaultProjectile>
 					<warmupTime>2.6</warmupTime>
-					<range>80</range>
+					<range>86</range>
 					<soundCast>Shot_SpartanLaser</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>18</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>4</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>8.0</reloadTime>
 					<ammoSet>AmmoSet_SpartanLaserInf</ammoSet>
 				</AmmoUser>
 				<FireModes>
@@ -297,7 +304,7 @@
   <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
     <defName>MA5D_ICWS</defName>
     <statBases>
-      <WorkToMake>32000</WorkToMake>
+      <WorkToMake>31000</WorkToMake>
       <SightsEfficiency>1.1</SightsEfficiency>
       <ShotSpread>0.08</ShotSpread>
       <SwayFactor>1.32</SwayFactor>
@@ -340,7 +347,7 @@
   <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
     <defName>BR85_Service_Rifle</defName>
     <statBases>
-      <WorkToMake>36000</WorkToMake>
+      <WorkToMake>35000</WorkToMake>
       <SightsEfficiency>1.5</SightsEfficiency>
       <ShotSpread>0.06</ShotSpread>
       <SwayFactor>1.4</SwayFactor>
@@ -351,7 +358,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
-      <defaultProjectile>Ammo_95x40mm_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_95x40mm_FMJ</defaultProjectile>
       <burstShotCount>3</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
       <warmupTime>1.1</warmupTime>
@@ -381,19 +388,19 @@
   <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
     <defName>M739_SAW</defName>
     <statBases>
-      <WorkToMake>55000</WorkToMake>
+      <WorkToMake>56000</WorkToMake>
       <SightsEfficiency>1.1</SightsEfficiency>
-      <ShotSpread>0.07</ShotSpread>
-      <SwayFactor>1.36</SwayFactor>
-      <Bulk>10</Bulk>
-      <Mass>4</Mass>
+      <ShotSpread>0.06</ShotSpread>
+      <SwayFactor>1.43</SwayFactor>
+      <Bulk>12</Bulk>
+      <Mass>6</Mass>
       <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
     </statBases>
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_762x51mmUNSC_FMJ</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
+      <warmupTime>1.25</warmupTime>
       <range>62</range>
       <burstShotCount>10</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
@@ -401,12 +408,12 @@
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
       <recoilPattern>Mounted</recoilPattern>
-      <recoilAmount>1.36</recoilAmount>
+      <recoilAmount>1.31</recoilAmount>
     </Properties>
     <costList>
-      <Steel>60</Steel>
-      <ComponentIndustrial>6</ComponentIndustrial>
-      <Chemfuel>20</Chemfuel>
+      <Steel>90</Steel>
+      <ComponentIndustrial>7</ComponentIndustrial>
+      <Chemfuel>30</Chemfuel>
     </costList>
     <AmmoUser>
       <magazineSize>128</magazineSize>
@@ -414,9 +421,9 @@
       <ammoSet>AmmoSet_762x51mmUNSC</ammoSet>
     </AmmoUser>
     <FireModes>
-      <aiUseBurstMode>True</aiUseBurstMode>
+      <aiUseBurstMode>FALSE</aiUseBurstMode>
       <aiAimMode>AimedShot</aiAimMode>
-      <aimedBurstShotCount>3</aimedBurstShotCount>
+      <aimedBurstShotCount>5</aimedBurstShotCount>
     </FireModes>
   </li>
 
@@ -447,10 +454,9 @@
       <recoilAmount>1.17</recoilAmount>
     </Properties>
     <costList>
-      <Steel>15</Steel>
-      <Plasteel>15</Plasteel>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>5</Chemfuel>
+      <Steel>35</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
     </costList>
     <AmmoUser>
       <magazineSize>60</magazineSize>
@@ -470,7 +476,7 @@
   <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
     <defName>SRS99C-S2_AM</defName>
     <statBases>
-      <WorkToMake>55000</WorkToMake>
+      <WorkToMake>56000</WorkToMake>
       <SightsEfficiency>3.5</SightsEfficiency>
       <ShotSpread>0.03</ShotSpread>
       <SwayFactor>1.88</SwayFactor>
@@ -483,16 +489,16 @@
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_145x114mmUNSC_FMJ</defaultProjectile>
       <warmupTime>3.2</warmupTime>
-      <range>91</range>
+      <range>90</range>
       <soundCast>Shot_SRS99C-S2_AM</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>11</muzzleFlashScale>
     </Properties>
     <costList>
-      <Steel>40</Steel>
-      <Plasteel>30</Plasteel>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>10</Chemfuel>
+      <Steel>80</Steel>
+      <Plasteel>20</Plasteel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <Chemfuel>30</Chemfuel>
     </costList>
     <AmmoUser>
       <magazineSize>4</magazineSize>
@@ -528,10 +534,9 @@
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <costList>
-      <Steel>30</Steel>
-      <Plasteel>25</Plasteel>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>10</Chemfuel>
+      <Steel>60</Steel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+      <Chemfuel>20</Chemfuel>
     </costList>
     <AmmoUser>
       <magazineSize>12</magazineSize>
@@ -548,7 +553,7 @@
   <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
     <defName>M6D_Personal_Defense_Weapon_System</defName>
     <statBases>
-      <WorkToMake>14000</WorkToMake>
+      <WorkToMake>13000</WorkToMake>
       <SightsEfficiency>0.75</SightsEfficiency>
       <ShotSpread>0.11</ShotSpread>
       <SwayFactor>1.35</SwayFactor>
@@ -567,10 +572,9 @@
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <costList>
-      <Steel>15</Steel>
-      <Plasteel>10</Plasteel>
-      <ComponentIndustrial>2</ComponentIndustrial>
-      <Chemfuel>8</Chemfuel>
+      <Steel>30</Steel>
+      <ComponentIndustrial>3</ComponentIndustrial>
+      <Chemfuel>10</Chemfuel>
     </costList>
     <AmmoUser>
       <magazineSize>12</magazineSize>
@@ -598,9 +602,9 @@
 				<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
 			</statBases>
 			<costList>
-				<Steel>60</Steel>
-				<FSX>4</FSX>
-				<ComponentIndustrial>4</ComponentIndustrial>
+				<Steel>50</Steel>
+      				<Chemfuel>20</Chemfuel>
+				<ComponentIndustrial>3</ComponentIndustrial>
 			</costList>
 			<Properties>
       				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -645,17 +649,18 @@
 			</statBases>
 			<costList>
 				<Steel>60</Steel>
-				<FSX>4</FSX>
-				<ComponentIndustrial>4</ComponentIndustrial>
+      				<Chemfuel>40</Chemfuel>
+      				<Plasteel>50</Plasteel>
+				<ComponentSpacer>2</ComponentSpacer>
 			</costList>
 			<Properties>
       				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Bullet_16x65mm_HE</defaultProjectile>
 				<burstShotCount>1</burstShotCount>
-				<warmupTime>1.4</warmupTime>
-				<range>75</range>
-        				<minRange>1.1</minRange>
+				<warmupTime>1.35</warmupTime>
+				<range>78</range>
+        				<minRange>1.5</minRange>
 				<soundCast>Shot_Halo_Railgun</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>
 				<muzzleFlashScale>12</muzzleFlashScale>
@@ -679,7 +684,7 @@
 		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>M41_SSR_MAV_AW</defName>
 			<statBases>
-				<WorkToMake>35000</WorkToMake>
+				<WorkToMake>45000</WorkToMake>
 				<Mass>8</Mass>
 				<Bulk>12.0</Bulk>
 				<SwayFactor>2</SwayFactor>
@@ -688,9 +693,10 @@
 				<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 			</statBases>
 			<costList>
-				<Steel>60</Steel>
-				<FSX>4</FSX>
-				<ComponentIndustrial>4</ComponentIndustrial>
+				<Steel>100</Steel>
+      				<Chemfuel>30</Chemfuel>
+      				<Plasteel>20</Plasteel>
+				<ComponentIndustrial>7</ComponentIndustrial>
 			</costList>
 			<Properties>
       				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -740,18 +746,17 @@
       <defaultProjectile>Bullet_762x51mmUNSC_FMJ_DMR</defaultProjectile>
       <burstShotCount>2</burstShotCount>
       <ticksBetweenBurstShots>45</ticksBetweenBurstShots>
-      <recoilAmount>1.47</recoilAmount>
+      <recoilAmount>1.56</recoilAmount>
       <warmupTime>1.2</warmupTime>
-      <range>70</range>
+      <range>72</range>
       <soundCast>Shot_DMR</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <costList>
-      <Steel>40</Steel>
-      <Plasteel>30</Plasteel>
-      <ComponentSpacer>1</ComponentSpacer>
-      <Chemfuel>10</Chemfuel>
+	<Steel>60</Steel>
+      	<Chemfuel>20</Chemfuel>
+	<ComponentIndustrial>6</ComponentIndustrial>
     </costList>
     <AmmoUser>
       <magazineSize>15</magazineSize>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -133,8 +133,8 @@
 			<!-- === Spartan Laser === -->
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>W-AV_M6_G-NR</defName>
-				<statBases>
-      		<WorkToMake>100000</WorkToMake>
+        <statBases>
+          <WorkToMake>100000</WorkToMake>
 					<Mass>19.07</Mass>
 					<Bulk>18.00</Bulk>
 					<SwayFactor>2</SwayFactor>
@@ -143,7 +143,7 @@
 					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 				</statBases>
 				<costList>
-				<Steel>100</Steel>
+				  <Steel>100</Steel>
           <Chemfuel>60</Chemfuel>
           <Plasteel>100</Plasteel>
 				  <ComponentSpacer>5</ComponentSpacer>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -598,7 +598,7 @@
 				<Bulk>7.0</Bulk>
 				<SwayFactor>1</SwayFactor>
 				<ShotSpread>0.12</ShotSpread>
-				<SightsEfficiency>1</SightsEfficiency>
+				<SightsEfficiency>1.1</SightsEfficiency>
 				<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
 			</statBases>
 			<costList>
@@ -611,7 +611,7 @@
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Bullet_40mmGrenade_UNSCHEDP</defaultProjectile>
 				<burstShotCount>1</burstShotCount>
-				<warmupTime>2</warmupTime>
+				<warmupTime>1.1</warmupTime>
 				<range>55</range>
         				<ai_AvoidFriendlyFireRadius>4</ai_AvoidFriendlyFireRadius>
         				<minRange>4</minRange>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -358,8 +358,8 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
-      <defaultProjectile>Bullet_95X40mmUNSC_FMJ</defaultProjectile>
-      <burstShotCount>3</burstShotCount>
+      <defaultProjectile>Bullet_95x40mmUNSC_FMJ</defaultProjectile>
+      <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
       <warmupTime>1.1</warmupTime>
       <range>60</range>
@@ -376,9 +376,10 @@
     <AmmoUser>
       <magazineSize>36</magazineSize>
       <reloadTime>3.5</reloadTime>
-      <ammoSet>AmmoSet_95X40mmUNSC</ammoSet>
+      <ammoSet>AmmoSet_95x40mmUNSC</ammoSet>
     </AmmoUser>
     <FireModes>
+      <aimedBurstShotCount>3</aimedBurstShotCount>
       <aiUseBurstMode>FALSE</aiUseBurstMode>
       <aiAimMode>AimedShot</aiAimMode>
     </FireModes>

--- a/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
+++ b/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
@@ -196,7 +196,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>1</amount>
+					<amount>2</amount>
 				</li>
 			</secondaryDamage>
       <armorPenetrationSharp>13</armorPenetrationSharp>      
@@ -219,7 +219,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>1</amount>
+					<amount>2</amount>
 				</li>
 			</secondaryDamage>
       <armorPenetrationSharp>9</armorPenetrationSharp>      
@@ -283,7 +283,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>10</amount>
+					<amount>11</amount>
 				</li>
 			</secondaryDamage>
       <armorPenetrationSharp>32</armorPenetrationSharp>      
@@ -305,7 +305,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>2</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
       <armorPenetrationSharp>16</armorPenetrationSharp>      

--- a/Patches/Mass Effect - Playable Geth/Geth_Weapons_CE.xml
+++ b/Patches/Mass Effect - Playable Geth/Geth_Weapons_CE.xml
@@ -226,12 +226,12 @@
 		<ComponentSpacer>1</ComponentSpacer>
 				</costList>
 				<Properties>
-					<recoilAmount>0.78</recoilAmount>
+					<recoilAmount>0.8</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_GethSMG</defaultProjectile>
 					<warmupTime>0.6</warmupTime>
-					<range>24</range>
+					<range>25</range>
 					<burstShotCount>10</burstShotCount>
 					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 					<soundCast>Shot_PlasmaSMG</soundCast>

--- a/Patches/Rimeffect Core/Weapons_MEcore.xml
+++ b/Patches/Rimeffect Core/Weapons_MEcore.xml
@@ -192,7 +192,7 @@
       <burstShotCount>3</burstShotCount>
       <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
       <warmupTime>1</warmupTime>
-      <range>56</range>
+      <range>57</range>
       <soundCast>RE_Shot_Vindicator</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
@@ -247,7 +247,7 @@
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_Tempest</defaultProjectile>
       <warmupTime>0.6</warmupTime>
-      <range>26</range>
+      <range>28</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
       <soundCast>RE_Shot_Tempest</soundCast>
@@ -294,7 +294,7 @@
       <WorkToMake>37500</WorkToMake>
       <SightsEfficiency>2.8</SightsEfficiency>
       <ShotSpread>0.03</ShotSpread>
-      <SwayFactor>1.47</SwayFactor>
+      <SwayFactor>1.46</SwayFactor>
       <Bulk>10.0</Bulk>
       <Mass>4.20</Mass>
       <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>

--- a/Patches/Rimeffect Extended Cut/Weapons_ME_ExtendedCut.xml
+++ b/Patches/Rimeffect Extended Cut/Weapons_ME_ExtendedCut.xml
@@ -138,9 +138,9 @@
     <defName>RE_Gun_SpacerBattleRifle</defName>
     <statBases>
       <WorkToMake>40000</WorkToMake>
-      <SightsEfficiency>1.25</SightsEfficiency>
+      <SightsEfficiency>1.35</SightsEfficiency>
       <ShotSpread>0.06</ShotSpread>
-      <SwayFactor>1.27</SwayFactor>
+      <SwayFactor>1.29</SwayFactor>
       <Bulk>8.8</Bulk>
       <Mass>4.5</Mass>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
@@ -150,7 +150,7 @@
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_L89_Basic</defaultProjectile>
       <warmupTime>1.0</warmupTime>
-      <range>58</range>
+      <range>60</range>
       <ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
       <burstShotCount>3</burstShotCount>
       <ticksBetweenBurstShots>28</ticksBetweenBurstShots>


### PR DESCRIPTION
Forgot to balance weapon costs, also fixed a few issues with the weapons.
Not sure why 5x23mm caseless drops casing now, it literally has caseless in the name.
I'm adding drop casing=false to every projectile because they inherit FN 5.7 as base, which drops casing by default. 

Also tweaked the ranges of ME weapons.

Another thing, pls pls pls do not replace the 9.5mmx40mm with 9.5 ammo from patches from some other mods, it is carefully balanced with regards to other ammo that I just uploaded, replacing it from some other mod will ruin the balance. A lot of things are there for a purpose.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
