### PR TITLE
Tweaks to warhammer

### DIFF
--- a/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
+++ b/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
@@ -1109,10 +1109,10 @@
           <capacities>
             <li>Blunt</li>
           </capacities>
-          <power>16</power>
-          <cooldownTime>2.91</cooldownTime>
+          <power>22</power>
+          <cooldownTime>2.36</cooldownTime>
           <chanceFactor>0.30</chanceFactor>
-          <armorPenetrationBlunt>6.25</armorPenetrationBlunt>
+          <armorPenetrationBlunt>12.8</armorPenetrationBlunt>
           <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
         </li>      
       </tools>
@@ -1122,8 +1122,9 @@
   <li Class="PatchOperationReplace">
     <xpath>/Defs/ThingDef[defName="CEC_TacticalSledgeHammer"]/statBases/Mass</xpath>
     <value>
-      <Mass>8.76</Mass>
-      <Bulk>12.0</Bulk>
+      <Mass>5.76</Mass>
+      <Bulk>9</Bulk>
+      <MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
     </value>
   </li>
 
@@ -1131,8 +1132,9 @@
     <xpath>/Defs/ThingDef[defName="CEC_TacticalSledgeHammer"]</xpath>
     <value>
       <equippedStatOffsets>
-        <MeleeCritChance>0.75</MeleeCritChance>
-        <MeleeParryChance>1</MeleeParryChance>
+		<MeleeCritChance>2.30</MeleeCritChance>
+		<MeleeParryChance>0.18</MeleeParryChance>
+		<MeleeDodgeChance>0.30</MeleeDodgeChance>	
       </equippedStatOffsets>
     </value>
   </li>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -104,7 +104,7 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]</xpath>
 		<value>
 			<equippedStatOffsets>
-				<MeleeCritChance>2.50</MeleeCritChance>
+				<MeleeCritChance>2.30</MeleeCritChance>
 				<MeleeParryChance>0.18</MeleeParryChance>
 				<MeleeDodgeChance>0.30</MeleeDodgeChance>	
 			</equippedStatOffsets>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -24,7 +24,7 @@
 						<li>Cut</li>
 					</capacities>
 					<power>22</power>
-					<cooldownTime>2.48</cooldownTime>
+					<cooldownTime>2.18</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
 					<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
 					<armorPenetrationSharp>0.72</armorPenetrationSharp>
@@ -82,8 +82,8 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>28</power>
-					<cooldownTime>2.79</cooldownTime>
+					<power>21</power>
+					<cooldownTime>2.28</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
 					<armorPenetrationBlunt>11.76</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -82,8 +82,8 @@
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>21</power>
-					<cooldownTime>2.28</cooldownTime>
+					<power>22</power>
+					<cooldownTime>2.36</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
 					<armorPenetrationBlunt>11.76</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>


### PR DESCRIPTION
Reduced warhammer damage and increased its attack speed.
28 base dmg will result in tons of destroyed head and torso with no chance of being downed. You can still destroy heads with a single blow, but it now requires the user to have high melee skills.

Also slightly decrease axe melee cooldown.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
