### PR TITLE
Patch teargas grenades, update Ancient Fallout Armory patch

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -37,6 +37,7 @@
     	<li>oskarpotocki.vanillafactionsexpanded.medievalmodule</li>
     	<li>vanillaexpanded.vwe</li>
 		<li>HLX.RimworldUNSCArmoury</li>
-    	<li>Argon.VMEuP</li>  
+    	<li>Argon.VMEuP</li>
+		<li>VanillaExpanded.VWEG</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -197,14 +197,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					<ArmorRating_Blunt>14</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Apparel_Armor.xml
+++ b/Patches/Ancient Fallout Armory/Apparel_Armor.xml
@@ -173,6 +173,48 @@
 				</value>
 			</li>
 
+			<!-- === Secret Service Armor === -->	
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>20</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="FallArmory_SecretServiceArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>8</CarryBulk>
+				</value>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
+++ b/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
@@ -125,14 +125,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>16</ArmorRating_Blunt>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
+++ b/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
@@ -113,6 +113,36 @@
 				</value>
 			</li>
 
+			<!-- === Secret Service Helmet === -->			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>16</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	  <Operation Class="PatchOperationFindMod">
+        <mods>
+          <li>Vanilla Weapons Expanded - Grenades</li>
+        </mods>
+    <match Class="PatchOperationFindMod">
+        <mods>
+          <li>Vanilla Weapons Expanded - Non-Lethal</li>
+        </mods>
+        
+      <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- Tear Gas Grenade Belt -->
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/costList</xpath>
+		<value>
+			<costList>
+			<VWE_TearGasGrenade>5</VWE_TearGasGrenade>
+			</costList>	
+		</value>
+		</li>	
+
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<value>
+			<ammoCountPerCharge>1</ammoCountPerCharge>
+		</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<label>throw tear gas</label>
+					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<onlyManualCast>True</onlyManualCast>
+					<warmupTime>1.5</warmupTime>
+					<range>10</range>
+					<minRange>5</minRange>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<soundCast>ThrowGrenade</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					<defaultProjectile>VWENL_Projectile_TearGasGrenade</defaultProjectile>
+					<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+				</li>
+			</verbs>
+		</value>
+		</li>
+
+			</operations>
+			</match>					
+		</match>			
+	</Operation>
+
+</Patch>
+

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
@@ -8,7 +8,7 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-        <!-- === Toxic Grenade === -->
+        <!-- === Tear Gas Grenade === -->
         <!-- == Projectile == -->
         <li Class="PatchOperationAdd">
           <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]</xpath>


### PR DESCRIPTION
Patches the tear gas grenade belt added when VWE - NL and VAE - Grenades are loaded together. Because this def is patched in by Grenades, Grenades must be loaded before CE.

Works as intended in testing. Closes #761 

Also adds stats to the Secret Service armor added in the update to Ancient Fallout Armory. Closes #768.