### PR TITLE
Fix #797

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -262,7 +262,7 @@ namespace CombatExtended
                 damageInfo.SetHitPart(neck);
             }
 
-            damageInfo.SetBodyRegion(bodyRegion);
+            damageInfo.SetBodyRegion(bodyRegion, BodyPartDepth.Outside);
             damageInfo.SetWeaponBodyPartGroup(bodyPartGroupDef);
             damageInfo.SetWeaponHediff(hediffDef);
             damageInfo.SetAngle(direction);


### PR DESCRIPTION
Vanilla has SetBodyRegion BodyPartDepth.Outside.

## Additions

Fixes #797 by setting melee attacks to always hit outside (legacy CE bug)

## Changes

Copy vanilla code for bodyregion

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #797

## Reasoning

Why did you choose to implement things this way, e.g.
- Vanilla doesn't have issue, and the difference is part of one line

## Alternatives

Idk think more about whether to target outside only? Not sure, this probably is enough detail

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
