### PR TITLE
Change AimTick calculation to respect AimingDelayFactor

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -109,7 +109,8 @@ namespace CombatExtended
             if (ShouldAim && !_isAiming)
             {
                 if (caster is Building_TurretGunCE turret)
-                {aimTicks = (int)Mathf.Lerp(AimTicksMin, AimTicksMax, targetDist / 100);
+                {
+                    aimTicks = (int)Mathf.Lerp(AimTicksMin, AimTicksMax, targetDist / 100);
                     turret.burstWarmupTicksLeft += aimTicks;
                     _isAiming = true;
                     return;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -104,17 +104,19 @@ namespace CombatExtended
         public override void WarmupComplete()
         {
             var targetDist = (currentTarget.Cell - caster.Position).LengthHorizontal;
-            var aimTicks = (int)Mathf.Lerp(AimTicksMin, AimTicksMax, (targetDist / 100));
+            var aimTicks = 0;
+
             if (ShouldAim && !_isAiming)
             {
                 if (caster is Building_TurretGunCE turret)
-                {
+                {aimTicks = (int)Mathf.Lerp(AimTicksMin, AimTicksMax, targetDist / 100);
                     turret.burstWarmupTicksLeft += aimTicks;
                     _isAiming = true;
                     return;
                 }
                 if (ShooterPawn != null)
                 {
+                    aimTicks = (int)(Mathf.Lerp(AimTicksMin, AimTicksMax, targetDist / 100) * ShooterPawn.GetStatValue(StatDefOf.AimingDelayFactor));
                     ShooterPawn.stances.SetStance(new Stance_Warmup(aimTicks, currentTarget, this));
                     _isAiming = true;
                     return;


### PR DESCRIPTION
## Changes

When pawn is shooting, AimingTicks is multiplied by pawn's AimingDelayFactor, causing pawns with lower AimingDelayFactor to aim faster.

## Reasoning

I thought this functionality was already in the mod, so I was quite surprised when I realized that this was not the case.  AimingDelayFactor could be modified by mods (one example is patch for Cybernetic Organism and Neural Network that uses AimingDelayFactor, but without effect), so, with this change, this stat is actually used.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a couple of minutes, tested pawns with various modifiers, and turrets in case I broke them (I didn't))
