### PR TITLE
Add support for publicizing assemblies during build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: prebuild
+      run: |
+        rm -rf AssemblyPublicizer
+        git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
     - name: build
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -25,9 +25,11 @@ jobs:
         wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/Make.py -O Make.py
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
+        rm -rf AssemblyPublicizer
+        git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
     - name: build
       run: |
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs 
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -29,7 +29,7 @@ jobs:
         git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
     - name: build
       run: |
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: prebuild
+      run: |
+        rm -rf AssemblyPublicizer
+        git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
     - name: build
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended


### PR DESCRIPTION
## Additions

Add support for generating and using publicized assemblies

## Reasoning

It's fast to write.  We want to get a release out tonight.
It's simple to use, as it builds the publicizer on-demand.

## Alternatives

Build / download the publicizer as a separate step of the workflow.  Expect the publicizer to exist on the path by the time Make.py is called.  
Use the nuget package TaskPublisher - No good way to do that, as it requires dotnet build, which can allow arbitrary code execution while compiling PRs.

## Future work
The list of assemblies to publish is contained in the .csproj, and should be dynamically read from there instead of hardcoded in the workflow file.  Also, the .csproj uses some variable expansions to reference the publicized libraries.  This is safely (but noisily) ignored.  

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
