### PR TITLE
RimWorld 1.3 Ideo darkness stats hidden

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -9,12 +9,12 @@ using Verse;
 
 namespace CombatExtended.HarmonyCE
 {
-    [HarmonyPatch(typeof(Pawn), nameof(Pawn.SpecialDisplayStats))]
+    [HarmonyPatch]
     public static class Harmony_Pawn
     {
         private static MethodBase mIdeologyActive_Get = AccessTools.PropertyGetter(typeof(ModsConfig), nameof(ModsConfig.IdeologyActive));
 
-        private static MethodBase TargetMethod()
+        public static MethodBase TargetMethod()
         {
             return AccessTools.Method(typeof(Pawn).GetNestedTypes(AccessTools.all).First(t => t.Name.Contains("SpecialDisplayStats")), "MoveNext");
         }

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -23,7 +23,7 @@ namespace CombatExtended.HarmonyCE
         {
             foreach (CodeInstruction code in instructions)
             {
-                if (code.OperandIs(mIdeologyActive_Get))
+                if (code.opcode == OpCodes.Call && code.OperandIs(mIdeologyActive_Get))
                 {
                     yield return new CodeInstruction(OpCodes.Ldc_I4_0).MoveLabelsFrom(code).MoveBlocksFrom(code);
                     continue;

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(Pawn), nameof(Pawn.SpecialDisplayStats))]
+    public static class Harmony_Pawn
+    {
+        private static MethodBase mIdeologyActive_Get = AccessTools.PropertyGetter(typeof(ModsConfig), nameof(ModsConfig.IdeologyActive));
+
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(Pawn).GetNestedTypes(AccessTools.all).First(t => t.Name.Contains("SpecialDisplayStats")), "MoveNext");
+        }
+
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            foreach (CodeInstruction code in instructions)
+            {
+                if (code.OperandIs(mIdeologyActive_Get))
+                {
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_0).MoveLabelsFrom(code).MoveBlocksFrom(code);
+                    continue;
+                }
+                yield return code;
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_Pawn.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn.cs
@@ -9,14 +9,21 @@ using Verse;
 
 namespace CombatExtended.HarmonyCE
 {
+    /*
+     * Patch for Pawn.SpecialDisplayStats inorder to remove the darkness stats since they are redundent
+     */
     [HarmonyPatch]
     public static class Harmony_Pawn
     {
+        private const string targetMethod = "MoveNext";
+
+        private const string targetType = "SpecialDisplayStats";
+
         private static MethodBase mIdeologyActive_Get = AccessTools.PropertyGetter(typeof(ModsConfig), nameof(ModsConfig.IdeologyActive));
 
         public static MethodBase TargetMethod()
         {
-            return AccessTools.Method(typeof(Pawn).GetNestedTypes(AccessTools.all).First(t => t.Name.Contains("SpecialDisplayStats")), "MoveNext");
+            return AccessTools.Method(typeof(Pawn).GetNestedTypes(AccessTools.all).First(t => t.Name.Contains(targetType)), targetMethod);
         }
 
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)


### PR DESCRIPTION
## Changes

- Darkness stats in Ideology are now hidden since they do nothing. It's done by patching `Pawn.SpecialDisplayStats`
