### PR TITLE
Patch Ideology Content

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-  <ThingDef Name="ApparelCarryGearBase" Abstract="True">
+  <ThingDef Name="ApparelCarryGearBase" ParentName="ApparelBase" Abstract="True">
     <techLevel>Industrial</techLevel>
     <category>Item</category>
     <thingClass>Apparel</thingClass>

--- a/Ideology/Patches/HeDiffDefs/Hediffs_Casts.xml
+++ b/Ideology/Patches/HeDiffDefs/Hediffs_Casts.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- Combat Command -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="CombatCommand"]/comps/li[@Class="HediffCompProperties_GiveHediffsInRange"]/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="CombatCommandBuff"]/comps/li[@Class="HediffCompProperties_Link"]/maxDistance</xpath>
+		<value>
+			<maxDistance>15</maxDistance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="CombatCommandBuff"]/stages/li/statOffsets</xpath>
+		<value>
+			<Suppressability>-0.25</Suppressability>
+		</value>
+	</Operation>
+
+	<!-- Marksman Command -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="MarksmanCommand"]/comps/li[@Class="HediffCompProperties_GiveHediffsInRange"]/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/HediffDef[defName="MarksmanCommandBuff"]/stages/li/statOffsets/AimingDelayFactor</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="MarksmanCommandBuff"]/stages/li</xpath>
+		<value>
+			<statFactors>
+				<ReloadSpeed>1.10</ReloadSpeed>
+			</statFactors>		
+		</value>
+	</Operation>
+
+	<!-- Beserker Trance -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="BerserkTrance"]/stages/li/statOffsets</xpath>
+		<value>
+			<Suppressability>-10</Suppressability>
+		</value>
+	</Operation>
+
+</Patch>
+

--- a/Ideology/Patches/PawnKindDefs_Ideology/PawnKinds.xml
+++ b/Ideology/Patches/PawnKindDefs_Ideology/PawnKinds.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <!-- ========== Special Pawnkinds ========== -->
+
+  <Operation Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="WellEquippedTraveler"]</xpath>
+  	<value>
+      <li Class="CombatExtended.LoadoutPropertiesExtension">
+        <primaryMagazineCount>
+          <min>3</min>
+          <max>5</max>
+        </primaryMagazineCount>
+        <sidearms>
+          <li>
+            <generateChance>0.50</generateChance>
+            <sidearmMoney>
+              <min>125</min>
+              <max>215</max>
+            </sidearmMoney>
+            <weaponTags>
+              <li>MedievalMeleeBasic</li>
+            </weaponTags>
+          </li>
+        </sidearms>        
+      </li>
+  	</value>
+  </Operation>
+
+  <!-- ========== Neutral Camps ========== -->
+
+  <Operation Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="Tribal_Miner" or defName="Tribal_Logger" or defName="Tribal_Farmer"]</xpath>
+  	<value>
+      <li Class="CombatExtended.LoadoutPropertiesExtension">
+        <primaryMagazineCount>
+          <min>10</min>
+          <max>18</max>
+        </primaryMagazineCount>
+        <sidearms>
+          <li>
+            <generateChance>0.45</generateChance>
+            <sidearmMoney>
+              <min>55</min>
+              <max>120</max>
+            </sidearmMoney>
+            <weaponTags>
+              <li>NeolithicMeleeBasic</li>
+            </weaponTags>
+          </li>
+        </sidearms>        
+      </li>
+  	</value>
+  </Operation>
+
+  <Operation Class="PatchOperationAddModExtension">
+  	<xpath>Defs/PawnKindDef[defName="Miner" or defName="Hunter" or defName="Logger" or defName="Farmer"]</xpath>
+  	<value>
+      <li Class="CombatExtended.LoadoutPropertiesExtension">
+        <primaryMagazineCount>
+          <min>3</min>
+          <max>5</max>
+        </primaryMagazineCount>
+        <sidearms>
+          <li>
+            <generateChance>0.25</generateChance>
+            <sidearmMoney>
+              <min>75</min>
+              <max>185</max>
+            </sidearmMoney>
+            <weaponTags>
+              <li>MedievalMeleeBasic</li>
+            </weaponTags>
+          </li>
+        </sidearms>
+      </li>
+  	</value>
+  </Operation>
+
+</Patch>
+

--- a/Ideology/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <!-- ========== Headwrap, Broadwrap ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Headwrap" or defName="Apparel_Broadwrap"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+  <!-- ========== Visage Mask ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_VisageMask"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+      <StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+    </value>
+  </Operation>
+
+  <!-- ========== Slicecap ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Slicecap"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+
+  <!-- ========== Collar ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Collar"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+
+  <!-- ========== Authority Cap ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_AuthorityCap"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>		  
+    </value>
+  </Operation>
+
+  <!-- ========== Tailcap ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Tailcap"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+  <!-- ========== Shadecone ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Shadecone"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+  <!-- ========== Flophat ========== -->
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Flophat"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <value>
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+    </value>
+  </Operation>
+
+</Patch>
+

--- a/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+
+	<!-- ========== Strap ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_BodyStrap"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+
+	<!-- ========== Burka ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Burka"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<Bulk>6</Bulk>
+			<WornBulk>2.5</WornBulk>
+			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<!-- ========== Robe ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Robe"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<Bulk>5</Bulk>
+			<WornBulk>2</WornBulk>
+			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+	<!-- ========== Blindfold ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Blindfold"]/statBases/StuffEffectMultiplierArmor</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+		</value>
+	</Operation>
+
+
+</Patch>
+

--- a/Ideology/Patches/ThingDefs_Misc/Items_Misc.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Items_Misc.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Base Dryad ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="DryadBase"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="DryadBase"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.19</MeleeDodgeChance>
+			<MeleeCritChance>0.06</MeleeCritChance>
+			<MeleeParryChance>0.04</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="DryadBase"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>0.99</cooldownTime>
+                    <surpriseAttack>
+                        <extraMeleeDamages>
+                        <li>
+                            <def>Stun</def>
+                            <amount>10</amount>
+                        </li>
+                        </extraMeleeDamages>
+                    </surpriseAttack>                    
+					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.03</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>0.99</cooldownTime>
+                    <surpriseAttack>
+                        <extraMeleeDamages>
+                        <li>
+                            <def>Stun</def>
+                            <amount>10</amount>
+                        </li>
+                        </extraMeleeDamages>
+                    </surpriseAttack>                        
+					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.03</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.77</cooldownTime>
+                    <surpriseAttack>
+                        <extraMeleeDamages>
+                        <li>
+                            <def>Stun</def>
+                            <amount>10</amount>
+                        </li>
+                        </extraMeleeDamages>
+                    </surpriseAttack>                        
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>2.880</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.1</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.19</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Clawer ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Dryad_Clawer"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>6</MoveSpeed>
+            <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+			<MeleeDodgeChance>0.25</MeleeDodgeChance>
+			<MeleeCritChance>0.25</MeleeCritChance>
+			<MeleeParryChance>0.09</MeleeParryChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Dryad_Clawer"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.19</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>2.550</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.85</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.19</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>2.550</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.85</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>28</power>
+					<cooldownTime>1.46</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<chanceFactor>2</chanceFactor>
+					<armorPenetrationSharp>1.95</armorPenetrationSharp>
+					<armorPenetrationBlunt>9.163</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>3.2</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.225</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
+	<!-- ========== Barkskin ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Dryad_Barkskin"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Dryad_Barkskin"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+</Patch>
+

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <loadFolders>
-  <v1.2>
+  <v1.3>
     <li>/</li>
 	 <li IfModActive="Ludeon.Rimworld.Royalty">Royalty</li>
-  </v1.2>
+   <li IfModActive="Ludeon.Rimworld.Ideology">Ideology</li>
+  </v1.3>
 </loadFolders>


### PR DESCRIPTION
## Additions

Patches all new content added by Ideology. Most of the content is unremarkable in regards to balance, save for the dryads.

All dryads save the Clawer and based fairly closely upon the labrador retriever stats. The Clawer is based mostly on the Warg, with slightly stronger attacks. These stats are fairly close to how they stack up in vanilla, compared to other vanilla creatures.

## Changes
- Adds a vanilla apparel base to CE carrying gear. Without it, favorite colors cause problems.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
