### PR TITLE
Compile with `-unsafe` flag

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -236,7 +236,7 @@ if PUBLICIZE:
 print(removed_libraries)
 #libraries = [l for l in libraries if not l.rsplit('/',1)[1] in removed_libraries]
     
-args = ["csc", "-warnaserror", "-nostdlib", "-target:library", f'-out:{OUTPUT}', *sources, *[f'-r:{r}' for r in libraries]]
+args = ["csc", "-unsafe", "-warnaserror", "-nostdlib", "-target:library", f'-out:{OUTPUT}', *sources, *[f'-r:{r}' for r in libraries]]
 
 if VERBOSE:
     print(HARMONY)


### PR DESCRIPTION

## Changes

Pass `-unsafe` flag to `csc`.


## Reasoning

Compiling against a publicized assebly without `-unsafe` flag results in runtime errors.

## Alternatives

Don't use a publicized assembly.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
