### PR TITLE
More 1.3 tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -210,16 +210,18 @@
         <east>
           <offset>(0,-0.05)</offset>
           <thin><offset>(0.2,0)</offset></thin>
-          <hulk><offset>(0,0)</offset></hulk>
+          <hulk><offset>(0.05,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
-		      <female><offset>(-0.1,0)</offset></female>	
+          <male><offset>(0.2,0)</offset></male>
+		      <female><offset>(0.2,0)</offset></female>	
         </east>
         <west>
           <offset>(0,-0.05)</offset>
           <thin><offset>(-0.2,0)</offset></thin>
-          <hulk><offset>(0,0)</offset></hulk>
+          <hulk><offset>(-0.05,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
-		      <female><offset>(0.1,0)</offset></female>		  
+          <male><offset>(-0.2,0)</offset></male>
+		      <female><offset>(-0.2,0)</offset></female>		  
         </west>
         <north>
           <offset>(0,-0.1)</offset> 

--- a/Ideology/Patches/HeDiffDefs/Hediffs_Casts.xml
+++ b/Ideology/Patches/HeDiffDefs/Hediffs_Casts.xml
@@ -4,11 +4,33 @@
 	<!-- Combat Command -->
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="CombatCommand"]/verbProperties/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="CombatCommand"]/statBases/Ability_EffectRadius</xpath>
+		<value>
+			<Ability_EffectRadius>14.9</Ability_EffectRadius>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mote_CombatCommand"]/graphicData/drawSize</xpath>
+		<value>
+			<drawSize>30</drawSize>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CombatCommand"]/comps/li[@Class="HediffCompProperties_GiveHediffsInRange"]/range</xpath>
 		<value>
 			<range>14.9</range>
 		</value>
 	</Operation>
+
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CombatCommandBuff"]/comps/li[@Class="HediffCompProperties_Link"]/maxDistance</xpath>
@@ -41,7 +63,7 @@
 		<xpath>Defs/HediffDef[defName="MarksmanCommandBuff"]/stages/li</xpath>
 		<value>
 			<statFactors>
-				<ReloadSpeed>1.10</ReloadSpeed>
+				<ReloadSpeed>1.20</ReloadSpeed>
 			</statFactors>		
 		</value>
 	</Operation>

--- a/Ideology/Patches/PawnKindDefs_Ideology/PawnKinds.xml
+++ b/Ideology/Patches/PawnKindDefs_Ideology/PawnKinds.xml
@@ -34,8 +34,8 @@
   	<value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>10</min>
-          <max>18</max>
+          <min>14</min>
+          <max>28</max>
         </primaryMagazineCount>
         <sidearms>
           <li>

--- a/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
+++ b/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
@@ -27,10 +27,21 @@
           <max>2000</max>
         </countRange>
         <thingDefCountRange>
-          <min>5</min>
-          <max>9</max>
+          <min>3</min>
+          <max>6</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>5</max>
+        </thingDefCountRange>
+      </li>       
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -88,7 +99,7 @@
         </countRange>
         <thingDefCountRange>
           <min>2</min>
-          <max>5</max>
+          <max>4</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Category">
@@ -98,6 +109,17 @@
           <max>0</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>5</min>
+          <max>60</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>2</max>
+        </thingDefCountRange>
+      </li>       
 		</value>
 	</Operation>
 
@@ -124,6 +146,17 @@
           <max>0</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>80</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>       
 		</value>
 	</Operation>
 


### PR DESCRIPTION
- Fixed the tribal pack visual offset.
- Increase the Ideology tribal pawn ammo
- Royalty: Add heavy ammo to traders
- Buff Marksman command reload bonus
- Increase range of combat command mote