### PR TITLE
Melee weapons tweak

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
@@ -123,7 +123,7 @@
 						<li>Stab</li>
 					</capacities>
 					<power>11</power>
-					<cooldownTime>1.26</cooldownTime>
+					<cooldownTime>1.2</cooldownTime>
 					<chanceFactor>1.33</chanceFactor>
 					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
 					<armorPenetrationSharp>0.42</armorPenetrationSharp>
@@ -550,7 +550,7 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Spear"]</xpath>
 		<value>
 			<equippedStatOffsets>
-				<MeleeCritChance>0.17</MeleeCritChance>
+				<MeleeCritChance>0.24</MeleeCritChance>
 				<MeleeParryChance>1.45</MeleeParryChance>
 				<MeleeDodgeChance>0.9</MeleeDodgeChance>
 			</equippedStatOffsets>
@@ -581,7 +581,7 @@
 					<capacities>
 						<li>Stab</li>
 					</capacities>
-					<power>18</power>
+					<power>20</power>
 					<cooldownTime>1.69</cooldownTime>
 					<chanceFactor>0.60</chanceFactor>
 					<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
@@ -597,7 +597,7 @@
 					<cooldownTime>1.56</cooldownTime>
 					<chanceFactor>0.30</chanceFactor>
 					<armorPenetrationBlunt>2.592</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.58</armorPenetrationSharp>
+					<armorPenetrationSharp>0.62</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 			</tools>


### PR DESCRIPTION
## Additions
I personally find the long sword deeply underwhelming, its stab attack is slow and does low damage. So I buffed it abit to make it less underwhelming.

I'd like to change the quality modifier for melee weapons in the the future, lower its effect on weapon melee damage output and more effect on weapon melee penetration + weapon durability.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
