### PR TITLE
Flare tweak

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -187,7 +187,7 @@
 
   <!-- ==================== Flare Gun ==================== -->
 
-  <ThingDef ParentName="BaseHumanMakeableGun">
+  <ThingDef ParentName="BaseMakeableGun">
     <defName>CE_FlareGun</defName>
     <label>flare gun</label>
     <description>An ancient, single-shot flare gun, used for signaling or illumination. Loaded from the breech, its barrel is too thin to fire anything but flares.</description>


### PR DESCRIPTION
Half of all tribal gunners are using flare guns instead of actual guns.
This tweak prevent flare guns from spawning in lieu of actual guns.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
