### PR TITLE
Rewrite make.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -29,7 +29,7 @@ jobs:
         git clone https://github.com/CombatExtended-Continued/AssemblyPublicizer
     - name: build
       run: |
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir -p Assemblies
         mkdir -p ${{ runner.temp }}/downloads
-        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer $PWD/AssemblyPublicizer
+        TEMP=${{ runner.temp }}/ python3 Make.py --download-libs --all-libs --publicizer $PWD/AssemblyPublicizer
     - name: package
       run: |
         mkdir CombatExtended

--- a/Building.md
+++ b/Building.md
@@ -12,7 +12,7 @@ and tell Make.py where to find it.
 
 The invocation used by CI is about as simple as it gets.
 `python Make.py --all-libs --download-libs` (for RW < 1.3), or
-`python Make.py --download-libs --all-libs --publicize Assembly-CSharp.dll,UnityEngine.CoreModule.dll --publicizer=$PWD/AssemblyPublicizer` (for RW >= 1.3)
+`python Make.py --download-libs --all-libs --publicizer=$PWD/AssemblyPublicizer` (for RW >= 1.3)
 
 ## Windows
 

--- a/Make.py
+++ b/Make.py
@@ -100,8 +100,8 @@ def makePublicizer(p, verbose):
         quiet = "-q" if verbose < 5 else ""
         cwd = os.getcwd()
         os.chdir(p)
-        downloadLib("Mono.Options", "6.6.0.161",f"{tdir}/downloads/mono.options.zip")
-        downloadLib("Mono.Cecil", "0.11.4",f"{tdir}/downloads/mono.cecil.zip")
+        downloadLib("Mono.Options", "6.6.0.161",f"{tdir}/downloads/mono.options.zip", verbose=verbose)
+        downloadLib("Mono.Cecil", "0.11.4",f"{tdir}/downloads/mono.cecil.zip", verbose=verbose)
         os.system(f"unzip {quiet} -o {tdir}/downloads/mono.cecil.zip -d .")
         os.system(f"unzip {quiet} -o {tdir}/downloads/mono.options.zip -d .")
         os.system("cp lib/net40/*dll .")

--- a/Make.py
+++ b/Make.py
@@ -29,14 +29,14 @@ class PublicizeTarget(object):
     outputName: str
 
 def parseArgs(argv):
-    argParser = argparse.ArgumentParser()
-    argParser.add_argument("--reference", type=str)
-    argParser.add_argument("--output", "-o", type=str, default="Assemblies/CombatExtended.dll")
-    argParser.add_argument("--csproj", type=str, default="Source/CombatExtended/CombatExtended.csproj")
-    argParser.add_argument("--all-libs", action="store_true", default=False)
-    argParser.add_argument("--verbose", "-v", action="count", default=0)
-    argParser.add_argument("--download-libs", action="store_true", default=False)
-    argParser.add_argument("--publicizer", type=str)
+    argParser = argparse.ArgumentParser(description="Automate compiling C# projects on Linux, using Mono")
+    argParser.add_argument("--reference", type=str, metavar="PATH", help="Location of Rimworld Reference libraries")
+    argParser.add_argument("--output", "-o", type=str, default="Assemblies/CombatExtended.dll", help="Output filename")
+    argParser.add_argument("--csproj", type=str, default="Source/CombatExtended/CombatExtended.csproj", help="C# project to build.")
+    argParser.add_argument("--all-libs", action="store_true", default=False, help="Reference all dlls in $reference, even those not specified by the .csproj file")
+    argParser.add_argument("--verbose", "-v", action="count", default=0, help="Increase verbosity, specify more times for more verbosity")
+    argParser.add_argument("--download-libs", action="store_true", default=False, help=f"Automatically download referenced packages to {tdir}/downloads and unpack them to $reference")
+    argParser.add_argument("--publicizer", type=str, metavar="PATH", help="Location of AssemblyPublicizer source code or parent directory of AssemblyPublicizer.exe")
 
     options = argParser.parse_args(argv[1:])
     if not options.download_libs and options.reference is None:

--- a/Make.py
+++ b/Make.py
@@ -240,8 +240,6 @@ def main(argv=sys.argv):
         os.system(f"cp -r {tdir}/downloads/unpack/ref/net472/* {options.reference}")
         os.system(f"cp -r {tdir}/downloads/unpack/lib/net472/* {options.reference}")
 
-    print(libraries)
-
     libraries = [resolveLibrary(l, options.reference, options.csproj, verbose) for l in libraries if '$' not in l.name]
 
     if options.all_libs:
@@ -258,6 +256,10 @@ def main(argv=sys.argv):
 
     libraries = [l for l in set(libraries) if not os.path.basename(l) in removed_libraries]
     args.extend([f'-out:{options.output}', *sources, *[f'-r:{r}' for r in libraries]])
+    if verbose > 2:
+        print(libraries)
+    if verbose > 6:
+        print(args)
     os.execvp(args[0], args)
     
 if __name__=='__main__':

--- a/Make.py
+++ b/Make.py
@@ -1,246 +1,247 @@
 #!/usr/bin/python3
-import sys
 import os
+import sys
+import argparse
 from xml.dom.minidom import parse as XMLOpen
-import subprocess
-
 import tempfile
+import time
+from dataclasses import dataclass
 
 tdir = tempfile.gettempdir()
 
-cwd = os.path.dirname(os.path.abspath(__file__))
+args = ["csc", "-unsafe", "-warnaserror", "-nostdlib", "-target:library"]
 
-usage = f"""
-python Make.py [--reference <path/to/rimworld>] [--harmony <path/to/0Harmony.dll>] [-o <output/path.dll>] [--csproj <path/to/Source/CombatExtended.csproj>] [--all-libs] [--verbose] [--download-libs] [--publicize <somelibrary.dll>,...] [--publicizer <path/to/AssemblyPublicizer_Source>]
 
-If unspecified: 
-  reference defaults to $RWREFERENCE or {os.path.abspath(cwd+'/../..')}
-  o defaults to Assemblies/CombatExtended.dll
-  csproj defaults to Source/CombatExtended/CombatExtended.csproj
+@dataclass
+class PackageReference(object):
+    name: str
+    version: str
+    destination: str
 
-  reference can point either to the base RimWorld directory, or to a directory containing all assemblies needed to compile (including 0Harmony.dll)
-    
-  harmony points to the 0Harmony.dll to use.  If omitted, $reference, $reference/Mods, and $reference/../../workshop/294100/2009463077 and $PWD are searched to find 0Harmony.dll
+@dataclass
+class LibraryReference(object):
+    name: str
+    hintPath: str
 
-  all-libs adds all libraries in $reference (or $reference/RimWorld*_Data/Managed) will be added to the library list
-  verbose outputs the values of $reference, $csproj, and $harmony after resolving them.
+@dataclass
+class PublicizeTarget(object):
+    inputName: str
+    outputName: str
 
-  download-libs fetches reference libraries from nuget.org to $TMP/rwreference, then sets reference to $TMP/rwreference
+def parseArgs(argv):
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument("--reference", type=str)
+    argParser.add_argument("--output", "-o", type=str, default="Assemblies/CombatExtended.dll")
+    argParser.add_argument("--csproj", type=str, default="Source/CombatExtended/CombatExtended.csproj")
+    argParser.add_argument("--all-libs", action="store_true", default=False)
+    argParser.add_argument("--verbose", "-v", action="count", default=0)
+    argParser.add_argument("--download-libs", action="store_true", default=False)
+    argParser.add_argument("--publicizer", type=str)
 
---publicize takes a comma-separated list of dlls and publicizes them, then uses the public outputs in place of the original.
---publicizer takes the path to the AssemblyPublicizer source code.  If needed, it will compile AssemblyPublicizer
-"""
+    options = argParser.parse_args(argv[1:])
+    if not options.download_libs and options.reference is None:
+        print("You must either set reference to where the rimworld reference assemblies are (including Harmony), or set the download-libs option")
+        exit(1)
+    if options.csproj is None or not os.path.exists(options.csproj):
+        print("You must specify the path to the .csproj file you wish to build")
+        exit(1)
 
-if "--help" in sys.argv or "-h" in sys.argv:
-    print(usage)
-    raise SystemExit(1)
+    if options.reference is None:
+        options.reference = f"{tdir}/rwreference"
 
-VERBOSE = "--verbose" in sys.argv or "-v" in sys.argv
-quiet = "" if VERBOSE else "-q"
+    return options
 
-DOWNLOAD_LIBS = '--download-libs' in sys.argv
 
-def findHarmony(ref):
-    if "0Harmony.dll" in os.listdir(ref):
-        return os.path.abspath(ref+"/0Harmony.dll")
-    if "Mods" in os.listdir(ref):
-        mref = ref + "/Mods"
-        if "Harmony" in os.listdir(mref):
-            return os.path.abspath(mref + "/Harmony/v1.1/Assemblies/0Harmony.dll")
-    p = os.path.abspath(ref+"/../../../../")
-    if "workshop" in os.listdir(p):
-        p += '/workshop'
-        if 'content' in os.listdir(p):
-            p += "/content"
-            if '294100' in os.listdir(p):
-                p += '/294100'
-                if '2009463077' in os.listdir(p):
-                    return os.path.abspath(p + '/2009463077/v1.1/Assemblies/0Harmony.dll')
-    return os.path.abspath(cwd+"/Assemblies/0Harmony.dll")
-                
-def findRimworld(ref):
-    ref = os.path.abspath(ref)
-    if ref.endswith("Managed"):
-        return ref
-    if "System.dll" in os.listdir(ref):
-        return ref
-    dirs = [d for d in os.listdir(ref) if d.startswith("RimWorld") and d.endswith("_Data")]
-    if dirs:
-        return ref + f"/{dirs[0]}/Managed"
-    
-def publicize(p):
-    cwd = os.getcwd()
-    os.chdir(p.rsplit('/',1)[0])
-    os.system(f"mono {PUBLICIZER_EXE} --exit -i {p} -o {p[:-4]}_publicized.dll")
-    os.chdir(cwd)
-
-def downloadLib(name, version, dest):
-    print(f"Downloading {version} of {name} from nuget")
+def downloadLib(name, version, dest, verbose):
+    if verbose:
+        print(f"Downloading {version} of {name} from nuget")
+    quiet = "-q" if verbose < 5 else ""
     if os.system(f"wget {quiet} https://www.nuget.org/api/v2/package/{name}/{version} -O {dest}"):
         raise Exception(f"Can't find version {version} of {name} on nuget")
 
-    
-def makePublicizer(p):
+def unpackLib(path, dest, verbose):
     cwd = os.getcwd()
-    os.chdir(p)
+    quiet = "-q" if verbose < 6 else ""
+    os.system(f"unzip {quiet} -o {path} -d {dest}")
     
-    downloadLib("Mono.Options", "6.6.0.161",f"{tdir}/downloads/mono.options.zip")
-    downloadLib("Mono.Cecil", "0.11.4",f"{tdir}/downloads/mono.cecil.zip")
-    os.system(f"unzip {quiet} -o {tdir}/downloads/mono.cecil.zip -d .")
-    os.system(f"unzip {quiet} -o {tdir}/downloads/mono.options.zip -d .")
-    os.system("cp lib/net40/*dll .")
-    os.system("csc -out:AssemblyPublicizer.exe ./AssemblyPublicizer/AssemblyPublicizer.cs ./AssemblyPublicizer/Properties/AssemblyInfo.cs -r:Mono.Options.dll -r:Mono.Cecil.dll")
-    os.system("mono --aot AssemblyPublicizer.exe")
+
+def resolveLibrary(library, reference, csproj, verbose):
+    if library.hintPath:
+        if verbose > 1:
+            print("Adding library via hintPath: {hintPath}")
+        base_dir = os.path.split(csproj)[0]
+        t_path = os.path.join(base_dir, library.hintPath)
+        if os.path.isabs(library.hintPath):
+            return os.path.abspath(t_path)
+        else:
+            return os.path.relpath(t_path)
+    if verbose > 1:
+        print("Searching for library named {library.name}.dll")
+    return os.path.join(reference, library.name+'.dll')
+    
+def publicize(p, publicizer, verbose):
+    if verbose:
+        print(f"Publicizing Assembly: {p}")
+    cwd = os.getcwd()
+    os.chdir(p.rsplit('/',1)[0])
+    os.system(f"mono {publicizer} --exit -i {p} -o {p[:-4]}_publicized.dll")
     os.chdir(cwd)
+    return p[:-4]+'_publicized.dll'
 
-def findArg(s):
-    if s in sys.argv:
-        return sys.argv.index(s)
-    return -1
-
-rindex =  findArg("--reference")
-if DOWNLOAD_LIBS:
-    os.system(f'mkdir -p {tdir}/rwreference')
-    RIMWORLD = f"{tdir}/rwreference"
-    HARMONY = f"{tdir}/rwreference/0Harmony.dll"
-else:
-    if rindex > -1:
-        RIMWORLD = sys.argv[rindex+1]
+def makePublicizer(p, verbose):
+    ap_path = os.path.join(p, "AssemblyPublicizer.exe")
+    
+    if os.path.exists(ap_path):
+        if verbose:
+            print("Reusing AssemblyPublicizer")
     else:
-        RIMWORLD = os.environ.get("RWREFERENCE", cwd+'/../..')    
-    RIMWORLD = findRimworld(RIMWORLD)
-        
-    hindex = findArg("--harmony")
-    if hindex > -1:
-        HARMONY = sys.argv[hindex + 1]
-    else:
-        HARMONY = findHarmony(RIMWORLD)
+        if verbose:
+            print("Making AssemblyPublicizer")
+        quiet = "-q" if verbose < 5 else ""
+        cwd = os.getcwd()
+        os.chdir(p)
+        downloadLib("Mono.Options", "6.6.0.161",f"{tdir}/downloads/mono.options.zip")
+        downloadLib("Mono.Cecil", "0.11.4",f"{tdir}/downloads/mono.cecil.zip")
+        os.system(f"unzip {quiet} -o {tdir}/downloads/mono.cecil.zip -d .")
+        os.system(f"unzip {quiet} -o {tdir}/downloads/mono.options.zip -d .")
+        os.system("cp lib/net40/*dll .")
+        os.system("csc -out:AssemblyPublicizer.exe ./AssemblyPublicizer/AssemblyPublicizer.cs ./AssemblyPublicizer/Properties/AssemblyInfo.cs -r:Mono.Options.dll -r:Mono.Cecil.dll")
+        os.system("mono --aot AssemblyPublicizer.exe")
+        os.chdir(cwd)
+    return ap_path
 
-pindex = findArg("--publicize")
-if pindex > -1:
-    PUBLICIZE=sys.argv[pindex+1].split(',')
-    pindex = findArg("--publicizer")
-    if pindex > -1:
-        PUBLICIZER_SOURCE = sys.argv[pindex+1]
-        PUBLICIZER_EXE = os.path.join(PUBLICIZER_SOURCE,"AssemblyPublicizer.exe")
-        if not os.path.exists(PUBLICIZER_EXE):
-            makePublicizer(PUBLICIZER_SOURCE)
-else:
-    PUBLICIZE=None
 
+def parse_csproj(csproj_path, verbose):
+    packages = []
+    sources = []
+    libraries = []
+    removed_libraries = []
+    base_dir = os.path.split(csproj_path)[0]
+    publicized_libraries = []
+    if verbose:
+        print("Parsing .csproj: {csproj_path}")
     
-    
-oindex = findArg("-o")
-
-if oindex > -1:
-    OUTPUT = sys.argv[oindex+1]
-else:
-    OUTPUT=cwd + "/Assemblies/CombatExtended.dll"
-
-cindex = findArg("--csproj")
-
-if cindex > -1:
-    CSPROJ = sys.argv[cindex + 1]
-else:
-    CSPROJ = "Source/CombatExtended/CombatExtended.csproj"
-
-base_dir = CSPROJ.rsplit('/',1)[0]
-
-
-    
-    
-with XMLOpen(CSPROJ) as csproj:
-    
-    if DOWNLOAD_LIBS:
-        os.system(f"mkdir -p {tdir}/downloads/unpack")
+    with XMLOpen(csproj_path) as csproj:
         for idx, package in enumerate(csproj.getElementsByTagName("PackageReference")):
             name = package.attributes['Include'].value
             version = package.attributes['Version'].value
             dest = f"{tdir}/downloads/rwref-{idx}.zip"
-            downloadLib(name, version, dest)
-            os.system(f"unzip {quiet} -o {tdir}/downloads/rwref-{idx}.zip -d {tdir}/downloads/unpack")
-        if VERBOSE:
-            print(os.listdir(tdir+'/downloads'))
-        os.system(f"cp -r {tdir}/downloads/unpack/ref/net472/* {tdir}/rwreference")
-        os.system(f"cp -r {tdir}/downloads/unpack/lib/net472/* {tdir}/rwreference")
-    
-    libraries = [HARMONY]
-    removed_libraries = []
-    sources = []
-    if "--all-libs" in sys.argv:
-        for reference in os.listdir(RIMWORLD):
-            if reference.endswith(".dll"):
-                libraries.append(RIMWORLD+"/"+reference)
+            packages.append(PackageReference(name, version, dest))
 
-    for reference in ['mscorlib.dll']:
-        libraries.append(RIMWORLD+'/'+reference)
+        for reference in csproj.getElementsByTagName("Reference"):
+            hintPath = reference.getElementsByTagName("HintPath")
+            if 'Remove' in reference.attributes:
+                assemblyName = reference.attributes['Remove'].value.rsplit('\\',1)[1]
+                removed_libraries.append(assemblyName)
 
-    for reference in csproj.getElementsByTagName("Reference"):
-        hintPath = reference.getElementsByTagName("HintPath")
-        if 'Remove' in reference.attributes:
-            assemblyName = reference.attributes['Remove'].value.rsplit('\\',1)[1]
-            removed_libraries.append(assemblyName)
-            
-            continue
-        if hintPath:
-            hintPath = hintPath[0].firstChild.data.strip()
-            hintPath = hintPath.replace("\\", "/")
-            hintPath = hintPath.replace("../../../../RimWorldWin64_Data/Managed", RIMWORLD)
-            hintPath = base_dir+'/'+hintPath
-        else:
-            hintPath = RIMWORLD+"/"+reference.attributes['Include'].value + '.dll'
-        if "0Harmony" in hintPath:
-            continue
-        if not os.path.exists(hintPath):
-            l = hintPath.rsplit('/', 1)[1]
-            for f in libraries:
-                if f.endswith(l):
-                    found = True
-                    break
-            else:
-                print(f"Library not found: {hintPath}")
+                continue
+            if hintPath:
+                hintPath = hintPath[0].firstChild.data.strip()
+                hintPath = hintPath.replace("\\", "/")
+            libraries.append(LibraryReference(reference.attributes['Include'].value, hintPath))
 
-            continue
-        libraries.append(hintPath)
 
-    for d, subds, files in os.walk(base_dir):
-        for f in files:
-            if f.endswith('.cs'):
-                p = os.path.join(d,f)
-                p = p.split(base_dir+'/', 1)[1]
-                sources.append(p)
-                
-    for source in csproj.getElementsByTagName("Compile"):
-        if 'Include' in source.attributes:
-            sources.append("Source/CombatExtended/"+source.attributes['Include'].value.replace("\\", "/"))
-        if 'Remove' in source.attributes:
-            v = source.attributes['Remove'].value.replace('\\', '/')
-            if v in sources:
-                sources.remove(v)
-            else:
-                if v.endswith('**'):
-                    print("Removing wildcard:",v)
-                    sl = len(sources)
-                    sources = [i for i in sources if not i.startswith(v[:-2])]
-                    print(f"Removed {sl-len(sources)}")
+        for d, subds, files in os.walk(base_dir):
+            for f in files:
+                if f.endswith('.cs'):
+                    p = os.path.join(d,f)
+                    p = p.split(base_dir+'/', 1)[1]
+                    sources.append(p)
+
+        for source in csproj.getElementsByTagName("Compile"):
+            if 'Include' in source.attributes:
+                sources.append(source.attributes['Include'].value.replace("\\", "/"))
+            if 'Remove' in source.attributes:
+                v = source.attributes['Remove'].value.replace('\\', '/')
+                if v in sources:
+                    sources.remove(v)
                 else:
-                    print("Directive to exclude non-existent file:", v)
-    sources = [(base_dir+'/'+i) for i in sources]
+                    if v.endswith('**'):
+                        if verbose:
+                            print("Removing wildcard:",v)
+                        sl = len(sources)
+                        sources = [i for i in sources if not i.startswith(v[:-2])]
+                        if verbose:
+                            print(f"Removed {sl-len(sources)}")
+                    else:
+                        print("Directive to exclude non-existent file:", v)
+        sources = [(base_dir+'/'+i) for i in sources]
 
-if PUBLICIZE:
-    for idx,l in enumerate(libraries):
-        if l.rsplit('/',1)[1] in PUBLICIZE:
-            libraries[idx] = l[:-4]+"_publicized.dll"
-            publicize(l)
+        publicize_task = [i for i in csproj.getElementsByTagName("Target")
+                          if 'Name' in i.attributes and i.attributes['Name'].value.startswith('Publi')]
+        variables = {}
+            
+        for pt in publicize_task:
+            
+            for pg in pt.getElementsByTagName("PropertyGroup"):
+                for var in pg.childNodes:
+                    if var.nodeName != '#text':
+                        val = var.firstChild.data.strip()
+                        if '\\' in val:
+                            variables[var.nodeName] = val.rsplit('\\', 1)[1]
+                        elif ')' in val:
+                            variables[var.nodeName] = val.rsplit(')', 1)[1]
+                        else:
+                            variables[var.nodeName] = val
+            for pub in pt.getElementsByTagName("Publicise"):
+                target = pub.attributes['TargetAssemblyPath'].value
+                
+                if '$' in target:
+                    target = target.replace('$', '%')
+                    target = target.replace(')', ')s')
+                    target = target % variables
 
-print(removed_libraries)
-#libraries = [l for l in libraries if not l.rsplit('/',1)[1] in removed_libraries]
+                output = target.rsplit('.',1)[0] + '_publicized.dll'
+                    
+                publicized_libraries.append(PublicizeTarget(target, output))
+
+    return packages, libraries, removed_libraries, publicized_libraries, sources
+
+def main(argv=sys.argv):
     
-args = ["csc", "-unsafe", "-warnaserror", "-nostdlib", "-target:library", f'-out:{OUTPUT}', *sources, *[f'-r:{r}' for r in libraries]]
+    options = parseArgs(argv)
+    verbose = options.verbose
 
-if VERBOSE:
-    print(HARMONY)
-    print(RIMWORLD)
-    print(CSPROJ)
+    os.system(f"mkdir -p {tdir}/downloads/unpack")
+    os.system(f"mkdir -p {options.reference}")
+    
+    
+    packages, libraries, removed_libraries, publicized_libraries, sources = parse_csproj(options.csproj, options.verbose)
+    if publicized_libraries:
+        if not options.publicizer:
+            print("This .csproj requires publicizing assemblies, but you have not provided a path to AssemblyPublicizer")
+            exit(1)
 
-os.execvp(args[0], args)
+        publicizer = makePublicizer(options.publicizer, verbose)
+              
+
+    if options.download_libs:
+        for package in packages:
+            downloadLib(package.name, package.version, package.destination, verbose=verbose)
+            unpackLib(package.destination, f"{tdir}/downloads/unpack", verbose=verbose)
+            time.sleep(1)
+        os.system(f"cp -r {tdir}/downloads/unpack/ref/net472/* {options.reference}")
+        os.system(f"cp -r {tdir}/downloads/unpack/lib/net472/* {options.reference}")
+
+    print(libraries)
+
+    libraries = [resolveLibrary(l, options.reference, options.csproj, verbose) for l in libraries if '$' not in l.name]
+
+    if options.all_libs:
+        for ref in os.listdir(options.reference):
+            if ref.endswith(".dll"):
+                libraries.append(os.path.join(options.reference, ref))
+
+    for p in publicized_libraries:
+        for l in libraries:
+            if os.path.basename(l) == p.inputName:
+                libraries.append(publicize(l, publicizer, verbose))
+                break
+                
+
+    libraries = [l for l in set(libraries) if not os.path.basename(l) in removed_libraries]
+    args.extend([f'-out:{options.output}', *sources, *[f'-r:{r}' for r in libraries]])
+    os.execvp(args[0], args)
+    
+if __name__=='__main__':
+    main(sys.argv)


### PR DESCRIPTION


## Changes

Uses a proper argument parser, which keeps the usage string in sync with the underlying options, handles short-form options, handles `--option=value` properly.
Uses a modular approach, with different steps broken into different functions, and without everything in the global namespace.
Reads the files to publicize from the `.csproj` directly.

## Reasoning

The existing Make.py started as a 15 line script barely smart enough to extract the list of `.cs` files to compile, and never intended for fully-automated use.  As the `.csproj` file complexity grew, more and more dirty hacks piled up, and the time to re-read and understand the script got worse.  So it was time to scrap it and do it right.

The new version parses the csproj in pieces, so if a new bit of information needs extracting from the csproj, adding that won't involve paging through a massive context block.

## Alternatives

Keep limping along with the old script.  It functions, so in a sense this wasn't needed until the next time the old script breaks.  But the requirements are currently fresh in memory, so it is easier to do now.

Don't speculatively build PRs.  This would let us use dotnet build with minimal risk, but make testing PRs much harder.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
