### PR TITLE
update the scorcher helmet

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -56,7 +56,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationAdd">

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -53,13 +53,13 @@
 					<WornBulk>1.8</WornBulk>					
 				</value>
 			</li>			
-			<li Class="PatchOperationReplace">
+			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>			
 			</li>
-			<li Class="PatchOperationReplace">
+			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>


### PR DESCRIPTION
The newest feral faction update changed the stats of the Scorcher Helmet, removing the blunt and sharp armor rating stats. Combat Extended is trying to replace these attributes with new values, but they no longer exist and thus the error is thrown. As such, the CE blunt and sharp armor stats are added



## Changes

-replaces the "PatchOperationReplace" with "PathOperationAdd" when referring to the sharp and blunt armor

## Reference


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
