### PR TITLE
Quick Fixes

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -83,7 +83,7 @@
       <MarketValue>3.99</MarketValue>
     </statBases>
 		<ammoClass>PlasteelCrossbowBolt</ammoClass>
-	<generateAllowChance>0</generateAllowChance>
+	<generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoCrossbowBoltBase">
@@ -113,6 +113,7 @@
       <MarketValue>1.29</MarketValue>
     </statBases>
     <ammoClass>FlameArrow</ammoClass>
+    <generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -98,7 +98,7 @@
       <MarketValue>1.07</MarketValue>
     </statBases>
     <ammoClass>PlasteelArrow</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
@@ -128,6 +128,7 @@
       <MarketValue>1.16</MarketValue>
     </statBases>
     <ammoClass>FlameArrow</ammoClass>
+    <generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles (short bow) ================== -->

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -84,7 +84,7 @@
       <MarketValue>3.06</MarketValue>
     </statBases>
     <ammoClass>PlasteelArrow</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
@@ -114,6 +114,7 @@
       <MarketValue>1.29</MarketValue>
     </statBases>
     <ammoClass>FlameArrow</ammoClass>
+    <generateAllowChance>0.2</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Patches/Arasaka Corporation [1.3]/7mmMiniRailgun.xml
+++ b/Patches/Arasaka Corporation [1.3]/7mmMiniRailgun.xml
@@ -57,7 +57,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base45ACPBullet">
 		<defName>Bullet_7mmMiniRailgun_Sabot</defName>
 		<label>7mm Railgun bullet (Sabot)</label>
 		<graphicData>

--- a/Patches/Arasaka Corporation [1.3]/BigBrainGyrojet.xml
+++ b/Patches/Arasaka Corporation [1.3]/BigBrainGyrojet.xml
@@ -92,7 +92,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base6mmSmartGyrojetBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Base6mmSmartGyrojetBullet" ParentName="Base45ACPBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Patch_Bodies.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Patch_Bodies.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>[O21] Forgotten Realms</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Add armor coverage (for pawns with non-zero armor that use human body) ========== -->
+
+      <!-- Illithid -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Body_Illithid"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <!-- Chitine -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "O21_FR_Chitine"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/PawnKinds_Misc.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/PawnKinds_Misc.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>[O21] Forgotten Realms</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to pawns with bows ========== -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>
+          /Defs/PawnKindDef[
+          @Name="O21_FR_NPCTribePawnBase_Bowman" or
+          @Name="O21_FR_NPCTribePawnBase_Hunter" or
+          @Name="O21_FR_NPCTribePawnBase_Miner" or
+          @Name="O21_FR_NPCTribePawnBase_Logger" or
+          @Name="O21_FR_NPCTribePawnBase_Farmer"]
+        </xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>12</min>
+              <max>20</max>
+            </primaryMagazineCount>
+            <sidearms>
+              <generateChance>0.3</generateChance>
+              <sidearmMoney>
+                <min>150</min>
+                <max>350</max>
+              </sidearmMoney>
+              <weaponTags>
+                <li>NeolithicMeleeBasic</li>
+                <li>MedievalMeleeDecent</li>
+              </weaponTags>
+            </sidearms>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Chitine.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Chitine.xml
@@ -8,7 +8,7 @@
       <operations>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]</xpath>
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
               <bodyShape>Humanoid</bodyShape>
@@ -20,11 +20,11 @@
           <success>Always</success>
           <operations>
             <li Class="PatchOperationTest">
-              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/comps</xpath>
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]/comps</xpath>
               <success>Invert</success>
             </li>
             <li Class="PatchOperationAdd">
-              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]</xpath>
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]</xpath>
               <value>
                 <comps />
               </value>
@@ -33,9 +33,9 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/statBases</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]/statBases</xpath>
           <value>
-            <NightVisionEfficiency>0.4</NightVisionEfficiency>
+            <NightVisionEfficiency>0.6</NightVisionEfficiency>
             <MeleeDodgeChance>1.1</MeleeDodgeChance>
             <MeleeCritChance>0.8</MeleeCritChance>
             <MeleeParryChance>0.85</MeleeParryChance>
@@ -45,7 +45,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/tools</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -84,7 +84,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/comps</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Chitine"]/comps</xpath>
           <value>
             <li>
               <compClass>CombatExtended.CompPawnGizmo</compClass>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Dwarf.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Dwarf.xml
@@ -35,6 +35,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Dwarf"]/statBases</xpath>
 				<value>
+					<NightVisionEfficiency>0.5</NightVisionEfficiency>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>0.8</MeleeCritChance>
 					<MeleeParryChance>0.8</MeleeParryChance>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Gith.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Gith.xml
@@ -35,6 +35,7 @@
         <li Class="PatchOperationAdd">
           <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Gith"]/statBases</xpath>
           <value>
+            <NightVisionEfficiency>0.4</NightVisionEfficiency>
             <MeleeDodgeChance>1</MeleeDodgeChance>
             <MeleeCritChance>1</MeleeCritChance>
             <MeleeParryChance>1</MeleeParryChance>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Goblin.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Goblin.xml
@@ -58,6 +58,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Goblin"]/statBases</xpath>
 					<value>
+						<NightVisionEfficiency>0.4</NightVisionEfficiency>
 						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<MeleeCritChance>0.6</MeleeCritChance>
 						<MeleeParryChance>0.8</MeleeParryChance>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Halfing.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Halfing.xml
@@ -8,7 +8,7 @@
       <operations>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]</xpath>
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
               <bodyShape>Humanoid</bodyShape>
@@ -20,11 +20,11 @@
           <success>Always</success>
           <operations>
             <li Class="PatchOperationTest">
-              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/comps</xpath>
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]/comps</xpath>
               <success>Invert</success>
             </li>
             <li Class="PatchOperationAdd">
-              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]</xpath>
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]</xpath>
               <value>
                 <comps />
               </value>
@@ -33,9 +33,8 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/statBases</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]/statBases</xpath>
           <value>
-            <NightVisionEfficiency>0.4</NightVisionEfficiency>
             <MeleeDodgeChance>1.1</MeleeDodgeChance>
             <MeleeCritChance>0.8</MeleeCritChance>
             <MeleeParryChance>0.85</MeleeParryChance>
@@ -45,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/tools</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -84,7 +83,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_ElfBase"]/comps</xpath>
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Halfling"]/comps</xpath>
           <value>
             <li>
               <compClass>CombatExtended.CompPawnGizmo</compClass>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Illlithids.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Illlithids.xml
@@ -43,6 +43,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Illithid"]/statBases</xpath>
 				<value>
+					<NightVisionEfficiency>0.6</NightVisionEfficiency>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
 					<MeleeParryChance>1</MeleeParryChance>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Kobold.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Kobold.xml
@@ -55,6 +55,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Kobold"]/statBases</xpath>
 				<value>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 					<CarryWeight>40</CarryWeight>
 					<CarryBulk>20</CarryBulk>
 					<MeleeDodgeChance>1.1</MeleeDodgeChance>

--- a/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Tabaxi.xml
+++ b/Patches/O21 Forgotten Realms/ThingDefs_Races/Race_Tabaxi.xml
@@ -35,6 +35,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="O21_FR_Tabaxi"]/statBases</xpath>
 				<value>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
 					<MeleeDodgeChance>1.1</MeleeDodgeChance>
 					<MeleeCritChance>0.8</MeleeCritChance>
 					<MeleeParryChance>0.8</MeleeParryChance>


### PR DESCRIPTION
## Additions
Any newly added projectiles that use basebullet as parent will throw error, replacing it with something else.