### PR TITLE
Fixed the xpath for Scorcher Helmet armor attributes

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -54,13 +54,13 @@
 				</value>
 			</li>			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>


### PR DESCRIPTION
## Changes

Updated the xpaths for the `ArmorRating_Blunt` and `Apparel_ScorcherHelmet` attributes for the Scorcher Helmet defined in the **Rimsenal - Feral Faction Pack** so that the patching operation now succeeds.

## Reasoning

The 31.07 update of the **Rimsenal - Feral Faction Pack** changed the stats of the Scorcher Helmet, removing the blunt and sharp armor rating attributes. Commit eb9adaa2888626d132bbaf51b5174580bb10ca34 reintroduces those attributes for Combat Extended, but has an incorrect xpath defined for the attributes which causes the patching operation to fail. 