### PR TITLE
SaveOurShip2 - remove ToxicSensitivity from Helmet

### DIFF
--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -57,7 +57,6 @@
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/equippedStatOffsets</xpath>
 		<value>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	   </li>
@@ -88,7 +87,6 @@
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/equippedStatOffsets</xpath>
 		<value>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 		</value>
 	   </li>


### PR DESCRIPTION
## Changes

- removed the adding of `ToxicSensitivity` equippedStatOffsets for `Apparel_SpaceSuitHelmet` & `Apparel_SpaceSuitHelmetHeavy`

## Reasoning

- ToxicSensitivity value is now part of the SOS2 mod and is identical with the patch

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
