### PR TITLE
Reduced amount of ThingOwner patches and total game startup time

### DIFF
--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -75,20 +75,6 @@ namespace CombatExtended.HarmonyCE
             //Post remove notification patch
             var postfixRemove = typeof(Harmony_ThingOwner_NotifyRemoved_Patch).GetMethod("Postfix");
             instance.Patch(baseThingOwnerType.GetMethod("NotifyRemoved", BindingFlags.Instance | BindingFlags.NonPublic), null, new HarmonyMethod(postfixRemove));
-            /*
-            var postfixTryAdd = typeof(Harmony_ThingOwner_TryAdd_Patch).GetMethod("Postfix");
-            var postfixTake = typeof(Harmony_ThingOwner_Take_Patch).GetMethod("Postfix");
-            var postfixRemove = typeof(Harmony_ThingOwner_Remove_Patch).GetMethod("Postfix");
-
-            var baseType = typeof(Thing);
-            var types = baseType.AllSubclassesNonAbstract().AddItem(baseType);
-            foreach (Type current in types)
-            {
-                var type = typeof(ThingOwner<>).MakeGenericType(current);
-                instance.Patch(type.GetMethod("TryAdd", new Type[] { typeof(Thing), typeof(bool) }), null, new HarmonyMethod(postfixTryAdd));
-                instance.Patch(type.GetMethod("Take", new Type[] { typeof(Thing), typeof(int) }), null, new HarmonyMethod(postfixTake));
-                instance.Patch(type.GetMethod("Remove", new Type[] { typeof(Thing) }), null, new HarmonyMethod(postfixRemove));
-            }*/
         }
 
         private static void PatchHediffWithComps(Harmony harmonyInstance)

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -63,6 +63,19 @@ namespace CombatExtended.HarmonyCE
         private static void PatchThingOwner()
         {
             // Need to patch ThingOwner<T> manually for all child classes of Thing
+            var baseThingOwnerType = typeof(ThingOwner);
+            //Post add notification patches
+            var postfixNotifyAdded = typeof(Harmony_ThingOwner_NotifyAdded_Patch).GetMethod("Postfix");
+            instance.Patch(baseThingOwnerType.GetMethod("NotifyAdded", BindingFlags.Instance | BindingFlags.NonPublic), null, new HarmonyMethod(postfixNotifyAdded));
+            var postfixNotifyAddedAndMergedWith = typeof(Harmony_ThingOwner_NotifyAddedAndMergedWith_Patch).GetMethod("Postfix");
+            instance.Patch(baseThingOwnerType.GetMethod("NotifyAddedAndMergedWith", BindingFlags.Instance | BindingFlags.NonPublic), null, new HarmonyMethod(postfixNotifyAddedAndMergedWith));
+            //Post take notification patch
+            var postfixTake = typeof(Harmony_ThingOwner_Take_Patch).GetMethod("Postfix");
+            instance.Patch(baseThingOwnerType.GetMethod("Take", new Type[] { typeof(Thing), typeof(int) }), null, new HarmonyMethod(postfixTake));
+            //Post remove notification patch
+            var postfixRemove = typeof(Harmony_ThingOwner_NotifyRemoved_Patch).GetMethod("Postfix");
+            instance.Patch(baseThingOwnerType.GetMethod("NotifyRemoved", BindingFlags.Instance | BindingFlags.NonPublic), null, new HarmonyMethod(postfixRemove));
+            /*
             var postfixTryAdd = typeof(Harmony_ThingOwner_TryAdd_Patch).GetMethod("Postfix");
             var postfixTake = typeof(Harmony_ThingOwner_Take_Patch).GetMethod("Postfix");
             var postfixRemove = typeof(Harmony_ThingOwner_Remove_Patch).GetMethod("Postfix");
@@ -75,7 +88,7 @@ namespace CombatExtended.HarmonyCE
                 instance.Patch(type.GetMethod("TryAdd", new Type[] { typeof(Thing), typeof(bool) }), null, new HarmonyMethod(postfixTryAdd));
                 instance.Patch(type.GetMethod("Take", new Type[] { typeof(Thing), typeof(int) }), null, new HarmonyMethod(postfixTake));
                 instance.Patch(type.GetMethod("Remove", new Type[] { typeof(Thing) }), null, new HarmonyMethod(postfixRemove));
-            }
+            }*/
         }
 
         private static void PatchHediffWithComps(Harmony harmonyInstance)

--- a/Source/CombatExtended/Harmony/Harmony_ThingOwner.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ThingOwner.cs
@@ -10,20 +10,28 @@ using HarmonyLib;
 namespace CombatExtended.HarmonyCE
 {
     // Need to patch all methods that can modify pawn's inventory to refresh CompInventory cache when it happens
-
-    //[HarmonyPatch(typeof(ThingOwner), "TryAdd", new Type[] { typeof(Thing), typeof(bool) })]
-    public class Harmony_ThingOwner_TryAdd_Patch
+    public class Harmony_ThingOwner_NotifyAdded_Patch
     {
-        public static void Postfix(ThingOwner __instance, bool __result)
+        public static void Postfix(ThingOwner __instance, Thing item)
         {
-            if (__result)
+            if (item != null)
             {
                 CE_Utility.TryUpdateInventory(__instance);
             }
         }
     }
 
-    //[HarmonyPatch(typeof(ThingOwner), "Take", new Type[] { typeof(Thing), typeof(int) })]
+    public class Harmony_ThingOwner_NotifyAddedAndMergedWith_Patch
+    {
+        public static void Postfix(ThingOwner __instance, Thing item, int mergedCount)
+        {
+            if (item != null && mergedCount != 0)
+            {
+                CE_Utility.TryUpdateInventory(__instance);
+            }
+        }
+    }
+
     public class Harmony_ThingOwner_Take_Patch
     {
         public static void Postfix(ThingOwner __instance, Thing __result)
@@ -35,12 +43,11 @@ namespace CombatExtended.HarmonyCE
         }
     }
 
-    //[HarmonyPatch(typeof(ThingOwner), "Remove", new Type[] { typeof(Thing) })]
-    public class Harmony_ThingOwner_Remove_Patch
+    public class Harmony_ThingOwner_NotifyRemoved_Patch
     {
-        public static void Postfix(ThingOwner __instance, bool __result)
+        public static void Postfix(ThingOwner __instance, Thing item)
         {
-            if (__result)
+            if (item != null)
             {
                 CE_Utility.TryUpdateInventory(__instance);
             }


### PR DESCRIPTION
## Changes

Replaced hundreds of generic ThingOwner<T> patches for several ThingOwner patches.

## Reasoning

On heavily modded game CE Controller take a long time (11 seconds) to patch all specific realisations of ThingOwner<T>:
```
11739.3835ms (self: 20.2696 ms) Loading CombatExtended.Controller mod class
- 11719.0974ms (self: 1.1003 ms) Apply Harmony patches
- - 1178.0265ms (self: 1178.0265 ms) instance.PatchAll
- - - 10244.3970ms (self: 4.6578 ms) PatchThingOwner
- - - - 0.0255ms (self: 0.0255 ms) Getting postfix methods
- - - - 94.6166ms (self: 94.6166 ms) Getting patching class collection
- - - - - 23.2577ms (self: 23.2577 ms) Patching Verse.Pawn
- - - - - 16.8603ms (self: 16.8603 ms) Patching Verse.Building
- - - - - 27.9172ms (self: 27.9172 ms) Patching Verse.Corpse
- - - - - 17.9170ms (self: 17.9170 ms) Patching Verse.Explosion
and 460+ patches for Thing subclasses (flames, motes, vanilla tornadoes and so on)
```
10+ seconds for Patch ThingOwner<T>

This patches in result just call compInventory.UpdateInventory() method to calculate total weight and bulk of pawn inventory.
Because of
- ThingOwner<T>.TryAdd method call base.NotifyAdded() and base.NotifyAddedAndMergedWith()
- ThingOwner<T>.Take method call base.Take()
- ThingOwner<T>.Remove method call base.NotifyRemoved()
it is enough to patch those 4 methods of base (non-generic ThingOwner) class for compInventory notification purposes.

In total of this changes CombatExtended.Controller executes much faster:
```
1459.7672ms (self: 11.8943 ms) Loading CombatExtended.Controller mod class
- 1447.8578ms (self: 0.7560 ms) Apply Harmony patches
- - 1140.1545ms (self: 1140.1545 ms) instance.PatchAll
- - - 21.2170ms (self: 0.2953 ms) PatchThingOwner
- - - - 20.9217ms (self: 20.9217 ms) Getting postfix methods
- - - 100.1254ms (self: 100.1254 ms) PatchHediffWithComps
- - - 118.6762ms (self: 118.6762 ms) GenRadial_RadialPatternCount
- - - 21.8618ms (self: 21.8618 ms) PawnColumnWorkers_Resize
- - - 45.0669ms (self: 45.0669 ms) PawnColumnWorkers_SwapButtons
 ```
PatchThingOwner now takes only 21 ms instead of 10200 ms.

Pawns inventory still updates correctly when pawn takes or drops items, but game starts 10+ seconds faster.
More mods player have - more time ThingOwner<T> patches takes.