### PR TITLE
Sling bullets recipe fix #934

### DIFF
--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -59,9 +59,9 @@
 
   <RecipeDef ParentName="AmmoRecipeNeolithicBase">
     <defName>MakeAmmo_Dart_Venom</defName>
-    <label>make venom arrows x10</label>
-    <description>Craft 10 venom arrows.</description>
-    <jobString>Making venom arrows.</jobString>
+    <label>make venom darts x10</label>
+    <description>Craft 10 venom darts for use with blowguns.</description>
+    <jobString>Making venom darts.</jobString>
 	  <workAmount>960</workAmount>
     <ingredients>
       <li>

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -120,8 +120,8 @@
 
   <RecipeDef ParentName="AmmoRecipeNeolithicBase">
     <defName>MakeAmmo_SlingBullet_Stone</defName>
-    <label>make stone sling bullets x10</label>
-    <description>Make 10 stone sling bullets.</description>
+    <label>make stone sling bullets x500</label>
+    <description>Make 500 stone sling bullets.</description>
     <jobString>Making stone sling bullets.</jobString>
     <ingredients>
       <li>
@@ -146,8 +146,8 @@
 
   <RecipeDef ParentName="AmmoRecipeNeolithicBase">
     <defName>MakeAmmo_SlingBullet_Steel</defName>
-    <label>make steel sling bullets x10</label>
-    <description>Make 10 steel sling bullets.</description>
+    <label>make steel sling bullets x100</label>
+    <description>Make 100 steel sling bullets.</description>
     <jobString>Making steel sling bullets.</jobString>
     <ingredients>
       <li>

--- a/Languages/Russian/DefInjected/RecipeDef/SlingBullet.xml
+++ b/Languages/Russian/DefInjected/RecipeDef/SlingBullet.xml
@@ -4,16 +4,16 @@
   <!-- Recipes -->
 
   <MakeAmmo_SlingBullet_Stone.label>сделать снаряды для пращи (камень)</MakeAmmo_SlingBullet_Stone.label>
-  <MakeAmmo_SlingBullet_Stone.description>Сделать 10 каменных снарядов для пращи.</MakeAmmo_SlingBullet_Stone.description>
+  <MakeAmmo_SlingBullet_Stone.description>Сделать 500 каменных снарядов для пращи.</MakeAmmo_SlingBullet_Stone.description>
   <MakeAmmo_SlingBullet_Stone.jobString>Делает каменные снаряды для пращи.</MakeAmmo_SlingBullet_Stone.jobString>
 
   <MakeAmmo_SlingBullet_Steel.label>сделать снаряды для пращи (сталь)</MakeAmmo_SlingBullet_Steel.label>
-  <MakeAmmo_SlingBullet_Steel.description>Сделать 10 стальных снарядов для пращи.</MakeAmmo_SlingBullet_Steel.description>
+  <MakeAmmo_SlingBullet_Steel.description>Сделать 100 стальных снарядов для пращи.</MakeAmmo_SlingBullet_Steel.description>
   <MakeAmmo_SlingBullet_Steel.jobString>Делает стальные снаряды для пращи.</MakeAmmo_SlingBullet_Steel.jobString>
 
 
   <!--<MakeAmmo_SlingBullet_Plasteel.label>сделать 10 пласталиевых снарядов для пращи</MakeAmmo_SlingBullet_Plasteel.label>-->
-  <!--<MakeAmmo_SlingBullet_Plasteel.description>Сделать 10 пласталиевых снарядов для пращи.</MakeAmmo_SlingBullet_Plasteel.description>-->
+  <!--<MakeAmmo_SlingBullet_Plasteel.description>Сделать 100 пласталиевых снарядов для пращи.</MakeAmmo_SlingBullet_Plasteel.description>-->
   <!--<MakeAmmo_SlingBullet_Plasteel.jobString>Делает пласталиевые снаряды для пращи.</MakeAmmo_SlingBullet_Plasteel.jobString>-->
 
 </LanguageData>

--- a/Languages/Spanish/DefInjected/RecipeDef/SlingBullet.xml
+++ b/Languages/Spanish/DefInjected/RecipeDef/SlingBullet.xml
@@ -3,39 +3,39 @@
 
   <!-- Recipes -->
 
-  <MakeAmmo_SlingBullet_Stone.label>make stone sling bullets x10</MakeAmmo_SlingBullet_Stone.label>
-  <MakeAmmo_SlingBullet_Stone.description>Make 10 stone sling bullets.</MakeAmmo_SlingBullet_Stone.description>
+  <MakeAmmo_SlingBullet_Stone.label>make stone sling bullets x500</MakeAmmo_SlingBullet_Stone.label>
+  <MakeAmmo_SlingBullet_Stone.description>Make 500 stone sling bullets.</MakeAmmo_SlingBullet_Stone.description>
   <MakeAmmo_SlingBullet_Stone.jobString>Making stone sling bullets.</MakeAmmo_SlingBullet_Stone.jobString>
 
-  <MakeAmmo_SlingBullet_Steel.label>make steel sling bullets x10</MakeAmmo_SlingBullet_Steel.label>
-  <MakeAmmo_SlingBullet_Steel.description>Make 10 steel sling bullets.</MakeAmmo_SlingBullet_Steel.description>
+  <MakeAmmo_SlingBullet_Steel.label>make steel sling bullets x500</MakeAmmo_SlingBullet_Steel.label>
+  <MakeAmmo_SlingBullet_Steel.description>Make 500 steel sling bullets.</MakeAmmo_SlingBullet_Steel.description>
   <MakeAmmo_SlingBullet_Steel.jobString>Making steel sling bullets.</MakeAmmo_SlingBullet_Steel.jobString>
 
-  <MakeAmmo_SlingBullet_Plasteel.label>make plasteel sling bullets x10</MakeAmmo_SlingBullet_Plasteel.label>
-  <MakeAmmo_SlingBullet_Plasteel.description>Make 10 plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.description>
+  <MakeAmmo_SlingBullet_Plasteel.label>make plasteel sling bullets x500</MakeAmmo_SlingBullet_Plasteel.label>
+  <MakeAmmo_SlingBullet_Plasteel.description>Make 500 plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.description>
   <MakeAmmo_SlingBullet_Plasteel.jobString>Making plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.jobString>
 
 
-  <!-- <MakeAmmo_SlingBullet_Stone.label>balas de piedra x10</MakeAmmo_SlingBullet_Stone.label>
-  <MakeAmmo_SlingBullet_Stone.description>Hacer 10 Balas de piedra.</MakeAmmo_SlingBullet_Stone.description>
-  <MakeAmmo_SlingBullet_Stone.jobString>Haciendo 10 Balas de piedra.</MakeAmmo_SlingBullet_Stone.jobString>
+  <!-- <MakeAmmo_SlingBullet_Stone.label>balas de piedra x500</MakeAmmo_SlingBullet_Stone.label>
+  <MakeAmmo_SlingBullet_Stone.description>Hacer 500 Balas de piedra.</MakeAmmo_SlingBullet_Stone.description>
+  <MakeAmmo_SlingBullet_Stone.jobString>Haciendo 500 Balas de piedra.</MakeAmmo_SlingBullet_Stone.jobString>
 
-  <MakeAmmo_SlingBullet_Steel.label>balas de acero x10</MakeAmmo_SlingBullet_Steel.label>
-  <MakeAmmo_SlingBullet_Steel.description>Hacer 10 Balas de acero.</MakeAmmo_SlingBullet_Steel.description>
-  <MakeAmmo_SlingBullet_Steel.jobString>Haciendo 10 Balas de acero.</MakeAmmo_SlingBullet_Steel.jobString>
+  <MakeAmmo_SlingBullet_Steel.label>balas de acero x100</MakeAmmo_SlingBullet_Steel.label>
+  <MakeAmmo_SlingBullet_Steel.description>Hacer 100 Balas de acero.</MakeAmmo_SlingBullet_Steel.description>
+  <MakeAmmo_SlingBullet_Steel.jobString>Haciendo 100 Balas de acero.</MakeAmmo_SlingBullet_Steel.jobString>
 
-  <MakeAmmo_SlingBullet_Plasteel.label>balas de plastiacero x10</MakeAmmo_SlingBullet_Plasteel.label>
-  <MakeAmmo_SlingBullet_Plasteel.description>Hacer 10 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.description>
-  <MakeAmmo_SlingBullet_Plasteel.jobString>Haciendo 10 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.jobString>
+  <MakeAmmo_SlingBullet_Plasteel.label>balas de plastiacero x100</MakeAmmo_SlingBullet_Plasteel.label>
+  <MakeAmmo_SlingBullet_Plasteel.description>Hacer 100 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.description>
+  <MakeAmmo_SlingBullet_Plasteel.jobString>Haciendo 100 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.jobString>
  -->
-  <!--<MakeSlingBullet_Stone.label>balas de piedra x10</MakeSlingBullet_Stone.label>-->
-  <!--<MakeSlingBullet_Stone.description>Hacer 10 Balas de piedra.</MakeSlingBullet_Stone.description>-->
-  <!--<MakeSlingBullet_Stone.jobString>Haciendo 10 Balas de piedra.</MakeSlingBullet_Stone.jobString>-->
-  <!--<MakeSlingBullet_Steel.label>balas de acero x10</MakeSlingBullet_Steel.label>-->
-  <!--<MakeSlingBullet_Steel.description>Hacer 10 Balas de acero.</MakeSlingBullet_Steel.description>-->
-  <!--<MakeSlingBullet_Steel.jobString>Haciendo 10 Balas de acero.</MakeSlingBullet_Steel.jobString>-->
-  <!--<MakeSlingBullet_Plasteel.label>balas de plastiacero x10</MakeSlingBullet_Plasteel.label>-->
-  <!--<MakeSlingBullet_Plasteel.description>Hacer 10 balas de plastiacero .</MakeSlingBullet_Plasteel.description>-->
-  <!--<MakeSlingBullet_Plasteel.jobString>Haciendo 10 balas de plastiacero .</MakeSlingBullet_Plasteel.jobString>-->
+  <!--<MakeSlingBullet_Stone.label>balas de piedra x500</MakeSlingBullet_Stone.label>-->
+  <!--<MakeSlingBullet_Stone.description>Hacer 500 Balas de piedra.</MakeSlingBullet_Stone.description>-->
+  <!--<MakeSlingBullet_Stone.jobString>Haciendo 500 Balas de piedra.</MakeSlingBullet_Stone.jobString>-->
+  <!--<MakeSlingBullet_Steel.label>balas de acero x100</MakeSlingBullet_Steel.label>-->
+  <!--<MakeSlingBullet_Steel.description>Hacer 100 Balas de acero.</MakeSlingBullet_Steel.description>-->
+  <!--<MakeSlingBullet_Steel.jobString>Haciendo 100 Balas de acero.</MakeSlingBullet_Steel.jobString>-->
+  <!--<MakeSlingBullet_Plasteel.label>balas de plastiacero x100</MakeSlingBullet_Plasteel.label>-->
+  <!--<MakeSlingBullet_Plasteel.description>Hacer 100 balas de plastiacero .</MakeSlingBullet_Plasteel.description>-->
+  <!--<MakeSlingBullet_Plasteel.jobString>Haciendo 100 balas de plastiacero .</MakeSlingBullet_Plasteel.jobString>-->
 
 </LanguageData>

--- a/Languages/SpanishLatin/DefInjected/RecipeDef/SlingBullet.xml
+++ b/Languages/SpanishLatin/DefInjected/RecipeDef/SlingBullet.xml
@@ -3,39 +3,39 @@
 
   <!-- Recipes -->
 
-  <MakeAmmo_SlingBullet_Stone.label>make stone sling bullets x10</MakeAmmo_SlingBullet_Stone.label>
-  <MakeAmmo_SlingBullet_Stone.description>Make 10 stone sling bullets.</MakeAmmo_SlingBullet_Stone.description>
+  <MakeAmmo_SlingBullet_Stone.label>make stone sling bullets x500</MakeAmmo_SlingBullet_Stone.label>
+  <MakeAmmo_SlingBullet_Stone.description>Make 500 stone sling bullets.</MakeAmmo_SlingBullet_Stone.description>
   <MakeAmmo_SlingBullet_Stone.jobString>Making stone sling bullets.</MakeAmmo_SlingBullet_Stone.jobString>
 
-  <MakeAmmo_SlingBullet_Steel.label>make steel sling bullets x10</MakeAmmo_SlingBullet_Steel.label>
-  <MakeAmmo_SlingBullet_Steel.description>Make 10 steel sling bullets.</MakeAmmo_SlingBullet_Steel.description>
+  <MakeAmmo_SlingBullet_Steel.label>make steel sling bullets x100</MakeAmmo_SlingBullet_Steel.label>
+  <MakeAmmo_SlingBullet_Steel.description>Make 100 steel sling bullets.</MakeAmmo_SlingBullet_Steel.description>
   <MakeAmmo_SlingBullet_Steel.jobString>Making steel sling bullets.</MakeAmmo_SlingBullet_Steel.jobString>
 
-  <MakeAmmo_SlingBullet_Plasteel.label>make plasteel sling bullets x10</MakeAmmo_SlingBullet_Plasteel.label>
-  <MakeAmmo_SlingBullet_Plasteel.description>Make 10 plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.description>
+  <MakeAmmo_SlingBullet_Plasteel.label>make plasteel sling bullets x100</MakeAmmo_SlingBullet_Plasteel.label>
+  <MakeAmmo_SlingBullet_Plasteel.description>Make 100 plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.description>
   <MakeAmmo_SlingBullet_Plasteel.jobString>Making plasteel sling bullets.</MakeAmmo_SlingBullet_Plasteel.jobString>
 
 
-  <!-- <MakeAmmo_SlingBullet_Stone.label>balas de piedra x10</MakeAmmo_SlingBullet_Stone.label>
-  <MakeAmmo_SlingBullet_Stone.description>Hacer 10 Balas de piedra.</MakeAmmo_SlingBullet_Stone.description>
-  <MakeAmmo_SlingBullet_Stone.jobString>Haciendo 10 Balas de piedra.</MakeAmmo_SlingBullet_Stone.jobString>
+  <!-- <MakeAmmo_SlingBullet_Stone.label>balas de piedra x500</MakeAmmo_SlingBullet_Stone.label>
+  <MakeAmmo_SlingBullet_Stone.description>Hacer 500 Balas de piedra.</MakeAmmo_SlingBullet_Stone.description>
+  <MakeAmmo_SlingBullet_Stone.jobString>Haciendo 500 Balas de piedra.</MakeAmmo_SlingBullet_Stone.jobString>
 
-  <MakeAmmo_SlingBullet_Steel.label>balas de acero x10</MakeAmmo_SlingBullet_Steel.label>
-  <MakeAmmo_SlingBullet_Steel.description>Hacer 10 Balas de acero.</MakeAmmo_SlingBullet_Steel.description>
-  <MakeAmmo_SlingBullet_Steel.jobString>Haciendo 10 Balas de acero.</MakeAmmo_SlingBullet_Steel.jobString>
+  <MakeAmmo_SlingBullet_Steel.label>balas de acero x100</MakeAmmo_SlingBullet_Steel.label>
+  <MakeAmmo_SlingBullet_Steel.description>Hacer 100 Balas de acero.</MakeAmmo_SlingBullet_Steel.description>
+  <MakeAmmo_SlingBullet_Steel.jobString>Haciendo 100 Balas de acero.</MakeAmmo_SlingBullet_Steel.jobString>
 
-  <MakeAmmo_SlingBullet_Plasteel.label>balas de plastiacero x10</MakeAmmo_SlingBullet_Plasteel.label>
-  <MakeAmmo_SlingBullet_Plasteel.description>Hacer 10 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.description>
-  <MakeAmmo_SlingBullet_Plasteel.jobString>Haciendo 10 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.jobString>
+  <MakeAmmo_SlingBullet_Plasteel.label>balas de plastiacero x100</MakeAmmo_SlingBullet_Plasteel.label>
+  <MakeAmmo_SlingBullet_Plasteel.description>Hacer 100 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.description>
+  <MakeAmmo_SlingBullet_Plasteel.jobString>Haciendo 100 balas de plastiacero.</MakeAmmo_SlingBullet_Plasteel.jobString>
  -->
-  <!--<MakeSlingBullet_Stone.label>balas de piedra x10</MakeSlingBullet_Stone.label>-->
-  <!--<MakeSlingBullet_Stone.description>Hacer 10 Balas de piedra.</MakeSlingBullet_Stone.description>-->
-  <!--<MakeSlingBullet_Stone.jobString>Haciendo 10 Balas de piedra.</MakeSlingBullet_Stone.jobString>-->
-  <!--<MakeSlingBullet_Steel.label>balas de acero x10</MakeSlingBullet_Steel.label>-->
-  <!--<MakeSlingBullet_Steel.description>Hacer 10 Balas de acero.</MakeSlingBullet_Steel.description>-->
-  <!--<MakeSlingBullet_Steel.jobString>Haciendo 10 Balas de acero.</MakeSlingBullet_Steel.jobString>-->
-  <!--<MakeSlingBullet_Plasteel.label>balas de plastiacero x10</MakeSlingBullet_Plasteel.label>-->
-  <!--<MakeSlingBullet_Plasteel.description>Hacer 10 balas de plastiacero .</MakeSlingBullet_Plasteel.description>-->
-  <!--<MakeSlingBullet_Plasteel.jobString>Haciendo 10 balas de plastiacero .</MakeSlingBullet_Plasteel.jobString>-->
+  <!--<MakeSlingBullet_Stone.label>balas de piedra x500</MakeSlingBullet_Stone.label>-->
+  <!--<MakeSlingBullet_Stone.description>Hacer 500 Balas de piedra.</MakeSlingBullet_Stone.description>-->
+  <!--<MakeSlingBullet_Stone.jobString>Haciendo 500 Balas de piedra.</MakeSlingBullet_Stone.jobString>-->
+  <!--<MakeSlingBullet_Steel.label>balas de acero x100</MakeSlingBullet_Steel.label>-->
+  <!--<MakeSlingBullet_Steel.description>Hacer 100 Balas de acero.</MakeSlingBullet_Steel.description>-->
+  <!--<MakeSlingBullet_Steel.jobString>Haciendo 100 Balas de acero.</MakeSlingBullet_Steel.jobString>-->
+  <!--<MakeSlingBullet_Plasteel.label>balas de plastiacero x100</MakeSlingBullet_Plasteel.label>-->
+  <!--<MakeSlingBullet_Plasteel.description>Hacer 100 balas de plastiacero .</MakeSlingBullet_Plasteel.description>-->
+  <!--<MakeSlingBullet_Plasteel.jobString>Haciendo 100 balas de plastiacero .</MakeSlingBullet_Plasteel.jobString>-->
 
 </LanguageData>

--- a/Patches/Core/ThingDefs_Items/Items_General.xml
+++ b/Patches/Core/ThingDefs_Items/Items_General.xml
@@ -83,5 +83,21 @@
     </value>
   </Operation>
 
+  <!-- Ensure chunks have stuffProps so they can be used in recipes (like "make stone sling bullets") whithout throwing "not a stuff" error -->
+  <Operation Class="PatchOperationSequence">
+    <success>Always</success>
+    <operations>
+      <li Class="PatchOperationTest">
+        <xpath>Defs/ThingDef[@Name="ChunkBase"]/stuffProps</xpath>
+        <success>Invert</success>
+      </li>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[@Name="ChunkBase"]</xpath>
+        <value>
+          <stuffProps></stuffProps>
+        </value>
+      </li>
+    </operations>
+  </Operation>
 </Patch>
 


### PR DESCRIPTION
## Additions

None
## Changes

- Added patch to Core that ensures that `@Name=ChunkBase` (stone and metal chunks) have `<stuffProps>` even if empty.
  It allows chunks to be used as ingredients in recipes without throwing "not a stuff" error.
- Updated some incorrect labels/descriptions for some neolithic ammo recipes: invalid count, darts instead of arrows

## References

- Fixes #934

## Reasoning

No idea why this is not vanilla (possibly me just being inexperienced). The only problem I can see with this solution is if some other mod will try to patchAdd stuffProps to chunks without checking for existence first causing incompatibility.

## Alternatives

Another option is to remove rock chunk from recipe and just create bullets from nothing. This can be justified as gathering good stones around instead of breaking large chunk into them.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long): about 5 minutes, just to test crafting and labels/descriptions
