### PR TITLE
Censored Armory Fix

### DIFF
--- a/Patches/Censored Armory/75x714mmR.xml
+++ b/Patches/Censored Armory/75x714mmR.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
   <Operation Class="PatchOperationFindMod">
@@ -160,9 +160,9 @@
 
         <RecipeDef ParentName="AmmoRecipeBase">
           <defName>MakeAmmo_75x714mmRShell_AP</defName>
-          <label>make 90mm AP cannon shells x5</label>
-          <description>Craft 5 90mm AP cannon shells.</description>
-          <jobString>Making 90mm AP cannon shells.</jobString>
+          <label>make 75x714mm AP cannon shells x5</label>
+          <description>Craft 5 75x714mm AP cannon shells.</description>
+          <jobString>Making 75x714mm AP cannon shells.</jobString>
           <workAmount>9800</workAmount>
           <ingredients>
             <li>
@@ -204,9 +204,9 @@
 
         <RecipeDef ParentName="AmmoRecipeBase">
           <defName>MakeAmmo_75x714mmRShell_HE</defName>
-          <label>make 90mm HE cannon shells x5</label>
-          <description>Craft 5 90mm HE cannon shells.</description>
-          <jobString>Making 90mm HE cannon shells.</jobString>
+          <label>make 75x714mm HE cannon shells x5</label>
+          <description>Craft 5 75x714mm HE cannon shells.</description>
+          <jobString>Making 75x714mm HE cannon shells.</jobString>
           <workAmount>9800</workAmount>
           <ingredients>
             <li>


### PR DESCRIPTION
- Fixed crafting recipes displaying **90mm** instead of **75x714mm**