### PR TITLE
Fix #902

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -174,7 +174,7 @@ namespace CombatExtended
         {
             get
             {
-                if (_lightingTracker == null)
+                if (_lightingTracker == null || _lightingTracker.map == null || _lightingTracker.map.Index < 0)
                 {
                     _lightingTracker = caster.Map.GetLightingTracker();
                 }


### PR DESCRIPTION
## Additions

Check Verb_LaunchProjectile LightingTracker (MapComponent) cache, which didn't update

## References

Closes #902 

## Reasoning

Fast

## Alternatives

Rewrite LightingTracker cache to be on CE_Utility with MapComponent-induced add/remove rather than on Verb-induced add/remove.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
