### PR TITLE
Better Infestations - updated patch's mod name target.

### DIFF
--- a/Patches/Better Infestations/Race_Insect.xml
+++ b/Patches/Better Infestations/Race_Insect.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Better Infestations 1.2</li>
+			<li>Better Infestations 1.3</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
## Changes

1. Patch mod name target from `Better Infestations 1.2` to `Better Infestations 1.3`.

## Reasoning

1. Better Infestations mod name changed when it updated from RimWorld 1.2 to 1.3.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
