### PR TITLE
Tweaks to Pre-Industrial Ammo and grenades

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -36,6 +36,7 @@
     </thingCategories>
     <stackLimit>4000</stackLimit>
     <tradeTags>
+      <li>CE_PreIndustrialAmmo</li>
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_FueledSmithy</li>
       <li>CE_AutoEnableCrafting_ElectricSmithy</li>
@@ -125,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>10</speed>
+			<speed>15</speed>
 		</projectile>
 	</ThingDef>
 
@@ -161,7 +162,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>17</speed>			
+			<speed>20</speed>			
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -176,9 +177,9 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationBlunt>8.12</armorPenetrationBlunt>
+			<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<speed>19</speed>				
+			<speed>24</speed>				
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
 		</projectile>
@@ -196,7 +197,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-      <speed>17</speed>	
+      			<speed>20</speed>	
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -214,7 +215,7 @@
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBlunt>3.28</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>
-      <speed>17</speed>	
+      			<speed>15</speed>	
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -37,6 +37,7 @@
 		<Bulk>0.12</Bulk>
 		</statBases>
 		<tradeTags>
+      		  <li>CE_PreIndustrialAmmo</li>
 		  <li>CE_AutoEnableTrade</li>
 		  <li>CE_AutoEnableCrafting_FueledSmithy</li>
 		  <li>CE_AutoEnableCrafting_ElectricSmithy</li>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -50,6 +50,7 @@
     </thingCategories>
     <stackLimit>5000</stackLimit>
     <tradeTags>
+      <li>CE_PreIndustrialAmmo</li>
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_FueledSmithy</li>
       <li>CE_AutoEnableCrafting_ElectricSmithy</li>
@@ -192,7 +193,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>26</speed>
-      <damageAmountBase>4</damageAmountBase>
+      <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>1.660</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.8</preExplosionSpawnChance>      <!-- 50 arrows per resource -->
@@ -232,7 +233,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>16</speed>
       <damageDef>Arrow</damageDef>
       <damageAmountBase>3</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
@@ -304,7 +305,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>37</speed>
-      <damageAmountBase>5</damageAmountBase>
+      <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.75</preExplosionSpawnChance>
@@ -344,7 +345,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
+      <speed>22</speed>
       <damageDef>Arrow</damageDef>
       <damageAmountBase>3</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>10</speed>
+      <speed>11</speed>
 		  <damageDef>ArrowVenom</damageDef>
 		  <damageAmountBase>3</damageAmountBase> 
       <armorPenetrationSharp>0.35</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -36,6 +36,7 @@
     </thingCategories>
     <stackLimit>1000</stackLimit>
     <tradeTags>
+      <li>CE_PreIndustrialAmmo</li>
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_FueledSmithy</li>
       <li>CE_AutoEnableCrafting_ElectricSmithy</li>
@@ -126,7 +127,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>12</speed>
+			<speed>14</speed>
 		</projectile>
 	</ThingDef>
 	
@@ -143,7 +144,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>11</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -160,7 +160,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<speed>17</speed>
+			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
@@ -176,7 +177,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<speed>20</speed>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
@@ -192,12 +194,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>17</speed>
 			<damageDef>Arrow</damageDef>
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>
 				<li>
 				<def>ArrowVenom</def>
-				<amount>3</amount>
+				<amount>2</amount>
 				</li>
 			</secondaryDamage>			
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
@@ -356,7 +359,7 @@
             <li>MedicineHerbal</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>3</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -35,7 +35,7 @@
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<speed>7</speed>
+			<speed>8</speed>
 			<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -35,7 +35,7 @@
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<speed>8</speed>
+			<speed>7</speed>
 			<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -32,6 +32,7 @@
     </thingCategories>
     <stackLimit>5000</stackLimit>
     <tradeTags>
+      <li>CE_PreIndustrialAmmo</li>
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_FueledSmithy</li>
       <li>CE_AutoEnableCrafting_ElectricSmithy</li>
@@ -77,7 +78,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Blunt</damageDef>
-			<speed>9</speed>
+			<speed>12</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -60,7 +60,7 @@
       <soundExplode>Explosion_Stun</soundExplode>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-      <speed>5</speed>
+      <speed>7</speed>
     </projectile>
   </ThingDef>
 
@@ -134,7 +134,7 @@
       <damageAmountBase>234</damageAmountBase>
       <explosionDelay>90</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-      <speed>3</speed>
+      <speed>4</speed>
     </projectile>
   </ThingDef>
 
@@ -202,7 +202,7 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>5</speed>
+      <speed>6</speed>
     </projectile>
   </ThingDef>
 
@@ -276,7 +276,7 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>5</speed>
+      <speed>6</speed>
     </projectile>
   </ThingDef>
 

--- a/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -509,8 +509,8 @@
 							<graphicClass>Graphic_Single</graphicClass>
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>33</speed>
-							<damageAmountBase>28</damageAmountBase> <!--Artifically reduced from 33-->
+							<speed>29</speed>
+							<damageAmountBase>17</damageAmountBase> <!--Artifically reduced from 33-->
 							<armorPenetrationBlunt>14.98</armorPenetrationBlunt>
 							<armorPenetrationSharp>4</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- All values are halved from original great arrow -->
@@ -526,7 +526,7 @@
 							<graphicClass>Graphic_Single</graphicClass>
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>36</speed>
+							<speed>34</speed>
 							<damageAmountBase>20</damageAmountBase>
 							<armorPenetrationBlunt>21.06</armorPenetrationBlunt>
 							<armorPenetrationSharp>8</armorPenetrationSharp>
@@ -543,8 +543,8 @@
 							<graphicClass>Graphic_Single</graphicClass>
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>37</speed>
-							<damageAmountBase>15</damageAmountBase>
+							<speed>38</speed>
+							<damageAmountBase>18</damageAmountBase>
 							<armorPenetrationBlunt>19.26</armorPenetrationBlunt>
 							<armorPenetrationSharp>12</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.375</preExplosionSpawnChance>
@@ -560,13 +560,13 @@
 							<graphicClass>Graphic_Single</graphicClass>
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>36</speed>
+							<speed>34</speed>
 							<damageDef>Arrow</damageDef>
-							<damageAmountBase>14</damageAmountBase>
+							<damageAmountBase>16</damageAmountBase>
 							<secondaryDamage>
 								<li>
 								<def>ArrowVenom</def>
-								<amount>6</amount>
+								<amount>4</amount>
 								</li>
 							</secondaryDamage>			
 							<armorPenetrationBlunt>21.06</armorPenetrationBlunt>
@@ -584,7 +584,7 @@
 							<graphicClass>Graphic_Single</graphicClass>
 						</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>36</speed>
+						<speed>29</speed>
 					  <damageDef>Arrow</damageDef>
 					  <damageAmountBase>6</damageAmountBase>
 					  <armorPenetrationBlunt>10.54</armorPenetrationBlunt>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -48,7 +48,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile/speed</xpath>
 		<value>
-			<speed>5</speed>
+			<speed>6</speed>
 		</value>
 	</Operation>
 
@@ -84,7 +84,7 @@
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<speed>5</speed>
+				<speed>6</speed>
 			</projectile>
 		</value>
 	</Operation>
@@ -241,7 +241,7 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>5</speed>
+				<speed>6</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>
@@ -378,7 +378,7 @@
 				<explosionDelay>60</explosionDelay>
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-				<speed>5</speed>
+				<speed>6</speed>
 			</projectile>
 		</value>
 	</Operation>

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -11,7 +11,7 @@
 
   <!-- ========== Neolithic bulk goods ========== -->
 
-  <Operation Class="PatchOperationAdd">
+ <Operation Class="PatchOperationAdd">
     <xpath>Defs/TraderKindDef[defName="Caravan_Neolithic_BulkGoods"]/stockGenerators</xpath>
     <value>
       <li Class="StockGenerator_Category">
@@ -41,6 +41,17 @@
           <min>15</min>
           <max>40</max>
         </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>30</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>3</max>
+        </thingDefCountRange>
       </li>
     </value>
   </Operation>
@@ -94,6 +105,18 @@
           <max>4</max>
         </countRange>
       </li>
+     <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>50</min>
+          <max>300</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
     </value>
   </Operation>
 
@@ -114,6 +137,17 @@
         <thingDefCountRange>
           <min>0</min>
           <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>30</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>3</max>
         </thingDefCountRange>
       </li>
     </value>
@@ -168,9 +202,20 @@
           <max>4</max>
         </countRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>60</min>
+          <max>300</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
     </value>
   </Operation>
-
 	<!-- ========== Outlander Base ========== -->
 
 	<Operation Class="PatchOperationAdd">

--- a/Patches/Core/TraderKinds.xml
+++ b/Patches/Core/TraderKinds.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Global ========== -->
+
+	<!-- Remove mortar shells -->
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/TraderKindDef/stockGenerators/li[tradeTag="MortarShell"]</xpath>
+	</Operation>
+
+  <!-- ========== Neolithic bulk goods ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Caravan_Neolithic_BulkGoods"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>15</min>
+          <max>40</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>15</min>
+          <max>40</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>30</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== War merchant ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Caravan_Neolithic_WarMerchant"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>5</min>
+          <max>20</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>5</min>
+          <max>20</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Animals">
+        <tradeTagsSell>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsSell>
+        <tradeTagsBuy>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsBuy>
+        <kindCountRange>
+          <min>1</min>
+          <max>2</max>
+        </kindCountRange>
+        <countRange>
+          <min>1</min>
+          <max>4</max>
+        </countRange>
+      </li>
+     <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>50</min>
+          <max>200</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Neolithic misc ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Caravan_Neolithic_Slaver" or defName="Caravan_Neolithic_ShamanMerchant"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>30</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+
+  <!-- ========== Neolithic Base ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Base_Neolithic_Standard"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Animals">
+        <tradeTagsSell>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsSell>
+        <tradeTagsBuy>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsBuy>
+        <kindCountRange>
+          <min>1</min>
+          <max>2</max>
+        </kindCountRange>
+        <countRange>
+          <min>-2</min>
+          <max>4</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_PreIndustrialAmmo</tradeTag>
+        <countRange>
+          <min>60</min>
+          <max>240</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+    </value>
+  </Operation>
+
+	<!-- ========== Outlander Base ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="Base_Outlander_Standard"]/stockGenerators</xpath>
+		<value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>25</min>
+          <max>100</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>25</min>
+          <max>100</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Ammo</tradeTag>
+        <countRange>
+          <min>500</min>
+          <max>2000</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>5</min>
+          <max>9</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>      
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Turret</tradeTag>
+        <thingDefCountRange>
+          <min>-2</min>
+          <max>4</max>
+        </thingDefCountRange>
+        <countRange>
+          <min>1</min>
+          <max>2</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Animals">
+        <tradeTagsSell>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsSell>
+        <tradeTagsBuy>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsBuy>
+        <kindCountRange>
+          <min>1</min>
+          <max>2</max>
+        </kindCountRange>
+        <countRange>
+          <min>-2</min>
+          <max>4</max>
+        </countRange>
+      </li>
+		</value>
+	</Operation>
+
+	<!-- ========== Outlander Caravan ========== -->
+
+	<!-- Pirate Merchant and Bulk Goods ammo -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="Caravan_Outlander_BulkGoods" or defName="Caravan_Outlander_PirateMerchant" or defName="Caravan_Outlander_Exotic"]/stockGenerators</xpath>
+		<value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Ammo</tradeTag>
+        <countRange>
+          <min>200</min>
+          <max>400</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>5</min>
+          <max>20</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>         
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+		</value>
+	</Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Caravan_Outlander_BulkGoods"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>35</min>
+          <max>80</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>35</min>
+          <max>80</max>
+        </countRange>
+      </li>
+    </value>
+  </Operation>
+
+	<!-- Combat Supplier -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="Caravan_Outlander_CombatSupplier"]/stockGenerators</xpath>
+		<value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>15</min>
+          <max>40</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>15</min>
+          <max>40</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Ammo</tradeTag>
+        <countRange>
+          <min>400</min>
+          <max>1000</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>5</max>
+        </thingDefCountRange>
+      </li>      
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Turret</tradeTag>
+        <thingDefCountRange>
+          <min>-4</min>
+          <max>2</max>
+        </thingDefCountRange>
+        <countRange>
+          <min>1</min>
+          <max>1</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Animals">
+        <tradeTagsSell>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsSell>
+        <tradeTagsBuy>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsBuy>
+        <kindCountRange>
+          <min>1</min>
+          <max>1</max>
+        </kindCountRange>
+        <countRange>
+          <min>-1</min>
+          <max>2</max>
+        </countRange>
+      </li>
+		</value>
+	</Operation>
+
+	<!-- ========== Orbital ========== -->
+
+	<!-- Pirate Merchant and Bulk Goods ammo -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="Orbital_BulkGoods" or defName="Orbital_PirateMerchant" or defName="Orbital_Exotic"]/stockGenerators</xpath>
+		<value>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Ammo</tradeTag>
+        <countRange>
+          <min>400</min>
+          <max>1000</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>15</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>            
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+		</value>
+	</Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/TraderKindDef[defName="Orbital_BulkGoods"]/stockGenerators</xpath>
+    <value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>50</min>
+          <max>100</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>50</min>
+          <max>100</max>
+        </countRange>
+      </li>
+    </value>
+  </Operation>
+
+	<!-- Combat Supplier -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraderKindDef[defName="Orbital_CombatSupplier"]/stockGenerators</xpath>
+		<value>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>FSX</thingDef>
+        <countRange>
+          <min>25</min>
+          <max>50</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_SingleDef">
+        <thingDef>Prometheum</thingDef>
+        <countRange>
+          <min>25</min>
+          <max>50</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Ammo</tradeTag>
+        <countRange>
+          <min>1000</min>
+          <max>3000</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>5</min>
+          <max>12</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>100</min>
+          <max>500</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>       
+      <li Class="StockGenerator_Category">
+        <categoryDef>Ammo</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_Turret</tradeTag>
+        <thingDefCountRange>
+          <min>-2</min>
+          <max>4</max>
+        </thingDefCountRange>
+        <countRange>
+          <min>1</min>
+          <max>2</max>
+        </countRange>
+      </li>
+      <li Class="StockGenerator_Category">
+        <categoryDef>WeaponsTurrets</categoryDef>
+        <thingDefCountRange>
+          <min>0</min>
+          <max>0</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Animals">
+        <tradeTagsSell>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsSell>
+        <tradeTagsBuy>
+          <li>CE_AnimalBoom</li>
+        </tradeTagsBuy>
+        <kindCountRange>
+          <min>1</min>
+          <max>1</max>
+        </kindCountRange>
+        <countRange>
+          <min>-1</min>
+          <max>2</max>
+        </countRange>
+      </li>
+		</value>
+	</Operation>
+
+</Patch>
+

--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
@@ -62,7 +62,7 @@
 								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
 								<armorPenetrationSharp>5</armorPenetrationSharp>
 								<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
-								<speed>23</speed>
+								<speed>26</speed>
 								<!-- 25 arrows per resource -->
 								<preExplosionSpawnThingDef>Ammo_ForsakensArrows</preExplosionSpawnThingDef>
 							</projectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>14</speed>
+			<speed>15</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -93,8 +93,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
-			<damageAmountBase>7</damageAmountBase>
+			<speed>19</speed>
+			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
@@ -110,8 +110,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
-			<damageAmountBase>6</damageAmountBase>
+			<speed>23</speed>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
@@ -127,13 +127,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
+			<speed>19</speed>
 			<damageDef>Arrow</damageDef>
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>
 				<li>
 				<def>ArrowVenom</def>
-				<amount>3</amount>
+				<amount>2</amount>
 				</li>
 			</secondaryDamage>			
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>

--- a/Patches/Kit's Roman Weapons/Roman_Weapons.xml
+++ b/Patches/Kit's Roman Weapons/Roman_Weapons.xml
@@ -368,7 +368,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<speed>7</speed>
+			<speed>9</speed>
 			<armorPenetrationBlunt>2.36</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.65</preExplosionSpawnChance>	<!-- 4 javelins per resource -->

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -222,7 +222,7 @@
 			<value>
 				<li Class="CombatExtended.CompProperties_Fragments">
 				  <fragments>
-					<Fragment_Small>30</Fragment_Small>
+					<Fragment_Small>27</Fragment_Small>
 				  </fragments>
 				</li>
 			</value>
@@ -410,8 +410,8 @@
 	  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>JI_Dunder</defName>
 		<statBases>
-				<Mass>5.0</Mass>
-				<MarketValue>5.25</MarketValue>
+				<Mass>2.5</Mass>
+				<MarketValue>8.25</MarketValue>
 				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				<SightsEfficiency>1</SightsEfficiency>
 		</statBases>
@@ -467,7 +467,7 @@
 			<label>throw mini grenades</label>
 			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<range>10.0</range>
+			<range>11.0</range>
 		  <minRange>4</minRange>
 			<warmupTime>0.8</warmupTime>
 			<noiseRadius>4</noiseRadius>

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -72,7 +72,7 @@
 				  <damageAmountBase>1</damageAmountBase>
 				  <explosionDelay>50</explosionDelay>
 				  <dropsCasings>false</dropsCasings>
-				  <speed>5</speed>
+				  <speed>6</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
@@ -104,7 +104,7 @@
 				  <damageAmountBase>10</damageAmountBase>
 				  <explosionDelay>80</explosionDelay>
 				  <dropsCasings>true</dropsCasings>
-				  <speed>5</speed>
+				  <speed>7</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
@@ -120,7 +120,7 @@
 				  <damageAmountBase>10</damageAmountBase>
 				  <explosionDelay>80</explosionDelay>
 				  <dropsCasings>false</dropsCasings>
-				  <speed>5</speed>
+				  <speed>6</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
@@ -150,8 +150,8 @@
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Arrow</damageDef>
-				<speed>100</speed>			
-				<damageAmountBase>7</damageAmountBase>
+				<speed>36</speed>			
+				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationBlunt>2.34</armorPenetrationBlunt>
 				<armorPenetrationSharp>2.5</armorPenetrationSharp>
 				<preExplosionSpawnChance>0.5</preExplosionSpawnChance>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
@@ -34,8 +34,8 @@
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>Bomb</damageDef>
-              <explosionDelay>40</explosionDelay>
-              <explosionRadius>3.5</explosionRadius>
+              <explosionDelay>60</explosionDelay>
+              <explosionRadius>2.5</explosionRadius>
               <damageAmountBase>50</damageAmountBase>
               <armorPenetrationSharp>0</armorPenetrationSharp>
               <armorPenetrationBlunt>0</armorPenetrationBlunt>
@@ -89,7 +89,7 @@
           <value>
             <li Class="CombatExtended.CompProperties_ExplosiveCE">
               <explosiveDamageType>Bomb</explosiveDamageType>
-              <explosiveRadius>3.5</explosiveRadius>
+              <explosiveRadius>2.5</explosiveRadius>
               <explosionSound>MortarBomb_Explode</explosionSound>
               <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
             </li>
@@ -111,7 +111,7 @@
             <MarketValue>5.05</MarketValue>
             <Mass>0.4</Mass>
             <Bulk>0.87</Bulk>
-            <SightsEfficiency>1</SightsEfficiency>
+            <SightsEfficiency>0.65</SightsEfficiency>
             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
           </statBases>
 

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -26,7 +26,7 @@
 
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <speed>35</speed>
+              <speed>12</speed>
               <flyOverhead>false</flyOverhead>
               <damageDef>Cut</damageDef>
               <damageAmountBase>16</damageAmountBase>
@@ -112,7 +112,7 @@
 
           <statBases>
             <Mass>1.2</Mass>
-            <Bulk>3.7</Bulk>
+            <Bulk>3.3</Bulk>
             <SightsEfficiency>0.45</SightsEfficiency>
             <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
           </statBases>
@@ -122,7 +122,7 @@
             <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>VFES_Tomahawk_Thrown</defaultProjectile>
-            <warmupTime>1.1</warmupTime>
+            <warmupTime>1.0</warmupTime>
             <range>10</range>
             <soundCast>Interact_BeatFire</soundCast>
           </Properties>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -114,7 +114,9 @@
             <Mass>1.2</Mass>
             <Bulk>3.3</Bulk>
             <SightsEfficiency>0.45</SightsEfficiency>
-            <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+            <ShotSpread>1.5</ShotSpread>
+			      <SwayFactor>2.5</SwayFactor>
+            <RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
           </statBases>
 
           <Properties>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -99,11 +99,11 @@
               <capacities>
                 <li>Cut</li>
               </capacities>
-              <power>24</power>
-              <cooldownTime>3.49</cooldownTime>
+              <power>23</power>
+              <cooldownTime>2.3</cooldownTime>
               <chanceFactor>0.30</chanceFactor>
-              <armorPenetrationBlunt>3</armorPenetrationBlunt>
-              <armorPenetrationSharp>0.6</armorPenetrationSharp>
+              <armorPenetrationBlunt>4</armorPenetrationBlunt>
+              <armorPenetrationSharp>0.78</armorPenetrationSharp>
               <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
             </li>
           </tools>
@@ -217,12 +217,12 @@
 				<xpath>Defs/ThingDef[defName="VFE_ThrowingAxe"]/statBases</xpath>
 				<value>
 					<statBases>
-						<SightsEfficiency>0.8</SightsEfficiency>
-						<ShotSpread>0.6</ShotSpread>
-						<SwayFactor>2</SwayFactor>
+						<SightsEfficiency>0.5</SightsEfficiency>
+            					<ShotSpread>1.5</ShotSpread>
+			      			<SwayFactor>2.5</SwayFactor>
 						<Bulk>1.25</Bulk>
 						<Mass>0.75</Mass>
-						<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
 					</statBases>
 					<stackLimit>25</stackLimit>				
 				</value>
@@ -236,8 +236,8 @@
 						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Vikings_ThrowingAxe_Thrown</defaultProjectile>
-						<warmupTime>1.5</warmupTime>
-						<range>16</range>
+						<warmupTime>1.0</warmupTime>
+						<range>10</range>
 						<soundCast>Interact_BeatFire</soundCast>
 					</li>
 				</verbs>
@@ -264,10 +264,10 @@
 									<li>Cut</li>
 								</capacities>
 								<power>18</power>
-								<cooldownTime>2.62</cooldownTime>
+								<cooldownTime>2.18</cooldownTime>
 								<chanceFactor>1.5</chanceFactor>
 								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-								<armorPenetrationSharp>1.25</armorPenetrationSharp>
+								<armorPenetrationSharp>0.62</armorPenetrationSharp>
 								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 							</li>
 						</tools>
@@ -328,7 +328,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Vikings_Harpoon_Thrown</defaultProjectile>
 						<warmupTime>0.8</warmupTime>
-						<range>16</range>
+						<range>12</range>
 						<soundCast>Interact_BeatFire</soundCast>
 					</li>
 				</verbs>
@@ -382,9 +382,9 @@
             <damageDef>Cut</damageDef>			
             <damageAmountBase>16</damageAmountBase>
             <speed>12</speed>
-            <armorPenetrationSharp>1.4</armorPenetrationSharp>
-            <armorPenetrationBlunt>27</armorPenetrationBlunt>
-            <preExplosionSpawnChance>0.50</preExplosionSpawnChance>
+            <armorPenetrationSharp>1.5</armorPenetrationSharp>
+            <armorPenetrationBlunt>3</armorPenetrationBlunt>
+            <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
             <preExplosionSpawnThingDef>VFE_ThrowingAxe</preExplosionSpawnThingDef>				
           </projectile>
         </ThingDef>
@@ -393,7 +393,7 @@
           <defName>Vikings_Harpoon_Thrown</defName>
           <label>thrown harpoon</label>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>12</damageAmountBase>
+            <damageAmountBase>13</damageAmountBase>
             <speed>8</speed>
             <armorPenetrationBlunt>4.54</armorPenetrationBlunt>
             <armorPenetrationSharp>1.8</armorPenetrationSharp>

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
@@ -39,13 +39,13 @@
 					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<onlyManualCast>True</onlyManualCast>
-					<warmupTime>1.5</warmupTime>
+					<warmupTime>0.8</warmupTime>
 					<range>10</range>
-					<minRange>5</minRange>
+					<minRange>3</minRange>
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowGrenade</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>14</muzzleFlashScale>
+					<muzzleFlashScale>0</muzzleFlashScale>
 					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
@@ -34,13 +34,13 @@
 					<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<onlyManualCast>True</onlyManualCast>
-					<warmupTime>1.5</warmupTime>
+					<warmupTime>0.8</warmupTime>
 					<range>10</range>
-					<minRange>5</minRange>
+					<minRange>3</minRange>
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowGrenade</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>14</muzzleFlashScale>
+					<muzzleFlashScale>0</muzzleFlashScale>
 					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
@@ -85,7 +85,7 @@
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowMolotovCocktail</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>14</muzzleFlashScale>
+					<muzzleFlashScale>10</muzzleFlashScale>
 					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>
@@ -130,7 +130,7 @@
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<soundCast>ThrowGrenade</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>14</muzzleFlashScale>
+					<muzzleFlashScale>0</muzzleFlashScale>
 					<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
 					<targetParams>
 						<canTargetLocations>true</canTargetLocations>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -312,7 +312,7 @@
           <statBases>
             <SightsEfficiency>0.5</SightsEfficiency>
             <ShotSpread>1.5</ShotSpread>
-			      <SwayFactor>2.5</SwayFactor>
+	    <SwayFactor>2</SwayFactor>
             <Bulk>0.35</Bulk>
             <Mass>0.15</Mass>
             <RangedWeapon_Cooldown>0.48</RangedWeapon_Cooldown>
@@ -322,7 +322,7 @@
             <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>VWE_FlyingBlade</defaultProjectile>
-            <warmupTime>0.7</warmupTime>
+            <warmupTime>0.66</warmupTime>
             <range>10</range>
             <soundCast>ThrowGrenade</soundCast>
              <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -242,10 +242,11 @@
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>RangedStab</damageDef>
-              <damageAmountBase>14</damageAmountBase>
+              <damageAmountBase>11</damageAmountBase>
               <flyOverhead>false</flyOverhead>
-              <speed>16</speed>
-              <armorPenetrationBase>0.18</armorPenetrationBase>
+              <speed>12</speed>
+               <armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+               <armorPenetrationSharp>0.4</armorPenetrationSharp>
               <preExplosionSpawnChance>0.80</preExplosionSpawnChance>
               <preExplosionSpawnThingDef>VWE_Throwing_Knives</preExplosionSpawnThingDef>
             </projectile>
@@ -309,17 +310,19 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Throwing_Knives</defName>
           <statBases>
-            <SightsEfficiency>1</SightsEfficiency>
+            <SightsEfficiency>0.5</SightsEfficiency>
+            <ShotSpread>1.5</ShotSpread>
+			      <SwayFactor>2.5</SwayFactor>
             <Bulk>0.35</Bulk>
             <Mass>0.15</Mass>
-            <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+            <RangedWeapon_Cooldown>0.48</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
             <label>Throw knife</label>
             <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>VWE_FlyingBlade</defaultProjectile>
-            <warmupTime>1</warmupTime>
+            <warmupTime>0.7</warmupTime>
             <range>10</range>
             <soundCast>ThrowGrenade</soundCast>
              <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>


### PR DESCRIPTION
So I've being patching a few medieval mods and I find weapons like the greatbow functionally useless due to its extremely slow projectile speed, it is actually impossible to hit anything with it.
I've tweaked the speed and damage of various pre-industrial projectiles, as well as adding them to neolithic traders.

Also standardised a few throwing weapons.
## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
