### PR TITLE
Added new Greydale armor items, and rebalanced the entire set

### DIFF
--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -8,6 +8,542 @@
 		<match Class="PatchOperationSequence">
 		 <operations>
 
+			<!-- ========== BEGIN: Greydale Armors ========== -->
+
+			<!-- ========== Security Armor =========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/costList/Steel</xpath>
+				<value>
+					<Steel>130</Steel>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>80</Plasteel>
+					<DevilstrandCloth>35</DevilstrandCloth>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>36000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>20</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases</xpath>
+				<value>
+					<Bulk>60</Bulk>
+					<WornBulk>8</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>4</CarryBulk>
+					<CarryWeight>25</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<!-- ========== Security Helmet =========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>15000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>29</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>9</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_SecurityHelmet"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- ========== Pioneer Armor =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>12000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>40</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>8</CarryBulk>
+					<CarryWeight>40</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<!-- ========== Pioneer Helmet =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>21000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>23</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3.5</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- ========== Nomad Armor =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>12000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>35</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/statBases</xpath>
+				<value>
+					<Bulk>90</Bulk>
+					<WornBulk>13</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>10</CarryBulk>
+					<CarryWeight>80</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadArmor"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<!-- ========== Nomad Helmet =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_NomadH"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_NomadH"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>			
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>21000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>29</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>9</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3.5</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_NomadH"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- ========== Medic Armor =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>12000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/statBases/Mass</xpath>
+				<value>
+					<Mass>40</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/statBases</xpath>
+				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>8</CarryBulk>
+					<CarryWeight>40</CarryWeight>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicArmor"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+
+			<!-- ========== Medic Helmet =========== -->
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/recipeMaker/researchPrerequisite</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/thingDef[defName="Apparel_MedicH"]/recipeMaker</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationReplace">
+					<xpath>Defs/thingDef[defName="Apparel_MedicH"]/recipeMaker/researchPrerequisite</xpath>
+					<value>
+						<researchPrerequisite>ReconArmor</researchPrerequisite>
+					</value>
+				</match>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/statBases/WorkToMake</xpath>
+				<value>
+					<WorkToMake>21000</WorkToMake>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>23</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3.5</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="Apparel_MedicH"]/apparel/layers</xpath>
+				<value>
+					<li>OnHead</li>
+					<li>StrappedHead</li>
+					<li>MiddleHead</li>
+				</value>
+			</li>
+
+			<!-- ========== END: Greydale Armors ========== -->
+			
 			<!-- ==========  Carbon Jumpsuit =========== -->
 
 			<li Class="PatchOperationAdd">
@@ -40,119 +576,7 @@
 					<li>Feet</li>
 				</value>
 			</li>
-
-			<!-- ========== Pioneer Armor =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases</xpath>
-				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>15</WornBulk>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/Mass</xpath>
-				<value>
-					<Mass>45</Mass>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>27</ArmorRating_Blunt>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Plasteel</xpath>
-				<value>
-					<Plasteel>80</Plasteel>
-					<DevilstrandCloth>35</DevilstrandCloth>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Steel</xpath>
-				<value>
-					<Steel>130</Steel>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/equippedStatOffsets</xpath>
-				<value>
-					<CarryWeight>45</CarryWeight>
-					<CarryBulk>15</CarryBulk>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/apparel/bodyPartGroups</xpath>
-				<value>
-					<li>Hands</li>
-					<li>Feet</li>
-				</value>
-			</li>
-
-
-			<!-- ========== Pioneer Helmet =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel> 
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>12</ArmorRating_Sharp>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>27</ArmorRating_Blunt>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
-				<value>
-					<SmokeSensitivity>-1</SmokeSensitivity>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/costList/Plasteel</xpath>
-				<value>
-					<Plasteel>25</Plasteel>
-					<DevilstrandCloth>10</DevilstrandCloth>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/apparel/layers</xpath>
-				<value>
-					<li>OnHead</li>
-					<li>StrappedHead</li>
-					<li>MiddleHead</li>
-				</value>
-			</li>
-			
+		
 			<!-- ========== Drop Suit =========== -->
 
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
## Additions
Added the new Greydale armor sets from Rimsenal (core):
- Security (Armor + Helmet)
- Nomad (Armor + Helmet)
- Medic (Armor + Helmet)

## Changes
Updated the stats for the Pioneer Armor + Helmet of the Greydale set.

## Reasoning
13/08/2021 update of Rimsenal (Core) introduced three new armor sets for the Greydale collection. These new items broke compatibility with CE. This patch addresses the compatibility problem, plus also incorporates the entire Greydale collection into CE and applies a level of rebalancing to the stats that I hope reflect the _spirit_ of the Greydale armor collection.

## Testing
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (30m)
