### PR TITLE
Patch Kobolds of the Rim, Various Fixes

### DIFF
--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -34,7 +34,7 @@
 
 	  <!-- Melee -->	
 		<li>Your chance to hit, parry, dodge or land a critical hit in melee is a comparison between your and the enemy skill. The higher the difference in skill levels, the bigger the disparity.</li>
-		<li>Your choice of weapon significantly affects your change to hit, parry, dodge or land a critical hit.</li>
+		<li>Your choice of weapon significantly affects your chance to hit, parry, dodge or land a critical hit.</li>
 		<li>Melee weapons can score critical hits. Blunt weapons will inflict a short stun, sharp weapons double their armor penetration, and animals knock down their target.</li>
 		<li>Heavy, blunt melee weapons may defeat thick armor when edged weapons fail.</li>
 		<li>Scoring a critical hit on a parry gives you a free riposte attack.</li>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -112,6 +112,7 @@
       <li>Leathery</li>
     </stuffCategories>
     <apparel>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <careIfDamaged>false</careIfDamaged>
       <careIfWornByCorpse>false</careIfWornByCorpse>
       <bodyPartGroups>
@@ -193,6 +194,7 @@
       </recipeUsers>
     </recipeMaker>
     <apparel>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <careIfDamaged>false</careIfDamaged>
       <careIfWornByCorpse>false</careIfWornByCorpse>
       <bodyPartGroups>

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -87,6 +87,7 @@
             <SmokeSensitivity>-1</SmokeSensitivity>
         </equippedStatOffsets>
         <apparel>
+            <countsAsClothingForNudity>false</countsAsClothingForNudity>
             <bodyPartGroups>
                 <li>Eyes</li>
                 <li>Teeth</li>
@@ -153,6 +154,7 @@
             <SmokeSensitivity>-0.6</SmokeSensitivity>
         </equippedStatOffsets>
         <apparel>
+            <countsAsClothingForNudity>false</countsAsClothingForNudity>
             <bodyPartGroups>
                 <li>Eyes</li>
                 <li>Teeth</li>
@@ -211,6 +213,7 @@
             <NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel>
         </statBases>
         <apparel>
+            <countsAsClothingForNudity>false</countsAsClothingForNudity>
             <bodyPartGroups>
                 <li>Eyes</li>
             </bodyPartGroups>
@@ -269,6 +272,7 @@
             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
         </statBases>
         <apparel>
+            <countsAsClothingForNudity>false</countsAsClothingForNudity>
             <bodyPartGroups>
                 <li>Eyes</li>
             </bodyPartGroups>

--- a/Patches/Kobolds of the Rim/Apparel_Kobold.xml
+++ b/Patches/Kobolds of the Rim/Apparel_Kobold.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kobolds of the Rim</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+		<!-- Simple Shirt -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kobold_SimpleShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!-- Tribal Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Kobold_TribalArmor"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName= "Kobold_TribalArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				<ArmorRating_Sharp>0.30</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<!-- Scout Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Kobold_ScoutArmor"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName= "Kobold_ScoutArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+				<ArmorRating_Blunt>1.3</ArmorRating_Blunt>
+				<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<!-- Tribal Hat -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kobold_TribalHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!-- Paint & Earrings -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kobold_ScoutPaint" or defName="Kobold_WarlordPaint" or defName="Kobold_GeneralEarring"]/statBases</xpath>
+			<value>
+				<Bulk>3</Bulk>
+				<WornBulk>0.05</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="Kobold_ScoutPaint" or defName="Kobold_WarlordPaint" or defName="Kobold_GeneralEarring"]/statBases/StuffEffectMultiplierArmor</xpath>
+		</li>
+
+		<!-- Shoulder Fur -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kobold_ShoulderFur"]/statBases</xpath>
+			<value>
+				<Bulk>3</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kobold_ShoulderFur"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!-- General & Warlord Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Kobold_GeneralArmor" or defName ="Kobold_WarlordArmor"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName= "Kobold_GeneralArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+				<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName= "Kobold_WarlordArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+				<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+			</value>
+		</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Kobolds of the Rim/Melee_Kobold.xml
+++ b/Patches/Kobolds of the Rim/Melee_Kobold.xml
@@ -1,0 +1,303 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Kobolds of the Rim</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+    <!-- Bone -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="Kobold_Bone"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>4</power>
+            <cooldownTime>1.78</cooldownTime>
+            <armorPenetrationBlunt>1</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>head</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>10</power>
+            <cooldownTime>3.01</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>3.75</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Bone"]/statBases</xpath>
+      <value>
+            <Bulk>3.75</Bulk>
+            <MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Bone"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.58</MeleeCritChance>
+          <MeleeParryChance>0.14</MeleeParryChance>
+          <MeleeDodgeChance>0.16</MeleeDodgeChance>	
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Bone"]/weaponTags</xpath>
+      <value>
+        <li>CE_OneHandedWeapon</li>
+      </value>
+    </li>
+
+    <!-- Bone Dagger -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneDagger"]/tools</xpath>
+      <value>
+          <tools>
+              <li Class="CombatExtended.ToolCE">
+                  <label>handle</label>
+                  <capacities>
+                      <li>Blunt</li>
+                  </capacities>
+                  <power>4</power>
+                  <cooldownTime>1.2</cooldownTime>
+                  <armorPenetration>0.071</armorPenetration>
+                  <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                  <label>point</label>
+                  <capacities>
+                      <li>Kobold_StabToxic</li>
+                  </capacities>
+                  <power>9.5</power>
+                  <cooldownTime>1.2</cooldownTime>
+                  <chanceFactor>1.33</chanceFactor>
+                  <armorPenetration>0.208</armorPenetration>
+                  <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+              </li>
+          </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneDagger"]/statBases</xpath>
+      <value>
+            <Bulk>0.15</Bulk>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneDagger"]</xpath>
+      <value>
+          <equippedStatOffsets>
+              <MeleeCritChance>0.1</MeleeCritChance>
+              <MeleeParryChance>0.1</MeleeParryChance>
+              <MeleeDodgeChance>0.05</MeleeDodgeChance>
+          </equippedStatOffsets>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneDagger"]/weaponTags</xpath>
+      <value>
+              <li>CE_OneHandedWeapon</li>
+      </value>
+    </li>
+
+    <!-- Ceremonial Dagger -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="Kobold_Dagger"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>1</power>
+            <cooldownTime>1.26</cooldownTime>
+            <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>blade</label>
+            <capacities>
+              <li>Kobold_CutToxic</li>
+            </capacities>
+            <power>10</power>
+            <cooldownTime>1.18</cooldownTime>
+            <armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.32</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>point</label>
+            <capacities>
+              <li>Kobold_StabToxic</li>
+            </capacities>
+            <power>11</power>
+            <cooldownTime>1.26</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.42</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Dagger"]/statBases</xpath>
+      <value>
+            <Bulk>1</Bulk>
+        <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Dagger"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.5</MeleeCritChance>
+          <MeleeParryChance>0.15</MeleeParryChance>
+          <MeleeDodgeChance>0.05</MeleeDodgeChance>	
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+    <!-- Bone Sword -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneSword"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>handle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>2</power>
+            <cooldownTime>1.44</cooldownTime>
+            <armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>point</label>
+            <capacities>
+              <li>Stab</li>
+            </capacities>
+            <power>27</power>
+            <cooldownTime>1.44</cooldownTime>
+            <armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.48</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>edge</label>
+            <capacities>
+              <li>Cut</li>
+            </capacities>
+            <power>20</power>
+            <cooldownTime>1.34</cooldownTime>
+            <chanceFactor>1.33</chanceFactor>
+            <armorPenetrationBlunt>0.956</armorPenetrationBlunt>
+            <armorPenetrationSharp>0.43</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneSword"]/statBases</xpath>
+      <value>
+        <Bulk>3.5</Bulk>
+        <MeleeCounterParryBonus>0.35</MeleeCounterParryBonus>				
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_BoneSword"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.2</MeleeCritChance>
+          <MeleeParryChance>0.35</MeleeParryChance>
+          <MeleeDodgeChance>0.2</MeleeDodgeChance>	
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+    <!-- Bone Spear -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName="Kobold_Spear"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>shaft</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>7</power>
+            <cooldownTime>1.35</cooldownTime>
+            <chanceFactor>0.15</chanceFactor>
+            <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>head</label>
+            <capacities>
+              <li>Kobold_StabToxic</li>
+            </capacities>
+            <power>18</power>
+            <cooldownTime>1.19</cooldownTime>
+            <chanceFactor>1.00</chanceFactor>
+            <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+            <armorPenetrationSharp>1.5</armorPenetrationSharp>
+            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Spear"]/statBases</xpath>
+      <value>
+          <Bulk>10</Bulk>
+          <MeleeCounterParryBonus>1.68</MeleeCounterParryBonus>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Kobold_Spear"]</xpath>
+      <value>
+        <equippedStatOffsets>
+          <MeleeCritChance>0.17</MeleeCritChance>
+          <MeleeParryChance>1.45</MeleeParryChance>
+          <MeleeDodgeChance>0.9</MeleeDodgeChance>
+        </equippedStatOffsets>
+      </value>
+    </li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Kobolds of the Rim/Patch_Body_Kobold.xml
+++ b/Patches/Kobolds of the Rim/Patch_Body_Kobold.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Kobolds of the Rim</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Add armor coverage (for pawns with non-zero armor that use human body) ========== -->
+
+      <!-- Kobold -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="KoboldLeftHorn"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="KoboldRightHorn"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Kobold"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Kobolds of the Rim/PawnKinds_Kobold.xml
+++ b/Patches/Kobolds of the Rim/PawnKinds_Kobold.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Kobolds of the Rim</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to pawns with bows ========== -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>
+          /Defs/PawnKindDef[defName="LTS_KoboldSkirmisher" or defName="LTS_KoboldWarlord"]
+        </xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>12</min>
+              <max>20</max>
+            </primaryMagazineCount>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Kobolds of the Rim/Race_Kobold.xml
+++ b/Patches/Kobolds of the Rim/Race_Kobold.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kobolds of the Rim</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationSequence">
+				<success>Always</success>
+				<operations>
+					<li Class="PatchOperationTest">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/comps</xpath>
+						<success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]</xpath>
+						<value>
+							<comps />
+						</value>
+					</li>
+				</operations>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/alienRace/generalSettings</xpath>
+				<value>
+					<forcedRaceTraitEntries>
+						<li>
+							<defName>Xenophobia</defName>
+							<degree>1</degree>
+							<chance>20</chance>
+						</li>
+					</forcedRaceTraitEntries>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/race/baseBodySize</xpath>
+				<value>
+					<baseBodySize>0.6</baseBodySize>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/statBases</xpath>
+				<value>
+					<NightVisionEfficiency>0.4</NightVisionEfficiency>
+					<CarryWeight>40</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<MeleeDodgeChance>1.1</MeleeDodgeChance>
+					<MeleeCritChance>0.4</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>teeth</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.01</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.57</cooldownTime>
+							<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right fist</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.57</cooldownTime>
+							<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.85</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.46</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Kobold"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+				
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
+++ b/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
@@ -47,7 +47,7 @@
 		<!-- Pelt Cap / Pelt Mantle -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Gunmar_Apparel_PeltMantle" or defName="Gunmar_Apparel_SunshadePeltMantle"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="Gunmar_Apparel_PeltMantle" or defName="Gunmar_Apparel_SunshadePeltMantle" or defName = "Gunmar_Apparel_WovenMantle"]/statBases</xpath>
 			<value>
 				<Bulk>3</Bulk>
 				<WornBulk>1</WornBulk>
@@ -64,7 +64,7 @@
 		<!-- Sunshade Pelt Cap -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName= "Gunmar_Apparel_PeltCap" or defName = "Gunmar_Apparel_SunshadePeltCap"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName= "Gunmar_Apparel_PeltCap" or defName = "Gunmar_Apparel_SunshadePeltCap" or defName = "Gunmar_Apparel_WovenCap"]/statBases</xpath>
 			<value>
 				<Bulk>1</Bulk>
 				<WornBulk>1</WornBulk>
@@ -72,7 +72,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName= "Gunmar_Apparel_PeltCap" or defName= "Gunmar_Apparel_SunshadePeltCap"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<xpath>Defs/ThingDef[defName= "Gunmar_Apparel_PeltCap" or defName= "Gunmar_Apparel_SunshadePeltCap" or defName = "Gunmar_Apparel_WovenCap"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
 			</value>
@@ -93,6 +93,69 @@
 			<value>
 				<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
 			</value>
+		</li>
+
+		<!-- Wraps -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "Gunmar_Apparel_WovenHandWraps" or defName = "Gunmar_Apparel_WovenLeggings" or defName = "Gunmar_Apparel_WovenFootWraps"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName= "Gunmar_Apparel_WovenHandWraps" or defName = "Gunmar_Apparel_WovenLeggings" or defName = "Gunmar_Apparel_WovenFootWraps"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!-- War Bow -->
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Gunmar_War_Bow</defName>
+			<statBases>
+				<SightsEfficiency>0.6</SightsEfficiency>
+				<ShotSpread>1</ShotSpread>
+				<SwayFactor>2</SwayFactor>
+				<Bulk>5.00</Bulk>
+				<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
+				<warmupTime>1.3</warmupTime>
+				<range>33</range>
+				<soundCast>Bow_Large</soundCast>
+			</Properties>
+			<AmmoUser>
+				<ammoSet>AmmoSet_GreatArrow</ammoSet>
+			</AmmoUser>
+			<FireModes />
+			<weaponTags>
+				<li>CE_Bow</li>
+			</weaponTags>
+			<researchPrerequisite>Greatbow</researchPrerequisite>
+			<AllowWithRunAndGun>false</AllowWithRunAndGun>
+		</li>
+
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gunmar_War_Bow"]/tools</xpath>
+			<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1.6</cooldownTime>
+					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
 		</li>
 
 		</operations>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -154,6 +154,7 @@ Kit's Gunpowder Weapons |
 Kit's Industrial Weapons |   
 Kit's Roman Weapons |
 Kit's VFE Weapons |
+Kobolds of the Rim  |
 Kurin, The Three Tailed Fox	|
 Leeani Playable Race	|
 Let's Have a Cat!	|


### PR DESCRIPTION
Patches Kobolds of the Rim (which I meant to make its own branch, but I'm an idiot...). Mod adds a kobold race, some pawnkinds, some apparel, and a few weapons. Most all based on existing stats.

A few fixes and adjustments.
- Update the patch for Tribal Warrior Set! mod.
- Packs, , gas masks, and NVGs no longer count as clothing for nudists.
- Fix typo