### PR TITLE
Update Traits_Patch_CE.xml

### DIFF
--- a/Patches/FalloutTraits/Traits_Patch_CE.xml
+++ b/Patches/FalloutTraits/Traits_Patch_CE.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Fallout Traits (Continued)</li>
+			<li>Fallout Traits</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
## Changes

Added a Line for original Fallout Traits mod

## Reasoning

The original [Fallout Traits](https://steamcommunity.com/sharedfiles/filedetails/?id=1209071221) mod got updated to 1.3 and Mile will not update his mod.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
