### PR TITLE
Kits Gunpowder Weapons Security Update

### DIFF
--- a/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
+++ b/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
@@ -258,8 +258,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>60.8</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>18.181</armorPenetrationBlunt>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>110</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
+++ b/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
@@ -13,23 +13,31 @@
 		<li Class="PatchOperationAdd">
 			<xpath>Defs</xpath>
 			<value>
-
+	
+	<!-- ==================== ThingCategories ========================== -->
+	
 	<ThingCategoryDef>
 		<defName>MortarGrenade</defName>
 		<label>Mortar Grenade</label>
 		<parent>AmmoGrenades</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberGrenade</iconPath>
 	</ThingCategoryDef>
-
+	
+	<ThingCategoryDef>
+		<defName>CannonBall</defName>
+		<label>Cannon Ball</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
+	</ThingCategoryDef>
+	
+	<ThingCategoryDef>
+		<defName>LargeCannonBall</defName>
+		<label>Large Cannon Ball</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberMortar</iconPath>
+	</ThingCategoryDef>
+	
 	<!-- ==================== AmmoSet ========================== -->
-
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_BlunderShot</defName>
-		<label>Blunder Shot</label>
-		<ammoTypes>
-			<Ammo_MusketBall>Bullet_BlunderShot_Ball</Ammo_MusketBall>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_MortarGrenade</defName>
@@ -38,9 +46,35 @@
 			<Ammo_MortarGrenade>Bullet_MortarGrenade</Ammo_MortarGrenade>      
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_BlunderShot</defName>
+		<label>Blunder Shot</label>
+		<ammoTypes>
+			<Ammo_MusketBall>Bullet_BlunderShot_Ball</Ammo_MusketBall>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_CannonBall</defName>
+		<label>Cannon Ball</label>
+		<ammoTypes>
+			<Ammo_CannonBall_Steel>Bullet_CannonBall_Steel</Ammo_CannonBall_Steel>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_LargeCannonBall</defName>
+		<label>Large Cannon Ball</label>
+		<ammoTypes>
+			<Shell_LargeCannonBall_Steel>Bullet_LargeCannonBall_Steel</Shell_LargeCannonBall_Steel>
+		</ammoTypes>
+		<isMortarAmmoSet>true</isMortarAmmoSet>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 	
+	<!-- ==== Mortar Grenade ==== -->
 	<ThingDef Class="CombatExtended.AmmoDef" Name="HandMortarBombBase" ParentName="AmmoBase" Abstract="True">
 		<description>Low velocity grenade fired from a hand mortar.</description>
 		<statBases>
@@ -73,8 +107,92 @@
 		<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
 	</ThingDef>
 
+	<!-- ==== Cannon Ball ==== -->
+	<ThingDef Class="CombatExtended.AmmoDef" Name="90mmCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>A head-sized ball of metal.</description>
+		<thingCategories>
+			<li>CannonBall</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FueledSmithy</li>
+			<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+		</tradeTags>
+		<statBases>
+			<MaxHitPoints>450</MaxHitPoints>
+			<Mass>12</Mass>
+			<Bulk>10</Bulk>
+		</statBases>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="90mmCannonShellBase">
+		<defName>Ammo_CannonBall_Steel</defName>
+		<label>Cannon Ball</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>.35</MarketValue>
+		</statBases>
+		<ammoClass>CannonBall</ammoClass>
+		<detonateProjectile>Bullet_CannonBall_Steel</detonateProjectile>
+	</ThingDef>
+	
+	<!-- ==== Large Steel Cannon Ball	==== -->
+	<ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<description>A large ball with the sole purpose of hitting the ground so hard that it causes shrapnel.</description>
+		<statBases>
+			<MaxHitPoints>550</MaxHitPoints>
+		</statBases>
+		<thingCategories>
+			<li>LargeCannonBall</li>
+		</thingCategories>
+		<stackLimit>25</stackLimit>
+		<isMortarAmmo>true</isMortarAmmo>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBaseCraftableBase" ParentName="81mmMortarShellBase" Abstract="True">
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FueledSmithy</li>
+			<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+		</tradeTags>
+	</ThingDef>
+	
+	<!-- Need to override mortar shell because of hardcoded vanilla references -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+		<defName>Shell_LargeCannonBall_Steel</defName>
+		<label>Large Cannon Ball</label>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>.5</MarketValue>
+			<Mass>16</Mass>
+			<Bulk>12</Bulk>
+		</statBases>
+		<ammoClass>CannonBall</ammoClass>
+		<detonateProjectile>Bullet_LargeCannonBall_Steel</detonateProjectile>
+		<comps>
+			<!-- Vanilla values -->
+			<li Class="CompProperties_Explosive">
+			<explosiveRadius>4</explosiveRadius>
+			<explosiveDamageType>Bomb</explosiveDamageType>
+			<!--<explosiveExpandPerStackcount>0.4</explosiveExpandPerStackcount>-->
+			<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<explodeOnKilled>True</explodeOnKilled>
+			<wickTicks>30~60</wickTicks>
+		  </li>
+		</comps>
+	</ThingDef>
+	
 	<!-- ================== Projectiles ================== -->
 
+	<!-- ==== Blunder Shot ==== -->
 	<ThingDef ParentName="Base12GaugeBullet">
 		<defName>Bullet_BlunderShot_Ball</defName>
 		<label>lead ball</label>
@@ -91,7 +209,8 @@
 			<speed>64</speed>
 		</projectile>
 	</ThingDef>
-
+	
+	<!-- ==== Mortar Grenade ==== -->
 	<ThingDef ParentName="Base40x46mmGrenadeBullet">
 		<defName>Bullet_MortarGrenade</defName>
 		<label>Mortar Grenade</label>
@@ -114,42 +233,187 @@
 			</li>
 		</comps>
 	</ThingDef>
+	
+	<!-- ==== Cannon Ball ==== -->
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Base90mmCannonShell" ParentName="BaseBullet" Abstract="true">
+		<graphicData>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>280</speed>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base90mmCannonShell">
+		<defName>Bullet_CannonBall_Steel</defName>
+		<label>Cannon Ball</label>
+		<thingClass>CombatExtended.BulletCE</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/Cannon/HEAT</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>60.8</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.181</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>12</damageAmountBase>
+				<explosiveDamageType>Bomb</explosiveDamageType>
+				<explosiveRadius>1.5</explosiveRadius>
+				<explosionSound>MortarBomb_Explode</explosionSound>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>2</Fragment_Large>
+					<Fragment_Small>12</Fragment_Small>
+				</fragments>
+		  </li>
+		</comps>
+	</ThingDef>
+	
+	<!-- ==== Large Steel Cannon Ball ==== -->
+	<ThingDef Name="Base81mmMortarShell" ParentName="BaseBullet" Abstract="true">
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>0</speed>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
+			<gravityFactor>5</gravityFactor>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base81mmMortarShell">
+		<defName>Bullet_LargeCannonBall_Steel</defName>
+		<label>Large Cannon Ball</label>
+		<graphicData>
+		  <texPath>Things/Projectile/Mortar/Illumination</texPath>
+		  <graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageDef>Bomb</damageDef>
+		  <damageAmountBase>56</damageAmountBase>
+		  <armorPenetrationSharp>0</armorPenetrationSharp>
+		  <armorPenetrationBlunt>128</armorPenetrationBlunt>
+		  <explosionRadius>2.5</explosionRadius>
+		  <flyOverhead>true</flyOverhead>
+		  <soundExplode>MortarBomb_Explode</soundExplode>
+		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		  <ai_IsIncendiary>false</ai_IsIncendiary>
+		</projectile>
+		<comps>
+		  <li Class="CombatExtended.CompProperties_Fragments">
+			<fragments>
+				<Fragment_Large>4</Fragment_Large>
+				<Fragment_Small>15</Fragment_Small>
+			</fragments>
+		  </li>
+		</comps>
+	</ThingDef>
+	
 	<!-- ==================== Recipes ========================== -->
-  
+	
+	<!-- ==== Mortar Grenade ==== -->
 	<RecipeDef ParentName="AmmoRecipeBase">
-	<defName>MakeAmmo_MortarGrenade</defName>
-	<label>Make Mortar Grenade x5</label>
-	<description>Craft 5 Mortar Grenades</description>
-	<jobString>Making Mortar Grenades</jobString>
-	<ingredients>
-		<li>
-		<filter>
+		<defName>MakeAmmo_MortarGrenade</defName>
+		<label>Make Mortar Grenade x5</label>
+		<description>Craft 5 Mortar Grenades</description>
+		<jobString>Making Mortar Grenades</jobString>
+		<ingredients>
+			<li>
+			<filter>
+				<thingDefs>
+				<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>15</count>
+			</li>
+			<li>
+			<filter>
+				<thingDefs>
+				<li>FSX</li>
+				</thingDefs>
+			</filter>
+			<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
 			<thingDefs>
 			<li>Steel</li>
-			</thingDefs>
-		</filter>
-		<count>15</count>
-		</li>
-		<li>
-		<filter>
-			<thingDefs>
 			<li>FSX</li>
 			</thingDefs>
-		</filter>
-		<count>10</count>
-		</li>
-	</ingredients>
-	<fixedIngredientFilter>
-		<thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		</thingDefs>
-	</fixedIngredientFilter>
-	<products>
-		<Ammo_MortarGrenade>5</Ammo_MortarGrenade>
-	</products>
-	<workAmount>8500</workAmount>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MortarGrenade>5</Ammo_MortarGrenade>
+		</products>
+		<workAmount>8500</workAmount>
+	</RecipeDef>
+	
+	<!-- ==== Cannon Ball ==== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_CannonBall_Steel</defName>
+		<label>Make Steel Cannon Balls x5</label>
+		<description>Craft 5 Steel Cannon Balls</description>
+		<jobString>Making Steel Cannon Balls</jobString>
+		<workAmount>24000</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_CannonBall_Steel>5</Ammo_CannonBall_Steel>
+		</products>
+	</RecipeDef>
+	
+	<!-- ==== Large Steel Cannon Ball ==== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeShell_LargeCannonBall_Steel</defName>
+		<label>Make Steel Large Cannon Balls x5</label>
+		<description>Craft 5 Steel Large Cannon Balls</description>
+		<jobString>Making Steel Large Cannon Balls</jobString>
+		<ingredients>
+			<li>
+			<filter>
+				<thingDefs>
+					<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>100</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Shell_LargeCannonBall_Steel>5</Shell_LargeCannonBall_Steel>
+		</products>
+		<workAmount>28000</workAmount>
 	</RecipeDef>
 	
 			</value>

--- a/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Security.xml
+++ b/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Security.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kit's Gunpowder Weapons</li>
+		</mods>
+	</Operation>
+
+		<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[			
+			defName = "KIT_Turret_Organ" or
+			defName = "KIT_Turret_12Pounder"or
+			defName = "KIT_Turret_Bombard"			
+		]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		</Operation>
+
+		<Operation Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[
+			defName = "KIT_Turret_Organ" or
+			defName = "KIT_Turret_12Pounder" or
+			defName = "KIT_Turret_Bombard"				 			
+		]/thingClass</xpath>
+        <value>
+          <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+        </value>
+		</Operation>
+
+        <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[	
+			defName = "KIT_Turret_Organ" or
+			defName = "KIT_Turret_12Pounder"or
+			defName = "KIT_Turret_Bombard"
+		]/fillPercent</xpath>
+        <value>
+          <fillPercent>0.85</fillPercent>
+        </value>
+      </Operation>
+	  
+	  <Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[			
+			defName = "KIT_Turret_Bombard"			
+		]/placeWorkers/li["PlaceWorker_ShowTurretRadius"]</xpath>
+		</Operation>
+
+		<!-- ========== 12 Pounder ========== -->
+		<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>KIT_Gun_12Pounder</defName>
+		  <statBases>
+		    <SightsEfficiency>1.50</SightsEfficiency>
+		    <ShotSpread>0.4</ShotSpread>
+		    <SwayFactor>1</SwayFactor>
+		    <Bulk>18</Bulk>
+		    <RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+		  </statBases>
+		  <Properties>
+		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		    <hasStandardCommand>true</hasStandardCommand>
+		    <defaultProjectile>Bullet_CannonBall_Steel</defaultProjectile>
+		    <warmupTime>1.4</warmupTime>
+		    <range>108</range>
+		    <soundCast>KIT_Shot_12Pounder</soundCast>
+		    <soundCastTail>GunTail_Medium</soundCastTail>
+		    <recoilPattern>Mounted</recoilPattern>
+		  </Properties>
+		  <AmmoUser>
+		    <magazineSize>1</magazineSize>
+		    <reloadTime>9.6</reloadTime>
+		    <ammoSet>AmmoSet_CannonBall</ammoSet>
+		  </AmmoUser>
+		  <FireModes>
+		    <aiAimMode>AimedShot</aiAimMode>
+		    <noSnapshot>true</noSnapshot>
+		    <noSingleShot>false</noSingleShot>
+		  </FireModes>
+		</Operation>
+
+		<Operation Class="PatchOperationAdd">
+		  <xpath>/Defs/ThingDef[defName = "KIT_Gun_12Pounder"]/weaponTags</xpath>
+		  <value>
+		    <li>TurretGun</li>
+		  </value>
+		</Operation>
+
+		<!-- Organ Gun -->
+		<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>KIT_Gun_Organ</defName>
+		  <statBases>
+		    <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+		    <SightsEfficiency>1</SightsEfficiency>
+		    <ShotSpread>0.04</ShotSpread>
+		    <SwayFactor>1.59</SwayFactor>
+		    <Bulk>15.54</Bulk>
+		  </statBases>
+		  <Properties>
+		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		    <hasStandardCommand>True</hasStandardCommand>
+		    <defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
+		    <warmupTime>3.2</warmupTime>
+		    <range>54</range>
+		    <burstShotCount>5</burstShotCount>
+		    <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+		    <soundCast>KIT_Shot_Organ</soundCast>
+		    <soundCastTail>GunTail_Medium</soundCastTail>
+		    <muzzleFlashScale>9</muzzleFlashScale>
+		    <recoilPattern>Mounted</recoilPattern>
+		    <targetParams>
+		    <canTargetLocations>True</canTargetLocations>
+		    </targetParams>
+		  </Properties>
+		  <AmmoUser>
+		    <magazineSize>100</magazineSize>
+		    <reloadTime>5.5</reloadTime>
+		    <ammoSet>AmmoSet_FastMusketBall</ammoSet>
+		  </AmmoUser>
+		  <FireModes>
+		    <aimedBurstShotCount>5</aimedBurstShotCount>
+		    <aiAimMode>SuppressFire</aiAimMode>
+		  </FireModes>
+		  <weaponTags Inherit="false">
+		    <li>TurretGun</li>
+		  </weaponTags>
+		</Operation>
+
+		<!-- ========== Bombard - Weapon ========== -->			
+
+		<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>KIT_Gun_Bombard</defName>
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+				<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_LargeCannonBall_Steel</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<minRange>15</minRange>
+				<range>156</range>
+				<burstShotCount>1</burstShotCount>
+				<soundCast>KIT_Shot_Bombard</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>
+				<muzzleFlashScale>8</muzzleFlashScale>
+				<circularError>1.2</circularError>
+				<requireLineOfSight>false</requireLineOfSight>
+				<indirectFirePenalty>0.3</indirectFirePenalty>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>1</magazineSize>
+				<reloadTime>7.5</reloadTime>
+				<ammoSet>AmmoSet_LargeCannonBall</ammoSet>
+			</AmmoUser>
+		</Operation>
+
+		<Operation Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "KIT_Gun_Bombard"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_Charges">
+					<chargeSpeeds>
+						<li>30</li>
+						<li>50</li>
+						<li>70</li>
+						<li>90</li>
+					</chargeSpeeds>
+				</li>
+			</value>
+		</Operation>
+			
+		<Operation Class="PatchOperationAdd">
+		  <xpath>/Defs/ThingDef[defName = "KIT_Gun_Bombard"]/weaponTags</xpath>
+		  <value>
+		    <li>TurretGun</li>
+		  </value>
+		</Operation>
+
+</Patch>    


### PR DESCRIPTION
## Additions
- Added compatibility for Bombard, 12-Pounder, and Organ
 
## Changes
- Buffed Cannon Ball blunt penetration from 18 to 110 (Why was this set to 18 in the first place, did I do that?)

## Reasoning
- Because Security/Turrets were patched in the initial merge and were removed in 1.3, I guess. 
- I just happened to see that the CannonBall somehow had a ridiculous 18 blunt penetration.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (20-30 minutes)
