### PR TITLE
Update and Fixes for Various Mods

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -22,6 +22,9 @@
 		<li>XeoNovaDan.ProperShotguns</li>
 		<li>swedishmask.ProperShotgunsPatch</li>		
 	</incompatibleWith>
+	<loadBefore>
+		<li>Atlas.AndroidTiers</li>
+	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>
 		<li>TheInfinityIQ.Halo.UNSC</li>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -135,8 +135,8 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>8</damageAmountBase>
       <pelletCount>9</pelletCount>
-      <armorPenetrationSharp>3.5</armorPenetrationSharp>
-      <armorPenetrationBlunt>5.52</armorPenetrationBlunt>
+      <armorPenetrationSharp>4</armorPenetrationSharp>
+      <armorPenetrationBlunt>4.52</armorPenetrationBlunt>
       <spreadMult>17.8</spreadMult>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -135,8 +135,8 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>8</damageAmountBase>
       <pelletCount>9</pelletCount>
-      <armorPenetrationSharp>4</armorPenetrationSharp>
-      <armorPenetrationBlunt>4.52</armorPenetrationBlunt>
+      <armorPenetrationSharp>3.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>5.52</armorPenetrationBlunt>
       <spreadMult>17.8</spreadMult>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -64,7 +64,7 @@
       <damageAmountBase>6</damageAmountBase> 
       <pelletCount>5</pelletCount>
       <armorPenetrationSharp>2</armorPenetrationSharp>
-      <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
+      <armorPenetrationBlunt>4.420</armorPenetrationBlunt>
       <spreadMult>27.8</spreadMult>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -47,7 +47,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="Base410BoreBullet" ParentName="BaseBullet" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>70</speed>
+      <speed>45</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
     </projectile>
@@ -61,11 +61,11 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>9</damageAmountBase> 
+      <damageAmountBase>6</damageAmountBase> 
       <pelletCount>5</pelletCount>
-      <armorPenetrationSharp>3</armorPenetrationSharp>
+      <armorPenetrationSharp>2</armorPenetrationSharp>
       <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
-      <spreadMult>17.8</spreadMult>
+      <spreadMult>27.8</spreadMult>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -47,7 +47,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="Base410BoreBullet" ParentName="BaseBullet" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>45</speed>
+      <speed>70</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
     </projectile>
@@ -61,11 +61,11 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>6</damageAmountBase> 
+      <damageAmountBase>9</damageAmountBase> 
       <pelletCount>5</pelletCount>
-      <armorPenetrationSharp>2</armorPenetrationSharp>
-      <armorPenetrationBlunt>4.420</armorPenetrationBlunt>
-      <spreadMult>27.8</spreadMult>
+      <armorPenetrationSharp>3</armorPenetrationSharp>
+      <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
+      <spreadMult>17.8</spreadMult>
     </projectile>
   </ThingDef>
 

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -151,7 +151,7 @@
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicSting</damageDef>
 							<damageAmountBase>7</damageAmountBase>
-							<speed>34</speed>
+							<speed>31</speed>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
 						</projectile>
@@ -163,8 +163,8 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicSting</damageDef>
-							<damageAmountBase>11</damageAmountBase>
-							<speed>28</speed>
+							<damageAmountBase>12</damageAmountBase>
+							<speed>27</speed>
 							<armorPenetrationSharp>7.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
 						</projectile>
@@ -202,8 +202,8 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicSting</damageDef>
-							<damageAmountBase>19</damageAmountBase>
-							<speed>20</speed>
+							<damageAmountBase>18</damageAmountBase>
+							<speed>19</speed>
 							<armorPenetrationSharp>2.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</projectile>
@@ -244,8 +244,8 @@
 						<comps>
 							<li Class="CombatExtended.CompProperties_Fragments">
 								<fragments>
-									<Fragment_Small>14</Fragment_Small>
-									<Fragment_Large>4</Fragment_Large>
+									<Fragment_Small>16</Fragment_Small>
+									<Fragment_Large>3</Fragment_Large>
 								</fragments>
 							</li>
 						</comps>
@@ -379,7 +379,7 @@
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_AcidSpit</damageDef>
 							<damageAmountBase>5</damageAmountBase>
-							<speed>40</speed>
+							<speed>36</speed>
 							<armorPenetrationSharp>7</armorPenetrationSharp>
 						</projectile>
 					</value>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -76,7 +76,7 @@
 				defName="AA_Thunderbeast"
 				]/statBases</xpath>
 					<value>
-						<AimingAccuracy>0.8</AimingAccuracy>
+						<AimingAccuracy>0.7</AimingAccuracy>
 					</value>
 				</li>
 				<!-- Different accuracy for spammy stuff -->

--- a/Patches/Android Tiers/Bodies/Android_Bodyparts_Bleed.xml
+++ b/Patches/Android Tiers/Bodies/Android_Bodyparts_Bleed.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+					<li>[1.0] Android tiers</li>
+					<li>Android tiers</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+  <li Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="MHeart"]/bleedRate</xpath>
+    <value>
+	<bleedRate>10</bleedRate>
+    </value>
+      </li>
+
+  <li Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="MLeftLung" or defName="MRightLung" or defName="MGenerator"]/bleedRate</xpath>
+    <value>
+	<bleedRate>5</bleedRate>
+    </value>
+      </li>
+
+  <li Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="MLeftKidney" or defName="MRightKidney" or defName="MLiver" or defName="MStomach" or defName="MRightServo"]/bleedRate</xpath>
+    <value>
+	<bleedRate>2.5</bleedRate>
+    </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_M7Mech.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_M7Mech.xml
@@ -13,6 +13,55 @@
 				<match Class="PatchOperationSequence">
 					<operations>
 					<!--Android4Tier-->
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "AndroidM7Mech"]/corePart/parts/li[def = "LeftMechanicalShoulder"]/parts/li[def = "LeftMechanicalArm"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalUpperActuator</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalUpperPiston</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "AndroidM7Mech"]/corePart/parts/li[def = "RightMechanicalShoulder"]/parts/li[def = "RightMechanicalArm"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalUpperActuator</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalUpperPiston</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "AndroidM7Mech"]/corePart/parts/li[def="RightMechanicalLeg" or def="LeftMechanicalLeg"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalLowerActuator</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalLowerPiston</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
 					<li Class="PatchOperationAdd">
 						<xpath>/Defs/BodyDef[defName="AndroidM7Mech"]/corePart/groups</xpath>
 						<value>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_T4Android.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_T4Android.xml
@@ -12,6 +12,56 @@
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>
+
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Android4Tier"]/corePart/parts/li[def = "LeftMechanicalShoulder"]/parts/li[def = "LeftMechanicalArm"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalUpperActuator</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalUpperPiston</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Android4Tier"]/corePart/parts/li[def = "RightMechanicalShoulder"]/parts/li[def = "RightMechanicalArm"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalUpperActuator</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalUpperPiston</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
+  <li Class="PatchOperationAdd">
+    <xpath>/Defs/BodyDef[defName = "Android4Tier"]/corePart/parts/li[def="RightMechanicalLeg" or def="LeftMechanicalLeg"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalLowerActuator</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalLowerPiston</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </li>
+
 					<!--Android4Tier-->
 					<li Class="PatchOperationAdd">
 						<xpath>/Defs/BodyDef[defName="Android4Tier"]/corePart/groups</xpath>
@@ -285,7 +335,7 @@
   <li Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="LeftMechanicalLeg" or defName="RightMechanicalLeg"]/hitPoints</xpath>
     <value>
-      <hitPoints>36</hitPoints>
+      <hitPoints>40</hitPoints>
     </value>
       </li>
 

--- a/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -57,7 +57,7 @@
 						</primaryMagazineCount>
 						<sidearms>
 							<li>
-								<generateChance>0.5</generateChance>
+								<generateChance>0.25</generateChance>
 								<sidearmMoney>
 									<min>20</min>
 									<max>120</max>

--- a/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -5,7 +5,7 @@
 		<operations>
 			<li Class="PatchOperationFindMod">
 			<mods><li>[1.0] Android tiers</li>
-		<li>Android tiers</li></mods>
+			      <li>Android tiers</li></mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 
@@ -66,6 +66,34 @@
 									<li>CE_Sidearm_Melee</li>
 								</weaponTags>
 							</li>
+	          						<li>
+              								<generateChance>0.075</generateChance>
+              								<sidearmMoney>
+                									<min>10</min>
+                									<max>100</max>
+              								</sidearmMoney>
+              								<weaponTags>
+                									<li>CE_FlareLauncher</li>
+              								</weaponTags>
+              								<magazineCount>
+                								<min>1</min>
+                								<max>1</max>
+              								</magazineCount>
+          							</li>
+							        <li>
+           								 <generateChance>0.125</generateChance>
+            								<sidearmMoney>
+             									 <min>10</min>
+              									<max>100</max>
+            								</sidearmMoney>
+           								 <weaponTags>
+      										<li>GrenadeDestructive</li>
+            								</weaponTags>
+            								<magazineCount>
+              								<min>0</min>
+              								<max>1</max>
+           								 </magazineCount>
+          							</li>
 						</sidearms>
 					</li>
 				</value>

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -111,11 +111,11 @@
 				  </value>
 				</li>
 				  
-				<!--<li Class="PatchOperationAttributeSet">
+				<li Class="PatchOperationAttributeSet">
 					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android1Tier" or defName="Android2Tier"]</xpath>
 					<attribute>ParentName</attribute>
 					<value>BasePawnSimple</value>
-				</li>-->
+				</li>
 				
 				<li Class="PatchOperationAddModExtension">
 				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android1Tier" or 

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -318,7 +318,7 @@
 				<li Class="PatchOperationAdd">
 				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android3Tier"]/statBases</xpath>
 				  <value>
-					<NightVisionEfficiency>0.2</NightVisionEfficiency>
+					<NightVisionEfficiency>0.25</NightVisionEfficiency>
 				    	<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1.1</MeleeCritChance>
 					<MeleeParryChance>1.1</MeleeParryChance>
@@ -387,10 +387,11 @@
 				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android4Tier"]/statBases</xpath>
 				  <value>
 					<NightVisionEfficiency>0.4</NightVisionEfficiency>
+					<AimingAccuracy>1.1</AimingAccuracy>
 				    	<MeleeDodgeChance>1.2</MeleeDodgeChance>
 					<MeleeCritChance>1.2</MeleeCritChance>
 					<MeleeParryChance>1.2</MeleeParryChance>
-					<Suppressability>0.3</Suppressability>
+					<Suppressability>0.33</Suppressability>
 					<SmokeSensitivity>0</SmokeSensitivity>
 				  </value>
 				</li>

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -111,11 +111,11 @@
 				  </value>
 				</li>
 				  
-				<li Class="PatchOperationAttributeSet">
+				<!--<li Class="PatchOperationAttributeSet">
 					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android1Tier" or defName="Android2Tier"]</xpath>
 					<attribute>ParentName</attribute>
 					<value>BasePawnSimple</value>
-				</li>
+				</li>-->
 				
 				<li Class="PatchOperationAddModExtension">
 				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Android1Tier" or 

--- a/Patches/Bastyon/Bast_Resources.xml
+++ b/Patches/Bastyon/Bast_Resources.xml
@@ -132,7 +132,6 @@
 					</value>
 				</li>
 
-
 				<!--Leather_Soul_Eater -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Leather_Soul_Eater"]/statBases/StuffPower_Armor_Sharp</xpath>
@@ -142,6 +141,28 @@
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Leather_Soul_Eater"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<!--Leather_Soul_Eater -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Leather_Vorpal_Bunny"
+							or defName="Leather_Vorpal_Bunny_Enraged"
+							or defName="Leather_Vorpal_Bunny_Iridescent"
+							or defName="Leather_Vorpal_Bunny_Pragmatic"
+							or defName="Leather_Vorpal_Bunny_Befouled"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Leather_Vorpal_Bunny"
+							or defName="Leather_Vorpal_Bunny_Enraged"
+							or defName="Leather_Vorpal_Bunny_Iridescent"
+							or defName="Leather_Vorpal_Bunny_Pragmatic"
+							or defName="Leather_Vorpal_Bunny_Befouled"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
 					</value>

--- a/Patches/Bastyon/Basty_Bodies.xml
+++ b/Patches/Bastyon/Basty_Bodies.xml
@@ -194,6 +194,28 @@
         </value>
       </li>
 
+      <li Class="PatchOperationAdd">
+        <xpath>
+          /Defs/BodyDef[defName="Bast_SvarogBody"]//*[
+          def="Bast_SavrogMainBody" or 
+          def="Bast_SmolderingFist"]/groups
+        </xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>
+          /Defs/BodyDef[defName="Bast_LightningElementalBody"]//*[
+          def="Bast_LightningElementalMainBody" or 
+          def="Bast_GalvanizedFist"]/groups
+        </xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
       </operations>
     </match>
   </Operation>

--- a/Patches/Bastyon/BetaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Bastyon/BetaAnimals_CE_Patch_Projectiles.xml
@@ -13,6 +13,8 @@
 				defName="Bast_Web" or
 				defName="Bast_AlluviumGoo" or
 				defName="Bast_CritterSpike" or
+				defName="Bast_BlisteringWind" or
+				defName="Bast_LightningBolt" or
 				defName="Bast_SnippingSnailAcid"]</xpath>
 					<value>
 						<thingClass>CombatExtended.BulletCE</thingClass>
@@ -22,7 +24,7 @@
 				<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Bast_Scire" or
-				defName="Bast_Alluvium"  or defName="Bast_Snipping_Snail"]/statBases</xpath>
+				defName="Bast_Alluvium"  or defName="Bast_Snipping_Snail" or defName="Bast_Soul_Eater" or defName="Bast_LightningBolt"]/statBases</xpath>
 					<value>
 						<AimingAccuracy>0.7</AimingAccuracy>
 					</value>
@@ -36,13 +38,28 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Bast_Bastyon" or defName="Bast_Blazing_Felidae"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="Bast_Bastyon" or defName="Bast_Blazing_Felidae" or defName="Bast_Svarog"]/statBases</xpath>
 					<value>
-						<AimingAccuracy>6.7</AimingAccuracy>
+						<ShootingAccuracyPawn>2</ShootingAccuracyPawn>
+						<AimingAccuracy>1</AimingAccuracy>
 					</value>
 				</li>
 
 				<!-- =============== Now defining Projectiles in CE Procedure ============= -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Bast_LightningBolt"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<flyOverhead>false</flyOverhead>
+						<damageDef>Bast_Electric</damageDef>
+						<damageAmountBase>8</damageAmountBase>
+						<stoppingPower>0.5</stoppingPower>
+						<speed>30</speed>
+						<armorPenetrationSharp>50</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.01</armorPenetrationBlunt>
+						</projectile>
+					</value>
+				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Bast_SnippingSnailAcid"]/projectile</xpath>

--- a/Patches/Bastyon/BetaAnimals_CE_Patch_VerbShootCE.xml
+++ b/Patches/Bastyon/BetaAnimals_CE_Patch_VerbShootCE.xml
@@ -51,7 +51,7 @@
 					</value>
 					</li>
 
-					<!-- Barbslinger -->
+					<!-- Grey spider -->
 
 					<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Bast_Gray_Terror"]/verbs</xpath>
@@ -75,7 +75,7 @@
 						</value>
 					</li>
 
-				<!-- Animalisk -->
+				<!-- Scire -->
 
 					<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Bast_Scire"]/verbs</xpath>
@@ -118,6 +118,74 @@
 								</li>
 							</verbs>
 						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Bast_Soul_Eater"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<defaultProjectile>Bast_BlisteringWind</defaultProjectile>
+							<warmupTime>3</warmupTime>
+							<burstShotCount>4</burstShotCount>
+							<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+							<minRange>1.9</minRange>
+							<range>12</range>
+							<soundCast>Bast_BlisteringWind</soundCast>
+							<muzzleFlashScale>0</muzzleFlashScale>
+							<label>blistering wind</label>
+							<commonality>0.8</commonality>
+							</li>
+						</verbs>
+					</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bast_LightningBolt</defaultProjectile>
+				<warmupTime>3</warmupTime>
+				<burstShotCount>3</burstShotCount>
+				<minRange>1.1</minRange>
+				<range>36</range>
+				<soundCast>Thunder_OnMap</soundCast>
+				<muzzleFlashScale>0</muzzleFlashScale>
+				<label>lightning bolt</label>
+				<commonality>.5</commonality>
+							</li>
+						</verbs>
+					</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Bast_Svarog"]/verbs</xpath>
+					<value>
+        				<verbs>
+						<li>
+							<verbClass>Verb_Shoot</verbClass>
+							<accuracyTouch>1</accuracyTouch>
+							<accuracyShort>1</accuracyShort>
+							<accuracyMedium>.85</accuracyMedium>
+							<accuracyLong>.75</accuracyLong>
+							<hasStandardCommand>true</hasStandardCommand>
+							<defaultProjectile>Bast_SvarogFireStream</defaultProjectile>
+							<warmupTime>3.5</warmupTime>
+							<burstShotCount>2</burstShotCount>
+							<minRange>3</minRange>
+							<range>12</range>
+							<soundCast>Bast_FireStream</soundCast>
+							<muzzleFlashScale>0</muzzleFlashScale>
+							<label>searing fire</label>
+							<commonality>1</commonality>
+						</li>
+					</verbs>
+					</value>
 					</li>
 
 				</operations>

--- a/Patches/Bastyon/CE_Patch_BastRace_All.xml
+++ b/Patches/Bastyon/CE_Patch_BastRace_All.xml
@@ -184,6 +184,13 @@
 				</value>
 			</li> 
 
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Bahlrin"]/race/baseBodySize</xpath>
+				<value>
+					<baseBodySize>1.1</baseBodySize>
+				</value>
+			</li> 
+
         			<!-- === Bastyon === -->
 
 			<li Class="PatchOperationAddModExtension">

--- a/Patches/Bastyon/CE_Patch_BastRace_All3.xml
+++ b/Patches/Bastyon/CE_Patch_BastRace_All3.xml
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Bastyon</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+       			<!-- === Cervus === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="Bast_Gleaming_Cervus"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Gleaming_Cervus"]/statBases/MoveSpeed</xpath>
+				<value>
+				<MoveSpeed>6.9</MoveSpeed>
+				<MeleeDodgeChance>0.4</MeleeDodgeChance>
+				<MeleeCritChance>0.17</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Gleaming_Cervus"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left hoof</label>
+					<capacities>
+						<li>Blunt</li><li>Poke</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right hoof</label>
+					<capacities>
+						<li>Blunt</li><li>Poke</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>BiteBlunt</li>
+					</capacities>
+					<power>3</power>
+					<cooldownTime>1.66</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.750</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1.97</cooldownTime>
+					<restrictedGender>Female</restrictedGender>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>daunting antlers</label>
+					<capacities>
+						<li>Poke</li><li>Scratch</li><li>Blunt</li>
+					</capacities>
+					<power>16</power>
+					<cooldownTime>2</cooldownTime>
+					<restrictedGender>Male</restrictedGender>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<armorPenetrationSharp>0.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				</li>
+					</tools>
+				</value>
+			</li> 
+
+        			<!-- === Bunnies === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="Bast_Vorpal_Bunny" 
+							or defName="Bast_Vorpal_Bunny_Befouled" 
+							or defName="Bast_Vorpal_Bunny_Enduring" 
+							or defName="Bast_Vorpal_Bunny_Enraged"
+							or defName="Bast_Vorpal_Bunny_Gilded" 
+							or defName="Bast_Vorpal_Bunny_Iridescent"
+							or defName="Bast_Vorpal_Bunny_Pragmatic"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+        			<!-- === Giving them non stupid stats === -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Vorpal_Bunny" 
+							or defName="Bast_Vorpal_Bunny_Befouled" 
+							or defName="Bast_Vorpal_Bunny_Enduring" 
+							or defName="Bast_Vorpal_Bunny_Enraged"
+							or defName="Bast_Vorpal_Bunny_Gilded" 
+							or defName="Bast_Vorpal_Bunny_Iridescent"
+							or defName="Bast_Vorpal_Bunny_Pragmatic"]/statBases</xpath>
+				<value>
+        					<statBases>
+            					<MoveSpeed>6.00</MoveSpeed>
+            					<ComfyTemperatureMin>0</ComfyTemperatureMin>
+            					<ComfyTemperatureMax>35</ComfyTemperatureMax>
+            					<MarketValue>250</MarketValue>
+            					<MeatAmount>30</MeatAmount>
+					<MeleeDodgeChance>0.33</MeleeDodgeChance>
+					<MeleeCritChance>0.07</MeleeCritChance>
+					<MeleeParryChance>0.00</MeleeParryChance>
+        					</statBases>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Vorpal_Bunny" 
+							or defName="Bast_Vorpal_Bunny_Befouled" 
+							or defName="Bast_Vorpal_Bunny_Enduring" 
+							or defName="Bast_Vorpal_Bunny_Enraged"
+							or defName="Bast_Vorpal_Bunny_Gilded" 
+							or defName="Bast_Vorpal_Bunny_Iridescent"
+							or defName="Bast_Vorpal_Bunny_Pragmatic"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>Head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li> 
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Vorpal_Bunny" 
+							or defName="Bast_Vorpal_Bunny_Befouled" 
+							or defName="Bast_Vorpal_Bunny_Enduring" 
+							or defName="Bast_Vorpal_Bunny_Enraged"
+							or defName="Bast_Vorpal_Bunny_Gilded" 
+							or defName="Bast_Vorpal_Bunny_Iridescent"
+							or defName="Bast_Vorpal_Bunny_Pragmatic"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>0.5</baseHealthScale>
+				</value>
+			</li> 
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/PawnKindDef[defName="Bast_Vorpal_Bunny" 
+							or defName="Bast_Vorpal_Bunny_Befouled" 
+							or defName="Bast_Vorpal_Bunny_Enduring" 
+							or defName="Bast_Vorpal_Bunny_Enraged"
+							or defName="Bast_Vorpal_Bunny_Gilded" 
+							or defName="Bast_Vorpal_Bunny_Iridescent"
+							or defName="Bast_Vorpal_Bunny_Pragmatic"]/combatPower</xpath>
+				<value>
+					<combatPower>20</combatPower>
+				</value>
+			</li> 
+
+
+       			<!-- === Svarog === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="Bast_Svarog"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Svarog"]/statBases/MoveSpeed</xpath>
+				<value>
+				<MoveSpeed>3</MoveSpeed>
+				<MeleeDodgeChance>1</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Svarog"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Svarog"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Svarog"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left smoldering fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.5</cooldownTime>
+					<extraMeleeDamages>
+						<li>
+						<def>Flame</def>
+						<amount>8</amount>
+						<chance>0.75</chance>
+						</li>
+					</extraMeleeDamages>	
+					<linkedBodyPartsGroup>Hands</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right smoldering fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.5</cooldownTime>
+					<extraMeleeDamages>
+						<li>
+						<def>Flame</def>
+						<amount>8</amount>
+						<chance>0.75</chance>
+						</li>
+					</extraMeleeDamages>
+					<linkedBodyPartsGroup>Hands</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
+				</li>
+					</tools>
+				</value>
+			</li> 
+
+       			<!-- === Lightning === -->
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]/statBases/MoveSpeed</xpath>
+				<value>
+				<MoveSpeed>3</MoveSpeed>
+				<MeleeDodgeChance>1</MeleeDodgeChance>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Bast_Lightning_Elemental"]/tools</xpath>
+				<value>
+					<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left galvanized fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.5</cooldownTime>
+					<extraMeleeDamages>
+						<li>
+						<def>Bast_Electric</def>
+						<amount>8</amount>
+						<chance>0.75</chance>
+						</li>
+					</extraMeleeDamages>	
+					<linkedBodyPartsGroup>Hands</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right galvanized fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>14</power>
+					<cooldownTime>1.5</cooldownTime>
+					<extraMeleeDamages>
+						<li>
+						<def>Bast_Electric</def>
+						<amount>8</amount>
+						<chance>0.75</chance>
+						</li>
+					</extraMeleeDamages>
+					<linkedBodyPartsGroup>Hands</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
+				</li>
+					</tools>
+				</value>
+			</li> 
+
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -189,13 +189,6 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/Mass</xpath>
-    <value>
-      <Mass>4.8</Mass>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/MaxHitPoints</xpath>
     <value>
       <MaxHitPoints>240</MaxHitPoints>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -659,7 +659,7 @@
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Bullet_16x65mm_HE</defaultProjectile>
 				<burstShotCount>1</burstShotCount>
-				<warmupTime>1.35</warmupTime>
+				<warmupTime>1.45</warmupTime>
 				<range>78</range>
         				<minRange>1.5</minRange>
 				<soundCast>Shot_Halo_Railgun</soundCast>

--- a/Patches/Rim Contractors Arsenal/PawnKindDefs/PawnKinds_Contractor.xml
+++ b/Patches/Rim Contractors Arsenal/PawnKindDefs/PawnKinds_Contractor.xml
@@ -35,6 +35,22 @@
 									<li>ContractorMisc</li>
 								</weaponTags>
 							</li>
+         							 <li>
+           								 <generateChance>0.2</generateChance>
+            								<sidearmMoney>
+             									 <min>10</min>
+              									<max>100</max>
+            								</sidearmMoney>
+           								 <weaponTags>
+              									<li>GrenadeSmoke</li>
+      									<li>GrenadeDestructive</li>
+      									<li>CE_GrenadeFlashbang</li>
+            								</weaponTags>
+            								<magazineCount>
+              								<min>0</min>
+              								<max>1</max>
+           								 </magazineCount>
+          							</li>
 						</sidearms>
 					</li>
 				</value>
@@ -60,7 +76,7 @@
 							</weaponTags>
 							<magazineCount>
 								<min>2</min>
-								<max>5</max>
+								<max>4</max>
 							</magazineCount>
 						</forcedSidearm>
 					</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
@@ -48,7 +48,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/costList/Plasteel</xpath>
 				<value>
-					<Plasteel>190</Plasteel>
+					<Plasteel>200</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
@@ -18,6 +18,7 @@
 					<ArmorRating_Sharp>19</ArmorRating_Sharp>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
+      					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 				</value>
 			</li>
 			

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/RangedContractors.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/RangedContractors.xml
@@ -144,7 +144,7 @@
 					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 					<soundCast>Shot_LightRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
@@ -185,7 +185,7 @@
 					<range>29</range>
 					<soundCast>Shot_ShotgunPumpContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>8</magazineSize>
@@ -225,7 +225,7 @@
 					<range>16</range>
 					<soundCast>Shot_PistolContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>7</magazineSize>
@@ -309,7 +309,7 @@
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 					<soundCast>Shot_HeavyRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>10</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>20</magazineSize>
@@ -397,7 +397,7 @@
 					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 					<soundCast>Shot_SMGContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>7</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
@@ -483,7 +483,7 @@
 					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 					<soundCast>Shot_LightRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
@@ -527,7 +527,7 @@
 					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 					<soundCast>Shot_LightRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
@@ -571,7 +571,7 @@
 					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 					<soundCast>Shot_HeavyRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
@@ -594,7 +594,7 @@
 					<Mass>13.50</Mass>
 					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 					<SightsEfficiency>3.51</SightsEfficiency>
-					<SwayFactor>2.67</SwayFactor>
+					<SwayFactor>2.36</SwayFactor>
 					<ShotSpread>0.06</ShotSpread>
 					<WorkToMake>59000</WorkToMake>
 				</statBases>
@@ -608,7 +608,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_12x65mmCharged</defaultProjectile>
-					<warmupTime>3.35</warmupTime>
+					<warmupTime>3.2</warmupTime>
 					<range>86</range>
 					<soundCast>Shot_HeavySniperContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
@@ -651,8 +651,8 @@
 					<warmupTime>0.5</warmupTime>
 					<range>25</range>
 					<burstShotCount>3</burstShotCount>
-					<ticksBetweenBurstShots>14</ticksBetweenBurstShots>
-					<soundCast>Shot_LNF35L</soundCast>
+					<ticksBetweenBurstShots>13</ticksBetweenBurstShots>
+					<soundCast>Shot_ShotgunContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<muzzleFlashScale>11</muzzleFlashScale>
 				</Properties>
@@ -699,7 +699,7 @@
 					<ticksBetweenBurstShots>21</ticksBetweenBurstShots>
 					<soundCast>Shot_HeavyRifleContractors</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>11</muzzleFlashScale>
+					<muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<FireModes>
 					<aimedBurstShotCount>2</aimedBurstShotCount>

--- a/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
+++ b/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
@@ -139,7 +139,8 @@
           def="Arm" or
           def="Hand" or
           def="Finger" or
-          def="Toe" or
+          def="Foot" or
+	  def="Toe" or
           def="Leg"]/groups
         </xpath>
         <value>

--- a/Patches/Rimeffect Core/Alliance_Pawns.xml
+++ b/Patches/Rimeffect Core/Alliance_Pawns.xml
@@ -40,6 +40,20 @@
 									<li>CE_Sidearm_Melee</li>
 								</weaponTags>
 							</li>
+          							<li>
+              								<generateChance>0.075</generateChance>
+              								<sidearmMoney>
+                									<min>10</min>
+                									<max>100</max>
+              								</sidearmMoney>
+              								<weaponTags>
+                									<li>CE_FlareLauncher</li>
+              								</weaponTags>
+              								<magazineCount>
+                								<min>1</min>
+                								<max>1</max>
+              								</magazineCount>
+          							</li>
 						</sidearms>
 					</li>
 				</value>
@@ -69,6 +83,21 @@
 									<li>CE_Sidearm_Melee</li>
 								</weaponTags>
 							</li>
+         							 <li>
+           								 <generateChance>0.125</generateChance>
+            								<sidearmMoney>
+             									 <min>10</min>
+              									<max>100</max>
+            								</sidearmMoney>
+           								 <weaponTags>
+              									<li>GrenadeSmoke</li>
+      									<li>GrenadeDestructive</li>
+            								</weaponTags>
+            								<magazineCount>
+              								<min>0</min>
+              								<max>1</max>
+           								 </magazineCount>
+          							</li>
 						</sidearms>
 					</li>
 				</value>

--- a/Patches/Rimeffect Core/Armor_ME.xml
+++ b/Patches/Rimeffect Core/Armor_ME.xml
@@ -50,6 +50,7 @@
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>0.5</WornBulk>
+      						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -182,6 +183,7 @@
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>0.5</WornBulk>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -312,6 +314,7 @@
 						<Bulk>8</Bulk>
 						<WornBulk>2.5</WornBulk>
 						<Mass>6</Mass>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -504,6 +507,13 @@
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="RE_Apparel_SpectreVisor"]/statBases</xpath>
+					<value>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 

--- a/Patches/Rimeffect Core/Armor_ME.xml
+++ b/Patches/Rimeffect Core/Armor_ME.xml
@@ -96,7 +96,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_LightAllianceHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>35</Plasteel>
+						<Plasteel>40</Plasteel>
 						<DevilstrandCloth>10</DevilstrandCloth>
 					</value>
 				</li>
@@ -152,7 +152,7 @@
 					<value>
     					<equippedStatOffsets>
 						<CarryWeight>12</CarryWeight>
-						<CarryBulk>55</CarryBulk>
+						<CarryBulk>35</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
 						<MoveSpeed>0.3</MoveSpeed>
@@ -229,7 +229,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_AllianceHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>45</Plasteel>
+						<Plasteel>50</Plasteel>
 						<DevilstrandCloth>10</DevilstrandCloth>
 					</value>
 				</li>
@@ -284,7 +284,7 @@
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_AllianceArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<CarryWeight>20</CarryWeight>
-						<CarryBulk>60</CarryBulk>
+						<CarryBulk>40</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
 						<ReloadSpeed>0.1</ReloadSpeed>
@@ -364,7 +364,7 @@
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_HeavyAllianceHelmet"]/costList</xpath>
 					<value>
 						<costList>
-							<Plasteel>55</Plasteel>
+							<Plasteel>65</Plasteel>
 							<DevilstrandCloth>15</DevilstrandCloth>
 							<ComponentSpacer>3</ComponentSpacer>
 						</costList>
@@ -422,7 +422,7 @@
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>75</CarryWeight>
-							<CarryBulk>75</CarryBulk>
+							<CarryBulk>60</CarryBulk>
 							<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
 							<PainShockThreshold>0.05</PainShockThreshold>
@@ -491,7 +491,7 @@
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>40</CarryWeight>
-							<CarryBulk>65</CarryBulk>
+							<CarryBulk>50</CarryBulk>
 							<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
 							<PainShockThreshold>0.1</PainShockThreshold>

--- a/Patches/Rimeffect Core/Armor_ME.xml
+++ b/Patches/Rimeffect Core/Armor_ME.xml
@@ -13,7 +13,6 @@
 					<xpath>Defs/ThingDef[defName="RE_Apparel_LightAllianceArmor" or defName="RE_Apparel_AllianceArmor" or defName="RE_Apparel_HeavyAllianceArmor" or defName="RE_Apparel_SpectreArmor"]/apparel/layers</xpath>
 					<value>
 						<li>Webbing</li>
-						<li>Backpack</li>
 					</value>
 				</li>
 

--- a/Patches/Rimeffect Core/ME_Abilities.xml
+++ b/Patches/Rimeffect Core/ME_Abilities.xml
@@ -10,21 +10,21 @@
 
             			<!-- Biotic -->			
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Biotic_Throw" or defName="RE_Biotic_Pull" ]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Biotic_Throw" or defName="RE_Biotic_Pull" ]/range</xpath>
 		<value>
       		<range>34</range>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Biotic_Annihilation" or defName="RE_Biotic_Dominate" or defName="RE_Biotic_Singularity" or defName="RE_Biotic_Flare" ]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Biotic_Annihilation" or defName="RE_Biotic_Dominate" or defName="RE_Biotic_Singularity" or defName="RE_Biotic_Flare" ]/range</xpath>
 		<value>
       		<range>40</range>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Biotic_Charge"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Biotic_Charge"]/range</xpath>
 		<value>
       		<range>46</range>
 		</value>
@@ -47,7 +47,7 @@
 		                <statOffsets>
       				<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
       				<AimingAccuracy>0.4</AimingAccuracy>
-                		</statOffsets>
+                			</statOffsets>
 		</value>
 	</li>
 
@@ -61,21 +61,21 @@
       </li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Tech_CryoBlast" or defName="RE_Tech_Incinerate"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Tech_CryoBlast" or defName="RE_Tech_Incinerate"]/range</xpath>
 		<value>
       		<range>36</range>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Tech_CombatDrone"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Tech_CombatDrone"]/range</xpath>
 		<value>
       		<range>24</range>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="RE_Tech_HexShield" or defName="RE_Tech_Overload" or defName="RE_Tech_Sabotage"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="RE_Tech_HexShield" or defName="RE_Tech_Overload" or defName="RE_Tech_Sabotage"]/range</xpath>
 		<value>
       		<range>26</range>
 		</value>

--- a/Patches/Rimeffect Core/ME_Machine.xml
+++ b/Patches/Rimeffect Core/ME_Machine.xml
@@ -29,7 +29,7 @@
       <RangedWeapon_Cooldown>0.1</RangedWeapon_Cooldown>
     </statBases>
     <techLevel>Ultra</techLevel>
-    <menuHidden>True</menuHidden>
+    <relicChance>0</relicChance>
     <tradeability>None</tradeability>
     <destroyOnDrop>true</destroyOnDrop>    
     <weaponTags>

--- a/Patches/Rimeffect Core/ME_Trader.xml
+++ b/Patches/Rimeffect Core/ME_Trader.xml
@@ -37,6 +37,17 @@
 							<max>4</max>
 						</thingDefCountRange>
 					</li>
+					<li Class="StockGenerator_Tag">
+        						<tradeTag>CE_HeavyAmmo</tradeTag>
+        						<countRange>
+          							<min>10</min>
+          							<max>50</max>
+        						</countRange>
+        						<thingDefCountRange>
+        							 <min>3</min>
+          							<max>6</max>
+        						</thingDefCountRange>
+      					</li>        
 				</value>
 			</li>
 
@@ -69,6 +80,18 @@
 							<max>3</max>
 						</thingDefCountRange>
 					</li>
+					<li Class="StockGenerator_Tag">
+        						<tradeTag>CE_HeavyAmmo</tradeTag>
+        						<countRange>
+          							<min>10</min>
+          							<max>20</max>
+        						</countRange>
+						<price>Cheap</price>
+        						<thingDefCountRange>
+        							<min>0</min>
+          							<max>3</max>
+        						</thingDefCountRange>
+      					</li>        
 				</value>
 			</li>
 
@@ -94,13 +117,24 @@
 						<tradeTag>ME_Ammo</tradeTag>
 						<countRange>
 							<min>120</min>
-							<max>500</max>
+							<max>400</max>
 						</countRange>
 						<thingDefCountRange>
 							<min>1</min>
 							<max>2</max>
 						</thingDefCountRange>
 					</li>
+     					<li Class="StockGenerator_Tag">
+        						<tradeTag>CE_HeavyAmmo</tradeTag>
+        						<countRange>
+          							<min>1</min>
+          							<max>5</max>
+        						</countRange>
+        						<thingDefCountRange>
+        							<min>-1</min>
+          							<max>3</max>
+        						</thingDefCountRange>
+      					</li>         
 				</value>
 			</li>
 

--- a/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
+++ b/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
@@ -104,7 +104,7 @@
 			  <RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
 			  <SightsEfficiency>1</SightsEfficiency>
 			  <ShotSpread>0.08</ShotSpread>
-			  <SwayFactor>1.33</SwayFactor>
+			  <SwayFactor>1.1</SwayFactor>
 			  <Bulk>1.00</Bulk>
 			</statBases>
 			<Properties>
@@ -144,7 +144,7 @@
 			  <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			  <SightsEfficiency>1.1</SightsEfficiency>
 			  <ShotSpread>0.03</ShotSpread>
-			  <SwayFactor>1.56</SwayFactor>
+			  <SwayFactor>1.36</SwayFactor>
 			  <Bulk>1.00</Bulk>
 			</statBases>
 			<Properties>
@@ -202,6 +202,9 @@
     			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[@Name="RE_AmmoBelts"]/recipeMaker</xpath>
 			</li>
+    			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name="RE_AmmoBelts"]/tradeTags</xpath>
+			</li>
 
 			<!-- Implant Hediffs -->
     			<li Class="PatchOperationAdd">
@@ -236,9 +239,12 @@
                			<description>A small capsule with a VI system, increasing the combat abilities of the user. Decreases the aiming time of the user.</description>
  		</value>
  		</li>
-		<li Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="RE_OmniToolHediff"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+
+		<li Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="RE_OmniToolHediff"]</xpath>
 		<value>
+    <comps>
+      <li Class="HediffCompProperties_VerbGiver">
 			<tools>
 				<li Class="CombatExtended.ToolCE">
 					<label>Stab</label>
@@ -263,6 +269,8 @@
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 				</li>
 			</tools>
+      </li>
+    </comps>
 		</value>
 	</li>
 

--- a/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
+++ b/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
@@ -240,11 +240,11 @@
  		</value>
  		</li>
 
-		<li Class="PatchOperationAdd">
+<!--		<li Class="PatchOperationAdd">
 		<xpath>Defs/HediffDef[defName="RE_OmniToolHediff"]</xpath>
 		<value>
-    <comps>
-      <li Class="HediffCompProperties_VerbGiver">
+    		<comps>
+      		<li Class="HediffCompProperties_VerbGiver">
 			<tools>
 				<li Class="CombatExtended.ToolCE">
 					<label>Stab</label>
@@ -269,11 +269,11 @@
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 				</li>
 			</tools>
-      </li>
-    </comps>
+      		</li>
+    		</comps>
 		</value>
 	</li>
-
+-->
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rimeffect Extended Cut/Headgear_ExtendedCut.xml
+++ b/Patches/Rimeffect Extended Cut/Headgear_ExtendedCut.xml
@@ -14,6 +14,7 @@
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>0.5</WornBulk>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -66,6 +67,12 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="RE_Apparel_ArchonVisor"]/statBases</xpath>
+					<value>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
+					</value>
+				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_ArchonVisor"]/equippedStatOffsets</xpath>

--- a/Patches/Rimeffect N7/Abilities_N7.xml
+++ b/Patches/Rimeffect N7/Abilities_N7.xml
@@ -11,14 +11,14 @@
             			<!-- Biotic -->			
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="REN7_DarkChannel"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="REN7_DarkChannel"]/range</xpath>
 		<value>
       		<range>48</range>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>Defs/RimEffect.AbilityDef[defName="REN7_Carnage"]/range</xpath>
+		<xpath>Defs/VFECore.Abilities.AbilityDef[defName="REN7_Carnage"]/range</xpath>
 		<value>
       		<range>60</range>
 		</value>

--- a/Patches/Rimeffect N7/Armor_N7.xml
+++ b/Patches/Rimeffect N7/Armor_N7.xml
@@ -28,14 +28,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>11</ArmorRating_Sharp>
+						<ArmorRating_Sharp>12</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>24</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -57,7 +57,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/equippedStatOffsets</xpath>
 					<value>
-						<AimingDelayFactor>-0.07</AimingDelayFactor>
+						<AimingDelayFactor>-0.075</AimingDelayFactor>
 						<ToxicSensitivity>-0.2</ToxicSensitivity>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
@@ -66,8 +66,8 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>35</Plasteel>
-						<DevilstrandCloth>10</DevilstrandCloth>
+						<Plasteel>45</Plasteel>
+						<DevilstrandCloth>12</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -92,7 +92,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7AdeptSuit"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
 					</value>
 				</li>
 
@@ -121,7 +121,7 @@
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7AdeptSuit"]/equippedStatOffsets</xpath>
 					<value>
 						<CarryWeight>12</CarryWeight>
-						<CarryBulk>55</CarryBulk>
+						<CarryBulk>40</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
 						<MoveSpeed>0.6</MoveSpeed>
@@ -140,7 +140,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7AdeptSuit"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>25</DevilstrandCloth>
+						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -187,7 +187,7 @@
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
-						<AimingDelayFactor>-0.07</AimingDelayFactor>
+						<AimingDelayFactor>-0.075</AimingDelayFactor>
 						<ToxicSensitivity>-0.5</ToxicSensitivity>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
@@ -196,8 +196,8 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>45</Plasteel>
-						<DevilstrandCloth>10</DevilstrandCloth>
+						<Plasteel>55</Plasteel>
+						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -214,7 +214,7 @@
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Armor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>60</Bulk>
-						<WornBulk>7</WornBulk>
+						<WornBulk>8</WornBulk>
 						<Mass>22</Mass>
 					</value>
 				</li>
@@ -251,7 +251,7 @@
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Armor"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<CarryWeight>22</CarryWeight>
-						<CarryBulk>60</CarryBulk>
+						<CarryBulk>45</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
       						<MoveSpeed>0.2</MoveSpeed>
@@ -271,7 +271,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Armor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>35</DevilstrandCloth>
+						<DevilstrandCloth>40</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -334,7 +334,7 @@
 					<value>
 						<costList>
 							<Plasteel>75</Plasteel>
-							<DevilstrandCloth>15</DevilstrandCloth>
+							<DevilstrandCloth>16</DevilstrandCloth>
 	  						<RE_ElementZero>10</RE_ElementZero>
 							<ComponentSpacer>3</ComponentSpacer>
 						</costList>
@@ -392,7 +392,7 @@
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>75</CarryWeight>
-							<CarryBulk>80</CarryBulk>
+							<CarryBulk>60</CarryBulk>
 							<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
 							<ToxicSensitivity>-0.5</ToxicSensitivity>
 							<PainShockThreshold>0.1</PainShockThreshold>
@@ -414,7 +414,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7HeavyArmor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>50</DevilstrandCloth>
+						<DevilstrandCloth>55</DevilstrandCloth>
 						<Hyperweave>10</Hyperweave>
 					</value>
 				</li>

--- a/Patches/Rimeffect N7/Armor_N7.xml
+++ b/Patches/Rimeffect N7/Armor_N7.xml
@@ -22,6 +22,7 @@
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>0.5</WornBulk>
+      						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -151,6 +152,7 @@
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>0.5</WornBulk>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 
@@ -254,7 +256,7 @@
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
       						<MoveSpeed>0.2</MoveSpeed>
-                                                			<Suppressability>-0.1</Suppressability>
+                                                				<Suppressability>-0.1</Suppressability>
       						<ReloadSpeed>0.15</ReloadSpeed>
 					</value>
 				</li>
@@ -281,6 +283,7 @@
 						<Bulk>8</Bulk>
 						<WornBulk>2.5</WornBulk>
 						<Mass>6</Mass>
+      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 

--- a/Patches/Rimeffect N7/Armor_N7.xml
+++ b/Patches/Rimeffect N7/Armor_N7.xml
@@ -12,7 +12,6 @@
 					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7AdeptSuit" or defName="REN7_Apparel_N7Armor" or defName="REN7_Apparel_N7HeavyArmor"]/apparel/layers</xpath>
 					<value>
 						<li>Webbing</li>
-						<li>Backpack</li>
 					</value>
 				</li>
 

--- a/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
+++ b/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
@@ -14,30 +14,63 @@
 		<xpath>Defs</xpath>
 		<value>
 
-  <DamageDef ParentName="Bomb">
+  <DamageDef>
     <defName>ME_Blacked</defName>
     <label>Blackholed</label>
+    <workerClass>DamageWorker_AddInjury</workerClass>
+    <externalViolence>true</externalViolence>
+    <isExplosive>true</isExplosive>
     <deathMessage>{0} is consumed by the void.</deathMessage>
-    <defaultDamage>150</defaultDamage>
+    <hediff>Shredded</hediff>
+    <hediffSolid>Crack</hediffSolid>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+    <impactSoundType>Blunt</impactSoundType>
+    <armorCategory>Sharp</armorCategory>
+    <minDamageToFragment>50</minDamageToFragment>
+    <defaultDamage>200</defaultDamage>
     <defaultStoppingPower>3.0</defaultStoppingPower>
     <defaultArmorPenetration>120000</defaultArmorPenetration>
-    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    <buildingDamageFactor>3</buildingDamageFactor>
-    <plantDamageFactor>3</plantDamageFactor>
-    <explosionCellMote>Mote_BlastDry</explosionCellMote>
+    <buildingDamageFactor>4</buildingDamageFactor>
+    <buildingDamageFactorPassable>2</buildingDamageFactorPassable>
+    <plantDamageFactor>4</plantDamageFactor>
+    <explosionAffectOutsidePartsOnly>false</explosionAffectOutsidePartsOnly>
+    <explosionHeatEnergyPerCell>-5</explosionHeatEnergyPerCell>
+    <explosionCellFleck>BlastDry</explosionCellFleck>
+    <explosionColorCenter>(1, 0.5, 0.3)</explosionColorCenter>
+    <explosionColorEdge>(0.6, 0.5, 0.4)</explosionColorEdge>
+    <soundExplosion>Explosion_Bomb</soundExplosion>
+    <combatLogRules>Damage_Bomb</combatLogRules>
   </DamageDef>
 
-  <DamageDef ParentName="Bomb">
+  <DamageDef>
     <defName>ME_BigKill</defName>
+    <label>Carnage</label>
+    <workerClass>DamageWorker_AddInjury</workerClass>
+    <externalViolence>true</externalViolence>
+    <isExplosive>true</isExplosive>
     <deathMessage>{0} is carnaged.</deathMessage>
+    <hediff>Shredded</hediff>
+    <hediffSolid>Crack</hediffSolid>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+    <impactSoundType>Blunt</impactSoundType>
+    <armorCategory>Sharp</armorCategory>
+    <minDamageToFragment>20</minDamageToFragment>
     <defaultDamage>43</defaultDamage>
     <defaultStoppingPower>1.0</defaultStoppingPower>
     <defaultArmorPenetration>150</defaultArmorPenetration>
-    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    <buildingDamageFactor>3</buildingDamageFactor>
-    <plantDamageFactor>3</plantDamageFactor>
-    <explosionCellMote>Mote_BlastDry</explosionCellMote>
+    <buildingDamageFactor>4</buildingDamageFactor>
+    <buildingDamageFactorPassable>2</buildingDamageFactorPassable>
+    <plantDamageFactor>4</plantDamageFactor>
+    <explosionAffectOutsidePartsOnly>false</explosionAffectOutsidePartsOnly>
+    <explosionHeatEnergyPerCell>5</explosionHeatEnergyPerCell>
+    <explosionCellFleck>BlastDry</explosionCellFleck>
+    <explosionColorCenter>(1, 0.5, 0.3)</explosionColorCenter>
+    <explosionColorEdge>(0.6, 0.5, 0.4)</explosionColorEdge>
+    <soundExplosion>Explosion_Bomb</soundExplosion>
+    <combatLogRules>Damage_Bomb</combatLogRules>
   </DamageDef>
+    	</value>
+  	</li>
 
   	<li Class='PatchOperationReplace'>
     	<xpath>/Defs/ThingDef[defName='REN7_Rocket_BlackHole']/projectile</xpath>

--- a/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
+++ b/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
@@ -25,7 +25,7 @@
     <hediffSolid>Crack</hediffSolid>
     <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
     <impactSoundType>Blunt</impactSoundType>
-    <armorCategory>Sharp</armorCategory>
+    <armorCategory>Blunt</armorCategory>
     <minDamageToFragment>50</minDamageToFragment>
     <defaultDamage>200</defaultDamage>
     <defaultStoppingPower>3.0</defaultStoppingPower>
@@ -53,7 +53,7 @@
     <hediffSolid>Crack</hediffSolid>
     <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
     <impactSoundType>Blunt</impactSoundType>
-    <armorCategory>Sharp</armorCategory>
+    <armorCategory>Blunt</armorCategory>
     <minDamageToFragment>20</minDamageToFragment>
     <defaultDamage>43</defaultDamage>
     <defaultStoppingPower>1.0</defaultStoppingPower>

--- a/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
+++ b/Patches/Rimeffect N7/ME_SpecialsExplosives.xml
@@ -13,68 +13,38 @@
 		<li Class="PatchOperationAdd">
 		<xpath>Defs</xpath>
 		<value>
-  <DamageDef>
+
+  <DamageDef ParentName="Bomb">
     <defName>ME_Blacked</defName>
     <label>Blackholed</label>
-    <workerClass>DamageWorker_AddInjury</workerClass>
-    <externalViolence>true</externalViolence>
-    <isExplosive>true</isExplosive>
     <deathMessage>{0} is consumed by the void.</deathMessage>
-    <hediff>Shredded</hediff>
-    <hediffSolid>Crack</hediffSolid>
-    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    <impactSoundType>Blunt</impactSoundType>
-    <armorCategory>Blunt</armorCategory>
-    <minDamageToFragment>15</minDamageToFragment>
-    <defaultDamage>120</defaultDamage>
-    <defaultStoppingPower>1.0</defaultStoppingPower>
+    <defaultDamage>150</defaultDamage>
+    <defaultStoppingPower>3.0</defaultStoppingPower>
     <defaultArmorPenetration>120000</defaultArmorPenetration>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
     <buildingDamageFactor>3</buildingDamageFactor>
     <plantDamageFactor>3</plantDamageFactor>
-    <explosionAffectOutsidePartsOnly>false</explosionAffectOutsidePartsOnly>
-    <explosionHeatEnergyPerCell>1</explosionHeatEnergyPerCell>
     <explosionCellMote>Mote_BlastDry</explosionCellMote>
-    <explosionColorCenter>(1, 0.5, 0.3)</explosionColorCenter>
-    <explosionColorEdge>(0.6, 0.5, 0.4)</explosionColorEdge>
-    <soundExplosion>Explosion_Bomb</soundExplosion>
-    <combatLogRules>Damage_Bomb</combatLogRules>
   </DamageDef>
 
-  <DamageDef>
+  <DamageDef ParentName="Bomb">
     <defName>ME_BigKill</defName>
-    <label>Blackholed</label>
-    <workerClass>DamageWorker_AddInjury</workerClass>
-    <externalViolence>true</externalViolence>
-    <isExplosive>true</isExplosive>
     <deathMessage>{0} is carnaged.</deathMessage>
-    <hediff>Shredded</hediff>
-    <hediffSolid>Crack</hediffSolid>
-    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    <impactSoundType>Blunt</impactSoundType>
-    <armorCategory>Blunt</armorCategory>
-    <minDamageToFragment>15</minDamageToFragment>
-    <defaultDamage>38</defaultDamage>
+    <defaultDamage>43</defaultDamage>
     <defaultStoppingPower>1.0</defaultStoppingPower>
-    <defaultArmorPenetration>120000</defaultArmorPenetration>
-    <buildingDamageFactor>4</buildingDamageFactor>
-    <plantDamageFactor>4</plantDamageFactor>
-    <explosionAffectOutsidePartsOnly>false</explosionAffectOutsidePartsOnly>
-    <explosionHeatEnergyPerCell>1</explosionHeatEnergyPerCell>
+    <defaultArmorPenetration>150</defaultArmorPenetration>
+    <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+    <buildingDamageFactor>3</buildingDamageFactor>
+    <plantDamageFactor>3</plantDamageFactor>
     <explosionCellMote>Mote_BlastDry</explosionCellMote>
-    <explosionColorCenter>(1, 0.5, 0.3)</explosionColorCenter>
-    <explosionColorEdge>(0.6, 0.5, 0.4)</explosionColorEdge>
-    <soundExplosion>Explosion_Bomb</soundExplosion>
-    <combatLogRules>Damage_Bomb</combatLogRules>
   </DamageDef>
-		</value>
-		</li>
 
   	<li Class='PatchOperationReplace'>
     	<xpath>/Defs/ThingDef[defName='REN7_Rocket_BlackHole']/projectile</xpath>
     	<value>
     	<projectile>
       		<damageDef>ME_Blacked</damageDef>
-      		<explosionRadius>9.9</explosionRadius>
+      		<explosionRadius>9.5</explosionRadius>
       		<flyOverhead>true</flyOverhead>
       		<speed>27</speed>
     	</projectile>
@@ -86,7 +56,7 @@
     	<value>
     	<projectile>
       	<damageDef>ME_BigKill</damageDef>
-      	<speed>70</speed>
+      	<speed>60</speed>
       	<explosionRadius>2</explosionRadius>
     	</projectile>
     	</value>

--- a/Patches/Rimeffect N7/Pawns_N7.xml
+++ b/Patches/Rimeffect N7/Pawns_N7.xml
@@ -28,6 +28,22 @@
 									<li>CE_Sidearm_Melee</li>
 								</weaponTags>
 							</li>
+         							 <li>
+           								 <generateChance>0.2</generateChance>
+            								<sidearmMoney>
+             									 <min>10</min>
+              									<max>100</max>
+            								</sidearmMoney>
+           								 <weaponTags>
+              									<li>GrenadeSmoke</li>
+      									<li>GrenadeDestructive</li>
+      									<li>CE_GrenadeFlashbang</li>
+            								</weaponTags>
+            								<magazineCount>
+              								<min>0</min>
+              								<max>1</max>
+           								 </magazineCount>
+          							</li>
 						</sidearms>
 					</li>
 				</value>

--- a/Patches/The Joris Experience/JorisShootCE.xml
+++ b/Patches/The Joris Experience/JorisShootCE.xml
@@ -23,6 +23,32 @@
 				-->
 
 					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="JE_BiblicallyAccurateJoris"]/verbs</xpath>
+							<value>
+		<verbs>
+			<li>
+				<verbClass>Verb_Shoot</verbClass>
+				<accuracyTouch>1</accuracyTouch>
+				<accuracyShort>1</accuracyShort>
+				<accuracyMedium>1</accuracyMedium>
+				<accuracyLong>1</accuracyLong>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>JE_HolyBolt</defaultProjectile>
+				<warmupTime>7</warmupTime>
+				<burstShotCount>1</burstShotCount>
+				<minRange>2</minRange>
+				<range>36</range>				
+				<muzzleFlashScale>0</muzzleFlashScale>
+				<label>holy fire</label>
+				<commonality>.8</commonality>
+			</li>
+
+
+		</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
 						<xpath>/Defs/ThingDef[defName="JECom_IsaacJoris"]/verbs</xpath>
 							<value>
 								<verbs>
@@ -64,7 +90,7 @@
 							</value>
 					</li>
 
-					<li Class="PatchOperationReplace">
+		<!--			<li Class="PatchOperationReplace">
 						<xpath>/Defs/ThingDef[defName="JE_Joku"]/verbs</xpath>
 							<value>
 								<verbs>
@@ -84,7 +110,7 @@
 								</verbs>
 							</value>
 					</li>
-
+		-->
 
 				</operations>
 			</match>

--- a/Patches/The Joris Experience/JorisShootCE.xml
+++ b/Patches/The Joris Experience/JorisShootCE.xml
@@ -45,6 +45,26 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="JE_NoitaJoris"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+											<hasStandardCommand>true</hasStandardCommand>
+											<defaultProjectile>JE_NoitaFireball</defaultProjectile>
+											<warmupTime>2</warmupTime>
+											<minRange>1.9</minRange>
+											<range>24</range>
+											<label>noita fireball</label>	  				
+											<soundCast>JE_FireSpit</soundCast>
+											<muzzleFlashScale>0</muzzleFlashScale>
+											<commonality>1</commonality>
+									</li>
+								</verbs>
+							</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
 						<xpath>/Defs/ThingDef[defName="JE_Joku"]/verbs</xpath>
 							<value>
 								<verbs>

--- a/Patches/The Joris Experience/Joris_Extended.xml
+++ b/Patches/The Joris Experience/Joris_Extended.xml
@@ -51,7 +51,9 @@
 					or defName="JECom_VoidJoris"
 					or defName="JE_XorismorphQueen"
 					or defName="JE_YugiJohris"
-					or defName="JE_ZombieJoris"]</xpath>
+					or defName="JE_ZombieJoris"
+					or defName="JE_JoskarBontocki"
+					or defName="JE_NoitaJoris"]</xpath>
 			<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -96,7 +98,9 @@
 					or defName="JE_QueenJorisTheSecond"
 					or defName="JE_SpongejorisSquarebonson"
 					or defName="JECom_SuperJoris"
-					or defName="JE_YugiJohris"]/combatPower</xpath>
+					or defName="JE_YugiJohris"
+					or defName="JE_JoskarBontocki"
+					or defName="JE_NoitaJoris"]/combatPower</xpath>
 			<value>
 				<combatPower>150</combatPower>
 			</value>
@@ -163,7 +167,9 @@
 					or defName="JECom_SuperJoris"
 					or defName="JE_FourLeggedUniJoris"
 					or defName="JE_YugiJohris"
-					or defName="JE_ZombieJoris"]/statBases</xpath>
+					or defName="JE_ZombieJoris"
+					or defName="JE_JoskarBontocki"
+					or defName="JE_NoitaJoris"]/statBases</xpath>
 			<value>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
 			<MeleeCritChance>0.38</MeleeCritChance>
@@ -207,7 +213,9 @@
 					or defName="JECom_SuperJoris"
 					or defName="JE_FourLeggedUniJoris"
 					or defName="JE_YugiJohris"
-					or defName="JE_ZombieJoris"]/race/baseBodySize</xpath>
+					or defName="JE_ZombieJoris"
+					or defName="JE_JoskarBontocki"
+					or defName="JE_NoitaJoris"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>1.75</baseBodySize>
 		</value>
@@ -246,7 +254,8 @@
 					or defName="JE_SpongejorisSquarebonson"
 					or defName="JECom_SuperJoris"
 					or defName="JE_FourLeggedUniJoris"
-					or defName="JE_YugiJohris"]/race/baseHealthScale</xpath>
+					or defName="JE_YugiJohris"
+					or defName="JE_JoskarBontocki"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>2</baseHealthScale>
 		</value>
@@ -276,7 +285,8 @@
 					or defName="JECom_PickleJoris"
 					or defName="JE_QueenJorisTheSecond"
 					or defName="JECom_RoundJoris"
-					or defName="JE_SpongejorisSquarebonson"]/tools</xpath>
+					or defName="JE_SpongejorisSquarebonson"
+					or defName="JE_NoitaJoris"]/tools</xpath>
           <value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">

--- a/Patches/The Joris Experience/Projectiles_Joris.xml
+++ b/Patches/The Joris Experience/Projectiles_Joris.xml
@@ -32,9 +32,18 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="JE_BiblicallyAccurateJoris" or defName="JE_Joku"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="JE_Joku"]/statBases</xpath>
 					<value>
-						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>2.5</ShootingAccuracyPawn>
+						<AimingAccuracy>1</AimingAccuracy>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="JE_BiblicallyAccurateJoris"]/statBases</xpath>
+					<value>
+						<ShootingAccuracyPawn>10</ShootingAccuracyPawn>
 						<AimingAccuracy>1</AimingAccuracy>
 					</value>
 				</li>

--- a/Patches/The Joris Experience/Projectiles_Joris.xml
+++ b/Patches/The Joris Experience/Projectiles_Joris.xml
@@ -16,11 +16,26 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="JE_NoitaFireball"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+					</value>
+				</li>
+
 				<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="JE_FatJorry" or defName="JECom_IsaacJoris"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="JE_FatJorry" or defName="JECom_IsaacJoris" or defName="JE_NoitaJoris"]/statBases</xpath>
 					<value>
 						<AimingAccuracy>0.6</AimingAccuracy>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="JE_BiblicallyAccurateJoris" or defName="JE_Joku"]/statBases</xpath>
+					<value>
+						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<AimingAccuracy>1</AimingAccuracy>
 					</value>
 				</li>
 
@@ -49,6 +64,24 @@
 							<speed>24</speed>
 							<armorPenetrationSharp>1</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						</projectile>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="JE_NoitaFireball"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<flyOverhead>false</flyOverhead>
+							<damageDef>Flame</damageDef>
+							<damageAmountBase>18</damageAmountBase>
+							<explosionRadius>1.1</explosionRadius>
+							<speed>27</speed>
+							<armorPenetrationSharp>50</armorPenetrationSharp>
+							<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+							<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
+							<ai_IsIncendiary>true</ai_IsIncendiary>
+							<soundExplode>Interact_Ignite</soundExplode>
 						</projectile>
 					</value>
 				</li>

--- a/Patches/The Joris Experience/Unique_Joris_Extended2.xml
+++ b/Patches/The Joris Experience/Unique_Joris_Extended2.xml
@@ -782,6 +782,82 @@
           </value>
         </li>
 
+        <!-- === Joskar=== -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="JE_JoskarBontocki"]/tools</xpath>
+          <value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>paintbrush</label>
+					<capacities>
+						<li>Blunt</li><li>Poke</li>
+					</capacities>
+					<power>17</power>
+					<cooldownTime>1.32</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>20</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>paintbrush</label>
+					<capacities>
+						<li>Blunt</li><li>Poke</li>
+					</capacities>
+					<power>17</power>
+					<cooldownTime>1.32</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>21</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>36</power>
+					<cooldownTime>2.45</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<surpriseAttack>
+						<extraMeleeDamages>
+							<li>
+								<def>Stun</def>
+								<amount>21</amount>
+							</li>
+						</extraMeleeDamages>
+					</surpriseAttack>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationSharp>1.8</armorPenetrationSharp>
+					<armorPenetrationBlunt>12</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>2.44</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+          </value>
+        </li>
+
       </operations>
     </match>
   </Operation>


### PR DESCRIPTION
Update and fixes for the following mods
-Contractor arsenal
-Rimeffect mods
-Rim-Sheks
-The Joris Experience
-Bastyon

-Android Tiers needs to be below CE in load order or it will throw lots of errors.
-Tweaked the very OP stats of the .410 buck, it fires smaller pellets with a much shorter barrel and lower pressure, no way is it 5/8 as good as a 12 gauge.
-Removed a duplicate line from core

For those who manage to test this before I do: please let me know if Joku and Bible Joris still shoot their stuff sideways. And if blackhole launcher and the carnage ability work sensibly(penetrates armour and do an appropriate amt of damage).
Also
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
