### PR TITLE
Fix AA + AB patch

### DIFF
--- a/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -45,6 +45,7 @@
 		</li>
 
 		<!-- ======== Red, Crystal and Mushroom Wood ======== -->
+
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/tools</xpath>
 			<value>
@@ -61,92 +62,90 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+    	<li Class="PatchOperationFindMod">
+        <mods>
+          <li>Alpha Animals</li>
+        </mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="AB_RawFishBase"]</xpath>
 			<value>
+				<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+			</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/equippedStatOffsets</xpath>
+				<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.2</MeleeCritChance>
 					<MeleeParryChance>1</MeleeParryChance>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 				</equippedStatOffsets>
-			</value>
-		</li>
+				</value>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases</xpath>
-			<value>
-				<Bulk>0.07</Bulk>
-				<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<Bulk>0.07</Bulk>
+					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
-			<value>
-				<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+				</value>
+			</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
-			<value>
-				<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+				</value>
+			</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
-			<value>
-				<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-			</value>
-		</li>
+		</operations>
+		</match>
 
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/SharpDamageMultiplier</xpath>
-			<value>
-				<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-			</value>
-		</li>
+		<nomatch Class="PatchOperationSequence">
+		<operations>
 
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/BluntDamageMultiplier</xpath>
-			<value>
-				<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<Bulk>0.07</Bulk>
+					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+				</value>
+			</li>
 
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/stuffProps/statFactors</xpath>
-			<value>
-				<Mass>0.3</Mass>
-				<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
-			</value>
-		</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+				</value>
+			</li>
+
+		</operations>
+		</nomatch>
+		</li>								
 
         <!-- === Misc. Raw Fish === -->
-
-        <li Class="PatchOperationSequence">
-          <success>Always</success>
-          <operations>
-            <li Class="PatchOperationTest">
-              <xpath>/Defs/ThingDef[@Name="AB_RawFishBase"]/weaponTags</xpath>
-              <success>Invert</success>
-            </li>
-            <li Class="PatchOperationAdd">
-              <xpath>/Defs/ThingDef[@Name="AB_RawFishBase"]</xpath>
-              <value>
-                <weaponTags />
-              </value>
-            </li>
-          </operations>
-        </li>
-
-        <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[@Name="AB_RawFishBase"]/weaponTags</xpath>
-          <value>
-            <li>CE_OneHandedWeapon</li>
-          </value>
-        </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[


### PR DESCRIPTION
Fixes some conditional patches that are needed depending on whether or not Alpha Animals is loaded along with Alpha Biomes. Rather than being conditional based upon the presence of particular ThingDefs, this simply has a set of operations for match/no match depending on whether or not AA is loaded.