### PR TITLE
Added damageDef and AP to flaregun to fix caliber and similar bugs

### DIFF
--- a/Defs/Ammo/Flare.xml
+++ b/Defs/Ammo/Flare.xml
@@ -100,7 +100,10 @@
       <texPath>Things/Projectile/Bullet_big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>   
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">      
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageDef>Smoke</damageDef>
+	    <armorPenetrationSharp>0</armorPenetrationSharp>
+	    <armorPenetrationBlunt>0</armorPenetrationBlunt>
     </projectile>     
   </ThingDef>
 


### PR DESCRIPTION
## Changes

Flares now have damageDef (smoke) and AP stats (all 0) to allow it used on the Caliber stat and to prevent other errors on displaying its stats.

## References

Previously caused problems like this:

```
What's That Mod: Exception generating def description for [CombatExtended.AmmoDef] Ammo_Flare from mod Combat Extended:
System.NullReferenceException: Object reference not set to an instance of an object
  at CombatExtended.AmmoUtility.GetProjectileReadout (Verse.ThingDef projectileDef, Verse.Thing weapon) [0x00192] in <ccb6738ca9da4e0ba4122c09aec10cab>:0 
  at CombatExtended.StatWorker_AmmoCaliber.GetExplanationUnfinalized (RimWorld.StatRequest req, Verse.ToStringNumberSense numberSense) [0x00142] in <ccb6738ca9da4e0ba4122c09aec10cab>:0 
  at WhatsThatMod.CE_Compat.GetProjectileReadout (Verse.ThingDef ammoThingDef) [0x00076] in <fcaba6e7ec2244bba77f10a924a9e8c8>:0 
  at WhatsThatMod.ModCore.DefWriter (System.Boolean doVanilla, System.Collections.Generic.HashSet`1[T] excludedMods, System.String vanillaName, System.String template) [0x00161] in <fcaba6e7ec2244bba77f10a924a9e8c8>:0 
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch2 (string)
WhatsThatMod.ModCore:DefWriter (bool,System.Collections.Generic.HashSet`1<string>,string,string)
WhatsThatMod.ModCore:WriteToDefs ()
WhatsThatMod.ModCore:Run ()
(wrapper dynamic-method) Verse.LongEventHandler:Verse.LongEventHandler.UpdateCurrentSynchronousEvent_Patch0 (bool&)
Verse.LongEventHandler:LongEventsUpdate (bool&)
(wrapper dynamic-method) Verse.Root:Verse.Root.Update_Patch1 (Verse.Root)
(wrapper dynamic-method) Verse.Root_Entry:Verse.Root_Entry.Update_Patch0 (Verse.Root_Entry)
```

and this:

```
Failed to find sane damage amount
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch2 (string)
Verse.Log:ErrorOnce (string,int)
Verse.ProjectileProperties:GetDamageAmount (single,System.Text.StringBuilder)
Verse.ProjectileProperties:GetDamageAmount (Verse.Thing,System.Text.StringBuilder)
CombatExtended.AmmoUtility:GetProjectileReadout (Verse.ThingDef,Verse.Thing)
CombatExtended.StatWorker_AmmoCaliber:GetExplanationUnfinalized (RimWorld.StatRequest,Verse.ToStringNumberSense)
WhatsThatMod.CE_Compat:GetProjectileReadout (Verse.ThingDef)
WhatsThatMod.ModCore:DefWriter (bool,System.Collections.Generic.HashSet`1<string>,string,string)
WhatsThatMod.ModCore:WriteToDefs ()
WhatsThatMod.ModCore:Run ()
(wrapper dynamic-method) Verse.LongEventHandler:Verse.LongEventHandler.UpdateCurrentSynchronousEvent_Patch0 (bool&)
Verse.LongEventHandler:LongEventsUpdate (bool&)
(wrapper dynamic-method) Verse.Root:Verse.Root.Update_Patch1 (Verse.Root)
(wrapper dynamic-method) Verse.Root_Entry:Verse.Root_Entry.Update_Patch0 (Verse.Root_Entry)
```

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
