### PR TITLE
Aspero Race Patch

### DIFF
--- a/Patches/Aspero Race/CE_Patch_Animal_Meatdrake.xml
+++ b/Patches/Aspero Race/CE_Patch_Animal_Meatdrake.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationAdd"> <!-- This thing is basically a big slower, stupider, iguana so using the CE Iguana as a base -->
+				<xpath>Defs/ThingDef[defName="Grei_MeatDrake"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.04</MeleeDodgeChance>
+					<MeleeCritChance>0.02</MeleeCritChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Grei_MeatDrake"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claws</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>2</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>3</power>
+							<cooldownTime>2.2</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.03</armorPenetrationSharp>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>5</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Grei_MeatDrake"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Serpentine</bodyShape>
+					</li>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_Bodies.xml
+++ b/Patches/Aspero Race/CE_Patch_Bodies.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationAdd"> <!-- Horns should be armored very well -->
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Horn"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd"> <!-- Tail should be armored the same as the rest of the body-->
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+<!-- The rest is identical to default humanoid, but since Aspero use a custom body the armor tags needs to be set seperately -->
+			<li Class="PatchOperationAdd"> 
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/BodyDef[defName = "Aspero_Body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+				<value>
+				  <li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_HediffParts.xml
+++ b/Patches/Aspero Race/CE_Patch_HediffParts.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SimpleAsperoTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					   <label>tail</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>0.5</power>
+						<cooldownTime>2</cooldownTime>
+						<chanceFactor>0.05</chanceFactor>
+						<armorPenetrationBlunt>0.01</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+			</li>
+			<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="CombatAsperoTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>spiked tail</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>11</power>
+						<cooldownTime>2</cooldownTime>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.42</armorPenetrationSharp>
+					</li>
+				</tools>
+			</value>
+			</li>
+			<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="CombatAsperoTail"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>transforming tail</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>1</cooldownTime>
+						<chanceFactor>0.3</chanceFactor>
+						<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						<armorPenetrationSharp>1</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+					    <label>transforming tail</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>4</cooldownTime>
+						<chanceFactor>0.3</chanceFactor>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.75</armorPenetrationSharp>
+					</li>
+				</tools>
+			</value>
+			</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_Pawnkinds.xml
+++ b/Patches/Aspero Race/CE_Patch_Pawnkinds.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+	  <match Class="PatchOperationAddModExtension"> <!-- tried to do off the pawnkind base but that didn't work soooo.....-->
+		<xpath>/Defs/PawnKindDef[@Name="AsperoPawnkindBase" or DefName="AsperoCivilian" or DefName="AsperoMilitia" or DefName="AsperoTrader" or DefName="AsperoOverseer" or DefName="AsperoSoldier" or DefName="AsperoESoldier" or DefName="AsperoSniper" or DefName="AsperoMeleeSoldier" or DefName="AsperoEMeleeSoldier"]</xpath>
+		<value>
+		  <li Class="CombatExtended.LoadoutPropertiesExtension">
+			<primaryMagazineCount>
+			  <min>1</min>
+			  <max>4</max>
+			</primaryMagazineCount>
+			<shieldMoney>
+			  <min>500</min>
+			  <max>1400</max>
+			</shieldMoney>
+			<shieldTags>
+			  <li>OutlanderShield</li>
+			</shieldTags>
+			<shieldChance>0.3</shieldChance>
+			<sidearms>
+			  <li>
+				<generateChance>0.5</generateChance>
+				<sidearmMoney>
+				  <min>60</min>
+				  <max>150</max>
+				</sidearmMoney>
+				<weaponTags>
+				  <li>CE_Sidearm_Melee</li>
+				</weaponTags>
+			  </li>
+			</sidearms>
+		  </li>
+		</value>
+	  </match>
+	</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_Race_Aspero.xml
+++ b/Patches/Aspero Race/CE_Patch_Race_Aspero.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/statBases</xpath>
+					<value>
+						<MeleeCritChance>0.9</MeleeCritChance>
+						<MeleeDodgeChance>0.9</MeleeDodgeChance>
+						<MeleeParryChance>1.1</MeleeParryChance>
+						<Suppressability>0.9</Suppressability>
+					</value>
+				</li>
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+					<li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]</xpath>
+					  <value>
+						<comps />
+					  </value>
+					</li>
+				  </operations>
+				</li>
+
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/comps</xpath>
+				  <value>
+					<li>
+					  <compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				  </value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationReplace">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Grei_Aspero"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left claws</label>
+						<capacities>
+							<li>Scratch</li>
+						</capacities>
+						<power>1.5</power>
+						<cooldownTime>1.3</cooldownTime>
+						<linkedBodyPartsGroup>Aspero_LeftClaw</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0.15</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right claws</label>
+						<capacities>
+							<li>Scratch</li>
+						</capacities>
+						<power>1.5</power>
+						<cooldownTime>1.3</cooldownTime>
+						<linkedBodyPartsGroup>Aspero_RightClaw</linkedBodyPartsGroup>
+						<armorPenetrationSharp>0.15</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.35</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationSharp>0.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>2</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<linkedBodyPartsGroup>Aspero_hornGroup</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationSharp>0.8</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.423</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>tail</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<linkedBodyPartsGroup>Aspero_TailGroup</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.423</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+			</match>
+		</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_Scenario.xml
+++ b/Patches/Aspero Race/CE_Patch_Scenario.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationAdd"> <!-- Same as crashlanded -->
+		<xpath>Defs/ScenarioDef[@Name="AsperoStart"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Ammo_303British_FMJ</thingDef>
+			  <count>100</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Ammo_44Magnum_FMJ</thingDef>
+			  <count>60</count>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/Patches/Aspero Race/CE_Patch_Scenario.xml
+++ b/Patches/Aspero Race/CE_Patch_Scenario.xml
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-	<Operation Class="PatchOperationAdd"> <!-- Same as crashlanded -->
-		<xpath>Defs/ScenarioDef[@Name="AsperoStart"]/scenario/parts</xpath>
-		<value>
-			<li Class="ScenPart_StartingThing_Defined">
-			  <def>StartingThing_Defined</def>
-			  <thingDef>Ammo_303British_FMJ</thingDef>
-			  <count>100</count>
-			</li>
-			<li Class="ScenPart_StartingThing_Defined">
-			  <def>StartingThing_Defined</def>
-			  <thingDef>Ammo_44Magnum_FMJ</thingDef>
-			  <count>60</count>
-			</li>
-		</value>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Aspero</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> <!-- Same as crashlanded -->
+					<xpath>Defs/ScenarioDef[@Name="AsperoStart"]/scenario/parts</xpath>
+					<value>
+						<li Class="ScenPart_StartingThing_Defined">
+							<def>StartingThing_Defined</def>
+							<thingDef>Ammo_303British_FMJ</thingDef>
+							<count>100</count>
+						</li>
+						<li Class="ScenPart_StartingThing_Defined">
+							<def>StartingThing_Defined</def>
+							<thingDef>Ammo_44Magnum_FMJ</thingDef>
+							<count>60</count>
+						</li>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
 </Patch>


### PR DESCRIPTION
## Additions

Add a folder in the patchs folder and support for the Aspero Race Mod didn't touch anything else.

## Changes


## References


## Reasoning

Why did you choose to implement things this way, e.g.
Was told in the discord it's better practice to commit to CE itself than patch within my own mod. So here I am.

## Alternatives


## Testing

Check tests you have performed:
- [ Check! ] Compiles without warnings (My additions are all xml I have no compiler)
- [ Nope! ] Game runs without errors 
Errors: 
Could not find type named CombatExtended.JobGiver_ModifyCarriedWeapon from node <li Class="CombatExtended.JobGiver_ModifyCarriedWeapon" />
Exception loading list element from XML: System.MissingMethodException: Default constructor not found for type Verse.AI.ThinkNode
Could not find a type named CombatExtended.WorkGiver_ModifyWeapon

But this happens without my additions too so I assume it's an existing error.

- [Check! ] (For compatibility patches) ...with and without patched mod loaded
- [ Sorta? ] Playtested a colony (specify how long) Existing errors prevent practical long term testing.  Tested a new scenario with and without my additions and both received the same errors.  No errors that I could noticeably trace to my additions. 
