### PR TITLE
[Bug]:Artillery and catapult in VEF-Security just don't run right.

### DIFF
--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -62,7 +62,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>166</speed>
+			<speed>0</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
@@ -139,7 +139,7 @@
 		<ThingDef Name="BaseCatapultBullet" ParentName="BaseBullet" Abstract="true">
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>	
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>44</speed>
+			  <speed>0</speed>
 			  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			  <soundAmbient>MortarRound_Ambient</soundAmbient>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- VEF-Security mortar turret bug fix.

## Changes

Change two mortar ammo def <speed> into 0.

## References

#1005 

## Reasoning

Curved shot ammo <speed> just should be 0, If I understand correctly.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
