### PR TITLE
Changes to Verb_ShootCEOneUse.cs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
@@ -40,9 +40,17 @@ namespace CombatExtended
             var inventory = ShooterPawn?.TryGetComp<CompInventory>();
             if (this.EquipmentSource != null && !this.EquipmentSource.Destroyed)
             {
-                this.EquipmentSource.Destroy(DestroyMode.Vanish);
+                if (this.EquipmentSource.stackCount > 1)
+                {
+                    this.EquipmentSource.stackCount--;
+                }
+                else
+                {
+                    this.EquipmentSource.Destroy(DestroyMode.Vanish);
+                }
             }
-            if (inventory != null && ShooterPawn?.jobs.curJob.def != CE_JobDefOf.OpportunisticAttack)
+            
+            if (ShooterPawn?.equipment.Primary == null && inventory != null && ShooterPawn?.jobs.curJob.def != CE_JobDefOf.OpportunisticAttack)
             {
                 var newGun = inventory.rangedWeaponList.FirstOrDefault(t => t.def == EquipmentSource.def);
                 if (newGun != null)


### PR DESCRIPTION
## Additions

Allows usage of inventory items without deleting them after 1 use. No added functionality by itself, but lets other mods use items that has this verb out of inventory (without equipping)

## Changes

1. Added check for stackCount, so if item is stack it won't get removed.
2. Added check for equipment for skipping weapon swap if equipment exists.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

This change is critical for my mod "Throw them" that lets you throw grenades and other things that use this verb out of inventory, without equipping. Patching this class with harmony is extremely hard even for experienced modders.
These changes don't change anything in vanilla CE.

## Alternatives

Harmony patch?

## Testing

Check tests you have performed:
- [+] Compiles without warnings
- [+] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [+] Playtested a colony. Tested behaviour with all CE grenades and LAWs (CE guns is included in modlist). Ran a couple of raids. Pretty much no visible effect or errors.
