### PR TITLE
Projectile mass and Apparel stats

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -126,7 +126,7 @@ namespace CombatExtended
 
                     if (app != null
                         && app.def.apparel.CoversBodyPart(hitPart)
-                        && !TryPenetrateArmor(dinfo.Def, app.GetStatValue(dinfo.Def.armorCategory.armorRatingStat), ref penAmount, ref dmgAmount, app))
+                        && !TryPenetrateArmor(dinfo.Def, app.GetModifiedStat(dinfo.Def.armorCategory.armorRatingStat, hitPart.def), ref penAmount, ref dmgAmount, app))
                     {
                         // Hit was deflected, convert damage type
                         //armorReduced = true;
@@ -196,7 +196,7 @@ namespace CombatExtended
             // Return damage info.
             dinfo.SetAmount(Mathf.CeilToInt(dmgAmount));
             return dinfo;
-        }
+        }        
 
         /// <summary>
         /// Calculates armor for penetrating damage types (Blunt, Sharp). Applies damage reduction based on armor penetration to armor ratio and calculates damage accordingly, with the difference being applied to the armor Thing. Also calculates whether a Sharp attack is deflected.

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -462,6 +462,37 @@ namespace CombatExtended
         }
 
         /// <summary>
+        /// Get modified stat value for an apparel with body part.
+        /// </summary>
+        /// <param name="apparel">Apparel</param>
+        /// <param name="stat">StatDef</param>
+        /// <param name="bodyPart">Modifier body part</param>
+        /// <returns>Modified stat value for provided apparel</returns>
+        public static float GetModifiedStat(this Apparel apparel, StatDef stat, BodyPartDef bodyPart)
+        {
+            var val = apparel.GetStatValue(stat);
+            var statExtension = apparel.def.GetModExtension<ApparelStatExtension>();
+            if (statExtension?.modifiers.NullOrEmpty() ?? true)
+                return val;
+            for (int i = 0; i < statExtension.modifiers.Count; i++)
+            {               
+                var partModifier = statExtension.modifiers[i];
+                if (partModifier.stat != stat || partModifier.parts.NullOrEmpty())
+                    continue;
+                for(int j = 0;j < partModifier.parts.Count; j++)
+                {                    
+                    BodyPartModifier bodyModifier = partModifier.parts[j];
+                    if(bodyModifier.part == bodyPart)                                            
+                        return val * bodyModifier.value;                    
+                }
+                // since we didn't find our target body part we should break.
+                break;
+            }
+            return val;
+        }
+
+
+        /// <summary>
         /// Extension method to determine whether a pawn has equipped a shield
         /// </summary>
         /// <returns>True if the pawn has a shield equipped</returns>

--- a/Source/CombatExtended/CombatExtended/Defs/ApparelBodyPartStatModifier.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ApparelBodyPartStatModifier.cs
@@ -13,18 +13,12 @@ namespace CombatExtended
         public void LoadDataFromXmlCustom(XmlNode xmlRoot)
         {
             DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "stat", xmlRoot.Name);
-
-            this.parts = new List<BodyPartModifier>();
-
-            XmlNodeList nodeList = xmlRoot.SelectNodes("parts");
-            if (nodeList != null)
+            parts ??= new List<BodyPartModifier>();
+            foreach (XmlNode node in xmlRoot.ChildNodes)
             {
-                foreach (XmlNode node in nodeList)
-                {
-                    BodyPartModifier modifier = new BodyPartModifier();
-                    modifier.LoadDataFromXmlCustom(node);
-                    this.parts.Add(modifier);
-                }
+                BodyPartModifier modifier = new BodyPartModifier();
+                modifier.LoadDataFromXmlCustom(node);                    
+                parts.Add(modifier);               
             }
         }
     }    

--- a/Source/CombatExtended/CombatExtended/Defs/ApparelBodyPartStatModifier.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ApparelBodyPartStatModifier.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Xml;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended
+{  
+    public class ApparelBodyPartStatModifier
+    {
+        public StatDef stat;
+        public List<BodyPartModifier> parts = new List<BodyPartModifier>();
+
+        public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+        {
+            DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "stat", xmlRoot.Name);
+
+            this.parts = new List<BodyPartModifier>();
+
+            XmlNodeList nodeList = xmlRoot.SelectNodes("parts");
+            if (nodeList != null)
+            {
+                foreach (XmlNode node in nodeList)
+                {
+                    BodyPartModifier modifier = new BodyPartModifier();
+                    modifier.LoadDataFromXmlCustom(node);
+                    this.parts.Add(modifier);
+                }
+            }
+        }
+    }    
+}

--- a/Source/CombatExtended/CombatExtended/Defs/ApparelStatExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ApparelStatExtension.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using Verse;
+
+namespace CombatExtended
+{
+    public partial class ApparelStatExtension : DefModExtension
+    {
+        public List<ApparelBodyPartStatModifier> modifiers = new List<ApparelBodyPartStatModifier>();        
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Defs/BodyPartModifier.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/BodyPartModifier.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended
+{
+    public class BodyPartModifier
+    {
+        public BodyPartDef part;
+        public float value;
+
+        public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+        {
+            DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "part", xmlRoot.Name);
+            value = ParseHelper.FromString<float>(xmlRoot.FirstChild.Value);
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -141,9 +141,10 @@ namespace CombatExtended
                     Find.BattleLog.Add(logEntry);                    
                 }                              
                 try
-                {                    
+                {
                     // Apply primary damage
-                    hitThing.TakeDamage(dinfo).AssociateWithLog(logEntry);
+                    DamageWorker.DamageResult damageResult = hitThing.TakeDamage(dinfo);
+                    damageResult.AssociateWithLog(logEntry);
                                         
                     if (!(hitThing is Pawn))
                     {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -545,7 +545,7 @@ namespace CombatExtended
             this.shotAngle = shotAngle;
             this.shotHeight = shotHeight;
             this.shotRotation = shotRotation;
-            this.shotSpeed = shotSpeed == -1 ? def.projectile.speed : shotSpeed;
+            this.shotSpeed = shotSpeed <= 0 ? def.projectile.speed : shotSpeed;
             Launch(launcher, origin, equipment);
             this.ticksToImpact = IntTicksToImpact;
         }


### PR DESCRIPTION
## Additions
- Added mass ratios to projectiles. (A passive system)
- Added the ability to apply modifiers on each stat of an apparel to a single body part. Example
```xml
<li Class="CombatExtended.ApparelStatExtension">
   <modifiers>
       <ArmorRating_Sharp>
           <Brain>0.2</Brain>
           <Neck>0.8</Neck>
       </ArmorRating_Sharp>
       <ArmorRating_Blunt>
           <Brain>0.1</Brain>
           <Neck>0.5</Neck>
       </ArmorRating_Blunt>
   </modifiers>
</li>
```
In this example brain will have a body 10% of the parent apparel armor. Note:  this is a  mod def extension and should be added to each apparel on a case by case basis. 

## Changes
- If a projectile is moving at less then it max speed then its damage will be lowered. 
- If a projectile has a missing percentage of mass its damage will be reduced.

Note that both changes of mass and speed won't affect CE without introducing a way to launch projectiles at lower speeds or mass thus both of these changes at the current time won't affect any damage.