### PR TITLE
Give manned turrets some inate accuracy

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -63,7 +63,7 @@
       </li>
     </comps>
     <statBases>
-			 <ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+			 <ShootingAccuracyTurret>2.0</ShootingAccuracyTurret>
 		</statBases>
     <recipeMaker>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -62,6 +62,9 @@
         <manWorkType>Violent</manWorkType>
       </li>
     </comps>
+    <statBases>
+			 <ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+		</statBases>
     <recipeMaker>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
       <workSkill>Crafting</workSkill>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -280,12 +280,12 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.16</recoilAmount>
+        <recoilAmount>1.06</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-        <warmupTime>1.3</warmupTime>
-        <range>62</range>
+        <warmupTime>1.1</warmupTime>
+        <range>65</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
         <soundCast>MediumMG</soundCast>

--- a/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
@@ -19,12 +19,12 @@
 						<Bulk>13.70</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.71</recoilAmount>
+						<recoilAmount>0.81</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-						<warmupTime>1.3</warmupTime>
-						<range>75</range>
+						<warmupTime>1.1</warmupTime>
+						<range>65</range>
 						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 						<burstShotCount>10</burstShotCount>
 						<soundCast>Shot_Minigun</soundCast>
@@ -53,7 +53,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_DP28MG"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>75</specialDisplayRadius>
+						<specialDisplayRadius>65</specialDisplayRadius>
 					</value>
 				</li>
 
@@ -76,12 +76,12 @@
 						<Bulk>18.54</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>1.25</recoilAmount>
+						<recoilAmount>1.22</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
 						<warmupTime>1.3</warmupTime>
-						<range>86</range>
+						<range>75</range>
 						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 						<burstShotCount>10</burstShotCount>
 						<soundCast>ShotM2</soundCast>
@@ -110,7 +110,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_M2HB"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>86</specialDisplayRadius>
+						<specialDisplayRadius>75</specialDisplayRadius>
 					</value>
 				</li>
 
@@ -139,7 +139,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
 						<warmupTime>1.3</warmupTime>
-						<range>86</range>
+						<range>75</range>
 						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 						<burstShotCount>20</burstShotCount>
 						<!-- Dual M2HBs firing side-by-side -->
@@ -170,7 +170,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_M2HBT"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>86</specialDisplayRadius>
+						<specialDisplayRadius>75</specialDisplayRadius>
 					</value>
 				</li>
 
@@ -193,12 +193,12 @@
 						<Bulk>8.02</Bulk>
 					</statBases>
 					<Properties>
-						<recoilAmount>0.65</recoilAmount>
+						<recoilAmount>0.55</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-						<warmupTime>2.3</warmupTime>
-						<range>86</range>
+						<warmupTime>1.8</warmupTime>
+						<range>75</range>
 						<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 						<burstShotCount>300</burstShotCount>
 						<soundCast>Shot_Minigun</soundCast>
@@ -228,7 +228,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_M134MG"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>86</specialDisplayRadius>
+						<specialDisplayRadius>75</specialDisplayRadius>
 					</value>
 				</li>
 
@@ -368,7 +368,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
 						<warmupTime>2.3</warmupTime>
-						<range>86</range>
+						<range>75</range>
 						<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
 						<burstShotCount>300</burstShotCount>
 						<soundCast>Shot_Minigun</soundCast>
@@ -394,7 +394,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_M134MGs"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>86</specialDisplayRadius>
+						<specialDisplayRadius>75</specialDisplayRadius>
 					</value>
 				</li>
 

--- a/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
@@ -256,11 +256,11 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
 						<warmupTime>1.3</warmupTime>
-						<range>78</range>
+						<range>75</range>
 						<minRange>6</minRange>
 						<ticksBetweenBurstShots>9</ticksBetweenBurstShots>
 						<burstShotCount>6</burstShotCount>
-						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCast>AGS</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
@@ -286,7 +286,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Turret_Mk19MGL"]/specialDisplayRadius</xpath>
 					<value>
-						<specialDisplayRadius>78</specialDisplayRadius>
+						<specialDisplayRadius>75</specialDisplayRadius>
 					</value>
 				</li>
 

--- a/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
+++ b/Patches/DefensiveMachineGunTurretPack/DMGT_CE_Patch_ThingDefs_Buildings_Security_Turrets.xml
@@ -514,8 +514,7 @@
 					<xpath>Defs/ThingDef[@Name="DMGTurretMannedBase"]</xpath>
 					<value>
 						<statBases>
-							<AimingAccuracy>0.9</AimingAccuracy>
-							<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+							<ShootingAccuracyTurret>2</ShootingAccuracyTurret>
 						</statBases>
 					</value>
 				</li>
@@ -524,8 +523,7 @@
 					<xpath>Defs/ThingDef[@Name="DMGTurretMannedBase"]/statBases</xpath>
 					<value>
 						<statBases>
-							<AimingAccuracy>0.9</AimingAccuracy>
-							<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+							<ShootingAccuracyTurret>2</ShootingAccuracyTurret>
 						</statBases>
 					</value>
 				</li>


### PR DESCRIPTION
Make manned turrets less horrible as well as balancing their guns a little.
They seem to inherit the aiming accuracy but not the shooting accuracy of the operator according to aluminium alman. So no aiming accuracy is added.

Honestly I'm uncertain of what would be the appropriate value, so controlled testing is required.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
