### PR TITLE
Fixed some hats layering

### DIFF
--- a/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
+++ b/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
@@ -74,6 +74,20 @@
 		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
     </value>
   </Operation>
+  
+  <!-- =========== Layering Fixes =========== -->
+  
+  <Operation Class="PatchOperationAdd">
+	<xpath>DefsDefs/ThingDef[defName="Apparel_Flophat" or 
+	defName="Apparel_Shadecone" or 
+	defName="Apparel_Tailcap" or 
+	defName="Apparel_AuthorityCap" or 
+	defName="Apparel_Slicecap" or
+	defName="Apparel_Headwrap" or 
+	defName="Apparel_Broadwrap"]/apparel/layers</xpath>
+	<value>
+		<li>MiddleHead</li>
+	</value>
 
 </Patch>
 

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -67,7 +67,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat" or defName="VAE_Headgear_ChefsToque" or defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap"]/apparel/layers</xpath>
 					<value>
 						<li>MiddleHead</li>
 					</value>

--- a/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
+++ b/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
@@ -82,8 +82,8 @@
           <xpath>Defs/ThingDef[defName="VIEHAR_Apparel_Beads"]/apparel/layers]</xpath>
           <value>
             <layers>
-							<li>StrappedHead</li>
-						</layers>
+		<li>StrappedHead</li>
+	    </layers>
           </value>
         </li>
 

--- a/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
+++ b/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
@@ -77,6 +77,15 @@
             <li>MiddleHead</li>
           </value>
         </li>
+        
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="VIEHAR_Apparel_Beads"]/apparel/layers]</xpath>
+          <value>
+            <layers>
+							<li>StrappedHead</li>
+						</layers>
+          </value>
+        </li>
 
       </operations>
     </match>

--- a/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
+++ b/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
@@ -57,7 +57,7 @@
           </value>
         </li>
 
-        <li Class="PatchOperationReplace">
+        <li Class="PatchOperationAdd">
           <xpath>Defs/ThingDef[
           defName="VIEHAR_Apparel_Beads" or
           defName="VIEHAR_Apparel_BishopHat" or
@@ -72,7 +72,7 @@
           defName="VIEHAR_Apparel_Skullcap" or 
           defName="VIEHAR_Apparel_SpikedSkullcap" or 
           defName="VIEHAR_Apparel_WideHat"
-          ]/apparel/layers/li[.="Overhead"]</xpath>
+          ]/apparel/layers]</xpath>
           <value>
             <li>MiddleHead</li>
           </value>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -4,21 +4,17 @@
   <!-- ========== Ladies Hat, Top Hat ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Apparel_HatLadies" or defName="Apparel_HatTop"]</xpath>
+    <xpath>Defs/ThingDef[defName="Apparel_HatLadies" or defName="Apparel_HatTop"]/statBases</xpath>
     <value>
-		<statBases>
 		  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-		</statBases>		  
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Apparel_HatLadies" or defName="Apparel_HatTop"]/apparel</xpath>
+    <xpath>Defs/ThingDef[defName="Apparel_HatLadies" or defName="Apparel_HatTop"]/apparel/layers</xpath>
     <value>
-		<layers Inherit="false">
-			<li>MiddleHead</li>
-		</layers>
-    </value>
+		<li>MiddleHead</li>
+	</value>
   </Operation>
 
   <!-- ========== Beret ========== -->
@@ -30,13 +26,11 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
+  <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Apparel_Beret"]/apparel/layers</xpath>
     <value>
-		<layers Inherit="false">
-			<li>MiddleHead</li>
-		</layers>
-    </value>
+		<li>MiddleHead</li>
+	</value>
   </Operation>
 
   <!-- ========== Coronet, Crown ========== -->
@@ -48,11 +42,11 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_Coronet" or defName="Apparel_Crown" or defName="Apparel_CrownStellic"]/apparel/layers/li[.="Overhead"]</xpath>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_Coronet" or defName="Apparel_Crown" or defName="Apparel_CrownStellic"]/apparel/layers</xpath>
     <value>
-      <li>MiddleHead</li>
-    </value>
+		<li>MiddleHead</li>
+	</value>
   </Operation>
 
   <!-- ========== Psychic Helmet ========== -->
@@ -71,11 +65,11 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_PsyfocusHelmet"]/apparel/layers/li[.="Overhead"]</xpath>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_PsyfocusHelmet"]/apparel/layers</xpath>
     <value>
-      <li>MiddleHead</li>
-    </value>
+		<li>MiddleHead</li>
+	</value>
   </Operation>
 
   <!-- ========== Psychic Skullcap ========== -->
@@ -94,8 +88,8 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_EltexSkullcap"]/apparel/layers/li[.="Overhead"]</xpath>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_EltexSkullcap"]/apparel/layers</xpath>
     <value>
       <li>MiddleHead</li>
     </value>


### PR DESCRIPTION
## Changes

Fixed the layering of some hats such as the ones added by both DLCs and those added by VE Apparel.

## Reasoning

Simply resolving a long-standing issue with certain CE patches that makes funny hat combinations possible, i.e. wearing two berets at once, wearing top hats under helmets
