### PR TITLE
Velocity Enhanced +T's Samurai Faction patch

### DIFF
--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -112,7 +112,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>16</speed>
+      <speed>32</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -112,7 +112,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>16</speed>
+			<speed>32</speed>
+      <gravityFactor>2</gravityFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -27,8 +27,8 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoCrossbowBoltBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>A crossbow bolt.</description>
     <statBases>
-      <Mass>0.131</Mass>
-      <Bulk>0.24</Bulk>
+      <Mass>0.04</Mass>
+      <Bulk>0.12</Bulk>
       <Flammability>1</Flammability>
     </statBases>
     <thingCategories>

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -125,7 +125,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>10</speed>
+			<speed>57</speed>
+      <gravityFactor>1.75</gravityFactor>
 		</projectile>
 	</ThingDef>
 
@@ -143,6 +144,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
+      <speed>40</speed>
 			<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
 			<preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
@@ -161,7 +163,6 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>17</speed>			
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -178,7 +179,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>8.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<speed>19</speed>				
+			<speed>64</speed>				
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
 		</projectile>
@@ -196,7 +197,6 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-      <speed>17</speed>	
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -214,7 +214,6 @@
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBlunt>3.28</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>
-      <speed>17</speed>	
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -79,7 +79,8 @@
 		<defName>Bullet_FastMusketBall</defName>
 		<label>musket ball</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>90</speed>	
+			<speed>120</speed>
+			<gravityFactor>1.33</gravityFactor>	
 			<damageAmountBase>26</damageAmountBase>		
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>65.8</armorPenetrationBlunt>				
@@ -92,7 +93,8 @@
 		<defName>Bullet_SlowMusketBall</defName>
 		<label>musket ball</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>50</speed>	
+			<speed>80</speed>
+			<gravityFactor>1.6</gravityFactor>	
 			<damageAmountBase>17</damageAmountBase>		
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>20</armorPenetrationBlunt>				

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -34,7 +34,7 @@
 		<description>A paper cartridge sealed with wax containing a round projectile and black powder, fired by early, smoothbore firearms.</description>
 		<statBases>
 		<Mass>0.087</Mass>
-		<Bulk>0.12</Bulk>
+		<Bulk>0.08</Bulk>
 		</statBases>
 		<tradeTags>
 		  <li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -41,8 +41,8 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoArrowBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>Simple arrow design with a cutting head attached to a wooden shaft.</description>
     <statBases>
-      <Mass>0.028</Mass>
-      <Bulk>0.08</Bulk>
+      <Mass>0.06</Mass>
+      <Bulk>0.18</Bulk>
       <Flammability>1</Flammability>
     </statBases>
     <thingCategories>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -140,7 +140,8 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>16</speed>
+      <speed>32</speed>
+      <gravityFactor>1.75</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -157,7 +158,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>16</speed>
+      <speed>32</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
       <armorPenetrationBlunt>0.88</armorPenetrationBlunt>
@@ -174,7 +175,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>40</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.02</armorPenetrationBlunt>
@@ -191,7 +192,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>26</speed>
+      <speed>45</speed>
       <damageAmountBase>4</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -208,7 +209,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>40</speed>
 		<damageDef>Arrow</damageDef>
 		<damageAmountBase>7</damageAmountBase>
 		<secondaryDamage>
@@ -232,7 +233,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>40</speed>
       <damageDef>Arrow</damageDef>
       <damageAmountBase>3</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
@@ -257,7 +258,8 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>ArrowHighVelocity</damageDef>
-      <speed>22</speed>
+      <speed>57</speed>
+      <gravityFactor>1.75</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -269,7 +271,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>40</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>1.740</armorPenetrationBlunt>
@@ -286,7 +288,6 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>5.9</armorPenetrationBlunt>
@@ -303,8 +304,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>37</speed>
-      <damageAmountBase>5</damageAmountBase>
+      <speed>65</speed>
+      <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.75</preExplosionSpawnChance>
@@ -320,7 +321,6 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
 	  <damageDef>Arrow</damageDef>
       <damageAmountBase>9</damageAmountBase>
 		<secondaryDamage>
@@ -344,7 +344,6 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
       <damageDef>Arrow</damageDef>
       <damageAmountBase>3</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>10</speed>
+      <speed>18</speed>
 		  <damageDef>ArrowVenom</damageDef>
 		  <damageAmountBase>3</damageAmountBase> 
       <armorPenetrationSharp>0.35</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -27,8 +27,8 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoGreatArrowBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>Heavy arrow designed to be fired from a great bow.</description>
     <statBases>
-      <Mass>0.105</Mass>
-      <Bulk>0.43</Bulk>
+      <Mass>0.08</Mass>
+      <Bulk>0.25</Bulk>
       <Flammability>1</Flammability>
     </statBases>
     <thingCategories>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -126,7 +126,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>12</speed>
+			<speed>55</speed>
+      <gravityFactor>1.75</gravityFactor>
 		</projectile>
 	</ThingDef>
 	
@@ -143,7 +144,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>11</speed>
+			<speed>40</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -160,7 +161,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
@@ -176,7 +177,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
+      <speed>62</speed>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
@@ -193,7 +195,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<secondaryDamage>
 				<li>
 				<def>ArrowVenom</def>

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -22,6 +22,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Stab</damageDef>
+			<gravityFactor>2</gravityFactor>
 		</projectile>
 	</ThingDef>
 	
@@ -34,8 +35,8 @@
 		<defName>Pilum_Thrown</defName>
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
-			<speed>7</speed>
+			<damageAmountBase>17</damageAmountBase>
+			<speed>14</speed>
 			<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -48,7 +49,7 @@
 		<label>pilum (fired)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>29</damageAmountBase>
-			<speed>32</speed>
+			<speed>50</speed>
 			<armorPenetrationBlunt>141.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.4</preExplosionSpawnChance> <!-- 1.67 javelins per resource -->

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -77,7 +77,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Blunt</damageDef>
-			<speed>9</speed>
+			<speed>18</speed>
+      <gravityFactor>2</gravityFactor>
 		</projectile>
 	</ThingDef>
 
@@ -94,7 +95,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>5</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.166</preExplosionSpawnChance>	<!-- 11.99 stones per resource -->
 			<preExplosionSpawnThingDef>Ammo_SlingBullet_Stone</preExplosionSpawnThingDef>
@@ -109,7 +110,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>			
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>1.72</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>	<!-- 20 stones per resource -->
 			<preExplosionSpawnThingDef>Ammo_SlingBullet_Steel</preExplosionSpawnThingDef>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -179,7 +179,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>40</speed>
+      <gravityFactor>2</gravityFactor>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -196,7 +197,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>30</speed>
+      <speed>53</speed>
+      <gravityFactor>1.75</gravityFactor>
       <damageDef>EMP</damageDef>
       <damageAmountBase>12</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -149,7 +149,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
+			<speed>40</speed>
+      <gravityFactor>2</gravityFactor>
 			<damageDef>Beanbag</damageDef>
 			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBlunt>13.78</armorPenetrationBlunt>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -60,7 +60,8 @@
       <soundExplode>Explosion_Stun</soundExplode>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-      <speed>5</speed>
+      <speed>10</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -81,7 +82,7 @@
       <Bulk>0.61</Bulk>
       <MarketValue>8.33</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
-      <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
       <li>CE_AI_AOE</li>
@@ -96,7 +97,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>1.8</warmupTime>
+        <warmupTime>0.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -134,7 +135,8 @@
       <damageAmountBase>234</damageAmountBase>
       <explosionDelay>90</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-      <speed>3</speed>
+      <speed>7</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -155,7 +157,7 @@
       <Bulk>4.72</Bulk>
       <MarketValue>25.51</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
-      <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
       <li>CE_AI_AOE</li>
@@ -170,7 +172,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>7.0</range>
-        <warmupTime>1.8</warmupTime>
+        <warmupTime>1.6</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -202,7 +204,8 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>5</speed>
+      <speed>10</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -222,7 +225,7 @@
       <Bulk>1.05</Bulk>
       <MarketValue>10.15</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
-      <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
       <li>CE_AI_SMOKE</li>
@@ -237,7 +240,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>1.8</warmupTime>
+        <warmupTime>0.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>
@@ -276,7 +279,8 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>5</speed>
+      <speed>10</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -296,7 +300,7 @@
       <Bulk>1.05</Bulk>
       <MarketValue>11.52</MarketValue>
       <SightsEfficiency>0.65</SightsEfficiency>
-      <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
     </statBases>
     <weaponTags>
       <li>CE_AI_AOE</li>
@@ -310,7 +314,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>10</range>
-        <warmupTime>1.8</warmupTime>
+        <warmupTime>0.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
         <soundCast>ThrowGrenade</soundCast>

--- a/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -48,7 +48,7 @@
 			<ShotSpread>1.5</ShotSpread>
 			<SwayFactor>2.5</SwayFactor>
 			<Bulk>3.5</Bulk>
-			<Mass>2.00</Mass>
+			<Mass>1.5</Mass>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 		</statBases>
 		<equippedAngleOffset>30</equippedAngleOffset>

--- a/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Core/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -601,12 +601,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="WoolBase"]/statBases</xpath>
-		<value>
-		  <Bulk>0.05</Bulk>
-		</value>
-	</Operation>
 
 	<!-- Megasloth Wool -->
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -48,7 +48,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile/speed</xpath>
 		<value>
-			<speed>5</speed>
+			<speed>10</speed>
 		</value>
 	</Operation>
 
@@ -84,7 +84,8 @@
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<speed>5</speed>
+				<speed>10</speed>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -195,7 +196,7 @@
 			<Mass>0.4</Mass>
 			<Bulk>0.87</Bulk>
 			<MarketValue>12.22</MarketValue>
-			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
 		<Properties>
@@ -241,7 +242,8 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>5</speed>
+				<speed>10</speed>
+				<gravityFactor>2</gravityFactor>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>
@@ -324,7 +326,7 @@
 			<Mass>0.6</Mass>
 			<Bulk>2.55</Bulk>
 			<MarketValue>7.05</MarketValue>
-			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
 		<Properties>
@@ -378,7 +380,8 @@
 				<explosionDelay>60</explosionDelay>
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-				<speed>5</speed>
+				<speed>10</speed>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -444,7 +447,7 @@
 			<Mass>0.4</Mass>
 			<Bulk>0.87</Bulk>
 			<MarketValue>21.09</MarketValue>
-			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>
 		</statBases>
 		<Properties>
@@ -471,4 +474,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -36,7 +36,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_Arrow_Stone</defaultProjectile>
       <warmupTime>1</warmupTime>
-      <range>28</range>
+      <range>27</range>
       <soundCast>Bow_Small</soundCast>
     </Properties>
     <AmmoUser>
@@ -84,7 +84,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>31</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -133,7 +133,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
       <warmupTime>1.3</warmupTime>
-      <range>33</range>
+      <range>35</range>
       <soundCast>Bow_Large</soundCast>
     </Properties>
     <AmmoUser>
@@ -164,4 +164,3 @@
   </Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -431,14 +431,21 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.1</baseBodySize>
+			<baseBodySize>1.8</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>1</baseHealthScale>
+			<baseHealthScale>1.8</baseHealthScale>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Dromedary"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>6.3</MoveSpeed>
 		</value>
 	</Operation>
 
@@ -459,4 +466,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -205,6 +205,13 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Cow"]/race/baseHealthScale</xpath>
+		<value>
+			<baseHealthScale>1.8</baseHealthScale>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Cow"]</xpath>
 		<value>
@@ -776,7 +783,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Horse"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>5</MoveSpeed>
+			<MoveSpeed>8</MoveSpeed>
 			<MeleeDodgeChance>0.11</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>
@@ -854,14 +861,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Horse"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.6</baseBodySize>
+			<baseBodySize>1.8</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Horse"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>1.6</baseHealthScale>
+			<baseHealthScale>1.8</baseHealthScale>
 		</value>
 	</Operation>
 
@@ -1062,7 +1069,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Donkey"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>4.2</MoveSpeed>
+			<MoveSpeed>5.3</MoveSpeed>
 			<MeleeDodgeChance>0.10</MeleeDodgeChance>
 			<MeleeCritChance>0.16</MeleeCritChance>
 			<MeleeParryChance>0.14</MeleeParryChance>
@@ -1159,4 +1166,3 @@
 
 
 </Patch>
-

--- a/Patches/T's Samurai Faction/T_Samurai_Ammo.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Ammo.xml
@@ -6,45 +6,34 @@
 		<mods>
 			<li>T's Samurai Faction</li>
 		</mods>
-		<match Class="PatchOperationFindMod">
-			<mods>
-				<li>Kit's Gunpowder Weapons</li>
-			</mods>
-			<match />
-			<nomatch Class="PatchOperationAdd">
-				<xpath>Defs</xpath>
-				<value>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
 
 				<ThingCategoryDef>
-					<defName>MortarGrenade</defName>
+					<defName>TSF_MortarGrenade</defName>
 					<label>Mortar Grenade</label>
 					<parent>AmmoGrenades</parent>
 					<iconPath>UI/Icons/ThingCategories/CaliberGrenade</iconPath>
 				</ThingCategoryDef>
 
 				<!-- ==================== AmmoSet ========================== -->
+
 				<CombatExtended.AmmoSetDef>
-					<defName>AmmoSet_MortarGrenade</defName>
+					<defName>AmmoSet_TSF_MortarGrenade</defName>
 					<label>Mortar Grenades</label>
 					<ammoTypes>
-						<Ammo_MortarGrenade>Bullet_MortarGrenade</Ammo_MortarGrenade>      
+						<Ammo_TSF_MortarGrenade>Bullet_TSF_MortarGrenade</Ammo_TSF_MortarGrenade>      
 					</ammoTypes>
 				</CombatExtended.AmmoSetDef>
 
 				<!-- ==================== Ammo ========================== -->
 				
-				<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBase" Abstract="True">
+				<ThingDef Class="CombatExtended.AmmoDef" Name="TSF_HandMortarBombBase" ParentName="AmmoBase" Abstract="True">
 					<description>Low velocity grenade fired from a hand mortar.</description>
-					<defName>Ammo_MortarGrenade</defName>
-					<label>Mortar Grenades</label>
-					<graphicData>
-						<texPath>ThirdParty/Kit's Weapons/Ammo/HandMortar/MortarGrenade</texPath>
-						<graphicClass>Graphic_Single</graphicClass>
-					</graphicData>
 					<statBases>
-						<Mass Inherit="False">0.5</Mass>
-						<Bulk>0.43</Bulk>
-						<MarketValue>5</MarketValue>
+						<Mass>0.8</Mass>
+						<Bulk>0.5</Bulk>
 					</statBases>
 					<tradeTags>
 						<li>CE_AutoEnableTrade</li>
@@ -52,17 +41,31 @@
 						<li>CE_AutoEnableCrafting_ElectricSmithy</li>
 					</tradeTags>
 					<thingCategories>
-						<li>MortarGrenade</li>
+						<li>TSF_MortarGrenade</li>
 					</thingCategories>
-					<stackLimit>200</stackLimit>
+					<stackLimit>100</stackLimit>
 					<cookOffFlashScale>20</cookOffFlashScale>
+				</ThingDef>
+				
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="TSF_HandMortarBombBase">
+					<defName>Ammo_TSF_MortarGrenade</defName>
+					<label>Mortar Grenades</label>
+					<graphicData>
+						<texPath>Things/Item/Equipment/Utility/TSFSmokeBomb/SmokeBomb</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<statBases>
+						<MarketValue>2.96</MarketValue>
+					</statBases>
 					<ammoClass>ExplosiveShell</ammoClass>
-					<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
+					<detonateProjectile>Bullet_TSF_MortarGrenade</detonateProjectile>
 				</ThingDef>
 
 				<!-- ================== Projectiles ================== -->
+
+
 				<ThingDef ParentName="Base40x46mmGrenadeBullet">
-					<defName>Bullet_MortarGrenade</defName>
+					<defName>Bullet_TSF_MortarGrenade</defName>
 					<label>Mortar Grenade</label>
 					<graphicData>
 						<texPath>Things/Projectile/Bullet_Big</texPath>
@@ -71,15 +74,14 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<explosionRadius>1</explosionRadius>
 						<damageDef>Bomb</damageDef>
-						<damageAmountBase>20</damageAmountBase>
+						<damageAmountBase>65</damageAmountBase>
 						<speed>24</speed>
-						<gravityFactor>2</gravityFactor>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 					</projectile>
 					<comps>
 						<li Class="CombatExtended.CompProperties_Fragments">
 						<fragments>
-							<Fragment_Small>12</Fragment_Small>
+							<Fragment_Large>12</Fragment_Large>
 						</fragments>
 						</li>
 					</comps>
@@ -88,8 +90,8 @@
 				<!-- ==================== Recipes ========================== -->
 			
 				<RecipeDef ParentName="AmmoRecipeBase">
-				<defName>MakeAmmo_MortarGrenade</defName>
-				<label>Make Mortar Grenade x10</label>
+				<defName>MakeAmmo_TSF_MortarGrenade</defName>
+				<label>Make Mortar Grenade x6</label>
 				<description>Craft 6 Mortar Grenades</description>
 				<jobString>Making Mortar Grenades</jobString>
 				<ingredients>
@@ -99,7 +101,7 @@
 						<li>Steel</li>
 						</thingDefs>
 					</filter>
-					<count>16</count>
+					<count>15</count>
 					</li>
 					<li>
 					<filter>
@@ -117,13 +119,12 @@
 					</thingDefs>
 				</fixedIngredientFilter>
 				<products>
-					<Ammo_MortarGrenade>8</Ammo_MortarGrenade>
+					<Ammo_TSF_MortarGrenade>6</Ammo_TSF_MortarGrenade>
 				</products>
-				<workAmount>8500</workAmount>
+				<workAmount>8000</workAmount>
 				</RecipeDef>
-		
-				</value>
-			</nomatch>
+				
+			</value>
 		</match>
     </Operation>
 

--- a/Patches/T's Samurai Faction/T_Samurai_Ammo.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Ammo.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+
+    <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>T's Samurai Faction</li>
+		</mods>
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Kit's Gunpowder Weapons</li>
+			</mods>
+			<match />
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+				<ThingCategoryDef>
+					<defName>MortarGrenade</defName>
+					<label>Mortar Grenade</label>
+					<parent>AmmoGrenades</parent>
+					<iconPath>UI/Icons/ThingCategories/CaliberGrenade</iconPath>
+				</ThingCategoryDef>
+
+				<!-- ==================== AmmoSet ========================== -->
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_MortarGrenade</defName>
+					<label>Mortar Grenades</label>
+					<ammoTypes>
+						<Ammo_MortarGrenade>Bullet_MortarGrenade</Ammo_MortarGrenade>      
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+
+				<!-- ==================== Ammo ========================== -->
+				
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBase" Abstract="True">
+					<description>Low velocity grenade fired from a hand mortar.</description>
+					<defName>Ammo_MortarGrenade</defName>
+					<label>Mortar Grenades</label>
+					<graphicData>
+						<texPath>ThirdParty/Kit's Weapons/Ammo/HandMortar/MortarGrenade</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<statBases>
+						<Mass Inherit="False">0.5</Mass>
+						<Bulk>0.43</Bulk>
+						<MarketValue>5</MarketValue>
+					</statBases>
+					<tradeTags>
+						<li>CE_AutoEnableTrade</li>
+						<li>CE_AutoEnableCrafting_FueledSmithy</li>
+						<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+					</tradeTags>
+					<thingCategories>
+						<li>MortarGrenade</li>
+					</thingCategories>
+					<stackLimit>200</stackLimit>
+					<cookOffFlashScale>20</cookOffFlashScale>
+					<ammoClass>ExplosiveShell</ammoClass>
+					<detonateProjectile>Bullet_MortarGrenade</detonateProjectile>
+				</ThingDef>
+
+				<!-- ================== Projectiles ================== -->
+				<ThingDef ParentName="Base40x46mmGrenadeBullet">
+					<defName>Bullet_MortarGrenade</defName>
+					<label>Mortar Grenade</label>
+					<graphicData>
+						<texPath>Things/Projectile/Bullet_Big</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>		
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<explosionRadius>1</explosionRadius>
+						<damageDef>Bomb</damageDef>
+						<damageAmountBase>20</damageAmountBase>
+						<speed>24</speed>
+						<gravityFactor>2</gravityFactor>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					</projectile>
+					<comps>
+						<li Class="CombatExtended.CompProperties_Fragments">
+						<fragments>
+							<Fragment_Small>12</Fragment_Small>
+						</fragments>
+						</li>
+					</comps>
+				</ThingDef>
+
+				<!-- ==================== Recipes ========================== -->
+			
+				<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeAmmo_MortarGrenade</defName>
+				<label>Make Mortar Grenade x10</label>
+				<description>Craft 6 Mortar Grenades</description>
+				<jobString>Making Mortar Grenades</jobString>
+				<ingredients>
+					<li>
+					<filter>
+						<thingDefs>
+						<li>Steel</li>
+						</thingDefs>
+					</filter>
+					<count>16</count>
+					</li>
+					<li>
+					<filter>
+						<thingDefs>
+						<li>FSX</li>
+						</thingDefs>
+					</filter>
+					<count>8</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+					<li>Steel</li>
+					<li>FSX</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<Ammo_MortarGrenade>8</Ammo_MortarGrenade>
+				</products>
+				<workAmount>8500</workAmount>
+				</RecipeDef>
+		
+				</value>
+			</nomatch>
+		</match>
+    </Operation>
+
+</Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
@@ -26,7 +26,7 @@
                 defName="TSFApparel_StrawCoat" or
                 defName="TSFApparel_StrawHat"]/statBases/ArmorRating_Sharp</xpath>
             <value>
-                <ArmorRating_Sharp>0.4</ArmorRating_Sharp>      
+                <ArmorRating_Sharp>0.25</ArmorRating_Sharp>      
             </value>
         </li>
 
@@ -52,7 +52,7 @@
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName="TSFApparel_NinjaMask"]/statBases/StuffEffectMultiplierArmor</xpath>
             <value>
-                <StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>      
+                <StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>      
             </value>
         </li>
 
@@ -241,7 +241,7 @@
                 defName="TSFApparel_SamuraiHelmet" or 
                 defName="TSFApparel_DaimyoHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
             <value>
-                <StuffEffectMultiplierArmor>2.6</StuffEffectMultiplierArmor>
+                <StuffEffectMultiplierArmor>2.8</StuffEffectMultiplierArmor>
             </value>
         </li>
 

--- a/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    
+    <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>T's Samurai Faction</li>
+		</mods>
+        <match Class="PatchOperationSequence">
+        <operations>
+
+<!--Utility-->
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SmokeBomb"]/costList</xpath>
+            <value>
+                <costList>
+                    <Steel>5</Steel>             
+                </costList>
+            </value>
+        </li>
+
+<!--Clothes-->
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_StrawCoat" or
+                defName="TSFApparel_StrawHat"]/statBases/ArmorRating_Sharp</xpath>
+            <value>
+                <ArmorRating_Sharp>0.4</ArmorRating_Sharp>      
+            </value>
+        </li>
+
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_NinjaMask" or
+                defName="TSFApparel_StrawCoat"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+            <value>
+                <MeleeDodgeChance>0.3</MeleeDodgeChance>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_NinjaMask"]/stuffCategories</xpath>
+            <value>
+                <stuffCategories>
+                    <li>Steeled</li>
+                </stuffCategories>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_NinjaMask"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_NinjaMask" or
+                defName="TSFApparel_Gi" or
+                defName="TSFApparel_Kimono"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_Gi" or
+                defName="TSFApparel_Kimono"]/statBases/Mass</xpath>
+            <value>
+                <Mass>1.2</Mass>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_Yukata" or
+                defName="TSFApparel_HaoriJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>      
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_HaoriJacket" or
+                defName="TSFApparel_Yukata"
+                ]/costStuffCount</xpath>
+            <value>
+                <costStuffCount>60</costStuffCount>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_Kimono"]/costStuffCount</xpath>
+            <value>
+                <costStuffCount>80</costStuffCount>
+            </value>
+        </li>
+
+<!--Armor-->
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_AshigaruArmor" or
+                defName="TSFApparel_AshigaruHelmet" or
+                defName="TSFApparel_SamuraiArmor" or
+                defName="TSFApparel_SamuraiHelmet" or
+                defName="TSFApparel_DaimyoHelmet"]/stuffCategories</xpath>
+            <value>
+                <stuffCategories>
+                    <li>Steeled</li>
+                </stuffCategories>      
+            </value>
+        </li>
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_AshigaruArmor" or 
+                defName="TSFApparel_SamuraiArmor"]/apparel/layers</xpath>
+            <value>
+                <layers>
+                    <li>Shell</li>             
+                </layers>
+            </value>
+        </li>
+
+<!--Ashigaru-->
+    <!--Armor-->      
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TSFApparel_AshigaruArmor"]/statBases</xpath>
+            <value>
+                <Bulk>40</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "TSFApparel_AshigaruArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1.6</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+        
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_AshigaruArmor"]/costStuffCount</xpath>
+            <value>
+                <costStuffCount>110</costStuffCount>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_AshigaruArmor"]/statBases/Mass</xpath>
+            <value>
+                <Mass>9</Mass>
+            </value>
+        </li>
+
+        <li Class="PatchOperationRemove">
+            <xpath>Defs/ThingDef[defName = "TSFApparel_AshigaruArmor"]/equippedStatOffsets</xpath>
+        </li>
+
+    <!--Helmet-->
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName = "TSFApparel_AshigaruHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+            </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TSFApparel_AshigaruHelmet"]/statBases</xpath>
+            <value>
+                <Bulk>6</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_AshigaruHelmet"]/statBases/Mass</xpath>
+            <value>
+                <Mass>1.8</Mass>
+            </value>
+        </li>
+
+<!--Samurai-->
+    <!--Armor-->
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor"]/statBases</xpath>
+            <value>
+                <Bulk>60</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor"]/costStuffCount</xpath>
+            <value>
+                <costStuffCount>160</costStuffCount>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor" or defName="TSFApparel_SamuraiArmor"]/apparel/layers</xpath>
+            <value>
+                <layers>
+                    <li>Shell</li>             
+                </layers>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>2.00</StuffEffectMultiplierArmor>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor"]/statBases/Mass</xpath>
+            <value>
+                <Mass>13</Mass>
+            </value>
+        </li>
+
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_SamuraiArmor"]/equippedStatOffsets</xpath>
+            <value>
+                <equippedStatOffsets>
+                    <MeleeDodgeChance>-0.10</MeleeDodgeChance>
+                    <Suppressability>-0.20</Suppressability>
+                </equippedStatOffsets>
+            </value>
+        </li>
+
+        <!--Helmet-->
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_SamuraiHelmet" or 
+                defName="TSFApparel_DaimyoHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>2.6</StuffEffectMultiplierArmor>
+            </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_SamuraiHelmet" or 
+                defName="TSFApparel_DaimyoHelmet"]/statBases</xpath>
+            <value>
+                <Bulk>8</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_SamuraiHelmet" or 
+                defName="TSFApparel_DaimyoHelmet"]/equippedStatOffsets</xpath>
+            <value>
+                <Suppressability>-0.10</Suppressability>
+            </value>
+        </li>   
+        
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[
+                defName="TSFApparel_SamuraiHelmet" or 
+                defName="TSFApparel_DaimyoHelmet"]/apparel/bodyPartGroups</xpath>
+            <value>
+                <bodyPartGroups>
+                    <li>UpperHead</li>
+                </bodyPartGroups>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSFApparel_DaimyoHelmet"]/costStuffCount</xpath>
+            <value>
+                <costStuffCount>55</costStuffCount>
+            </value>
+        </li>
+    </operations>
+    </match>
+</Operation>
+
+</Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Pawnkinds.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Pawnkinds.xml
@@ -21,8 +21,8 @@
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>200</min>
+									<max>300</max>
 								</sidearmMoney>
 								<weaponTags>
 									<li>NeolithicMeleeBasic</li>
@@ -35,24 +35,20 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/PawnKindDef[
-						defName="TSF_AshigaruMatchlock" or
-						defName="TSF_AshigaruMortar"]</xpath>
+					<xpath>/Defs/PawnKindDef[defName="TSF_AshigaruMortar"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>10</min>
-								<max>15</max>
+								<min>8</min>
+								<max>12</max>
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>200</min>
+									<max>300</max>
 								</sidearmMoney>
 								<weaponTags>
-									<li>NeolithicMeleeBasic</li>
-									<li>MedievalMeleeDecent</li>
-									<li>SamuraiMeleeBasic</li>
+									<li>SamuraiMeleeSidearm</li>
 								</weaponTags>
 							</forcedSidearm>
 						</li>
@@ -66,16 +62,16 @@
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>20</min>
+								<min>25</min>
 								<max>35</max>
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>200</min>
+									<max>300</max>
 								</sidearmMoney>
 								<weaponTags>
-									<li>SamuraiMeleeAdvanced</li>
+									<li>SamuraiMeleeSidearm</li>
 								</weaponTags>
 							</forcedSidearm>
 						</li>
@@ -84,21 +80,22 @@
 
 				<li Class="PatchOperationAddModExtension">
 					<xpath>/Defs/PawnKindDef[
+						defName="TSF_AshigaruMatchlock" or
 						defName="TSF_SamuraiWarriorMatchlock" or
 						defName="TSF_NinjaMatchlock"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
-								<min>10</min>
-								<max>15</max>
+								<min>15</min>
+								<max>20</max>
 							</primaryMagazineCount>
 							<forcedSidearm>
 								<sidearmMoney>
-									<min>150</min>
-									<max>250</max>
+									<min>200</min>
+									<max>300</max>
 								</sidearmMoney>
 								<weaponTags>
-									<li>SamuraiMeleeAdvanced</li>
+									<li>SamuraiMeleeSidearm</li>
 								</weaponTags>
 							</forcedSidearm>
 						</li>
@@ -108,15 +105,21 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/PawnKindDef[
 						defName="TSF_TownGaurd" or
-						defName="TSF_AshigaruYumi" or
-						defName="TSF_AshigaruMatchlock" or
-						defName="TSF_AshigaruMortar" or
+						@Name="TSF_AshigaruBase" or
 						defName="TSF_SamuraiWarriorYumi" or
 						defName="TSF_SamuraiWarriorMatchlock" or
 						defName="TSF_Noble" or
 						@Name="TSF_Ninjabase"]/apparelRequired</xpath>
 					<value>
 						<li>Apparel_TribalBackpack</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/PawnKindDef[
+						@Name="TSF_Ninjabase"]/weaponMoney</xpath>
+					<value>
+						<weaponMoney>250~600</weaponMoney>
 					</value>
 				</li>
 
@@ -133,6 +136,7 @@
 						defName="TSF_SamuraiDaimyo" or
 						defName="TSF_Noble"]/itemQuality</xpath>
 					<value>
+						<itemQuality>Excellent</itemQuality>
 					</value>
 				</li>
 
@@ -146,10 +150,9 @@
 						</li>
 					</value>
 				</li>
-              
-            </operations>
+			
+			</operations>
 		</match>  
 	</Operation>
-
 
 </Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Pawnkinds.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Pawnkinds.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>T's Samurai Faction</li>
+        </mods>
+		<match Class="PatchOperationSequence">
+            <operations>
+			
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_TownGaurd" or
+						defName="TSF_AshigaruYumi"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>20</min>
+								<max>30</max>
+							</primaryMagazineCount>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>150</min>
+									<max>250</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>NeolithicMeleeBasic</li>
+									<li>MedievalMeleeDecent</li>
+									<li>SamuraiMeleeBasic</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_AshigaruMatchlock" or
+						defName="TSF_AshigaruMortar"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>15</max>
+							</primaryMagazineCount>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>150</min>
+									<max>250</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>NeolithicMeleeBasic</li>
+									<li>MedievalMeleeDecent</li>
+									<li>SamuraiMeleeBasic</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_SamuraiWarriorYumi" or
+						defName="TSF_Noble"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>20</min>
+								<max>35</max>
+							</primaryMagazineCount>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>150</min>
+									<max>250</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>SamuraiMeleeAdvanced</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_SamuraiWarriorMatchlock" or
+						defName="TSF_NinjaMatchlock"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>10</min>
+								<max>15</max>
+							</primaryMagazineCount>
+							<forcedSidearm>
+								<sidearmMoney>
+									<min>150</min>
+									<max>250</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>SamuraiMeleeAdvanced</li>
+								</weaponTags>
+							</forcedSidearm>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_TownGaurd" or
+						defName="TSF_AshigaruYumi" or
+						defName="TSF_AshigaruMatchlock" or
+						defName="TSF_AshigaruMortar" or
+						defName="TSF_SamuraiWarriorYumi" or
+						defName="TSF_SamuraiWarriorMatchlock" or
+						defName="TSF_Noble" or
+						@Name="TSF_Ninjabase"]/apparelRequired</xpath>
+					<value>
+						<li>Apparel_TribalBackpack</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_TownGaurd" or
+						defName="TSF_Peasant" or
+						@Name="TSF_Ninjabase" or
+						@Name="TSF_AshigaruBase"]/itemQuality</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/PawnKindDef[
+						defName="TSF_SamuraiDaimyo" or
+						defName="TSF_Noble"]/itemQuality</xpath>
+					<value>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ScenarioDef[defName="WanderingRonin"]/scenario/parts</xpath>
+					<value>
+						<li Class="ScenPart_StartingThing_Defined">
+							<def>StartingThing_Defined</def>
+							<thingDef>Ammo_Arrow_Steel</thingDef>
+							<count>80</count>
+						</li>
+					</value>
+				</li>
+              
+            </operations>
+		</match>  
+	</Operation>
+
+
+</Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Melee.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Melee.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>T's Samurai Faction</li>
+		</mods>
+        <match Class="PatchOperationSequence">
+        <operations>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Sake"]/tools</xpath>
+                <value>
+                    <tools>
+                        <li Class="CombatExtended.ToolCE">
+                            <capacities>
+                                <li>Blunt</li>
+                            </capacities>
+                            <power>2</power>
+                            <cooldownTime>2.22</cooldownTime>
+                            <chanceFactor>1.33</chanceFactor>
+                            <armorPenetrationBlunt>0.338</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>neck</label>
+                            <capacities>
+                                <li>Poke</li>
+                            </capacities>
+                            <power>1</power>
+                            <cooldownTime>3.33</cooldownTime>
+                            <armorPenetrationBlunt>0.150</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Neck</linkedBodyPartsGroup>
+                        </li>
+                    </tools>
+                </value>
+            </li>
+
+            
+            <li Class="PatchOperationRemove">
+                <xpath>Defs/ThingDef[
+                    defName="TSF_Yari" or
+                    defName="TSF_Katana" or
+                    defName="TSF_Odachi" or
+                    defName="TSF_Naginata"]/equippedStatOffsets</xpath>
+            </li>
+
+        <!-- ========== Yari ========== -->
+
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="TSF_Yari"]/statBases</xpath>
+                <value>
+                    <Bulk>12</Bulk>
+                    <MeleeCounterParryBonus>1.68</MeleeCounterParryBonus>
+                </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="TSF_Yari"]</xpath>
+                <value>
+                    <equippedStatOffsets>
+                        <MeleeCritChance>0.17</MeleeCritChance>
+                        <MeleeParryChance>1.45</MeleeParryChance>
+                        <MeleeDodgeChance>0.9</MeleeDodgeChance>
+                    </equippedStatOffsets>
+                </value>
+            </li>
+            
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Yari"]/tools</xpath>
+                <value>
+                    <tools>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>shaft</label>
+                            <capacities>
+                                <li>Blunt</li>
+                            </capacities>
+                            <power>7</power>
+                            <cooldownTime>2.20</cooldownTime>
+                            <chanceFactor>0.15</chanceFactor>
+                            <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>shaft</label>
+                            <capacities>
+                                <li>Poke</li>
+                            </capacities>
+                            <power>4</power>
+                            <cooldownTime>1.79</cooldownTime>
+                            <chanceFactor>0.05</chanceFactor>
+                            <armorPenetrationBlunt>1</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>head</label>
+                            <capacities>
+                                <li>Stab</li>
+                            </capacities>
+                            <power>25</power>
+                            <cooldownTime>1.8</cooldownTime>
+                            <chanceFactor>0.90</chanceFactor>
+                            <armorPenetrationBlunt>5</armorPenetrationBlunt>
+                            <armorPenetrationSharp>2.65</armorPenetrationSharp>
+                            <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+                        </li>
+                    </tools>
+                </value>
+            </li>
+
+        <!-- ========== Katana ========== -->
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="TSF_Katana"]/statBases</xpath>
+                <value>
+                    <Bulk>7</Bulk>
+                    <MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+                </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="TSF_Katana"]</xpath>
+                <value>
+                    <equippedStatOffsets>
+                        <MeleeCritChance>0.63</MeleeCritChance>
+                        <MeleeParryChance>0.75</MeleeParryChance>
+                        <MeleeDodgeChance>0.4</MeleeDodgeChance>	
+                    </equippedStatOffsets>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Katana"]/tools</xpath>
+                <value>
+                    <tools>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>handle</label>
+                            <capacities>
+                                <li>Poke</li>
+                            </capacities>
+                            <power>3</power>
+                            <cooldownTime>1.69</cooldownTime>
+                            <chanceFactor>0.10</chanceFactor>
+                            <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>point</label>
+                            <capacities>
+                                <li>Stab</li>
+                            </capacities>
+                            <power>18</power>
+                            <cooldownTime>1.69</cooldownTime>
+                            <chanceFactor>0.60</chanceFactor>
+                            <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                            <armorPenetrationSharp>1.35</armorPenetrationSharp>
+                            <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>edge</label>
+                            <capacities>
+                                <li>Cut</li>
+                            </capacities>
+                            <power>30</power>
+                            <cooldownTime>1.56</cooldownTime>
+                            <chanceFactor>0.30</chanceFactor>
+                            <armorPenetrationBlunt>2.592</armorPenetrationBlunt>
+                            <armorPenetrationSharp>0.65</armorPenetrationSharp>
+                            <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                        </li>
+                    </tools>
+                </value>
+            </li>
+
+        <!--Odachi-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/ThingDef[defName="TSF_Odachi"]/statBases</xpath>
+                <value>
+                  <Bulk>12</Bulk>
+                  <MeleeCounterParryBonus>0.70</MeleeCounterParryBonus>
+                </value>
+              </li>
+
+              <li Class="PatchOperationAdd">
+              <xpath>/Defs/ThingDef[defName="TSF_Odachi"]</xpath>
+              <value>
+                  <equippedStatOffsets>
+                  <MeleeCritChance>0.80</MeleeCritChance>
+                  <MeleeParryChance>0.60</MeleeParryChance>
+                  <MeleeDodgeChance>0.30</MeleeDodgeChance>
+                  </equippedStatOffsets>
+              </value>
+            </li>
+
+              <li Class="PatchOperationReplace">
+              <xpath>/Defs/ThingDef[defName="TSF_Odachi"]/tools</xpath>
+              <value>
+                  <tools>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>handle</label>
+                      <capacities>
+                          <li>Poke</li>
+                      </capacities>
+                      <power>5</power>
+                      <cooldownTime>1.69</cooldownTime>
+                      <chanceFactor>0.05</chanceFactor>
+                      <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                      <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                  </li>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>point</label>
+                      <capacities>
+                          <li>Stab</li>
+                      </capacities>
+                      <power>22</power>
+                      <cooldownTime>1.98</cooldownTime>
+                      <chanceFactor>0.50</chanceFactor>
+                      <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                      <armorPenetrationSharp>1.45</armorPenetrationSharp>
+                      <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                  </li>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>edge</label>
+                      <capacities>
+                          <li>Cut</li>
+                      </capacities>
+                      <power>42</power>
+                      <cooldownTime>2.86</cooldownTime>
+                      <chanceFactor>0.45</chanceFactor>
+                      <armorPenetrationBlunt>3.592</armorPenetrationBlunt>
+                      <armorPenetrationSharp>0.70</armorPenetrationSharp>
+                      <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                  </li>
+                  </tools>
+              </value>
+            </li>
+
+
+        <!--Naginata-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/ThingDef[defName="TSF_Naginata"]/statBases</xpath>
+                <value>
+                  <Bulk>12</Bulk>
+                  <MeleeCounterParryBonus>1.27</MeleeCounterParryBonus>
+                </value>
+              </li>
+
+              <li Class="PatchOperationAdd">
+              <xpath>/Defs/ThingDef[defName="TSF_Naginata"]</xpath>
+              <value>
+                  <equippedStatOffsets>
+                  <MeleeCritChance>0.08</MeleeCritChance>
+                  <MeleeParryChance>0.95</MeleeParryChance>
+                  <MeleeDodgeChance>1.27</MeleeDodgeChance>
+                  </equippedStatOffsets>
+              </value>
+              </li>
+
+              <li Class="PatchOperationReplace">
+              <xpath>/Defs/ThingDef[defName="TSF_Naginata"]/tools</xpath>
+              <value>
+                  <tools>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>shaft</label>
+                      <capacities>
+                          <li>Poke</li>
+                      </capacities>
+                      <power>8</power>
+                      <cooldownTime>1.3</cooldownTime>
+                      <chanceFactor>0.05</chanceFactor>
+                      <armorPenetrationBlunt>5</armorPenetrationBlunt>
+                      <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+                  </li>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>edge</label>
+                      <capacities>
+                          <li>Stab</li>
+                      </capacities>
+                      <power>18</power>
+                      <cooldownTime>1.8</cooldownTime>
+                      <chanceFactor>0.20</chanceFactor>
+                      <armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+                      <armorPenetrationSharp>1.6</armorPenetrationSharp>
+                      <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                  </li>
+                  <li Class="CombatExtended.ToolCE">
+                      <label>edge</label>
+                      <capacities>
+                          <li>Cut</li>
+                      </capacities>
+                      <power>28</power>
+                      <cooldownTime>2.3</cooldownTime>
+                      <chanceFactor>0.75</chanceFactor>
+                      <armorPenetrationBlunt>4.6</armorPenetrationBlunt>
+                      <armorPenetrationSharp>0.75</armorPenetrationSharp>
+                      <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                  </li>
+                  </tools>
+              </value>
+              </li>
+        </operations>
+        </match>
+    </Operation>
+</Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Melee.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Melee.xml
@@ -103,7 +103,7 @@
                             <cooldownTime>1.8</cooldownTime>
                             <chanceFactor>0.90</chanceFactor>
                             <armorPenetrationBlunt>5</armorPenetrationBlunt>
-                            <armorPenetrationSharp>2.65</armorPenetrationSharp>
+                            <armorPenetrationSharp>2.5</armorPenetrationSharp>
                             <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                         </li>
                     </tools>
@@ -114,8 +114,24 @@
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="TSF_Katana"]/statBases</xpath>
                 <value>
-                    <Bulk>7</Bulk>
+                    <Bulk>6</Bulk>
                     <MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Katana"]/statBases/Mass</xpath>
+                <value>
+                    <Mass>1.3</Mass>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Katana"]/weaponTags</xpath>
+                <value>
+                    <weaponTags>
+                        <li>SamuraiMeleeSidearm</li>
+                    </weaponTags>
                 </value>
             </li>
 
@@ -177,10 +193,17 @@
             <li Class="PatchOperationAdd">
                 <xpath>/Defs/ThingDef[defName="TSF_Odachi"]/statBases</xpath>
                 <value>
-                  <Bulk>12</Bulk>
+                  <Bulk>10</Bulk>
                   <MeleeCounterParryBonus>0.70</MeleeCounterParryBonus>
                 </value>
-              </li>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="TSF_Odachi"]/statBases/Mass</xpath>
+                <value>
+                    <Mass>2.6</Mass>
+                </value>
+            </li>
 
               <li Class="PatchOperationAdd">
               <xpath>/Defs/ThingDef[defName="TSF_Odachi"]</xpath>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+<Operation Class="PatchOperationFindMod">
+  <mods>
+    <li>T's Samurai Faction</li>
+  </mods>
+      <match Class="PatchOperationSequence">
+      <operations>
+    
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[
+            defName="TSF_Tanegashima_Short" or
+            defName="TSF_Tanegashima_Matchlock" or
+            defName="TSF_Hand_Mortar"
+            ]/tools</xpath>
+          <value>
+          <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>stock</label>
+            <capacities>
+            <li>Blunt</li>
+            </capacities>
+            <power>8</power>
+            <cooldownTime>1.55</cooldownTime>
+            <chanceFactor>1.5</chanceFactor>
+            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>barrel</label>
+            <capacities>
+            <li>Blunt</li>
+            </capacities>
+            <power>5</power>
+            <cooldownTime>2.02</cooldownTime>
+            <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>muzzle</label>
+            <capacities>
+            <li>Poke</li>
+            </capacities>
+            <power>8</power>
+            <cooldownTime>1.55</cooldownTime>
+            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+          </li>
+          </tools>
+          </value>
+        </li>
+
+        <!-- Short Gun -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+            <defName>TSF_Tanegashima_Short</defName>
+            <statBases>
+              <WorkToMake>12000</WorkToMake>
+              <Bulk>4.75</Bulk>
+              <Mass>2.5</Mass>
+              <SwayFactor>1.22</SwayFactor>
+              <ShotSpread>0.30</ShotSpread>
+              <SightsEfficiency>0.7</SightsEfficiency>
+              <RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
+            </statBases>
+            <costList>
+              <Steel>35</Steel>
+              <WoodLog>8</WoodLog>
+              <ComponentIndustrial>1</ComponentIndustrial>
+            </costList>
+            <Properties>
+              <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+              <hasStandardCommand>True</hasStandardCommand>
+              <defaultProjectile>Bullet_SlowMusketBall</defaultProjectile>
+              <warmupTime>1.1</warmupTime>
+              <range>24</range>
+              <soundCast>Shot_Musket</soundCast>
+              <soundCastTail>GunTail_Light</soundCastTail>
+              <muzzleFlashScale>9</muzzleFlashScale>
+            </Properties>
+            <AmmoUser>
+              <magazineSize>1</magazineSize>
+              <reloadTime>6.5</reloadTime>
+              <ammoSet>AmmoSet_SlowMusketBall</ammoSet>
+            </AmmoUser>
+            <FireModes>
+              <aiAimMode>AimedShot</aiAimMode>
+            </FireModes>
+            <weaponTags>
+              <li>NeolithicRangedHeavy</li>
+              <li>NeolithicRangedChief</li>
+              <li>CE_OneHandedWeapon</li>
+            </weaponTags>
+          </li>
+
+        <!-- Long Gun -->
+          <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+            <defName>TSF_Tanegashima_Matchlock</defName>
+            <statBases>
+              <WorkToMake>20000</WorkToMake>
+              <Mass>4.8</Mass>
+              <Bulk>14.9</Bulk>
+              <SwayFactor>1.92</SwayFactor>
+              <ShotSpread>0.25</ShotSpread>
+              <SightsEfficiency>1</SightsEfficiency>
+              <RangedWeapon_Cooldown>1.35</RangedWeapon_Cooldown>
+            </statBases>
+            <costList>
+              <Steel>65</Steel>
+              <WoodLog>15</WoodLog>
+              <ComponentIndustrial>1</ComponentIndustrial>
+            </costList>
+            <Properties>
+              <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+              <hasStandardCommand>True</hasStandardCommand>
+              <defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
+              <warmupTime>1.3</warmupTime>
+              <range>40</range>
+              <soundCast>Shot_Musket</soundCast>
+              <soundCastTail>GunTail_Medium</soundCastTail>
+              <muzzleFlashScale>12</muzzleFlashScale>
+            </Properties>
+            <AmmoUser>
+              <magazineSize>1</magazineSize>
+              <reloadTime>7</reloadTime>
+              <ammoSet>AmmoSet_FastMusketBall</ammoSet>
+            </AmmoUser>
+            <FireModes>
+              <aiAimMode>AimedShot</aiAimMode>
+            </FireModes>
+            <weaponTags>
+              <li>NeolithicRangedHeavy</li>
+              <li>NeolithicRangedChief</li>
+            </weaponTags>
+          </li>
+
+        <!--Hand Mortar-->
+          <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+            <defName>TSF_Hand_Mortar</defName>
+            <statBases>
+              <Mass>7.5</Mass>
+              <Bulk>12.9</Bulk>
+              <SwayFactor>1.92</SwayFactor>
+              <ShotSpread>1</ShotSpread>
+              <SightsEfficiency>0.7</SightsEfficiency>
+              <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+            </statBases>
+            <Properties>
+              <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+              <hasStandardCommand>True</hasStandardCommand>
+              <defaultProjectile>Bullet_MortarGrenade</defaultProjectile>
+              <warmupTime>1.6</warmupTime>
+              <range>37</range>
+              <soundCast>Shot_IncendiaryLauncher</soundCast>
+              <soundCastTail>GunTail_Medium</soundCastTail>
+              <muzzleFlashScale>12</muzzleFlashScale>
+              <targetParams>
+                <canTargetLocations>True</canTargetLocations>
+              </targetParams>		  
+            </Properties>
+            <AmmoUser>
+              <magazineSize>1</magazineSize>
+              <reloadTime>9</reloadTime>
+              <ammoSet>AmmoSet_MortarGrenade</ammoSet>
+            </AmmoUser>
+            <FireModes>
+              <aiAimMode>AimedShot</aiAimMode>
+            </FireModes>
+          </li>
+
+            <!-- ========== Yumi ========== -->
+          <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+            <defName>TSF_Yumi</defName>
+            <statBases>
+              <SightsEfficiency>0.6</SightsEfficiency>
+              <ShotSpread>1</ShotSpread>
+              <SwayFactor>2</SwayFactor>
+              <Bulk>8.00</Bulk>
+              <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
+            </statBases>
+            <costList>
+              <WoodLog>15</WoodLog>
+            </costList>
+            <Properties>
+              <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+              <hasStandardCommand>true</hasStandardCommand>
+              <defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
+              <warmupTime>1.2</warmupTime>
+              <range>32</range>
+              <soundCast>Bow_Recurve</soundCast>
+            </Properties>
+            <AmmoUser>
+              <ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
+            </AmmoUser>
+            <FireModes/>
+            <weaponTags>
+              <li>CE_Bow</li>
+            </weaponTags>
+            <researchPrerequisite>RecurveBow</researchPrerequisite>
+            <AllowWithRunAndGun>false</AllowWithRunAndGun>
+          </li>
+
+          <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TSF_Yumi"]/tools</xpath>
+            <value>
+              <tools>
+                <li Class="CombatExtended.ToolCE">
+                    <capacities>
+                      <li>Blunt</li>
+                    </capacities>
+                    <power>7</power>
+                    <cooldownTime>1.6</cooldownTime>
+            <armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+                </li>
+              </tools>
+            </value>
+          </li>
+
+        <!--Shuriken-->
+    
+        <!-- == Projectile == -->
+        <li Class="PatchOperationReplace">
+            <xpath>/Defs/ThingDef[defName="TSF_Star_Thrown"]/projectile</xpath>
+            <value>
+              <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                <damageDef>Cut</damageDef>
+                <damageAmountBase>6</damageAmountBase>
+                <flyOverhead>false</flyOverhead>
+                <speed>30</speed>
+                <gravityFactor>2</gravityFactor>
+                <armorPenetrationSharp>0.5</armorPenetrationSharp>
+                <armorPenetrationBlunt>1</armorPenetrationBlunt>
+                <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+                <preExplosionSpawnThingDef>TSF_Shuriken</preExplosionSpawnThingDef>
+              </projectile>
+            </value>
+          </li>
+
+          <!-- == Weapon == -->
+          <li Class="PatchOperationAttributeSet">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]</xpath>
+            <attribute>ParentName</attribute>
+            <value>BaseWeapon</value>
+          </li>
+          
+          <li Class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]</xpath> 
+            <value>
+              <thingCategories>
+                <li>WeaponsRanged</li>
+              </thingCategories>
+            </value>
+          </li>
+  
+          <li Class="PatchOperationRemove">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]/recipeMaker</xpath>
+          </li>
+  
+          <li Class="PatchOperationRemove">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]/costStuffCount</xpath>
+          </li>
+  
+          <li Class="PatchOperationRemove">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]/stuffCategories</xpath>
+          </li>
+  
+  
+          <li Class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]</xpath>
+            <value>
+              <thingClass>CombatExtended.AmmoThing</thingClass>
+              <stackLimit>75</stackLimit>
+              <resourceReadoutPriority>First</resourceReadoutPriority>
+            </value>
+          </li>
+  
+          <li Class="PatchOperationAttributeSet">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]</xpath>
+            <attribute>Class</attribute>
+            <value>CombatExtended.AmmoDef</value>
+          </li>
+  
+          <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+            <defName>TSF_Shuriken</defName>
+            <statBases>
+              <SightsEfficiency>0.5</SightsEfficiency>
+              <Bulk>0.20</Bulk>
+              <Mass>0.30</Mass>
+              <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
+            </statBases>
+            <Properties>
+              <label>Throw shuriken</label>
+              <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+              <hasStandardCommand>True</hasStandardCommand>
+              <defaultProjectile>TSF_Star_Thrown</defaultProjectile>
+              <warmupTime>0.6</warmupTime>
+              <range>9</range>
+              <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+              <burstShotCount>3</burstShotCount>
+              <onlyManualCast>true</onlyManualCast>
+              <stopBurstWithoutLos>false</stopBurstWithoutLos>
+              <soundCast>Interact_BeatFire</soundCast>
+              <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>
+              <targetParams>
+                <canTargetLocations>true</canTargetLocations>
+              </targetParams>
+            </Properties>
+            <weaponTags>
+              <li>CE_OneHandedWeapon</li>
+            </weaponTags>
+          </li>
+  
+          <li Class="PatchOperationReplace">
+            <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]/tools</xpath>
+            <value>
+              <tools>
+                <li Class="CombatExtended.ToolCE">
+                  <label>point</label>
+                  <capacities>
+                    <li>Stab</li>
+                  </capacities>
+                  <power>5</power>
+                  <cooldownTime>1.26</cooldownTime>
+                  <chanceFactor>1.33</chanceFactor>
+                  <armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+                  <armorPenetrationSharp>0.3</armorPenetrationSharp>
+                  <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                </li>
+              </tools>
+            </value>
+          </li>
+
+          <!-- == Recipe == -->
+          <li Class="PatchOperationAdd">
+            <xpath>Defs</xpath>
+            <value>
+              <RecipeDef ParentName="GrenadeRecipeBase">
+                <defName>MakeTSF_Shuriken</defName>
+                <label>make throwing knives x10</label>
+                <description>Craft 10 throwing knives.</description>
+                <jobString>Making throwing knives.</jobString>
+                <ingredients>
+                  <li>
+                    <filter>
+                      <thingDefs>
+                        <li>Steel</li>
+                      </thingDefs>
+                    </filter>
+                    <count>10</count>
+                  </li>
+                </ingredients>
+                <fixedIngredientFilter>
+                  <thingDefs>
+                    <li>Steel</li>
+                  </thingDefs>
+                </fixedIngredientFilter>
+                <products>
+                  <TSF_Shuriken>10</TSF_Shuriken>
+                </products>
+                <recipeUsers>
+                  <li>FueledSmithy</li>
+                  <li>ElectricSmithy</li>
+                </recipeUsers>
+              </RecipeDef>
+            </value>
+          </li>
+        </operations>
+      </match>
+  </Operation>
+</Patch>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
@@ -80,7 +80,7 @@
             </Properties>
             <AmmoUser>
               <magazineSize>1</magazineSize>
-              <reloadTime>6.5</reloadTime>
+              <reloadTime>7</reloadTime>
               <ammoSet>AmmoSet_SlowMusketBall</ammoSet>
             </AmmoUser>
             <FireModes>
@@ -122,7 +122,7 @@
             </Properties>
             <AmmoUser>
               <magazineSize>1</magazineSize>
-              <reloadTime>7</reloadTime>
+              <reloadTime>7.5</reloadTime>
               <ammoSet>AmmoSet_FastMusketBall</ammoSet>
             </AmmoUser>
             <FireModes>
@@ -141,14 +141,14 @@
               <Mass>7.5</Mass>
               <Bulk>12.9</Bulk>
               <SwayFactor>1.92</SwayFactor>
-              <ShotSpread>1</ShotSpread>
-              <SightsEfficiency>0.7</SightsEfficiency>
+              <ShotSpread>0.8</ShotSpread>
+              <SightsEfficiency>0.8</SightsEfficiency>
               <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
             </statBases>
             <Properties>
               <verbClass>CombatExtended.Verb_ShootCE</verbClass>
               <hasStandardCommand>True</hasStandardCommand>
-              <defaultProjectile>Bullet_MortarGrenade</defaultProjectile>
+              <defaultProjectile>Bullet_TSF_MortarGrenade</defaultProjectile>
               <warmupTime>1.6</warmupTime>
               <range>37</range>
               <soundCast>Shot_IncendiaryLauncher</soundCast>
@@ -160,8 +160,8 @@
             </Properties>
             <AmmoUser>
               <magazineSize>1</magazineSize>
-              <reloadTime>9</reloadTime>
-              <ammoSet>AmmoSet_MortarGrenade</ammoSet>
+              <reloadTime>8</reloadTime>
+              <ammoSet>AmmoSet_TSF_MortarGrenade</ammoSet>
             </AmmoUser>
             <FireModes>
               <aiAimMode>AimedShot</aiAimMode>
@@ -216,7 +216,21 @@
             </value>
           </li>
 
-        <!--Shuriken-->
+<!--Shuriken (removed because I can't make it not hurt internal organs too often)-->
+
+<!--disable this disabler part in case of fix for above problem
+          <li Class="PatchOperationRemove">
+            <xpath>Defs/ThingDef[
+              defName="TSF_Star_Thrown" or
+              defName="TSF_Shuriken"]</xpath>
+          </li>
+          
+          <li Class="PatchOperationRemove">
+            <xpath>/Defs/PawnKindDef[
+              @Name="TSF_Ninjabase"]/weaponTags</xpath>
+          </li>
+
+-->
     
         <!-- == Projectile == -->
         <li Class="PatchOperationReplace">
@@ -224,19 +238,21 @@
             <value>
               <projectile Class="CombatExtended.ProjectilePropertiesCE">
                 <damageDef>Cut</damageDef>
-                <damageAmountBase>6</damageAmountBase>
+                <damageAmountBase>5</damageAmountBase>
                 <flyOverhead>false</flyOverhead>
                 <speed>30</speed>
                 <gravityFactor>2</gravityFactor>
-                <armorPenetrationSharp>0.5</armorPenetrationSharp>
-                <armorPenetrationBlunt>1</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.16</armorPenetrationSharp>
+                <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
                 <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
                 <preExplosionSpawnThingDef>TSF_Shuriken</preExplosionSpawnThingDef>
               </projectile>
             </value>
           </li>
 
+
           <!-- == Weapon == -->
+
           <li Class="PatchOperationAttributeSet">
             <xpath>/Defs/ThingDef[defName="TSF_Shuriken"]</xpath>
             <attribute>ParentName</attribute>
@@ -283,7 +299,7 @@
           <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
             <defName>TSF_Shuriken</defName>
             <statBases>
-              <SightsEfficiency>0.5</SightsEfficiency>
+              <SightsEfficiency>0.4</SightsEfficiency>
               <Bulk>0.20</Bulk>
               <Mass>0.30</Mass>
               <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
@@ -294,7 +310,7 @@
               <hasStandardCommand>True</hasStandardCommand>
               <defaultProjectile>TSF_Star_Thrown</defaultProjectile>
               <warmupTime>0.6</warmupTime>
-              <range>9</range>
+              <range>8</range>
               <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
               <burstShotCount>3</burstShotCount>
               <onlyManualCast>true</onlyManualCast>
@@ -330,15 +346,14 @@
             </value>
           </li>
 
-          <!-- == Recipe == -->
           <li Class="PatchOperationAdd">
             <xpath>Defs</xpath>
             <value>
               <RecipeDef ParentName="GrenadeRecipeBase">
                 <defName>MakeTSF_Shuriken</defName>
-                <label>make throwing knives x10</label>
-                <description>Craft 10 throwing knives.</description>
-                <jobString>Making throwing knives.</jobString>
+                <label>make shurikens x10</label>
+                <description>Craft 10 shurikens.</description>
+                <jobString>Making shurikens.</jobString>
                 <ingredients>
                   <li>
                     <filter>
@@ -354,6 +369,7 @@
                     <li>Steel</li>
                   </thingDefs>
                 </fixedIngredientFilter>
+                <workAmount>500</workAmount>
                 <products>
                   <TSF_Shuriken>10</TSF_Shuriken>
                 </products>
@@ -364,6 +380,7 @@
               </RecipeDef>
             </value>
           </li>
+
         </operations>
       </match>
   </Operation>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
@@ -35,6 +35,7 @@
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageAmountBase>8</damageAmountBase>
+              <speed>42</speed>			
               <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
               <armorPenetrationSharp>1.85</armorPenetrationSharp>			
               <preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
@@ -53,7 +54,6 @@
               <damageAmountBase>12</damageAmountBase>
               <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
               <armorPenetrationSharp>2.85</armorPenetrationSharp>
-              <speed>18</speed>			
               <preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -70,7 +70,7 @@
               <damageAmountBase>10</damageAmountBase>
               <armorPenetrationBlunt>8.12</armorPenetrationBlunt>
               <armorPenetrationSharp>4</armorPenetrationSharp>
-              <speed>20</speed>				
+              <speed>64</speed>				
               <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
             </projectile>
@@ -88,7 +88,6 @@
               <damageAmountBase>12</damageAmountBase>
               <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
               <armorPenetrationSharp>2.5</armorPenetrationSharp>
-              <speed>18</speed>	
               <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -106,7 +105,6 @@
               <damageAmountBase>5</damageAmountBase>
               <armorPenetrationBlunt>3.28</armorPenetrationBlunt>
               <armorPenetrationSharp>1.5</armorPenetrationSharp>
-              <speed>18</speed>	
             </projectile>
           </ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
@@ -33,6 +33,8 @@
 
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <speed>10</speed>
+              <gravityFactor>2</gravityFactor>
               <damageDef>Bomb</damageDef>
               <explosionDelay>40</explosionDelay>
               <explosionRadius>3.5</explosionRadius>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -26,7 +26,8 @@
 
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <speed>35</speed>
+              <speed>25</speed>
+              <gravityFactor>2</gravityFactor>
               <flyOverhead>false</flyOverhead>
               <damageDef>Cut</damageDef>
               <damageAmountBase>16</damageAmountBase>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Domestic.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Domestic.xml
@@ -51,7 +51,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="VFEV_WoolyCow"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.7</baseBodySize>
+			<baseBodySize>1.8</baseBodySize>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="VFEV_WoolyCow"]/statBases/MoveSpeed</xpath>
+		<value>
+			<MoveSpeed>4.8</MoveSpeed>
 		</value>
 	</li>
 

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -312,7 +312,7 @@
             <ShotSpread>1.5</ShotSpread>
             <SwayFactor>2.5</SwayFactor>
             <Bulk>3</Bulk>
-            <Mass>1.75</Mass>
+            <Mass>1.5</Mass>
             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					</statBases>
 					<stackLimit>25</stackLimit>				
@@ -328,7 +328,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Vikings_Harpoon_Thrown</defaultProjectile>
 						<warmupTime>0.8</warmupTime>
-						<range>16</range>
+						<range>9</range>
 						<soundCast>Interact_BeatFire</soundCast>
 					</li>
 				</verbs>
@@ -381,7 +381,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Cut</damageDef>			
             <damageAmountBase>16</damageAmountBase>
-            <speed>12</speed>
+            <speed>22</speed>
             <armorPenetrationSharp>1.4</armorPenetrationSharp>
             <armorPenetrationBlunt>27</armorPenetrationBlunt>
             <preExplosionSpawnChance>0.50</preExplosionSpawnChance>
@@ -393,8 +393,8 @@
           <defName>Vikings_Harpoon_Thrown</defName>
           <label>thrown harpoon</label>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>12</damageAmountBase>
-            <speed>8</speed>
+            <damageAmountBase>16</damageAmountBase>
+            <speed>15</speed>
             <armorPenetrationBlunt>4.54</armorPenetrationBlunt>
             <armorPenetrationSharp>1.8</armorPenetrationSharp>
             <secondaryDamage>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -56,7 +56,8 @@
             <damageDef>RangedStab</damageDef>
             <damageAmountBase>7</damageAmountBase>
             <flyOverhead>false</flyOverhead>
-            <speed>14</speed>
+            <speed>22</speed>
+            <gravityFactor>1.5</gravityFactor>
             <armorPenetrationBlunt>0.45</armorPenetrationBlunt>
             <armorPenetrationSharp>0.26</armorPenetrationSharp>
             <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
@@ -222,7 +223,8 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>5</speed>
+				<speed>10</speed>
+        <gravityFactor>2</gravityFactor>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
@@ -32,6 +32,8 @@
           <xpath>/Defs/ThingDef[defName="VWE_Projectile_ToxicGrenade"]/projectile</xpath>
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <speed>10</speed>
+              <gravityFactor>2</gravityFactor>
               <damageDef>VWE_ToxicGas</damageDef>
               <explosionRadius>3.9</explosionRadius>
               <damageAmountBase>10</damageAmountBase>
@@ -104,7 +106,7 @@
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>VWE_Projectile_ToxicGrenade</defaultProjectile>
             <range>12</range>
-            <warmupTime>1.8</warmupTime>
+            <warmupTime>1.2</warmupTime>
             <soundCast>ThrowGrenade</soundCast>
             <noiseRadius>4</noiseRadius>
             <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -167,13 +167,13 @@
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
-						<defaultProjectile>Projectile_Arrow_Steel</defaultProjectile>
+						<defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
 						<warmupTime>1</warmupTime>
 						<range>33</range>
 						<soundCast>VWE_Bow_Compound</soundCast>
 					</Properties>
 					<AmmoUser>
-						<ammoSet>AmmoSet_Arrow</ammoSet>
+						<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags Inherit="false">

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -162,7 +162,7 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_SlowMusketBall</defaultProjectile>
-            <warmupTime>1.66</warmupTime>
+            <warmupTime>1.2</warmupTime>
             <range>12</range>
             <soundCast>VWE_Shot_Musket</soundCast>
             <soundCastTail>GunTail_Light</soundCastTail>
@@ -215,8 +215,8 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
-            <warmupTime>2.5</warmupTime>
-            <range>45</range>
+            <warmupTime>1.6</warmupTime>
+            <range>40</range>
             <soundCast>VWE_Shot_Musket</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>12</muzzleFlashScale>
@@ -244,7 +244,8 @@
               <damageDef>RangedStab</damageDef>
               <damageAmountBase>14</damageAmountBase>
               <flyOverhead>false</flyOverhead>
-              <speed>16</speed>
+              <speed>22</speed>
+              <gravityFactor>1.5</gravityFactor>
               <armorPenetrationBase>0.18</armorPenetrationBase>
               <preExplosionSpawnChance>0.80</preExplosionSpawnChance>
               <preExplosionSpawnThingDef>VWE_Throwing_Knives</preExplosionSpawnThingDef>

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -67,6 +67,8 @@
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>Blunt</damageDef>
+              <speed>15</speed>
+              <gravityFactor>2</gravityFactor>
               <damageAmountBase>15</damageAmountBase>
               <armorPenetrationBlunt>3.12</armorPenetrationBlunt>
               <dropsCasings>false</dropsCasings>


### PR DESCRIPTION
VELOCITY ENHANCED_______
javelins, VE harpoon, 2x speed and gravity factor, 1.5kg mass(javelin, harpoon), slight damage increase

sling: 2x speed and grav, small damage increase

arrows: 1.75x speed and grav

great arrows: no idea why the hell these were so much slower than even short bow arrows, brought them up to slightly slower than recurve
also, increased damage a bit too, base values were, again, wierdly low

crossbow bolts, VFE heavy crossbow: ditto ridiculously slow, should be about the same as warbows, brought up to new recurve bow values

some minor changes to make other throwing weapons more consistent 

most hand grenades : 10c/s, 2x grav, 0.8s warmup, 0.6s cooldown
(stick bomb still significantly slower)

40x46 grenades: 2x speed and grav

shotgun Bean: 2x speed and grav
shotgun EMP: 1.75x speed and grav

made horses and dromedaries not slow(8c/s and 6.3cs/s respectively) , dromedaries had really small body size for some reason, upped it and horses to 1.8



T'S SAMURAI FACTION PATCH______

Same as previous PR but with proprietary hand mortar grenade def