### PR TITLE
Patch Eltex Bodysuit Mod

### DIFF
--- a/Patches/Eltex Bodysuit/Apparel_Various.xml
+++ b/Patches/Eltex Bodysuit/Apparel_Various.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Eltex Bodysuit</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- == Eltex Bodysuit == -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="eltex_bodysuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -104,6 +104,7 @@ Dragonian Race	|
 Dragon's Descent    |
 Dragons!	|
 ED-Shields	|
+Eltex Bodysuit  |
 Epona The centaur race  |
 Equiums Horse Race	|
 Erin's Critter Collection |


### PR DESCRIPTION
A very small patch for the Eltex Bodysuit mod, which adds a single piece of apparel. The mod is currently still for RW 1.2, but it loads and works in 1.3 without errors.