### PR TITLE
Tweaks to shell balance

### DIFF
--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -85,7 +85,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>452</damageAmountBase>
-			<explosionRadius>5</explosionRadius>
+			<explosionRadius>10.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
@@ -93,7 +93,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>100</Fragment_Small>
+					<Fragment_Small>60</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -93,7 +93,7 @@
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
 					<Fragment_Large>40</Fragment_Large>
-					<Fragment_Small>80</Fragment_Small>
+					<Fragment_Small>100</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -49,13 +49,15 @@
     <ammoClass>GrenadeHE</ammoClass>
     <comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>38</damageAmountBase>
+			<damageAmountBase>40</damageAmountBase>
 			<explosiveDamageType>Bomb</explosiveDamageType>
 			<explosiveRadius>2</explosiveRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  </li>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-          <Fragment_Shell>250</Fragment_Shell>
+          			<Fragment_Large>3</Fragment_Large>
+          			<Fragment_Small>28</Fragment_Small>
 			</fragments>
 		  </li>
     </comps>
@@ -69,7 +71,7 @@
       <shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <speed>35</speed>
+		  <speed>0</speed>
           <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
           <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
           <soundAmbient>MortarRound_Ambient</soundAmbient>
@@ -86,19 +88,17 @@
 	</graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>112</damageAmountBase>
-      <explosionRadius>1</explosionRadius>
-	  <soundExplode>MortarBomb_Explode</soundExplode>
+      <damageAmountBase>40</damageAmountBase>
+      <explosionRadius>2</explosionRadius>
+	<soundExplode>MortarBomb_Explode</soundExplode>
+	<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <ai_IsIncendiary>true</ai_IsIncendiary>
     </projectile>
 		<comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>75</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>2</explosiveRadius>
-		  </li>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-          <Fragment_Shell>250</Fragment_Shell>
+          			<Fragment_Large>3</Fragment_Large>
+          			<Fragment_Small>28</Fragment_Small>
 			</fragments>
 		  </li>
 		</comps>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -49,15 +49,15 @@
     <ammoClass>GrenadeHE</ammoClass>
     <comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>40</damageAmountBase>
+			<damageAmountBase>42</damageAmountBase>
 			<explosiveDamageType>Bomb</explosiveDamageType>
 			<explosiveRadius>2</explosiveRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  </li>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-          			<Fragment_Large>3</Fragment_Large>
-          			<Fragment_Small>28</Fragment_Small>
+          <Fragment_Large>3</Fragment_Large>
+          <Fragment_Small>12</Fragment_Small>
 			</fragments>
 		  </li>
     </comps>
@@ -72,10 +72,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <speed>0</speed>
-          <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-          <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-          <soundAmbient>MortarRound_Ambient</soundAmbient>
-          <flyOverhead>true</flyOverhead>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <flyOverhead>true</flyOverhead>
 		</projectile>
 	</ThingDef>
 
@@ -88,17 +88,17 @@
 	</graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>40</damageAmountBase>
+      <damageAmountBase>42</damageAmountBase>
       <explosionRadius>2</explosionRadius>
-	<soundExplode>MortarBomb_Explode</soundExplode>
-	<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <soundExplode>MortarBomb_Explode</soundExplode>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
     </projectile>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-          			<Fragment_Large>3</Fragment_Large>
-          			<Fragment_Small>28</Fragment_Small>
+        <Fragment_Large>3</Fragment_Large>
+        <Fragment_Small>12</Fragment_Small>
 			</fragments>
 		  </li>
 		</comps>
@@ -111,6 +111,7 @@
     <label>make 50mm type 89 HE mortar shells x5</label>
     <description>Craft 5 50mm type 89 HE mortar shells.</description>
     <jobString>Making 50mm type 89 HE mortar shells.</jobString>
+    <workAmount>3000</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -118,7 +119,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>16</count>
+        <count>10</count>
       </li>
       <li>
         <filter>
@@ -126,7 +127,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>3</count>
+        <count>2</count>
       </li>
       <li>
         <filter>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -82,7 +82,7 @@
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>0</damageAmountBase>
 		<explosiveDamageType>PrometheumFlame</explosiveDamageType>
-		<explosiveRadius>7</explosiveRadius>
+		<explosiveRadius>5.0</explosiveRadius>
         <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
         <preExplosionSpawnChance>0.5</preExplosionSpawnChance>
         <explosionSound>MortarIncendiary_Explode</explosionSound>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -82,9 +82,9 @@
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<damageAmountBase>0</damageAmountBase>
 		<explosiveDamageType>PrometheumFlame</explosiveDamageType>
-		<explosiveRadius>5.0</explosiveRadius>
+		<explosiveRadius>4.5</explosiveRadius>
         <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-        <preExplosionSpawnChance>0.5</preExplosionSpawnChance>
+        <preExplosionSpawnChance>0.25</preExplosionSpawnChance>
         <explosionSound>MortarIncendiary_Explode</explosionSound>
 		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 	  </li>
@@ -224,7 +224,7 @@
       <damageAmountBase>0</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>5</explosionRadius>
+      <explosionRadius>4.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.15</preExplosionSpawnChance>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -224,7 +224,7 @@
       <damageAmountBase>0</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>7</explosionRadius>
+      <explosionRadius>5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.15</preExplosionSpawnChance>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -305,7 +305,7 @@
       <damageAmountBase>0</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>7</explosionRadius>
+      <explosionRadius>6.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.15</preExplosionSpawnChance>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -305,7 +305,7 @@
       <damageAmountBase>0</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>9.5</explosionRadius>
+      <explosionRadius>7</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.15</preExplosionSpawnChance>


### PR DESCRIPTION
Some tweaks to bad balance(extremely overpowered shells) that's being bugging me immensely.
How is that Incendiary shell has huge radius and do guaranteed stunlock + continuous damage against all target, whereas HE shells are next to useless and probably won't do damage even on direct hits because fragments are a joke and Area explosions are even worse.

I'll probably tweak the HE armour pen in later PR.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
