### PR TITLE
Removed patches on minified things

### DIFF
--- a/Defs/ThingDefs_Items/Items_Turrets.xml
+++ b/Defs/ThingDefs_Items/Items_Turrets.xml
@@ -3,7 +3,7 @@
 
   <!-- ======================= Minified things ========================= -->
 
-  <ThingDef ParentName="MinifiedBase" Name="MinifiedTurretBase" Abstract="True">
+  <ThingDef ParentName="MinifiedThing" Name="MinifiedTurretBase" Abstract="True">
     <thingCategories>
       <li>WeaponsTurrets</li>
     </thingCategories>

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -34,7 +34,7 @@
 
   <!-- ======================= Minified things ========================= -->
 
-  <ThingDef ParentName="MinifiedBase">
+  <ThingDef ParentName="MinifiedThing">
     <defName>MinifiedTurretGun</defName>
     <label>improvised turret</label>
     <thingCategories>

--- a/Patches/Core/ThingDefs_Items/Items_General.xml
+++ b/Patches/Core/ThingDefs_Items/Items_General.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-  <!-- ========== Minified Thing ========== -->
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="MinifiedThing"]</xpath>
-		<attribute>Name</attribute>
-		<value>MinifiedBase</value>
-	</Operation>
-  
-  <Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="MinifiedTree"]</xpath>
-		<attribute>ParentName</attribute>
-		<value>MinifiedBase</value>
-	</Operation>
-
   <!-- ========== Resource RawPlant ========== -->
 
   <Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Additions
N/A

## Changes
- Replaced custom attribute name "MinifiedBase" with core name "MinifiedThing" (added by 1.3)

## References
- Contributes towards #1045

## Reasoning
- Ensures broader compatibility with the core game and other mods 
  - since minified/ extracted trees are no longer being modified, they should behave as expected
  - other mods that derive from minified thing don't have to patch specifically for CE

## Alternatives
- N/A, best practice is to leave vanilla bases alone

## Testing
- [x] Compiles without warnings (no compilation needed)
- [ ] Game runs without errors (errors present not related to minified things)
- [ ] (For compatibility patches) ...with and without patched mod loaded (N/A)
- [x] Playtested a colony (<1 minute, dev mode placed turrets and ensure that they could be minified)
