### PR TITLE
Balance Firearrows

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -216,9 +216,9 @@
       <damageDef>Flame</damageDef>
       <damageAmountBase>1</damageAmountBase>
       <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
-      <speed>20</speed>	
+      <preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+      <explosionChanceToStartFire>0.33</explosionChanceToStartFire>
+      <speed>14</speed>	
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -238,8 +238,8 @@
       <damageDef>Flame</damageDef>
       <damageAmountBase>1</damageAmountBase>
       <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+      <explosionChanceToStartFire>0.33</explosionChanceToStartFire>
     </projectile>
   </ThingDef>
 
@@ -344,8 +344,8 @@
       <damageDef>Flame</damageDef>
       <damageAmountBase>1</damageAmountBase>
       <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+      <explosionChanceToStartFire>0.33</explosionChanceToStartFire>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -223,8 +223,8 @@
       <damageDef>Flame</damageDef>
       <damageAmountBase>1</damageAmountBase>
       <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+      <explosionChanceToStartFire>0.33</explosionChanceToStartFire>
     </projectile>
 	</ThingDef>
   


### PR DESCRIPTION
You remember how fire arrows got nerfed because it's overpowered(100% chance to set pawn on fire when it hits) and is better than everyother type of arrows?

Fire arrows are now just flamethrowers.


## Testing

Check tests you have performed:
- [c] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
