### PR TITLE
Patch Mechanite Plague Mod

### DIFF
--- a/Patches/Mechanite Plague/Patch_AddAmmo.xml
+++ b/Patches/Mechanite Plague/Patch_AddAmmo.xml
@@ -1,0 +1,482 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Mechanite Plague</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+
+	<CombatExtended.AmmoCategoryDef>
+		<defName>MP_MechDart</defName>
+		<label>mechanite dart</label>
+		<labelShort>M-Dart</labelShort>
+		<description>A dart designed to apply the Mechanite Plague. While dart weapons are normally non-lethal, the lack of concern for target preservation gives these darts the lethality of the average FMJ round.</description>
+	</CombatExtended.AmmoCategoryDef>
+	
+	<CombatExtended.AmmoCategoryDef>
+		<defName>MP_MechShell</defName>
+		<label>plague</label>
+		<description>A mortar shell designed to apply the Mechanite Plague. Combines high explosive power with the power of the plague, resulting in a lethal combination.</description>
+	</CombatExtended.AmmoCategoryDef>
+
+	<!-- ====== AmmoSet ====== -->
+	<CombatExtended.AmmoSetDef>
+		<defName>MP_AmmoSet_MechDart_Heavy</defName>
+		<label>16mm mechanite dart</label>
+		<ammoTypes>
+			<MP_Ammo_MechDart_Heavy>MP_Bullet_MechDart_Heavy</MP_Ammo_MechDart_Heavy>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ====== Ammo ====== -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+		<defName>MP_Ammo_MechDart_Heavy</defName>
+		<description>Hefty darts used to apply the Mechanite Plague from a distance. Used in heavier dart-based weaponry.</description>
+		<label>16mm mechanite dart cartridge</label>
+		<graphicData>
+			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.03</Mass>
+			<Bulk>0.04</Bulk>
+			<MarketValue>0.514</MarketValue>
+		</statBases>
+		<ammoClass>MP_MechDart</ammoClass>
+	</ThingDef>
+
+	<!-- ====== Projectiles ====== -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>MP_Bullet_MechDart_Heavy</defName>
+		<label>16mm mechanite dart</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_BulletInfect</damageDef>
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>108</armorPenetrationBlunt>
+			<speed>120</speed>
+		</projectile>
+		<modExtensions>
+            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+                <addHediffChance>1.00</addHediffChance>
+				<hediffLowerValue>0.23</hediffLowerValue>
+				<hediffUpperValue>0.26</hediffUpperValue>
+            </li>
+        </modExtensions>
+	</ThingDef>
+
+	<!-- ====== Recipes ====== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Ammo_MechDart_Heavy</defName> <!-- has to be named like this. deal with it. -->
+		<label>make 16mm mechanite dart cartridge x200</label>
+		<description>Craft 200 16mm mechanite dart cartridges.</description>
+		<jobString>Making 16mm mechanite dart cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Ammo_MechDart_Heavy>200</MP_Ammo_MechDart_Heavy>
+		</products>
+		<workAmount>6000</workAmount>
+	</RecipeDef>
+
+	<!-- ====== AmmoSet ====== -->
+	<CombatExtended.AmmoSetDef>
+		<defName>MP_AmmoSet_MechDart_Light</defName>
+		<label>11mm mechanite dart</label>
+		<ammoTypes>
+			<MP_Ammo_MechDart_Light>MP_Bullet_MechDart_Light</MP_Ammo_MechDart_Light>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ====== Ammo ====== -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+		<defName>MP_Ammo_MechDart_Light</defName>
+		<description>Small darts used to apply the Mechanite Plague from a distance. Used in lighter dart-based weaponry.</description>
+		<label>11mm mechanite dart cartridge</label>
+		<graphicData>
+			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.015</Mass>
+			<Bulk>0.02</Bulk>
+			<MarketValue>0.31</MarketValue>
+		</statBases>
+		<ammoClass>MP_MechDart</ammoClass>
+	</ThingDef>
+
+	<!-- ====== Projectiles ====== -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>MP_Bullet_MechDart_Light</defName>
+		<label>11mm mechanite dart</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_BulletInfect</damageDef>
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>6</armorPenetrationBlunt>
+			<speed>36</speed>
+		</projectile>
+		<modExtensions>
+            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+                <addHediffChance>1.00</addHediffChance>
+                <hediffLowerValue>0.13</hediffLowerValue>
+                <hediffUpperValue>0.15</hediffUpperValue>
+            </li>
+        </modExtensions>
+	</ThingDef>
+
+	<!-- ====== Recipes ====== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Ammo_MechDart_Light</defName> <!-- has to be named like this. deal with it. -->
+		<label>make 11mm mechanite dart cartridge x200</label>
+		<description>Craft 200 11mm mechanite dart cartridges.</description>
+		<jobString>Making 11mm mechanite dart cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Ammo_MechDart_Light>200</MP_Ammo_MechDart_Light>
+		</products>
+		<workAmount>3600</workAmount>
+	</RecipeDef>
+
+	<!-- ====== Ammo ====== -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+		<defName>MP_Plague_Shell_81mm</defName>
+		<label>81mm mortar shell (Plague)</label>
+		<graphicData>
+			<texPath>Things/CE/PlagueShellCE</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>67.80</MarketValue>
+			<Mass>5.00</Mass>
+			<Bulk>8.51</Bulk>
+		</statBases>
+		<ammoClass>MP_MechShell</ammoClass>
+		<detonateProjectile>MP_Bullet_81mmMortarShell_Plague</detonateProjectile>
+		<comps>
+			<li Class="CompProperties_Explosive">
+				<explosiveRadius>2.5</explosiveRadius>
+				<explosiveDamageType>MP_BlastInfectMortar</explosiveDamageType>
+				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				<explodeOnKilled>True</explodeOnKilled>
+				<wickTicks>30~60</wickTicks>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<!-- ====== Bullet ====== -->	
+	<ThingDef ParentName="Base81mmMortarShell">
+		<defName>MP_Bullet_81mmMortarShell_Plague</defName>
+		<label>81mm mortar shell (plague)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Mortar/HE</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_BlastInfectMortar</damageDef>
+			<damageAmountBase>132</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<explosionRadius>2.5</explosionRadius>
+			<flyOverhead>true</flyOverhead>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<ai_IsIncendiary>true</ai_IsIncendiary>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>15</Fragment_Large>
+					<Fragment_Small>80</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<!-- ====== Recipe ====== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Plague_Shell_81mm</defName>
+		<label>make 81mm plague mortar shells x5</label>
+		<description>Craft 5 81mm plague mortar shells.</description>
+		<jobString>Making 81mm plague mortar shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+				  <thingDefs>
+					<li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Plague_Shell_81mm>5</MP_Plague_Shell_81mm>
+		</products>
+		<workAmount>12000</workAmount>
+		<researchPrerequisite>MP_MechaniteMortar</researchPrerequisite>
+	</RecipeDef>
+
+	<!-- ====== AmmoSet ====== -->
+	<CombatExtended.AmmoSetDef>
+		<defName>MP_AmmoSet_MechShrapnel</defName>
+		<label>mechanite shrapnel</label>
+		<ammoTypes>
+			<MP_Ammo_MechShrapnel>MP_Bullet_MechShrapnel</MP_Ammo_MechShrapnel>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ====== Ammo ====== -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+		<defName>MP_Ammo_MechShrapnel</defName>
+		<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition.</description>
+		<label>mechanite shrapnel cartridge</label>
+		<graphicData>
+			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.02</Mass>
+			<Bulk>0.01</Bulk>
+			<MarketValue>0.196</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>MP_Bullet_MechShrapnel</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ====== Projectiles ====== -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+		<defName>MP_Bullet_MechShrapnel</defName>
+		<label>mechanite shrapnel</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_BulletInfect</damageDef>
+			<damageAmountBase>16</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>20</armorPenetrationBlunt>
+			<speed>36</speed>
+		</projectile>
+		<modExtensions>
+            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+                <addHediffChance>0.75</addHediffChance>
+				<hediffLowerValue>0.06</hediffLowerValue>
+				<hediffUpperValue>0.08</hediffUpperValue>
+            </li>
+        </modExtensions>
+	</ThingDef>
+
+	<!-- ====== Recipes ====== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Ammo_MechShrapnel</defName> <!-- has to be named like this. deal with it. -->
+		<label>make mechanite shrapnel cartridge x500</label>
+		<description>Craft 500 mechanite shrapnel cartridges.</description>
+		<jobString>Making mechanite shrapnel cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Ammo_MechShrapnel>500</MP_Ammo_MechShrapnel>
+		</products>
+		<workAmount>4400</workAmount>
+	</RecipeDef>
+
+	<!-- ====== AmmoSet ====== -->
+	<CombatExtended.AmmoSetDef>
+		<defName>MP_AmmoSet_MechDart_Neolithic</defName>
+		<label>neolithic mechanite dart</label>
+		<ammoTypes>
+			<MP_Ammo_MechDart_Neolithic>MP_Bullet_MechDart_Neolithic</MP_Ammo_MechDart_Neolithic>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ====== Ammo ====== -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+		<defName>MP_Ammo_MechDart_Neolithic</defName>
+		<description>Neolithic darts used to apply the Mechanite Plague from a distance. Due to the lack of a sophisticated injection mechanism, these darts may fail to apply the plague.</description>
+		<label>neolithic mechanite dart</label>
+		<graphicData>
+			<texPath>Things/Ammo/Neolithic/Dart</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.01</Mass>
+			<Bulk>0.012</Bulk>
+			<Flammability>1</Flammability>
+			<MarketValue>0.524</MarketValue>
+		</statBases>
+		<ammoClass>MP_MechDart</ammoClass>
+	</ThingDef>
+
+	<!-- ====== Projectiles ====== -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+		<defName>MP_Bullet_MechDart_Neolithic</defName>
+		<label>Neolithic mechanite dart</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_ArrowInfect</damageDef>
+			<damageAmountBase>5</damageAmountBase>
+			<armorPenetrationSharp>0.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.72</armorPenetrationBlunt>
+			<speed>24</speed>
+		</projectile>
+		<modExtensions>
+            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+                <addHediffChance>0.80</addHediffChance>
+                <hediffLowerValue>0.14</hediffLowerValue>
+                <hediffUpperValue>0.17</hediffUpperValue>
+            </li>
+        </modExtensions>
+	</ThingDef>
+
+	<!-- ====== Recipes ====== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Ammo_MechDart_Neolithic</defName> <!-- has to be named like this. deal with it. -->
+		<label>make neolithic mechanite dart x25</label>
+		<description>Craft 25 neolithic mechanite darts.</description>
+		<jobString>Making 25 neolithic mechanite darts.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>WoodLog</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>1</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Ammo_MechDart_Neolithic>25</MP_Ammo_MechDart_Neolithic>
+		</products>
+		<workAmount>800</workAmount>
+	</RecipeDef>
+
+		</value>
+	</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Mechanite Plague/PawnKinds_MechanitePlague.xml
+++ b/Patches/Mechanite Plague/PawnKinds_MechanitePlague.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Mechanite Plague</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+				
+	<!-- Tribal Blowdarter -->
+	<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/PawnKindDef[defName="MP_Tribal_Blowdarter"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>18</min>
+					<max>32</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</li>
+	
+	<!-- Mercenary Plaguebringer -->
+	<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
+		<value>
+			<apparelRequired>
+				<li>Apparel_Backpack</li>
+			</apparelRequired>
+		</value>
+	</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Mechanite Plague/ThingDef_Misc.xml
+++ b/Patches/Mechanite Plague/ThingDef_Misc.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Mechanite Plague</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+			
+	<!-- =========== Apparel =========== -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]/statBases</xpath>
+		<value>
+			<Bulk>3</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<CarryBulk>10</CarryBulk>
+			</equippedStatOffsets>
+		</value>
+	</li>
+	
+	<!-- =========== Mortars & IED =========== -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
+		<value>
+			<MP_Plague_Shell_81mm>MP_Bullet_81mmMortarShell_Plague</MP_Plague_Shell_81mm>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationRemove"> <!-- -->
+		<xpath>Defs/ThingDef[defName="MP_Shell_Plague"]</xpath>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+	<xpath>Defs/ThingDef[defName="MP_TrapIED_PlagueSharpnel"]/costList</xpath>
+		<value>
+			<costList>
+				<MP_Plague_Shell_81mm>2</MP_Plague_Shell_81mm>
+			</costList>
+		</value>
+	</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Mechanite Plague/ThingDef_Races.xml
+++ b/Patches/Mechanite Plague/ThingDef_Races.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Mechanite Plague</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+	<!-- =========== Burster =========== -->
+	<li Class="PatchOperationAddModExtension">
+	<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]</xpath>
+	<value>
+		<li Class="CombatExtended.RacePropertiesExtensionCE">
+			<bodyShape>QuadrupedLow</bodyShape>
+		</li>
+	</value>
+	</li>
+
+	<!-- Armor values for the creature. -->
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]</xpath>
+		<value>
+			<statBases>
+				<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				<MeleeDodgeChance>0.22</MeleeDodgeChance>
+				<MeleeCritChance>0.05</MeleeCritChance>
+				<MeleeParryChance>0.04</MeleeParryChance>
+			</statBases>
+		</value>
+	</li>
+	
+	<!-- Define attacks. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/tools</xpath>
+		<value>
+		<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>fangs</label>
+				<capacities>
+					<li>MP_BiteInfect</li>
+				</capacities>
+				<power>9</power>
+				<cooldownTime>0.83</cooldownTime>
+				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+				<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				<armorPenetrationBlunt>0.768</armorPenetrationBlunt>
+				<armorPenetrationSharp>0.77</armorPenetrationSharp>
+			</li>  
+			<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>1</power>
+				<cooldownTime>3.57</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+				<chanceFactor>0.2</chanceFactor>
+				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+				</li>
+		</tools>
+	</value>
+	</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Mechanite Plague/ThingDefs_Weapons.xml
+++ b/Patches/Mechanite Plague/ThingDefs_Weapons.xml
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Mechanite Plague</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>			
+			
+			<!-- =========== Ranged Weaponry =========== -->
+		
+			<!-- Melee attacks for ranged weapons -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MP_Gun_MechaniteBlowpipe"]/tools</xpath>
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>shaft</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.2</cooldownTime>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+					</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MP_Gun_MechaniteDarter"]/tools</xpath>
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>grip</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.54</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+						<capacities>
+						<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.54</cooldownTime>
+						<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>
+					Defs/ThingDef[defName="MP_Gun_MechaniteStinger" or defName="MP_Gun_MechaniteTempest"]/tools
+				</xpath>
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>stock</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>barrel</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+						<capacities>
+						<li>Poke</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Mechanite Blowpipe -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_MechaniteBlowpipe</defName>
+				<statBases>
+					<Mass>1.00</Mass>
+					<SightsEfficiency>0.6</SightsEfficiency>
+					<ShotSpread>1</ShotSpread>
+					<SwayFactor>2</SwayFactor>
+					<Bulk>1.00</Bulk>
+					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+					<WoodLog>5</WoodLog>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechDart_Neolithic</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>14</range>
+					<soundCast>Bow_Small</soundCast>
+				</Properties>
+				<AmmoUser>
+					<ammoSet>MP_AmmoSet_MechDart_Neolithic</ammoSet>
+				</AmmoUser>
+				<FireModes />
+				<weaponTags>
+					<li>CE_Bow</li>
+				</weaponTags>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!-- Mechanite Darter -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_MechaniteDarter</defName>
+				<statBases>
+					<Mass>2.20</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.18</ShotSpread>
+					<SwayFactor>1.47</SwayFactor>
+					<Bulk>2.20</Bulk>
+					<WorkToMake>7500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>5</WoodLog>
+					<Steel>25</Steel>
+					<ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechDart_Light</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>Shot_Autopistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>8</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>MP_AmmoSet_MechDart_Light</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_Sidearm</li>
+					<li>CE_AI_BROOM</li>
+					<li>CE_OneHandedWeapon</li>
+				</weaponTags>
+				<researchPrerequisite>MP_MechaniteWeaponsIndustrial</researchPrerequisite>
+			</li>
+			
+			<!-- Mechanite Stinger -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_MechaniteStinger</defName>
+				<statBases>
+					<Mass>3.2</Mass>
+					<RangedWeapon_Cooldown>0.81</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.6</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.54</SwayFactor>
+					<Bulk>11.20</Bulk>
+					<WorkToMake>27500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>55</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+					<Chemfuel>10</Chemfuel>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechDart_Heavy</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>72</range>
+					<soundCast>Shot_SniperRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>MP_AmmoSet_MechDart_Heavy</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_SR</li>
+				</weaponTags>
+				<researchPrerequisite>MP_MechaniteWeaponsIndustrial</researchPrerequisite>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!-- Mechanite Tempest -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_MechaniteTempest</defName>
+				<statBases>
+					<Mass>6.10</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.18</SightsEfficiency>
+					<ShotSpread>0.1</ShotSpread>
+					<SwayFactor>1.50</SwayFactor>
+					<Bulk>8.60</Bulk>
+					<WorkToMake>32000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>65</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.25</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechShrapnel</defaultProjectile>
+					<warmupTime>1.25</warmupTime>
+					<range>46</range>
+					<burstShotCount>8</burstShotCount>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>48</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>MP_AmmoSet_MechShrapnel</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>4</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AR</li>
+				</weaponTags>
+				<researchPrerequisite>MP_MechaniteWeaponsIndustrial</researchPrerequisite>
+			</li>
+			
+			<!-- =========== Turrets =========== -->
+			
+			<!-- Shared Traits -->
+			<li Class="PatchOperationReplace"> <!-- make taller -->
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace"> <!-- change thing class -->
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd"> <!-- shooting accuracy, part one -->
+			<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace"> <!-- shooting accuracy, part two??? -->
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace"> <!-- set burst cooldown -->
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove"> <!-- remove refuelable -->
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret" or defName="MP_Turret_PlagueShredder"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+			
+			<!-- Turret: Plague Turret -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_PlagueTurret</defName>
+				<statBases>
+					<Mass>8.00</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.48</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>2.48</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechDart_Heavy</defaultProjectile>
+					<warmupTime>1.7</warmupTime>
+					<range>68</range>
+					<soundCast>Shot_SniperRifle</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>MP_AmmoSet_MechDart_Heavy</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+		
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret"]/costList/MP_MechaniteCanister</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueTurret"]/description</xpath>
+				<value>
+					<description>A portable, automatic, long-ranged turret, designed to fire Mechanite Plague inflicitng darts. It lacks raw damage potential, but the plague application makes it a good supporting defense. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
+				</value>
+			</li>
+			
+			<!-- Turret: Plague Shredder -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_PlagueShredder</defName>
+				<statBases>
+					<Mass>25.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.09</SwayFactor>
+					<Bulk>7.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.48</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechShrapnel</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>20</range>
+					<burstShotCount>20</burstShotCount>
+					<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>400</magazineSize>
+					<reloadTime>9.2</reloadTime>
+					<ammoSet>MP_AmmoSet_MechShrapnel</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueShredder"]/costList/MP_MechaniteCanister</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MP_Turret_PlagueShredder"]/description</xpath>
+				<value>
+					<description>A portable, automatic turret that fires a barrage of Mechanite Plague inducing shrapnel. While incredibly powerful, it has a short range and is rather ammo hungry. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
+				</value>
+			</li>
+		
+			<!-- =========== Melee Weaponry =========== -->
+			
+			<!-- Plague Needle -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.45</MeleeCritChance>
+						<MeleeParryChance>0.14</MeleeParryChance>
+						<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.29</cooldownTime>
+							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>MP_CutInfect</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.21</cooldownTime>
+							<armorPenetrationBlunt>0.396</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.36</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.29</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.46</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Plague Claw -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<MeleeCounterParryBonus>0.46</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.28</MeleeCritChance>
+						<MeleeParryChance>0.46</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>25</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.38</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>MP_CutInfect</li>
+							</capacities>
+							<power>17</power>
+							<cooldownTime>1.2</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.34</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Plague Fang -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/statBases</xpath>
+				<value>
+					<Bulk>16</Bulk>
+					<MeleeCounterParryBonus>0.83</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.09</MeleeCritChance>
+						<MeleeParryChance>0.82</MeleeParryChance>
+						<MeleeDodgeChance>0.67</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.47</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.94</cooldownTime>
+							<chanceFactor>0.05</chanceFactor>
+							<armorPenetrationBlunt>1.4</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>30</power> <!-- owie -->
+							<cooldownTime>1.29</cooldownTime>
+							<chanceFactor>1.00</chanceFactor>
+							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.58</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+	
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -182,6 +182,7 @@ Magic Wands |
 Marilyn the Mincho Worshipper Witch |
 Mass Effect - Playable Geth |
 Martens - Nature's Most Adorable Assassins  |
+Mechanite Plague    |
 Mechanoids Extraordinaire	|
 Medical System Expansion	|
 Medieval Overhaul   |


### PR DESCRIPTION
Adds a patch for the Mechanite Plague Mod, which includes weapons, pawnkinds, new ammo types, and some apparel. This patch was made by the mod author, who asked it be integrated into CE in place of the current patch on their side, which will be removed after the next CE update.