### PR TITLE
Remove unnecessary Ammo.Def Classes from projectiles

### DIFF
--- a/Defs/Ammo/Advanced/10x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/10x18mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base10x18mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base10x18mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -91,7 +91,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base10x18mmChargedBullet">
+  <ThingDef ParentName="Base10x18mmChargedBullet">
     <defName>Bullet_10x18mmCharged</defName>
     <label>10x18mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -107,7 +107,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base10x18mmChargedBullet">
+  <ThingDef ParentName="Base10x18mmChargedBullet">
     <defName>Bullet_10x18mmCharged_AP</defName>
     <label>10x18mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -123,7 +123,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base10x18mmChargedBullet">
+  <ThingDef ParentName="Base10x18mmChargedBullet">
     <defName>Bullet_10x18mmCharged_Ion</defName>
     <label>10x18mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -80,7 +80,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base12GaugeChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base12GaugeChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -91,7 +91,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeChargedBullet">
+  <ThingDef ParentName="Base12GaugeChargedBullet">
     <defName>Bullet_12GaugeCharged</defName>
     <label>charge shot pellet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -109,7 +109,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeChargedBullet">
+  <ThingDef ParentName="Base12GaugeChargedBullet">
     <defName>Bullet_12GaugeCharged_Slug</defName>
     <label>charge shot (Slug)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -125,7 +125,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeChargedBullet">
+  <ThingDef ParentName="Base12GaugeChargedBullet">
     <defName>Bullet_12GaugeCharged_Ion</defName>
     <label>charge shot (Ion slug)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -48,7 +48,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_12mmRailgun_Sabot</defName>
 		<label>12mm Railgun bullet (Sabot)</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/12x70mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x70mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base12x65mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base12x65mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -92,7 +92,7 @@
   </ThingDef>
 
   <!-- normal charged bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12x65mmChargedBullet">
+  <ThingDef ParentName="Base12x65mmChargedBullet">
     <defName>Bullet_12x65mmCharged</defName>
     <label>12x65mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -109,7 +109,7 @@
   </ThingDef>
 
   <!-- concentrated bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12x65mmChargedBullet">
+  <ThingDef ParentName="Base12x65mmChargedBullet">
     <defName>Bullet_12x65mmCharged_AP</defName>
     <label>12x65mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -126,7 +126,7 @@
   </ThingDef>
 
   <!-- ion bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12x65mmChargedBullet">
+  <ThingDef ParentName="Base12x65mmChargedBullet">
     <defName>Bullet_12x65mmCharged_Ion</defName>
     <label>12x65mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -47,7 +47,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base15x65mmDiffusingChargedBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base15x65mmDiffusingChargedBullet" ParentName="BaseBullet" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>116</speed>
@@ -55,7 +55,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base15x65mmDiffusingChargedBullet">
+	<ThingDef ParentName="Base15x65mmDiffusingChargedBullet">
 		<defName>Bullet_15x65mmDiffusingCharged_Buck</defName>
 		<label>diffusing charged shot</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+  <ThingDef ParentName="BaseBullet">
     <defName>Bullet_5x35mmCharged</defName>
     <label>5x35mm Charged bullet</label>
     <graphicData>

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -52,7 +52,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+  <ThingDef ParentName="BaseBullet">
     <defName>Bullet_60x225mmGamma_Standard</defName>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <label>radiation cannon shell</label>

--- a/Defs/Ammo/Advanced/6mmRailgun.xml
+++ b/Defs/Ammo/Advanced/6mmRailgun.xml
@@ -47,7 +47,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_6mmRailgun_Sabot</defName>
 		<label>6mm Railgun bullet (Sabot)</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base6x18mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base6x18mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -91,7 +91,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+  <ThingDef ParentName="Base6x18mmChargedBullet">
     <defName>Bullet_6x18mmCharged</defName>
     <label>6x18mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -107,7 +107,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+  <ThingDef ParentName="Base6x18mmChargedBullet">
     <defName>Bullet_6x18mmCharged_AP</defName>
     <label>6x18mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -123,7 +123,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x18mmChargedBullet">
+  <ThingDef ParentName="Base6x18mmChargedBullet">
     <defName>Bullet_6x18mmCharged_Ion</defName>
     <label>6x18mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+  <ThingDef ParentName="BaseBullet">
     <defName>Bullet_6x22mmCharged</defName>
     <label>6x22mm Charged bullet</label>
     <graphicData>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base6x24mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base6x24mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -91,7 +91,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+  <ThingDef ParentName="Base6x24mmChargedBullet">
     <defName>Bullet_6x24mmCharged</defName>
     <label>6x24mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -107,7 +107,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+  <ThingDef ParentName="Base6x24mmChargedBullet">
     <defName>Bullet_6x24mmCharged_AP</defName>
     <label>6x24mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -123,7 +123,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base6x24mmChargedBullet">
+  <ThingDef ParentName="Base6x24mmChargedBullet">
     <defName>Bullet_6x24mmCharged_Ion</defName>
     <label>6x24mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -79,7 +79,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base70mmMechanoidGrenadeBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base70mmMechanoidGrenadeBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
@@ -90,7 +90,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base70mmMechanoidGrenadeBullet">
+	<ThingDef ParentName="Base70mmMechanoidGrenadeBullet">
 		<defName>Bullet_70mmMechanoidGrenade_HE</defName>
 		<label>70mm mechanoid grenade (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -110,7 +110,7 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base70mmMechanoidGrenadeBullet">
+	<ThingDef ParentName="Base70mmMechanoidGrenadeBullet">
 		<defName>Bullet_70mmMechanoidGrenade_EMP</defName>
 		<label>70mm mechanoid grenade (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -47,7 +47,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_8mmRailgun_Sabot</defName>
 		<label>8mm Railgun bullet (Sabot)</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base8x35mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base8x35mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -92,7 +92,7 @@
   </ThingDef>
 
   <!-- normal charged bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+  <ThingDef ParentName="Base8x35mmChargedBullet">
     <defName>Bullet_8x35mmCharged</defName>
     <label>8x35mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -109,7 +109,7 @@
   </ThingDef>
 
   <!-- concentrated bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+  <ThingDef ParentName="Base8x35mmChargedBullet">
     <defName>Bullet_8x35mmCharged_AP</defName>
     <label>8x35mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -126,7 +126,7 @@
   </ThingDef>
 
   <!-- ion bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x35mmChargedBullet">
+  <ThingDef ParentName="Base8x35mmChargedBullet">
     <defName>Bullet_8x35mmCharged_Ion</defName>
     <label>8x35mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -80,7 +80,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base8x50mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base8x50mmChargedBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -92,7 +92,7 @@
   </ThingDef>
 
   <!-- normal charged bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x50mmChargedBullet">
+  <ThingDef ParentName="Base8x50mmChargedBullet">
     <defName>Bullet_8x50mmCharged</defName>
     <label>8x50mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -109,7 +109,7 @@
   </ThingDef>
 
   <!-- concentrated bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x50mmChargedBullet">
+  <ThingDef ParentName="Base8x50mmChargedBullet">
     <defName>Bullet_8x50mmCharged_AP</defName>
     <label>8x50mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -126,7 +126,7 @@
   </ThingDef>
 
   <!-- ion bullets -->
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base8x50mmChargedBullet">
+  <ThingDef ParentName="Base8x50mmChargedBullet">
     <defName>Bullet_8x50mmCharged_Ion</defName>
     <label>8x50mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -62,7 +62,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_PlasmaCellHeavy</defName>
 		<label>Plasma Bolt</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/PlasmaCellPistol.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellPistol.xml
@@ -61,7 +61,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_PlasmaCellPistol</defName>
 		<label>Plasma Bolt</label>
 		<graphicData>

--- a/Defs/Ammo/Advanced/PlasmaCellRifle.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellRifle.xml
@@ -61,7 +61,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+	<ThingDef ParentName="BaseBullet">
 		<defName>Bullet_PlasmaCellRifle</defName>
 		<label>Plasma Bolt</label>
 		<graphicData>

--- a/Defs/Ammo/Flare.xml
+++ b/Defs/Ammo/Flare.xml
@@ -83,7 +83,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="BaseFlareBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="BaseFlareBullet" ParentName="BaseBullet" Abstract="true">
     <thingClass>CombatExtended.ProjectileCE_Flare</thingClass>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">      
       <speed>0</speed>      
@@ -93,7 +93,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFlareBullet">
+  <ThingDef ParentName="BaseFlareBullet">
     <defName>Bullet_Flare</defName>
     <label>flare</label>
     <graphicData>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -95,7 +95,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base83mmPIATGrenade" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base83mmPIATGrenade" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
@@ -106,7 +106,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base83mmPIATGrenade">
+	<ThingDef ParentName="Base83mmPIATGrenade">
 		<defName>Bullet_83mmPIATGrenade_HEAT</defName>
 		<label>83mm PIAT grenade (HEAT)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -132,7 +132,7 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base83mmPIATGrenade">
+	<ThingDef ParentName="Base83mmPIATGrenade">
 		<defName>Bullet_83mmPIATGrenade_HE</defName>
 		<label>83mm PIAT grenade (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -150,7 +150,7 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base83mmPIATGrenade">
+	<ThingDef ParentName="Base83mmPIATGrenade">
 		<defName>Bullet_83mmPIATGrenade_EMP</defName>
 		<label>83mm PIAT grenade (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -100,7 +100,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base127x108mmBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base127x108mmBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -112,7 +112,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base127x108mmBullet">
+  <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_FMJ</defName>
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -122,7 +122,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base127x108mmBullet">
+  <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_Incendiary</defName>
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -138,7 +138,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base127x108mmBullet">
+  <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_HE</defName>
     <label>12.7x108mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -154,7 +154,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base127x108mmBullet">
+  <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_Sabot</defName>
     <label>12.7x108mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -97,7 +97,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base132x92mmSRTuFBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base132x92mmSRTuFBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base132x92mmSRTuFBullet">
+	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_FMJ</defName>
 		<label>13.2mm TuF bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base132x92mmSRTuFBullet">
+	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_Incendiary</defName>
 		<label>13.2x92mmSR TuF bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base132x92mmSRTuFBullet">
+	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_HE</defName>
 		<label>13.2x92mmSR TuF bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base132x92mmSRTuFBullet">
+	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_Sabot</defName>
 		<label>13.2x92mmSR TuF bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -98,7 +98,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base145x114mmBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base145x114mmBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base145x114mmBullet">
+  <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_FMJ</defName>
     <label>14.5x114mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base145x114mmBullet">
+  <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_Incendiary</defName>
     <label>14.5x114mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base145x114mmBullet">
+  <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_HE</defName>
     <label>14.5x114mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base145x114mmBullet">
+  <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_Sabot</defName>
     <label>14.5x114mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -98,7 +98,7 @@
 	
 	<!-- ================== Projectile ================== -->
 
-    <ThingDef Class="CombatExtended.AmmoDef" Name="Base152x169mmBullet" ParentName="BaseBullet" Abstract="true">
+    <ThingDef Name="Base152x169mmBullet" ParentName="BaseBullet" Abstract="true">
       <graphicData>
         <texPath>Things/Projectile/Bullet_Big</texPath>
         <graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
       </projectile>
     </ThingDef>
     
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base152x169mmBullet">
+    <ThingDef ParentName="Base152x169mmBullet">
       <defName>Bullet_152x169mm_FMJ</defName>
       <label>15.2x169mm bullet (FMJ)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
       </projectile>
     </ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base152x169mmBullet">
+    <ThingDef ParentName="Base152x169mmBullet">
       <defName>Bullet_152x169mm_Incendiary</defName>
       <label>15.2x169mm bullet (AP-I)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
       </projectile>
     </ThingDef>
     
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base152x169mmBullet">
+    <ThingDef ParentName="Base152x169mmBullet">
       <defName>Bullet_152x169mm_HE</defName>
       <label>15.2x169mm bullet (HE)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
       </projectile>
     </ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base152x169mmBullet">
+    <ThingDef ParentName="Base152x169mmBullet">
       <defName>Bullet_152x169mm_Sabot</defName>
       <label>15.2x169mm bullet (Sabot)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -98,7 +98,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base2BoreBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base2BoreBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base2BoreBullet">
+	<ThingDef ParentName="Base2BoreBullet">
 		<defName>Bullet_2Bore_FMJ</defName>
 		<label>2-Bore bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
 		</projectile>
 	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base2BoreBullet">
+  <ThingDef ParentName="Base2BoreBullet">
     <defName>Bullet_2Bore_Incendiary</defName>
     <label>2-Bore bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base2BoreBullet">
+  <ThingDef ParentName="Base2BoreBullet">
     <defName>Bullet_2Bore_HE</defName>
     <label>2-Bore bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base2BoreBullet">
+  <ThingDef ParentName="Base2BoreBullet">
     <defName>Bullet_2Bore_Sabot</defName>
     <label>2-Bore bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -98,7 +98,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base20x102mmNATOBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base20x102mmNATOBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x102mmNATOBullet">
+    <ThingDef ParentName="Base20x102mmNATOBullet">
       <defName>Bullet_20x102mmNATO_FMJ</defName>
       <label>20x102mm NATO bullet (FMJ)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
       </projectile>
     </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x102mmNATOBullet">
+	<ThingDef ParentName="Base20x102mmNATOBullet">
 		<defName>Bullet_20x102mmNATO_Incendiary</defName>
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x102mmNATOBullet">
+	<ThingDef ParentName="Base20x102mmNATOBullet">
 		<defName>Bullet_20x102mmNATO_HE</defName>
 		<label>20x102mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x102mmNATOBullet">
+	<ThingDef ParentName="Base20x102mmNATOBullet">
 		<defName>Bullet_20x102mmNATO_Sabot</defName>
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -99,7 +99,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base20x110mmHispanoBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base20x110mmHispanoBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -111,7 +111,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x110mmHispanoBullet">
+  <ThingDef ParentName="Base20x110mmHispanoBullet">
     <defName>Bullet_20x110mmHispano_FMJ</defName>
     <label>20mm Hispano bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -121,7 +121,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x110mmHispanoBullet">
+  <ThingDef ParentName="Base20x110mmHispanoBullet">
     <defName>Bullet_20x110mmHispano_Incendiary</defName>
     <label>20mm Hispano bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -137,7 +137,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x110mmHispanoBullet">
+  <ThingDef ParentName="Base20x110mmHispanoBullet">
     <defName>Bullet_20x110mmHispano_HE</defName>
     <label>20mm Hispano bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -153,7 +153,7 @@
     </projectile>
   </ThingDef>
 
-   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x110mmHispanoBullet">
+   <ThingDef ParentName="Base20x110mmHispanoBullet">
     <defName>Bullet_20x110mmHispano_Sabot</defName>
     <label>14.5x114mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -98,7 +98,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base20x128mmOerlikonBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base20x128mmOerlikonBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x128mmOerlikonBullet">
+  <ThingDef ParentName="Base20x128mmOerlikonBullet">
     <defName>Bullet_20x128mmOerlikon_FMJ</defName>
     <label>20x128mm Oerlikon bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x128mmOerlikonBullet">
+	<ThingDef ParentName="Base20x128mmOerlikonBullet">
 		<defName>Bullet_20x128mmOerlikon_Incendiary</defName>
 		<label>20mm Oerlikon bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x128mmOerlikonBullet">
+	<ThingDef ParentName="Base20x128mmOerlikonBullet">
 		<defName>Bullet_20x128mmOerlikon_HE</defName>
 		<label>20mm Oerlikon bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
 		</projectile>
 	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x128mmOerlikonBullet">
+  <ThingDef ParentName="Base20x128mmOerlikonBullet">
     <defName>Bullet_20x128mmOerlikon_Sabot</defName>
     <label>20x128mm Oerlikon bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -98,7 +98,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base20x82mmMauserBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base20x82mmMauserBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x82mmMauserBullet">
+  <ThingDef ParentName="Base20x82mmMauserBullet">
     <defName>Bullet_20x82mmMauser_FMJ</defName>
     <label>20mm Mauser bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x82mmMauserBullet">
+  <ThingDef ParentName="Base20x82mmMauserBullet">
     <defName>Bullet_20x82mmMauser_Incendiary</defName>
     <label>20mm Mauser bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x82mmMauserBullet">
+  <ThingDef ParentName="Base20x82mmMauserBullet">
     <defName>Bullet_20x82mmMauser_HE</defName>
     <label>20mm Mauser bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x82mmMauserBullet">
+  <ThingDef ParentName="Base20x82mmMauserBullet">
     <defName>Bullet_20x82mmMauser_Sabot</defName>
     <label>20mm Mauser bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -98,7 +98,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base20x99mmRShVAKBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base20x99mmRShVAKBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x99mmRShVAKBullet">
+  <ThingDef ParentName="Base20x99mmRShVAKBullet">
     <defName>Bullet_20x99mmRShVAK_FMJ</defName>
     <label>20mmR ShVAK bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x99mmRShVAKBullet">
+  <ThingDef ParentName="Base20x99mmRShVAKBullet">
     <defName>Bullet_20x99mmRShVAK_Incendiary</defName>
     <label>20mmR ShVAK bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x99mmRShVAKBullet">
+  <ThingDef ParentName="Base20x99mmRShVAKBullet">
     <defName>Bullet_20x99mmRShVAK_HE</defName>
     <label>20mmR ShVAK bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20x99mmRShVAKBullet">
+  <ThingDef ParentName="Base20x99mmRShVAKBullet">
     <defName>Bullet_20x99mmRShVAK_Sabot</defName>
     <label>20mmR ShVAK bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -98,7 +98,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base25x137mmNATOBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base25x137mmNATOBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25x137mmNATOBullet">
+  <ThingDef ParentName="Base25x137mmNATOBullet">
     <defName>Bullet_25x137mmNATO_FMJ</defName>
     <label>25x137mm NATO bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25x137mmNATOBullet">
+	<ThingDef ParentName="Base25x137mmNATOBullet">
 		<defName>Bullet_25x137mmNATO_Incendiary</defName>
 		<label>25x137mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25x137mmNATOBullet">
+	<ThingDef ParentName="Base25x137mmNATOBullet">
 		<defName>Bullet_25x137mmNATO_HE</defName>
 		<label>25x137mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base25x137mmNATOBullet">
+	<ThingDef ParentName="Base25x137mmNATOBullet">
 		<defName>Bullet_25x137mmNATO_Sabot</defName>
 		<label>25x137mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -97,7 +97,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base300WinchesterMagnumBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base300WinchesterMagnumBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base300WinchesterMagnumBullet">
+  <ThingDef ParentName="Base300WinchesterMagnumBullet">
     <defName>Bullet_300WinchesterMagnum_FMJ</defName>
     <label>.300 Winchester Magnum bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base300WinchesterMagnumBullet">
+  <ThingDef ParentName="Base300WinchesterMagnumBullet">
     <defName>Bullet_300WinchesterMagnum_Incendiary</defName>
     <label>.300 Winchester Magnum bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base300WinchesterMagnumBullet">
+  <ThingDef ParentName="Base300WinchesterMagnumBullet">
     <defName>Bullet_300WinchesterMagnum_HE</defName>
     <label>.300 Winchester Magnum bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base300WinchesterMagnumBullet">
+  <ThingDef ParentName="Base300WinchesterMagnumBullet">
     <defName>Bullet_300WinchesterMagnum_Sabot</defName>
     <label>.300 Winchester Magnum bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -98,7 +98,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base30x173mmNATOBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base30x173mmNATOBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base30x173mmNATOBullet">
+  <ThingDef ParentName="Base30x173mmNATOBullet">
     <defName>Bullet_30x173mmNATO_FMJ</defName>
     <label>30x173mm NATO bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -120,7 +120,7 @@
     </projectile>
   </ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base30x173mmNATOBullet">
+	<ThingDef ParentName="Base30x173mmNATOBullet">
 		<defName>Bullet_30x173mmNATO_Incendiary</defName>
 		<label>30x173mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -136,7 +136,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base30x173mmNATOBullet">
+	<ThingDef ParentName="Base30x173mmNATOBullet">
 		<defName>Bullet_30x173mmNATO_HE</defName>
 		<label>30x173mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -152,7 +152,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base30x173mmNATOBullet">
+	<ThingDef ParentName="Base30x173mmNATOBullet">
 		<defName>Bullet_30x173mmNATO_Sabot</defName>
 		<label>30x173mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -112,7 +112,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base338LapuaBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base338LapuaBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -124,7 +124,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338LapuaBullet">
+  <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_FMJ</defName>
     <label>.338 Lapua Magnum bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -134,7 +134,7 @@
     </projectile>
   </ThingDef>
 
-<!--   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338LapuaBullet">
+<!--   <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_HP</defName>
     <label>.338 Lapua Magnum bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -144,7 +144,7 @@
     </projectile>
   </ThingDef> -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338LapuaBullet">
+  <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_Incendiary</defName>
     <label>.338 Lapua Magnum bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -160,7 +160,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338LapuaBullet">
+  <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_HE</defName>
     <label>.338 Lapua Magnum bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -176,7 +176,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338LapuaBullet">
+  <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_Sabot</defName>
     <label>.338 Lapua Magnum bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -112,7 +112,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base338NormaBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base338NormaBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -124,7 +124,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338NormaBullet">
+  <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_FMJ</defName>
     <label>.338 Norma Magnum bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -134,7 +134,7 @@
     </projectile>
   </ThingDef>
 
-  <!-- <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338NormaBullet">
+  <!-- <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_HP</defName>
     <label>.338 Norma Magnum bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -143,7 +143,7 @@
     </projectile>
   </ThingDef> -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338NormaBullet">
+  <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_Incendiary</defName>
     <label>.338 Norma Magnum bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -159,7 +159,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338NormaBullet">
+  <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_HE</defName>
     <label>.338 Norma Magnum bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -175,7 +175,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base338NormaBullet">
+  <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_Sabot</defName>
     <label>.338 Norma Magnum bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -97,7 +97,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base408CheyenneTacticalBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base408CheyenneTacticalBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base408CheyenneTacticalBullet">
+  <ThingDef ParentName="Base408CheyenneTacticalBullet">
     <defName>Bullet_408CheyenneTactical_FMJ</defName>
     <label>.408 Cheyenne Tactical bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base408CheyenneTacticalBullet">
+  <ThingDef ParentName="Base408CheyenneTacticalBullet">
     <defName>Bullet_408CheyenneTactical_Incendiary</defName>
     <label>.408 Cheyenne Tactical bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base408CheyenneTacticalBullet">
+  <ThingDef ParentName="Base408CheyenneTacticalBullet">
     <defName>Bullet_408CheyenneTactical_HE</defName>
     <label>.408 Cheyenne Tactical bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base408CheyenneTacticalBullet">
+  <ThingDef ParentName="Base408CheyenneTacticalBullet">
     <defName>Bullet_408CheyenneTactical_Sabot</defName>
     <label>.408 Cheyenne Tactical bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -127,7 +127,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base470NitroExpressBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base470NitroExpressBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -139,7 +139,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+  <ThingDef ParentName="Base470NitroExpressBullet">
     <defName>Bullet_470NitroExpress_FMJ</defName>
     <label>.470 Nitro Express bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -149,7 +149,7 @@
     </projectile>
   </ThingDef>
 
-<!-- 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+<!-- 	<ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_AP</defName>
 		<label>.470 Nitro Express bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -159,7 +159,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+	<ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_HP</defName>
 		<label>.470 Nitro Express bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -169,7 +169,7 @@
 		</projectile>
 	</ThingDef> -->
 
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+	  <ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_Incendiary</defName>
 		<label>.470 Nitro Express bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -185,7 +185,7 @@
 		</projectile>
 	  </ThingDef>
 	  
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+	  <ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_HE</defName>
 		<label>.470 Nitro Express bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -201,7 +201,7 @@
 		</projectile>
 	  </ThingDef>
 
-	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base470NitroExpressBullet">
+	  <ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_Sabot</defName>
 		<label>.470 Nitro Express bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -99,7 +99,7 @@
   
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base50BMGBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base50BMGBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -111,7 +111,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base50BMGBullet">
+  <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_FMJ</defName>
     <label>.50 BMG bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -121,7 +121,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base50BMGBullet">
+  <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_Incendiary</defName>
     <label>.50 BMG bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -137,7 +137,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base50BMGBullet">
+  <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_HE</defName>
     <label>.50 BMG bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -153,7 +153,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base50BMGBullet">
+  <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_Sabot</defName>
     <label>.50 BMG bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -97,7 +97,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base55BoysBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base55BoysBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base55BoysBullet">
+	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_FMJ</defName>
 		<label>.55 Boys bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base55BoysBullet">
+	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_Incendiary</defName>
 		<label>.55 Boys bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base55BoysBullet">
+	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_HE</defName>
 		<label>.55 Boys bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base55BoysBullet">
+	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_Sabot</defName>
 		<label>.55 Boys bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -97,7 +97,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base600NitroExpressBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base600NitroExpressBullet" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Bullet_Big</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
+  <ThingDef ParentName="Base600NitroExpressBullet">
     <defName>Bullet_600NitroExpress_FMJ</defName>
     <label>.600 Nitro Express bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
+  <ThingDef ParentName="Base600NitroExpressBullet">
     <defName>Bullet_600NitroExpress_Incendiary</defName>
     <label>.600 Nitro Express bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
+  <ThingDef ParentName="Base600NitroExpressBullet">
     <defName>Bullet_600NitroExpress_HE</defName>
     <label>.600 Nitro Express bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base600NitroExpressBullet">
+  <ThingDef ParentName="Base600NitroExpressBullet">
     <defName>Bullet_600NitroExpress_Sabot</defName>
     <label>.600 Nitro Express bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -97,7 +97,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base950JDJBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base950JDJBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Big</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -109,7 +109,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base950JDJBullet">
+	<ThingDef ParentName="Base950JDJBullet">
 		<defName>Bullet_950JDJ_FMJ</defName>
 		<label>.950 JDJ bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -119,7 +119,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base950JDJBullet">
+	<ThingDef ParentName="Base950JDJBullet">
 		<defName>Bullet_50JDJ_Incendiary</defName>
 		<label>.950 JDJ bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -135,7 +135,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base950JDJBullet">
+	<ThingDef ParentName="Base950JDJBullet">
 		<defName>Bullet_50JDJ_HE</defName>
 		<label>.950 JDJ bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -151,7 +151,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base950JDJBullet">
+	<ThingDef ParentName="Base950JDJBullet">
 		<defName>Bullet_50JDJ_Sabot</defName>
 		<label>.950 JDJ bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -119,7 +119,7 @@
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="BaseCrossbowBoltProjectile" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="BaseCrossbowBoltProjectile" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Arrow_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -135,7 +135,7 @@
 			x = preExplosionSpawnChance,
 			r = resource cost. -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+	<ThingDef ParentName="BaseCrossbowBoltProjectile">
 		<defName>Projectile_CrossbowBolt_Stone</defName>
 		<label>crossbow bolt (stone)</label>
 		<graphicData>
@@ -151,7 +151,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+	<ThingDef ParentName="BaseCrossbowBoltProjectile">
 		<defName>Projectile_CrossbowBolt_Steel</defName>
 		<label>crossbow bolt (steel)</label>
 		<graphicData>
@@ -168,7 +168,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+	<ThingDef ParentName="BaseCrossbowBoltProjectile">
 		<defName>Projectile_CrossbowBolt_Plasteel</defName>
 		<label>crossbow bolt (plasteel)</label>
 		<graphicData>
@@ -185,7 +185,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+	<ThingDef ParentName="BaseCrossbowBoltProjectile">
 		<defName>Projectile_CrossbowBolt_Venom</defName>
 		<label>crossbow bolt (venom)</label>
 		<graphicData>
@@ -203,7 +203,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseCrossbowBoltProjectile">
+	<ThingDef ParentName="BaseCrossbowBoltProjectile">
 		<defName>Projectile_CrossbowBolt_Flame</defName>
 		<label>crossbow bolt (flame)</label>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>       

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -134,7 +134,7 @@
 
   <!-- ================== Projectiles (short bow) ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="BaseArrowProjectile" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="BaseArrowProjectile" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Arrow_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -150,7 +150,7 @@
 			x = preExplosionSpawnChance,
 			r = resource cost. -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Stone</defName>
     <label>arrow (stone)</label>
     <graphicData>
@@ -167,7 +167,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Steel</defName>
     <label>arrow (steel)</label>
     <graphicData>
@@ -184,7 +184,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Plasteel</defName>
     <label>arrow (plasteel)</label>
     <graphicData>
@@ -201,7 +201,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Venom</defName>
     <label>arrow (venom)</label>
     <graphicData>
@@ -225,7 +225,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Flame</defName>
     <label>arrow (flame)</label>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
@@ -245,7 +245,7 @@
 
   <!-- ================== Projectiles (Recurve Bow) ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="BaseStreamlinedArrowProjectile" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="BaseStreamlinedArrowProjectile" ParentName="BaseBullet" Abstract="true">
     <graphicData>
       <texPath>Things/Projectile/Arrow_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -256,7 +256,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
+  <ThingDef ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Stone</defName>
     <label>streamlined arrow (stone)</label>
     <graphicData>
@@ -273,7 +273,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
+  <ThingDef ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Steel</defName>
     <label>streamlined arrow (steel)</label>
     <graphicData>
@@ -290,7 +290,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
+  <ThingDef ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Plasteel</defName>
     <label>streamlined arrow (plasteel)</label>
     <graphicData>
@@ -307,7 +307,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
+  <ThingDef ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Venom</defName>
     <label>streamlined arrow (venom)</label>
     <graphicData>
@@ -331,7 +331,7 @@
     </projectile>
   </ThingDef>
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
+  <ThingDef ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Flame</defName>
     <label>streamlined arrow (flame)</label>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>        

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -39,7 +39,7 @@
   
   <!-- ================== Projectiles ================== -->
   
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+  <ThingDef ParentName="BaseArrowProjectile">
     <defName>Projectile_Dart_Venom</defName>
     <label>poison dart</label>
     <graphicData>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -120,7 +120,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="BaseGreatArrowProjectile" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="BaseGreatArrowProjectile" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Arrow_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -136,7 +136,7 @@
 			x = preExplosionSpawnChance,
 			r = resource cost. -->
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Stone</defName>
 		<label>great arrow (stone)</label>
 		<graphicData>
@@ -152,7 +152,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Steel</defName>
 		<label>great arrow (steel)</label>
 		<graphicData>
@@ -169,7 +169,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Plasteel</defName>
 		<label>great arrow (plasteel)</label>
 		<graphicData>
@@ -186,7 +186,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Venom</defName>
 		<label>great arrow (venom)</label>
 		<graphicData>
@@ -210,7 +210,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
+	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Flame</defName>
 		<label>great arrow (flame)</label>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -15,7 +15,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseProjectileNeolithic" Name="BasePilumProjectile" Abstract="true">
+	<ThingDef ParentName="BaseProjectileNeolithic" Name="BasePilumProjectile" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Pilum</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -30,7 +30,7 @@
 		x = preExplosionSpawnChance,
 		r = resource cost. -->
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+	<ThingDef ParentName="BasePilumProjectile">
 		<defName>Pilum_Thrown</defName>
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -43,7 +43,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+	<ThingDef ParentName="BasePilumProjectile">
 		<defName>Pilum_Fired</defName>
 		<label>pilum (fired)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -71,7 +71,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="BaseSlingBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="BaseSlingBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Mote/Stone</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -87,7 +87,7 @@
 			x = preExplosionSpawnChance,
 			r = resource cost. -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseSlingBullet">
+	<ThingDef ParentName="BaseSlingBullet">
 		<defName>Projectile_SlingBullet_Stone</defName>
 		<label>sling bullet (stone)</label>
 		<graphicData>
@@ -102,7 +102,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseSlingBullet">
+	<ThingDef ParentName="BaseSlingBullet">
 		<defName>Projectile_SlingBullet_Steel</defName>
 		<label>sling bullet (steel)</label>
 		<graphicData>

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Defs>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
+	<ThingDef ParentName="BaseFragment">
 		<defName>Fragment_Large</defName>
 		<label>large fragments</label>
 		<graphicData>
@@ -18,7 +18,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
+	<ThingDef ParentName="BaseFragment">
 		<defName>Fragment_Small</defName>
 		<label>small fragments</label>
 		<graphicData>
@@ -37,7 +37,7 @@
 	
 	<!-- ================== 120mm mortar shell ================== -->
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
+	<ThingDef ParentName="BaseFragment">
 		<defName>Fragment_Shell</defName>
 		<label>shell fragments</label>
 		<graphicData>
@@ -55,7 +55,7 @@
 
 	<!-- ================== Grenade ================== -->
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
+	<ThingDef ParentName="BaseFragment">
 		<defName>Fragment_GrenadeFrag</defName>
 		<label>grenade fragments</label>
 		<graphicData>
@@ -73,7 +73,7 @@
 
 	<!-- ================== Rocket ================== -->
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
+	<ThingDef ParentName="BaseFragment">
 		<defName>Fragment_RocketFrag</defName>
 		<label>rocket fragments</label>
 		<graphicData>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -116,7 +116,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base12GaugeBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base12GaugeBullet" ParentName="BaseBullet" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>72</speed>
@@ -125,7 +125,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+  <ThingDef ParentName="Base12GaugeBullet">
     <defName>Bullet_12Gauge_Buck</defName>
     <label>buckshot pellet</label>
     <graphicData>
@@ -141,7 +141,7 @@
     </projectile>
   </ThingDef>
 
-  <!-- <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet"> -->
+  <!-- <ThingDef ParentName="Base12GaugeBullet"> -->
   <!-- <defName>Bullet_12Gauge_Bird</defName> -->
   <!-- <label>birdshot pellet</label> -->
   <!-- <graphicData> -->
@@ -156,7 +156,7 @@
   <!-- </projectile> -->
   <!-- </ThingDef> -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+  <ThingDef ParentName="Base12GaugeBullet">
     <defName>Bullet_12Gauge_Slug</defName>
     <label>shotgun slug</label>
     <graphicData>
@@ -171,7 +171,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+  <ThingDef ParentName="Base12GaugeBullet">
     <defName>Bullet_12Gauge_Beanbag</defName>
     <label>beanbag</label>
     <graphicData>
@@ -188,7 +188,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+  <ThingDef ParentName="Base12GaugeBullet">
     <defName>Bullet_12Gauge_ElectroSlug</defName>
     <label>EMP slug</label>
     <graphicData>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -114,7 +114,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base20GaugeBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base20GaugeBullet" ParentName="BaseBullet" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>84</speed>
@@ -123,7 +123,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20GaugeBullet">
+	<ThingDef ParentName="Base20GaugeBullet">
 		<defName>Bullet_20Gauge_Buck</defName>
 		<label>buckshot pellet</label>
 		<graphicData>
@@ -138,7 +138,7 @@
 		</projectile>
 	</ThingDef>
 
-	<!-- <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20GaugeBullet">
+	<!-- <ThingDef ParentName="Base20GaugeBullet">
 		<defName>Bullet_20Gauge_Bird</defName>
 		<label>birdshot pellet</label>
 		<graphicData>
@@ -153,7 +153,7 @@
 		</projectile>
 	</ThingDef> -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20GaugeBullet">
+	<ThingDef ParentName="Base20GaugeBullet">
 		<defName>Bullet_20Gauge_Slug</defName>
 		<label>shotgun slug</label>
 		<graphicData>
@@ -167,7 +167,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20GaugeBullet">
+	<ThingDef ParentName="Base20GaugeBullet">
 		<defName>Bullet_20Gauge_Beanbag</defName>
 		<label>beanbag</label>
 		<graphicData>
@@ -182,7 +182,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base20GaugeBullet">
+	<ThingDef ParentName="Base20GaugeBullet">
 		<defName>Bullet_20Gauge_ElectroSlug</defName>
 		<label>EMP slug</label>
 		<graphicData>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -101,7 +101,7 @@
 	
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Base23x75mmRBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base23x75mmRBullet" ParentName="BaseBullet" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>78</speed>
@@ -110,7 +110,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base23x75mmRBullet">
+	<ThingDef ParentName="Base23x75mmRBullet">
 		<defName>Bullet_23x75mmR_Buck</defName>
 		<label>buckshot pellet</label>
 		<graphicData>
@@ -126,7 +126,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base23x75mmRBullet">
+	<ThingDef ParentName="Base23x75mmRBullet">
 		<defName>Bullet_23x75mmR_Slug</defName>
 		<label>shotgun slug</label>
 		<graphicData>
@@ -141,7 +141,7 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base23x75mmRBullet">
+	<ThingDef ParentName="Base23x75mmRBullet">
 		<defName>Bullet_23x75mmR_Beanbag</defName>
 		<label>beanbag</label>
 		<graphicData>
@@ -157,7 +157,7 @@
 		</projectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base23x75mmRBullet">
+	<ThingDef ParentName="Base23x75mmRBullet">
 		<defName>Bullet_23x75mmR_ElectroSlug</defName>
 		<label>EMP slug</label>
 		<graphicData>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -44,7 +44,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base410BoreBullet" ParentName="BaseBullet" Abstract="true">
+  <ThingDef Name="Base410BoreBullet" ParentName="BaseBullet" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>70</speed>
@@ -53,7 +53,7 @@
     </projectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base410BoreBullet">
+  <ThingDef ParentName="Base410BoreBullet">
     <defName>Bullet_410Bore_Buck</defName>
     <label>buckshot pellet</label>
     <graphicData>

--- a/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/PlasmaCellShotgun.xml
+++ b/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/PlasmaCellShotgun.xml
@@ -67,7 +67,7 @@
         </ThingDef>
 
         <!-- === Projectile === -->
-        <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+        <ThingDef ParentName="BaseBullet">
           <defName>Bullet_PlasmaCellShotgun</defName>
           <label>Plasma Bolt</label>
           <graphicData>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
@@ -56,7 +56,7 @@
         </ThingDef>
 
         <!-- === Projectile === -->
-        <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+        <ThingDef ParentName="BaseBullet">
           <defName>Bullet_M73_HE</defName>
           <label>M73 Rocket (HE)</label>
           <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>

--- a/Patches/Vanilla Weapons Expanded/Ammo/Whip.xml
+++ b/Patches/Vanilla Weapons Expanded/Ammo/Whip.xml
@@ -12,7 +12,7 @@
         <li Class="PatchOperationAdd">
           <xpath>Defs</xpath>
           <value>
-            <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBullet">
+            <ThingDef ParentName="BaseBullet">
               <thingClass>CombatExtended.BulletCE</thingClass>
               <defName>Bullet_VWE_Whip</defName>
               <label>whip slash</label>


### PR DESCRIPTION
Resolves long-running issue of projectiles incorrectly having ammo.def classes.

Closes #995 