### PR TITLE
Make vanilla power armours more distinct

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -257,21 +257,14 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/Flammability</xpath>
     <value>
-      <Flammability>0</Flammability>
+      <Flammability>0.25</Flammability>
     </value>
   </Operation>
   
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/Mass</xpath>
     <value>
-      <Mass>3.6</Mass>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/Mass</xpath>
-    <value>
-      <Mass>3.6</Mass>
+      <Mass>3.0</Mass>
     </value>
   </Operation>
 
@@ -292,7 +285,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/ArmorRating_Blunt</xpath>
     <value>
-      <ArmorRating_Blunt>28</ArmorRating_Blunt>
+      <ArmorRating_Blunt>26</ArmorRating_Blunt>
     </value>
   </Operation>
 
@@ -311,7 +304,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>50</Plasteel>
+      <Plasteel>45</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -294,7 +294,7 @@
     <value>
       <equippedStatOffsets>
         <PsychicSensitivity>-0.2</PsychicSensitivity>
-        <AimingAccuracy>0.1</AimingAccuracy>
+        <AimingAccuracy>0.15</AimingAccuracy>
         <ToxicSensitivity>-0.50</ToxicSensitivity>
         <SmokeSensitivity>-1</SmokeSensitivity>
       </equippedStatOffsets>
@@ -304,7 +304,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>45</Plasteel>
+      <Plasteel>50</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -491,7 +491,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/statBases/Flammability</xpath>
 		<value>
-			<Flammability>0</Flammability>
+			<Flammability>0.2</Flammability>
 		</value>
 	</Operation>
 
@@ -505,7 +505,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>40</ArmorRating_Blunt>
+			<ArmorRating_Blunt>34</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -523,7 +523,7 @@
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>8</CarryBulk>
 			<ToxicSensitivity>-0.50</ToxicSensitivity>
-			<MoveSpeed>0.1</MoveSpeed>
+			<MoveSpeed>0.4</MoveSpeed>
 		</equippedStatOffsets>
 		</value>
 	</Operation>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -27,14 +27,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>21</ArmorRating_Blunt> <!-- Blunt armor is based off it being 9mm RHA worth of sharp armor. -->
+						<ArmorRating_Blunt>20</ArmorRating_Blunt> <!-- Blunt armor is based off it being 9mm RHA worth of sharp armor. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases/Flammability</xpath>
 					<value>
-						<Flammability>0</Flammability>
+						<Flammability>0.25</Flammability>
 					</value>
 				</li>
 
@@ -51,7 +51,7 @@
 						<PsychicSensitivity>-0.1</PsychicSensitivity>
 						<AimingDelayFactor>-0.05</AimingDelayFactor>
 						<ToxicSensitivity>-0.1</ToxicSensitivity>
-            <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+            					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 					</value>
 				</li>
 
@@ -84,7 +84,7 @@
 					<value>
 						<Bulk>40</Bulk> <!-- It's supposed to be just small enough to be able to wear something on the shell layer, I think dropping it to this is good enough. -->
 						<WornBulk>6</WornBulk>
-						<Mass>25</Mass>
+						<Mass>20</Mass>
 					</value>
 				</li>
 
@@ -98,14 +98,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt> <!-- Blunt armor is based off it being 12mm RHA worth of sharp armor. -->
+						<ArmorRating_Blunt>28</ArmorRating_Blunt> <!-- Blunt armor is based off it being 12mm RHA worth of sharp armor. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/Flammability</xpath>
 					<value>
-						<Flammability>0</Flammability>
+						<Flammability>0.25</Flammability>
 					</value>
 				</li>
 
@@ -119,14 +119,14 @@
 				<li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/equippedStatOffsets/MoveSpeed</xpath>
           <value>
-            <MoveSpeed>0.92</MoveSpeed>
+            <MoveSpeed>0.50</MoveSpeed>
           </value>
 				</li>
         
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/equippedStatOffsets/MentalBreakThreshold</xpath>
 					<value>
-						<CarryWeight>60</CarryWeight>
+						<CarryWeight>25</CarryWeight>
 						<CarryBulk>7.5</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<ToxicSensitivity>-0.3</ToxicSensitivity>
@@ -143,7 +143,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>25</DevilstrandCloth>
+						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
@@ -64,6 +64,7 @@
 			<CarryBulk>20</CarryBulk>
 			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 		</value>
 	</Operation>
 
@@ -263,7 +264,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocust"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>38</ArmorRating_Blunt>
+			<ArmorRating_Blunt>32</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -277,7 +278,7 @@
     <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_ArmorLocust"]/statBases/JumpRange</xpath>
         <value>
-            <JumpRange>30</JumpRange>
+            <JumpRange>32</JumpRange>
         </value>
     </Operation>
 	


### PR DESCRIPTION
Currently they feel exactly the same, so I've taken some steps to make them different, Recon armour has less blunt(why do they have almost as much blunt as power armour?), but is more zoomie, Cataphract armour is slower and has difficulty dodging.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
