### PR TITLE
[VAE] Buff otter stats

### DIFF
--- a/Patches/Vanilla Animals Expanded/BorealForest_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/BorealForest_Animals.xml
@@ -165,8 +165,8 @@
           <xpath>/Defs/ThingDef[defName="AEXP_Otter"]/statBases</xpath>
 
           <value>
-            <MeleeDodgeChance>0.05</MeleeDodgeChance>
-            <MeleeCritChance>0</MeleeCritChance>
+            <MeleeDodgeChance>0.24</MeleeDodgeChance>
+            <MeleeCritChance>0.02</MeleeCritChance>
             <MeleeParryChance>0.03</MeleeParryChance>
           </value>
         </li>
@@ -182,8 +182,16 @@
                 <li>Scratch</li>
               </capacities>
               <power>3</power>
-              <cooldownTime>3.7</cooldownTime>
+              <cooldownTime>1</cooldownTime>
               <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+              <surpriseAttack>
+                <extraMeleeDamages>
+                  <li>
+                    <def>Stun</def>
+                    <amount>20</amount>
+                  </li>
+                </extraMeleeDamages>
+              </surpriseAttack>
               <armorPenetrationSharp>0.01</armorPenetrationSharp>
               <armorPenetrationBlunt>0.02</armorPenetrationBlunt>
             </li>
@@ -193,8 +201,16 @@
                 <li>Scratch</li>
               </capacities>
               <power>3</power>
-              <cooldownTime>3.7</cooldownTime>
+              <cooldownTime>1</cooldownTime>
               <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+              <surpriseAttack>
+                <extraMeleeDamages>
+                  <li>
+                    <def>Stun</def>
+                    <amount>20</amount>
+                  </li>
+                </extraMeleeDamages>
+              </surpriseAttack>
               <armorPenetrationSharp>0.01</armorPenetrationSharp>
               <armorPenetrationBlunt>0.02</armorPenetrationBlunt>
             </li>
@@ -203,9 +219,17 @@
                 <li>Bite</li>
               </capacities>
               <power>3</power>
-              <cooldownTime>3.3</cooldownTime>
+              <cooldownTime>1.5</cooldownTime>
               <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-              <armorPenetrationSharp>1.1</armorPenetrationSharp>
+              <surpriseAttack>
+                <extraMeleeDamages>
+                  <li>
+                    <def>Stun</def>
+                    <amount>20</amount>
+                  </li>
+                </extraMeleeDamages>
+              </surpriseAttack>
+              <armorPenetrationSharp>1.5</armorPenetrationSharp>
               <armorPenetrationBlunt>0.01</armorPenetrationBlunt>
             </li>
             <li Class="CombatExtended.ToolCE">
@@ -214,7 +238,7 @@
                 <li>Blunt</li>
               </capacities>
               <power>2</power>
-              <cooldownTime>3</cooldownTime>
+              <cooldownTime>1.2</cooldownTime>
               <chanceFactor>0.2</chanceFactor>
               <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
               <armorPenetrationBlunt>0.03</armorPenetrationBlunt>


### PR DESCRIPTION
## Changes

Currently, VAE Boreal Forest's Otter is rather weak and prone to getting
mauled and even killed by small prey animals (rats, hares, squirrels
etc.). This patch aims to buff the otter's stats to make them more
realistic for a predator of its kind and size. I've opted to bring the
otter's melee stats closer to those of the RimWorld fox, as both the Eurasian
otter[1] and the North American otter[2] are similar in terms of mass
and body size to the red fox[3].

Specifically:
* Increase melee dodge chance to 24%, up from 5% (it's 27% for foxes)
* Increase melee critical chance to 2%, up from 0 (2% for foxes)
* Add surprise attack effect to the 2x claws and 1x teeth attack
  providing stun and a bonus 20 damage (just like foxes)
* Reduce cooldown time of claws from 3.7 to 1 (0.91 for foxes)
* Reduce cooldown time of teeth from 3.3 to 1.5 (just like foxes)
* Increase armor sharp pen for teeth to 1.5, up from 1.1 (just like
  foxes)
* Reduce cooldown for head attack from 3 to 1.2 (just like foxes)

---
[1] https://en.wikipedia.org/wiki/Eurasian_otter
[2] https://en.wikipedia.org/wiki/North_American_river_otter
[3] https://en.wikipedia.org/wiki/Red_fox

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - spawned in a couple otters into a quicktest colony and arranged some 1v1s between them and various prey (a rat, a hare and a squirrel)
