### PR TITLE
Improve performance of job searching relating to turrets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_DefenderReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_DefenderReloadTurret.cs
@@ -38,18 +38,15 @@ namespace CombatExtended
                 if (!JobGiverUtils_Reload.CanReload(pawn, turret, forced: false, emergency: true)) { return false; }
                 return turret.ShouldReload(ammoReloadThreshold);
             };
-            Thing hopefullyTurret = GenClosest.ClosestThingReachable(pawn.Position,
-                                             pawn.Map,
-                                             ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial),
-                                             PathEndMode.Touch,
-                                             TraverseParms.For(pawn),
-                                             100f,
-                                             _isTurretThatNeedsReloadingNow);
 
-            var actuallyTurret = hopefullyTurret as Building_TurretGunCE;
-            if (actuallyTurret == null) { return null; }
-            return actuallyTurret;
+            var hopefullyTurret = pawn.Map.GetComponent<TurretTracker>().ClosestTurret(
+                pawn.Position,
+                PathEndMode.Touch,
+                TraverseParms.For(pawn),
+                100f,
+                _isTurretThatNeedsReloadingNow);
 
+            return hopefullyTurret as Building_TurretGunCE;
         }
 
     

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_ManTurretsNearPointCE.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_ManTurretsNearPointCE.cs
@@ -15,16 +15,16 @@ namespace CombatExtended
         /// <remarks>Overriden to avoid invalid type cast exception.</remarks>
         public override Job TryGiveJob(Pawn pawn)
         {
-            var thing = GenClosest.ClosestThingReachable(
+            var thing = pawn.Map.GetComponent<TurretTracker>().ClosestTurret(
                 GetRoot(pawn),
-                pawn.Map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial), PathEndMode.InteractionCell, TraverseParms.For(pawn),
+                PathEndMode.InteractionCell,
+                TraverseParms.For(pawn),
                 maxDistFromPoint,
                 t => t.def.hasInteractionCell &&
                      t.def.HasComp(typeof(CompMannable)) &&
                      pawn.CanReserve(t) &&
                      FindAmmoForTurret(pawn, t) != null);
-
+            
             if (thing == null)
             {
                 return null;
@@ -39,7 +39,7 @@ namespace CombatExtended
         /// <remarks>Copied from <see cref="JobDriver_ManTurret.FindAmmoForTurret" />.</remarks>
         private static Thing FindAmmoForTurret(Pawn pawn, Thing turret)
         {
-	    var compAmmo = (turret as Building_Turret)?.GetAmmo();
+	        var compAmmo = (turret as Building_Turret)?.GetAmmo();
             if (compAmmo == null || !compAmmo.UseAmmo)
             {
                 return null;

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_ManTurretsNearSelfCE.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_ManTurretsNearSelfCE.cs
@@ -15,16 +15,16 @@ namespace CombatExtended
         /// <remarks>Overriden to avoid invalid type cast exception.</remarks>
         public override Job TryGiveJob(Pawn pawn)
         {
-            var thing = GenClosest.ClosestThingReachable(
+            var thing = pawn.Map.GetComponent<TurretTracker>().ClosestTurret(
                 GetRoot(pawn),
-                pawn.Map,
-                ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial), PathEndMode.InteractionCell, TraverseParms.For(pawn),
+                PathEndMode.InteractionCell,
+                TraverseParms.For(pawn),
                 maxDistFromPoint,
                 t => t.def.hasInteractionCell &&
                      t.def.HasComp(typeof(CompMannable)) &&
                      pawn.CanReserve(t) &&
                      FindAmmoForTurret(pawn, t) != null);
-
+            
             if (thing == null)
             {
                 return null;

--- a/Source/CombatExtended/CombatExtended/TurretTracker.cs
+++ b/Source/CombatExtended/CombatExtended/TurretTracker.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using Verse;
 using RimWorld;
+using Verse.AI;
 
 namespace CombatExtended
 {
@@ -27,6 +29,15 @@ namespace CombatExtended
             {
                 Turrets.Remove(t);
             }
+        }
+
+        // Returns the closest turret to `position` on the which matches the criteria set in `validator`
+        public Thing ClosestTurret(IntVec3 position, PathEndMode pathEndMode, TraverseParms parms, float maxDist,
+            Predicate<Thing> validator = null)
+        {
+            return GenClosest.ClosestThingReachable(
+                position, map, ThingRequest.ForUndefined(), pathEndMode,
+                parms, maxDist, validator, Turrets);
         }
     }
 }


### PR DESCRIPTION
Change `JobGiver`s which use `Building_Turret`s to use the turret cache map component. Improves performance for larger bases significantly by not searching every artificial building on the map.

Should not introduce any new behaviors. 

_Technically_ the old method searched all `Building`s on the map, and would sometimes omit a check to ensure the building was infact a subclass of `Building_Turret`, this however seemed to be rejected in other methods, as they assume that the thing passed was in fact a turret, and would early out in the case it wasn't.

If there are in fact examples of things CE considers turrets which do not subclass `Building_Turret`, the `Turret_Tracker` class should be updated.
