### PR TITLE
Fix mechanoid breach raids

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1235,7 +1235,6 @@
       <soundCast>InfernoCannon_Fire</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
-      <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
       <minRange>5</minRange>
       <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
     </Properties>
@@ -1302,7 +1301,6 @@
       <soundCast>ThumpCannon_Fire</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>14</muzzleFlashScale>
-      <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
       <minRange>4</minRange>
       <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
     </Properties>


### PR DESCRIPTION
## Changes

In CE, the termites' thump cannon and the centipedes' inferno cannon are
designated as a weapon usable for breaching via an
`ai_IsBuildingDestroyer` tag, and both have a friendly fire avoidance
radius set via `ai_AvoidFriendlyFireRadius`.

This ends up breaking mechanoid breach raids: vanilla's
`JobGiver_AIBreaching`, responsible for controlling breaching behavior,
will only let a pawn use a weapon that has `ai_AvoidFriendlyFireRadius` set
if that pawn is the designated "solo attacker" for the raid, as decided
by `LordToil_AssaultColonyBreaching` - which explicitly prevents selecting
"solo attackers" for mechanoid raids. As a result, the mech raid breaks
as neither the inferno cannon centipedes nor the thump cannon termites
can use their weapons for breaching, and other mechs do not have
suitable breaching weapons. By contrast, in vanilla, the thump cannon is
usable for breaching but has no friendly fire avoidance radius, while
the inferno cannon is not usable for breaching at all, which is why this
is not a problem with vanilla mech breacher raids.

As a fix, remove `ai_AvoidFriendlyFireRadius` from the inferno cannon and
the thump cannon to make them usable for breaching. With this change, if
a raid consists of a single termite and a single inferno cannon
centipede, the termite will be doing the breaching and the centipede
will dutifully follow it. If a raid contains additional mechanoids, then
the termite and all inferno cannon centipedes will be doing breaching,
with other mechs following them.

We could alternatively transpile `LordToil_AssaultColonyBreaching` and
allow it to designate "solo attackers" for mechanoid breacher raids as
well, but it is not clear to me why vanilla treats mech breacher raids
differently here, and the exact difference between "solo attackers" and
regular breachers is also something I do not see clearly yet.

## References
- Closes #1015 

## Testing
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony 
- Tested on autotest and with an existing save that had a bugged mech breach raid wandering about.
