### PR TITLE
Alternative fix for mechanoid breach raids (I)

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_JobGiver_AIBreaching.cs
+++ b/Source/CombatExtended/Harmony/Harmony_JobGiver_AIBreaching.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    /// <summary>
+    /// Transpile <see cref="JobGiver_AIBreaching.UpdateBreachingTarget(Pawn, Verb)"/> to allow mechanoids to use breaching weapons
+    /// with a nonzero friendly fire avoidance radius.
+    /// </summary>
+    [HarmonyPatch(typeof(JobGiver_AIBreaching), nameof(JobGiver_AIBreaching.UpdateBreachingTarget))]
+    internal static class Harmony_JobGiver_AIBreaching
+    {
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> instructionsList = instructions.ToList();
+
+            MethodInfo mIsSoloAttackVerb = AccessTools.Method(typeof(BreachingUtility), nameof(BreachingUtility.IsSoloAttackVerb));
+            MethodInfo pRaceProps = AccessTools.DeclaredPropertyGetter(typeof(Pawn), nameof(Pawn.RaceProps));
+            MethodInfo pIsMechanoid = AccessTools.DeclaredPropertyGetter(typeof(RaceProperties), nameof(RaceProperties.IsMechanoid));
+
+            Label checkNoDesignatedSoloAttackerExistsLabel = generator.DefineLabel();
+
+            for (int i = 0; i < instructionsList.Count; i++)
+            {
+                // If the current pawn's weapon is only usable for "solo attack", i.e. has a nonzero friendly fire avoidance radius,
+                // ensure the pawn can still use it if they are a mechanoid. Mechanoid breach raids never have a designated solo attacker,
+                // so they would not be able to use breaching weapons with a friendly fire avoidance radius without this change.
+                if (instructionsList[i].Branches(out Label? checkPawnIsSoloAttackerLabel) && instructionsList[i - 1].Calls(mIsSoloAttackVerb))
+                {
+                    instructionsList[i + 1].labels.Add(checkNoDesignatedSoloAttackerExistsLabel);
+
+                    yield return new CodeInstruction(OpCodes.Brfalse_S, checkNoDesignatedSoloAttackerExistsLabel);
+                    yield return new CodeInstruction(OpCodes.Ldarg_1); // pawn
+                    yield return new CodeInstruction(OpCodes.Callvirt, pRaceProps);
+                    yield return new CodeInstruction(OpCodes.Callvirt, pIsMechanoid);
+                    yield return new CodeInstruction(OpCodes.Brfalse_S, (Label)checkPawnIsSoloAttackerLabel);
+                }
+                else
+                {
+                    yield return instructionsList[i];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Changes

This is an alternative solution to fixing mechanoid breach raids. As
outlined in more detail on #1080, mech breach raids are currently broken
because they cannot utilize breaching weapons that have a nonzero
friendly fire avoidance radius. #1080 sidesteps that by removing the
friendly fire avoidance radius from mechanoid breach weapons (the thump
cannon and the inferno cannon), while this patch instead transpiles the
breaching jobgiver to add an exemption for mechs and let them utilize
these weapons.

## References
- Closes #1015 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested mech breach raids in autotest game.
