### PR TITLE
Prevent using ranged weapons with shield belts

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
@@ -1,88 +1,20 @@
 ﻿using HarmonyLib;
 using Verse;
 using RimWorld;
-using Verse.AI;
 
 namespace CombatExtended.HarmonyCE
 {
 
-
+    /// <summary>
+    /// Prevent using ranged verbs other than binoculars (artillery spotting) for shield belt users.
+    /// </summary>
     [HarmonyPatch(typeof(ShieldBelt), nameof(ShieldBelt.AllowVerbCast))]
     internal static class ShieldBelt_PatchAllowVerbCast
     {
-        internal static void Postfix(ref bool __result, Verb verb)
+        internal static bool Prefix(ref bool __result, Verb verb)
         {
-            var mark = verb as Verb_MarkForArtillery;
-            if (mark != null)
-            {
-                __result = true;
-                return;
-            }
-
-            if (!Controller.settings.TurretsBreakShields)
-            {
-                if (verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile)
-                {
-                    Pawn casterPawn = verb.caster as Pawn;
-                    if (casterPawn == null)
-                    {
-                        __result = true;
-                        return;
-                    }
-                    if (verb.caster is Building_Turret)
-                    {
-                        __result = true;
-                        return;
-                    }
-                }
-            }
-
-            //Original:
-            //          return !(verb is Verb_LaunchProjectile) || ReachabilityImmediate.CanReachImmediate(root, targ, map, PathEndMode.Touch, null);
-
-            //Preferred form:
-            //          return !(verb is Verb_LaunchProjectile || verb is Verb_LaunchProjectileCE) || ReachabilityImmediate.CanReachImmediate(root, targ, map, PathEndMode.Touch, null);
-
-            /*
-             *  A   B   C   D       E
-             *  0   0   0   1       1
-             *  0   0   1   1       0
-             *  0   1   0   1       1
-             *  0   1   1   1       1
-             *  1   0   0   0       0
-             *  1   0   1   0       0
-             *  1   1   0   1       1
-             *  1   1   1   1       1
-             *
-             * A = verb is Verb_LaunchProjectile
-             * B = ReachabilityImmediate(..)
-             * C = verb is Verb_LaunchProjectile_CE
-             * D = (!A) || B
-             * E = (!A && !C) || B
-             *
-             * We know A, C and D. Can we get E?
-             *
-             *  A   C   D       E
-             *  0   0   1       1
-             *  0   1   1       0
-             *  0   0   1       1
-             *  0   1   1       1   ==> Duplicate of line 2, but a different result
-             *  1   0   0       0
-             *  1   1   0       0
-             *  1   0   1       1
-             *  1   1   1       1
-             *
-             *  This can only be distinguished if we know B, in which case the solution is B.
-             *  And interestingly, the result is correct otherwise! See how D == E for all entries except for line 2.
-             */
-
-            //if (A=0 && C=1 && D=1) E=B;
-            //if (!(verb is Verb_LaunchProjectile) && (verb is Verb_LaunchProjectileCE) && __result)
-            //{
-            //    __result = ReachabilityImmediate.CanReachImmediate(root, targ, map, PathEndMode.Touch, null);
-            //}
-
-            //NOTE. The method could maybe be transpiled or something fancy
+            __result = verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
+            return false;
         }
     }
 


### PR DESCRIPTION

## Changes

In #767, the old shield belt patch was disabled due to breakage, which
now allows for ranged weapons to be used even if their wielder is
wearing a shield belt. Fix the shield belt patch to correctly consider
both vanilla and CE ranged verbs when determining if they can be used
while wearing a shield, maintaining the existing exception for CE
binoculars.

Also remove various dead code from the shield belt patch. Vanilla shield
belts no longer run a reachability check in 1.3 and the relevant part of
the patch got commented out in #767, so let's get rid of it. Likewise,
the turret-related parts also seem to be dead code, as the
TurretsBreakShields settings only controls whether a pawn's shield belt
should be disabled while they're manning a turret, not whether they can
fire the turret - which they already can do irrespective of this patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony:
- verified in autotest that a colonist can use a ranged weapon without a shield belt, cannot use a ranged weapon while wearing a shield belt, and can use a turret while wearing a shield belt - and that the shield belt is disabled while operating a turret as per mod config.
