### PR TITLE
Avoid potential loop while reloading turrets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/Utils/JobGiverUtils_Reload.cs
@@ -149,6 +149,12 @@ namespace CombatExtended.CombatExtended.Jobs.Utils
         {
 			Predicate<Thing> validator = (Thing potentialAmmo) =>
 			{
+				// Don't try to reload a turret with ammo that's currently cooking off, that would be bad
+				if (potentialAmmo is AmmoThing ammoThing && ammoThing.IsCookingOff)
+                {
+					return false;
+                }
+
 				if (potentialAmmo.IsForbidden(pawn) || !pawn.CanReserve(potentialAmmo))
 				{
 					return false;

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -16,7 +16,7 @@ namespace CombatExtended
         #region Properties
 
         public AmmoDef AmmoDef => def as AmmoDef;
-        public bool IsCookingOff => numToCookOff > 0;
+        public bool IsCookingOff => numToCookOff > 0 && this.CanCookOffOrDetonate();
 
         #endregion
 
@@ -25,7 +25,7 @@ namespace CombatExtended
         public override void PreApplyDamage(ref DamageInfo dinfo, out bool absorbed)
         {
             base.PreApplyDamage(ref dinfo, out absorbed);
-            if (!absorbed && Spawned && dinfo.Def.ExternalViolenceFor(this))
+            if (!absorbed && Spawned && this.CanCookOffOrDetonate() && dinfo.Def.ExternalViolenceFor(this))
             {
                 if (HitPoints - dinfo.Amount > 0)
                 {
@@ -171,6 +171,12 @@ namespace CombatExtended
             //Such that save-reloading doesn't stop ammo cookoff
             Scribe_Values.Look(ref numToCookOff, "numToCookOff", 0);
         }
+
+        /// <summary>
+        /// Determine whether this ammunition type can cook off in some way.
+        /// </summary>
+        private bool CanCookOffOrDetonate() => AmmoDef?.cookOffProjectile != null || AmmoDef?.detonateProjectile != null;
+
         #endregion
     }
 }


### PR DESCRIPTION


## Changes

Currently, the jobgiver for reloading turrets may give out a job to
reload a turret with a stack of ammo that's currently cooking off, which
results in a loop as it causes the jobdriver to fail the job. As a fix,
ensure that the jobgiver does not attempt to use ammo which is cooking
off.

For correctness, also make sure that ammo types which can never cook off
(e.g. 12x64mm mechanoid ammo) are never considered to be cooking off.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - verified the fix on a save where I encountered this error
