### PR TITLE
Patch Twi'lek Race

### DIFF
--- a/Patches/Twi'lek Race/Patch_Bodies.xml
+++ b/Patches/Twi'lek Race/Patch_Bodies.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Twi'lek Race (Continued)</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Add armor coverage (for pawns with non-zero armor that use human body) ========== -->
+
+      <!-- Illithid -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName = "Twilek_body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Twi'lek Race/PawnKinds_Twilek.xml
+++ b/Patches/Twi'lek Race/PawnKinds_Twilek.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Twi'lek Race (Continued)</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to pawns with ranged weapons. ========== -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/PawnKindDef[@Name="TwilekMilBase"]</xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>4</min>
+              <max>7</max>
+            </primaryMagazineCount>
+            <sidearms>
+            <li>
+              <generateChance>0.15</generateChance>
+              <sidearmMoney>
+                <min>150</min>
+                <max>350</max>
+              </sidearmMoney>
+              <weaponTags>
+                <li>NeolithicMeleeBasic</li>
+                <li>MedievalMeleeDecent</li>
+              </weaponTags>
+            </li>  
+            </sidearms>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Twi'lek Race/Race_Twilek.xml
+++ b/Patches/Twi'lek Race/Race_Twilek.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Twi'lek Race (Continued)</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]</xpath>
+          <value>
+            <li Class="CombatExtended.RacePropertiesExtensionCE">
+              <bodyShape>Humanoid</bodyShape>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationSequence">
+          <success>Always</success>
+          <operations>
+            <li Class="PatchOperationTest">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]/comps</xpath>
+              <success>Invert</success>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]</xpath>
+              <value>
+                <comps />
+              </value>
+            </li>
+          </operations>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]/statBases</xpath>
+          <value>
+            <NightVisionEfficiency>0.4</NightVisionEfficiency>
+            <MeleeDodgeChance>1.1</MeleeDodgeChance>
+            <MeleeCritChance>0.8</MeleeCritChance>
+            <MeleeParryChance>0.85</MeleeParryChance>
+            <CarryWeight>35</CarryWeight>
+            <CarryBulk>20</CarryBulk>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>left fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>right fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>4.49</cooldownTime>
+                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                <chanceFactor>0.2</chanceFactor>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Twilek"]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -287,6 +287,7 @@ Tribal Warrior Set! |
 Tsar Armory	|
 Turk's Guns |
 Turret Collection	|
+Twi'lek Race    |
 Ultratech: Altered Carbon Remastered |
 Vanilla Animals Expanded |
 Vanilla Apparel Expanded	|


### PR DESCRIPTION
## Additions
- Patches the Twi'lek mod. It adds 1 race with a custom body, and some pawnkinds.

## References
- Closes #1019 

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
