### PR TITLE
RPG-7 tweaks

### DIFF
--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -48,7 +48,7 @@
     </graphicData>
     <statBases>
       <MarketValue>57.78</MarketValue>
-      <Mass>2.8</Mass>
+      <Mass>2.6</Mass>
       <Bulk>9.37</Bulk>
     </statBases>
     <ammoClass>RocketHEAT</ammoClass>
@@ -64,7 +64,7 @@
     </graphicData>
     <statBases>
       <MarketValue>123.58</MarketValue>
-      <Mass>4.7</Mass>
+      <Mass>4.5</Mass>
       <Bulk>12.99</Bulk>
     </statBases>
     <ammoClass>RocketThermobaric</ammoClass>
@@ -80,7 +80,7 @@
     </graphicData>
     <statBases>
       <MarketValue>38.96</MarketValue>
-      <Mass>2.2</Mass>
+      <Mass>2.0</Mass>
       <Bulk>1.89</Bulk>
     </statBases>
     <stackLimit>100</stackLimit>    
@@ -141,7 +141,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>5</explosionRadius>
       <damageDef>Thermobaric</damageDef>
-      <damageAmountBase>275</damageAmountBase>
+      <damageAmountBase>300</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -220,7 +220,7 @@
     </products>
   </RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_RPG7Grenade_Thermobaric</defName>
     <label>make RPG-7 thermobaric grenades x5</label>
     <description>Craft 5 RPG-7 thermobaric grenades.</description>
@@ -241,7 +241,15 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>38</count>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>64</count>
       </li>
       <li>
         <filter>
@@ -256,6 +264,7 @@
       <thingDefs>
         <li>Steel</li>
         <li>FSX</li>
+        <li>Prometheum</li>
         <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -109,7 +109,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>304</damageAmountBase>
+      <damageAmountBase>275</damageAmountBase>
       <armorPenetrationSharp>500</armorPenetrationSharp>
       <armorPenetrationBlunt>44.956</armorPenetrationBlunt>
     </projectile>
@@ -225,7 +225,7 @@
     <label>make RPG-7 thermobaric grenades x5</label>
     <description>Craft 5 RPG-7 thermobaric grenades.</description>
     <jobString>Making RPG-7 thermobaric grenades.</jobString>
-    <workAmount>22400</workAmount>
+    <workAmount>20400</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -241,7 +241,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>16</count>
       </li>
       <li>
         <filter>
@@ -249,7 +249,7 @@
             <li>Prometheum</li>
           </thingDefs>
         </filter>
-        <count>64</count>
+        <count>22</count>
       </li>
       <li>
         <filter>


### PR DESCRIPTION
I dunno why all RPG-7 ammo is about 0.2kg heavier than they are on the internet, so I've changed it.
I also changed the thermobaric ammo to do abit more damage, require advanced ammunition tech to craft and need Prometheum to make.

Who knew that thermobaric warhead require incendiary agent to craft? Crazy.
## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
