### PR TITLE
Reverting firearrow changes

### DIFF
--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -228,18 +228,24 @@
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
     <defName>Projectile_Arrow_Flame</defName>
     <label>arrow (flame)</label>
-    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
     <graphicData>
       <texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <explosionRadius>0.1</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <speed>16</speed>
+      <damageDef>Arrow</damageDef>
+      <damageAmountBase>3</damageAmountBase>
+      <armorPenetrationSharp>0.2</armorPenetrationSharp>
+      <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+      <secondaryDamage>
+        <li>
+          <def>Flame</def>
+          <amount>1</amount>
+          <chance>0.33</chance>
+        </li>
+      </secondaryDamage>
+      <!-- destroyed on use -->
     </projectile>
   </ThingDef>
 
@@ -334,18 +340,23 @@
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
     <defName>Projectile_StreamlinedArrow_Flame</defName>
     <label>streamlined arrow (flame)</label>
-    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>        
     <graphicData>
       <texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <explosionRadius>0.1</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <speed>22</speed>
+      <damageDef>Arrow</damageDef>
+      <damageAmountBase>3</damageAmountBase>
+      <armorPenetrationSharp>0.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>2.96</armorPenetrationBlunt>
+      <secondaryDamage>
+        <li>
+          <def>Flame</def>
+          <amount>1</amount>
+          <chance>0.33</chance>
+        </li>
+      </secondaryDamage>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -213,18 +213,22 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Flame</defName>
 		<label>great arrow (flame)</label>
-    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
 		<graphicData>
 			<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <explosionRadius>0.2</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <damageDef>Arrow</damageDef>
+      <damageAmountBase>3</damageAmountBase>
+      <armorPenetrationBlunt>1.18</armorPenetrationBlunt>
+      <armorPenetrationSharp>1</armorPenetrationSharp>
+      <secondaryDamage>
+        <li>
+          <def>Flame</def>
+          <amount>1</amount>
+          <chance>0.33</chance>
+        </li>
+      </secondaryDamage>
     </projectile>
 	</ThingDef>
   


### PR DESCRIPTION
Reverting a recent change to firearrows because making them into long range flamethrower is really OP and obnoxious.
Since a fully satisfactory solution is unlikely to be found in the short term, I propose reverting it now rather than leaving it in.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
