### PR TITLE
Reduce fire starting chance of fire arrows

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -213,11 +213,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.2</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+	  <damageDef>ArrowFire</damageDef>
+	  <damageAmountBase>11</damageAmountBase>
+	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
       <speed>20</speed>	
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -214,7 +214,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.2</explosionRadius>
 	  <damageDef>ArrowFire</damageDef>
-	  <damageAmountBase>11</damageAmountBase>
+	  <damageAmountBase>3</damageAmountBase>
 	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
       <speed>20</speed>	

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -236,7 +236,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.1</explosionRadius>
 	  <damageDef>ArrowFire</damageDef>
-	  <damageAmountBase>10</damageAmountBase>
+	  <damageAmountBase>2</damageAmountBase>
 	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
@@ -340,11 +340,10 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.1</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+	  <damageDef>ArrowFire</damageDef>
+	  <damageAmountBase>2</damageAmountBase>
+	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -235,11 +235,10 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.1</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+	  <damageDef>ArrowFire</damageDef>
+	  <damageAmountBase>10</damageAmountBase>
+	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -220,11 +220,10 @@
 		</graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.2</explosionRadius>
-      <damageDef>Flame</damageDef>
-      <damageAmountBase>1</damageAmountBase>
-      <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
-      <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <explosionChanceToStartFire>1</explosionChanceToStartFire>
+      <damageDef>ArrowFire</damageDef>
+      <damageAmountBase>10</damageAmountBase>
+      <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+      <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -221,7 +221,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.2</explosionRadius>
       <damageDef>ArrowFire</damageDef>
-      <damageAmountBase>10</damageAmountBase>
+      <damageAmountBase>3</damageAmountBase>
       <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>

--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -106,6 +106,11 @@
     <hediff>VenomousArrow</hediff>
   </DamageDef>
 
+<DamageDef ParentName="Arrow">
+	<defName>ArrowFire</defName>
+	<soundExplosion>Bow_Large</soundExplosion>
+</DamageDef>
+
   <DamageDef ParentName="Bullet">
     <defName>Tranquilizer</defName>
     <label>tranquilizer</label>


### PR DESCRIPTION

## Changes

Make sure that fire arrows don't start a fire on every hit. Flame damage
type effectively guarantees that the target will be set on fire
irrespective of explosionChanceToStartFire, and CE chemfuel puddles also
autoignite, so use Arrow damage type instead with a chance to spawn a
chemfuel puddle (that will then ignite).

The chance to spawn chemfuel is kind of a placeholder value atm. We
could fine-tune it with additional testing.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested arrows in autotestt
