### PR TITLE
Buff Crude Projectile Speed

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>15</speed>
+			<speed>23</speed>
 		</projectile>
 	</ThingDef>
 
@@ -162,7 +162,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>20</speed>			
+			<speed>30</speed>			
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -179,7 +179,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<speed>24</speed>				
+			<speed>36</speed>				
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
 		</projectile>
@@ -197,7 +197,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-      <speed>20</speed>	
+      <speed>30</speed>	
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -218,7 +218,7 @@
       <postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <explosionChanceToStartFire>1</explosionChanceToStartFire>
-      <speed>20</speed>	
+      <speed>30</speed>	
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -141,7 +141,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>16</speed>
+      <speed>24</speed>
     </projectile>
   </ThingDef>
 
@@ -158,7 +158,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>16</speed>
+      <speed>24</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
       <armorPenetrationBlunt>0.88</armorPenetrationBlunt>
@@ -175,7 +175,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>36</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.02</armorPenetrationBlunt>
@@ -192,7 +192,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>26</speed>
+      <speed>36</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -209,7 +209,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>36</speed>
 		<damageDef>Arrow</damageDef>
 		<damageAmountBase>7</damageAmountBase>
 		<secondaryDamage>
@@ -264,7 +264,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>33</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>1.740</armorPenetrationBlunt>
@@ -281,7 +281,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
+      <speed>38</speed>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>5.9</armorPenetrationBlunt>
@@ -298,7 +298,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>37</speed>
+      <speed>38</speed>
       <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
@@ -315,7 +315,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
+      <speed>38</speed>
 	  <damageDef>Arrow</damageDef>
       <damageAmountBase>9</damageAmountBase>
 		<secondaryDamage>

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>11</speed>
+      <speed>22</speed>
 		  <damageDef>ArrowVenom</damageDef>
 		  <damageAmountBase>3</damageAmountBase> 
       <armorPenetrationSharp>0.35</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -127,7 +127,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>14</speed>
+			<speed>22</speed>
 		</projectile>
 	</ThingDef>
 	
@@ -160,7 +160,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>17</speed>
+			<speed>26</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
@@ -177,7 +177,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>30</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -194,7 +194,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>17</speed>
+			<speed>28</speed>
 			<damageDef>Arrow</damageDef>
 			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -35,7 +35,7 @@
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<speed>8</speed>
+			<speed>16</speed>
 			<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -48,7 +48,7 @@
 		<label>pilum (fired)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>29</damageAmountBase>
-			<speed>38</speed>
+			<speed>44</speed>
 			<armorPenetrationBlunt>141.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.4</preExplosionSpawnChance> <!-- 1.67 javelins per resource -->

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -78,7 +78,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Blunt</damageDef>
-			<speed>12</speed>
+			<speed>20</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,10 +10,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>44</damageAmountBase>
-			<speed>20</speed>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>28</armorPenetrationBlunt>
+			<damageAmountBase>31</damageAmountBase>
+			<speed>100</speed>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>175</armorPenetrationBlunt>
 			<gravityFactor>15</gravityFactor>
 		</projectile>
 	</ThingDef>
@@ -27,64 +27,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>10</damageAmountBase>
-			<speed>20</speed>
-			<armorPenetrationSharp>1</armorPenetrationSharp>
-			<armorPenetrationBlunt>10</armorPenetrationBlunt>
-			<gravityFactor>15</gravityFactor>
-		</projectile>
-	</ThingDef>
-	
-	<!-- ================== 120mm mortar shell ================== -->
-	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
-		<defName>Fragment_Shell</defName>
-		<label>shell fragments</label>
-		<graphicData>
-			<texPath>Things/Projectile/Fragments/Fragment_Medium</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Fragment</damageDef>
-			<damageAmountBase>18</damageAmountBase>
-			<speed>50</speed>
-			<armorPenetrationBase>0.25</armorPenetrationBase>
-			<gravityFactor>15</gravityFactor>
-		</projectile>
-	</ThingDef>
-
-	<!-- ================== Grenade ================== -->
-	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
-		<defName>Fragment_GrenadeFrag</defName>
-		<label>grenade fragments</label>
-		<graphicData>
-			<texPath>Things/Projectile/Fragments/Fragment_Medium</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Fragment</damageDef>
-			<damageAmountBase>12</damageAmountBase>
-			<speed>30</speed>
-			<armorPenetrationBase>0.25</armorPenetrationBase>
-			<gravityFactor>15</gravityFactor>
-		</projectile>
-	</ThingDef>
-
-	<!-- ================== Rocket ================== -->
-	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseFragment">
-		<defName>Fragment_RocketFrag</defName>
-		<label>rocket fragments</label>
-		<graphicData>
-			<texPath>Things/Projectile/Fragments/Fragment_Small</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Fragment</damageDef>
-			<damageAmountBase>14</damageAmountBase>
-			<speed>40</speed>
-			<armorPenetrationBase>0.25</armorPenetrationBase>
+			<damageAmountBase>7</damageAmountBase>
+			<speed>80</speed>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
 			<gravityFactor>15</gravityFactor>
 		</projectile>
 	</ThingDef>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -60,7 +60,7 @@
       <soundExplode>Explosion_Stun</soundExplode>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-      <speed>7</speed>
+      <speed>10</speed>
     </projectile>
   </ThingDef>
 
@@ -134,7 +134,7 @@
       <damageAmountBase>234</damageAmountBase>
       <explosionDelay>90</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-      <speed>4</speed>
+      <speed>8</speed>
     </projectile>
   </ThingDef>
 
@@ -202,7 +202,7 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>6</speed>
+      <speed>12</speed>
     </projectile>
   </ThingDef>
 
@@ -276,7 +276,7 @@
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>6</speed>
+      <speed>12</speed>
     </projectile>
   </ThingDef>
 

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -1337,7 +1337,7 @@
 							<explosionDelay>60</explosionDelay>
 							<dropsCasings>false</dropsCasings>
 							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-							<speed>5</speed>
+							<speed>10</speed>
 						</projectile>
 					</value>
 				</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -48,7 +48,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile/speed</xpath>
 		<value>
-			<speed>6</speed>
+			<speed>12</speed>
 		</value>
 	</Operation>
 
@@ -84,7 +84,7 @@
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<speed>6</speed>
+				<speed>12</speed>
 			</projectile>
 		</value>
 	</Operation>
@@ -241,7 +241,7 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>6</speed>
+				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>
@@ -378,7 +378,7 @@
 				<explosionDelay>60</explosionDelay>
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-				<speed>6</speed>
+				<speed>12</speed>
 			</projectile>
 		</value>
 	</Operation>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
@@ -176,12 +176,12 @@
 				<xpath>/Defs/ThingDef[defName="GR_Proj_ThrownSac"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>6</speed>
+						<speed>12</speed>
 						<flyOverhead>False</flyOverhead>
 						<damageDef>Bomb</damageDef>
 						<damageAmountBase>30</damageAmountBase>
-			                                                <explosionRadius >2.5</explosionRadius >
-			                                                 <explosionDelay>60</explosionDelay>
+						<explosionRadius >2.5</explosionRadius >
+						<explosionDelay>60</explosionDelay>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -571,7 +571,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>7</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
+++ b/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
@@ -27,7 +27,7 @@
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					  <damageDef>KijinDarkMatter</damageDef>
-					  <speed>3</speed>
+					  <speed>6</speed>
 					  <damageAmountBase>1</damageAmountBase>
 					  <armorPenetrationSharp>0.25</armorPenetrationSharp>
 					  <armorPenetrationBlunt>2</armorPenetrationBlunt>
@@ -77,7 +77,7 @@
 					  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 					  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
 					  <preExplosionSpawnChance>1</preExplosionSpawnChance>
-					  <speed>5</speed>
+					  <speed>8</speed>
 					</projectile>
 				  </ThingDef>
 				</value>

--- a/Patches/LTS Military/Weapons.xml
+++ b/Patches/LTS Military/Weapons.xml
@@ -614,7 +614,7 @@
               <dropsCasings>true</dropsCasings>
               <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
               <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-              <speed>5</speed>
+              <speed>12</speed>
             </projectile>
           </value>
         </li>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
@@ -30,7 +30,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>Blunt</damageDef>
 						<damageAmountBase>20</damageAmountBase>
-						<speed>5</speed>
+						<speed>8</speed>
 						<armorPenetrationBlunt>100</armorPenetrationBlunt>
 					</projectile>
 				</value>
@@ -43,7 +43,7 @@
 						<flyOverhead>false</flyOverhead>
 						<damageDef>Burn</damageDef>
 						<damageAmountBase>1</damageAmountBase>
-						<speed>5</speed>
+						<speed>8</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
+++ b/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
@@ -353,7 +353,7 @@
 					<damageAmountBase>10</damageAmountBase>
 					<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 					<preExplosionSpawnChance>1</preExplosionSpawnChance>
-					<speed>5</speed>
+					<speed>12</speed>
 					<ai_IsIncendiary>true</ai_IsIncendiary>
 				</projectile>
 			</value>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -222,7 +222,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -349,7 +349,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -491,7 +491,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -622,7 +622,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -753,7 +753,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -884,7 +884,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
@@ -105,7 +105,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>5</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>
@@ -205,7 +205,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>2</speed>
+						<speed>6</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Proj_BallisticKnifeBlade.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Proj_BallisticKnifeBlade.xml
@@ -25,7 +25,7 @@
 							<damageAmountBase>4</damageAmountBase>
 							<armorPenetrationBlunt>0.38</armorPenetrationBlunt>
 							<armorPenetrationSharp>1</armorPenetrationSharp>			
-							<speed>4</speed>
+							<speed>6</speed>
 						</projectile>
 					</ThingDef>
 

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -69,7 +69,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>2</speed>
+						<speed>6</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -72,7 +72,7 @@
 				  <damageAmountBase>1</damageAmountBase>
 				  <explosionDelay>50</explosionDelay>
 				  <dropsCasings>false</dropsCasings>
-				  <speed>6</speed>
+				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
@@ -88,7 +88,7 @@
 				  <damageAmountBase>200</damageAmountBase>
 				  <explosionDelay>500</explosionDelay>
 				  <dropsCasings>false</dropsCasings>
-				  <speed>5</speed>
+				  <speed>10</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
@@ -104,7 +104,7 @@
 				  <damageAmountBase>10</damageAmountBase>
 				  <explosionDelay>80</explosionDelay>
 				  <dropsCasings>true</dropsCasings>
-				  <speed>7</speed>
+				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
@@ -119,9 +119,9 @@
 				  <damageDef>KineticImpact</damageDef>
 				  <explosionDelay>80</explosionDelay>
 				  <dropsCasings>false</dropsCasings>
-				  <speed>6</speed>
+				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</projectile>
 			</value>
 		</li>	

--- a/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
+++ b/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
@@ -56,7 +56,7 @@
 				<dropsCasings>false</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<speed>4</speed>
+				<speed>8</speed>
 			</projectile>
 		</value>
 	</li>

--- a/Patches/Save Our Ship 2/Weapons_Grenades.xml
+++ b/Patches/Save Our Ship 2/Weapons_Grenades.xml
@@ -32,7 +32,7 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>5</speed>
+				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantWeapons_Ranged.xml
@@ -1023,7 +1023,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>RangedBlunt</damageDef>
 							<damageAmountBase>39</damageAmountBase>
-							<speed>4</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>24</armorPenetrationBlunt>
 							<armorPenetrationSharp>0</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -1049,7 +1049,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>RangedBlunt</damageDef>
 							<damageAmountBase>39</damageAmountBase>
-							<speed>4</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>24</armorPenetrationBlunt>
 							<armorPenetrationSharp>0</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -1072,7 +1072,7 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageAmountBase>45</damageAmountBase>
-							<speed>5</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>67.5</armorPenetrationBlunt>
 							<armorPenetrationSharp>5</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.50</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -1097,7 +1097,7 @@
 							<pelletCount>12</pelletCount>
 							<spreadMult>2</spreadMult>
 							<damageAmountBase>12</damageAmountBase>
-							<speed>5</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>3.12</armorPenetrationBlunt>
 							<armorPenetrationSharp>2</armorPenetrationSharp>
 						</projectile>
@@ -1120,7 +1120,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>RangedBlunt</damageDef>
 							<damageAmountBase>57</damageAmountBase>
-							<speed>4</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>72</armorPenetrationBlunt>
 							<armorPenetrationSharp>0</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.25</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -1145,7 +1145,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>RangedBlunt</damageDef>
 							<damageAmountBase>57</damageAmountBase>
-							<speed>4</speed>
+							<speed>8</speed>
 							<armorPenetrationBlunt>72</armorPenetrationBlunt>
 							<armorPenetrationSharp>0</armorPenetrationSharp>
 							<preExplosionSpawnChance>0.25</preExplosionSpawnChance>	<!-- 4 javelins per resource -->

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -275,7 +275,7 @@
 						<dropsCasings>true</dropsCasings>
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-						<speed>7</speed>
+						<speed>12</speed>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
@@ -40,7 +40,7 @@
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<explosionRadius>0.9</explosionRadius>
 					<damageDef>Flame</damageDef>
-					<speed>8</speed>
+					<speed>10</speed>
 					<ai_IsIncendiary>true</ai_IsIncendiary>
 				</projectile>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -394,7 +394,7 @@
           <label>thrown harpoon</label>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageAmountBase>13</damageAmountBase>
-            <speed>8</speed>
+            <speed>10</speed>
             <armorPenetrationBlunt>4.54</armorPenetrationBlunt>
             <armorPenetrationSharp>1.8</armorPenetrationSharp>
             <secondaryDamage>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -222,7 +222,7 @@
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
-				<speed>5</speed>
+				<speed>10</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 			</projectile>
 		</value>

--- a/Patches/Weapons+/WeaponsPlus_Projectiles.xml
+++ b/Patches/Weapons+/WeaponsPlus_Projectiles.xml
@@ -20,7 +20,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Stab</damageDef>
             <damageAmountBase>10</damageAmountBase>
-            <speed>6</speed>
+            <speed>12</speed>
             <armorPenetrationSharp>0.5</armorPenetrationSharp>
             <armorPenetrationBlunt>2</armorPenetrationBlunt>
             <preExplosionSpawnChance>0.6</preExplosionSpawnChance>


### PR DESCRIPTION
## Changes

Adjust fragmentation:
- Remove old, unused fragment defs (shell, rocket, grenade).
- Increased velocity sharp armor penetration of Large and Small fragments.

Increase velocity of many simple projectiles and grenades.
- Increased velocity of arrows, bolts, and javelins by 30% - 50%
- Increased velocity of many grenades and throwables by 1.5 - 2x.

## Reasoning

**Fragments:**
Shrapnel AP stats were old placeholders, and they could be reasonably well stopped by normal clothing, despite generally being high velocity. They now fly faster and pierce more armor--while not generally well shaped to pierce armor, they make up for it be being very fast. Small fragments should be stopped or significantly slowed by a flak jacket, large fragments can be stopped by decent ballistic armor.

**Velocity Changes:**
The ineffectiveness of grenades and arrows/bolts/javelins due to their low-velocity has been an ongoing complaint for quite a while. Though their current speeds are to scale (albeit on the high end) to their realistic velocities, the linear conversion of speed and the non-linear conversion of range make slower projectiles ineffective, given that their long flight time means they usually miss by a wide margin against any moving target.

The increase in speed _only_ adjusts the projectile speed, without changing the projectile blunt AP or damage. This should somewhat remedy the issues caused by their slow speed without making them too powerful.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
