### PR TITLE
Support krafs-publicizer

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -192,6 +192,13 @@ def parse_publicize(csproj):
             output = target.rsplit('.',1)[0] + '_publicized.dll'
 
             publicized_libraries.append(PublicizeTarget(target, output))
+    if not publicized_libraries:
+        publicize_task = [i.attributes['Include'].value for i in csproj.getElementsByTagName("Publicize")
+                          if 'Include' in i.attributes]
+        for pub in publicize_task:
+            publicized_libraries.append(PublicizeTarget(pub+'.dll', pub+'_publicized.dll'))
+            
+    
     return publicized_libraries
 
 def parse_csproj(csproj_path, verbose):


### PR DESCRIPTION
## Additions

Describe the functionality added by your code, e.g.
.csproj files using krafs publicizer work properly with `Make.py`


## References

Links to the associated issues, e.g.
Necessary for #1100


## Reasoning

Krafs publicizer is simpler to set up in the .csproj.  A single PackageReference, and then direct `<ItemGroup><Publicize Include="name"/>` instead of lots of boilerplate.  Since Make.py was looking for the boilerplate, it didn't see the Publicize directive.

## Alternatives

Statically list libraries to publicize.
Keep using existing publicizer.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
