### PR TITLE
Allow smoke to settle slowly when very dense

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -68,7 +68,7 @@ namespace CombatExtended
 		if (Rand.Range(0,10) == 5) {
 		  float d = density * 0.0001f;
 		  if (density > 300) {
-		      if (Random.Range(0, (int)(0.01*MaxDensity)) < d) {
+		      if (Random.Range(0, (int)(MaxDensity)) < d) {
 			  FilthMaker.TryMakeFilth(Position, Map, ThingDefOf.Filth_Ash, 1, FilthSourceFlags.None);
 		      }
 		  }


### PR DESCRIPTION

## Changes

Thick smoke stuck indoors settles at a very slow rate now.

## Reasoning

Smoke should eventually settle, both for QoL and reality.

## Alternatives

Make smoke settle rate tunable in XML.  Not a single line fix.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
