### PR TITLE
Attachments Mag bug fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -454,12 +454,11 @@ namespace CombatExtended
         /// Failure to unload occurs if the weapon doesn't use a magazine.
         /// </remarks>
         public bool TryUnload(bool forceUnload = false)
-        {
-            Thing outThing;
-            return TryUnload(out outThing, forceUnload);
+        {            
+            return TryUnload(out Thing _, forceUnload);
         }
 
-        public bool TryUnload(out Thing droppedAmmo, bool forceUnload = false)
+        public bool TryUnload(out Thing droppedAmmo, bool forceUnload = false, IntVec3? position = null)
         {
             droppedAmmo = null;
             if (!HasMagazine || (Holder == null && turret == null))
@@ -478,18 +477,20 @@ namespace CombatExtended
             // Add remaining ammo back to inventory
             Thing ammoThing = ThingMaker.MakeThing(currentAmmoInt);
             ammoThing.stackCount = curMagCountInt;
-            bool doDrop = false;
 
-            if (CompInventory != null)
+            bool doDrop;
+            
+            if (position == null && CompInventory != null)
                 doDrop = (curMagCountInt != CompInventory.container.TryAdd(ammoThing, ammoThing.stackCount)); // TryAdd should report how many ammoThing.stackCount it stored.
             else
                 doDrop = true; // Inventory was null so no place to shift the ammo besides the ground.
+            
 
             if (doDrop)
             {
                 // NOTE: If we get here from ThingContainer.TryAdd() it will have modified the ammoThing.stackCount to what it couldn't take.
                 //Thing outThing;
-                if (!GenThing.TryDropAndSetForbidden(ammoThing, Position, Map, ThingPlaceMode.Near, out droppedAmmo, turret.Faction != Faction.OfPlayer))
+                if (!GenThing.TryDropAndSetForbidden(ammoThing, position ?? Position , Map, ThingPlaceMode.Near, out droppedAmmo, turret?.Faction != Faction.OfPlayer))
                 {
                     Log.Warning(String.Concat(this.GetType().Assembly.GetName().Name + " :: " + this.GetType().Name + " :: ",
                                              "Unable to drop ", ammoThing.LabelCap, " on the ground, thing was destroyed."));

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ModifyWeapon.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ModifyWeapon.cs
@@ -94,7 +94,13 @@ namespace CombatExtended
             Toil modifyToil = new Toil();
             modifyToil.defaultCompleteMode = ToilCompleteMode.Instant;            
             modifyToil.initAction = () =>
-            {                
+            {
+                CompAmmoUser compAmmo = Weapon.TryGetComp<CompAmmoUser>();
+                if (compAmmo != null && compAmmo.HasMagazine && compAmmo.UseAmmo && !compAmmo.MagazineEmpty && !compAmmo.TryUnload(out _, forceUnload: true, pawn.Position))
+                {
+                    Log.Warning("CE: Failed to unload ammo from weapon before modifying it");
+                    Log.TryOpenLogWindow();
+                }
                 if (TryModifyWeapon())
                 {                    
                     this.EndJobWith(JobCondition.Succeeded);                    

--- a/Source/CombatExtended/CombatExtended/Things/WeaponPlatform.cs
+++ b/Source/CombatExtended/CombatExtended/Things/WeaponPlatform.cs
@@ -294,7 +294,22 @@ namespace CombatExtended
         /// Used to update the internel config lists
         /// </summary>
         public void UpdateConfiguration()
-        {            
+        {
+            /*
+             * <=========    Gun safety     =========> 
+             * 
+             * If any changes are being made, make sure to check for ammo related issues.
+             */
+            CompAmmoUser ammoUser = this.TryGetComp<CompAmmoUser>();
+
+            if((!_removalList.NullOrEmpty() || !_additionList.NullOrEmpty()) && ammoUser != null && ammoUser.UseAmmo && ammoUser.HasMagazine && ammoUser.MagSize < ammoUser.CurMagCount)
+            {
+                ammoUser.CurMagCount = ammoUser.MagSize;
+                Log.Warning("CE: Had to reset curMagCount since it had a value bigger than mag size");
+            }
+            /*
+             * <=========    rebuilding     =========> 
+             */
             _removalList.Clear();
             _additionList.Clear();
             /*


### PR DESCRIPTION
## Changes

- Fixed issues related to the magazine count being larger than the magazine size due to a removed magazine attachment.
- Now pawns will unload all guns before making any changes to them.
- Added new consistency checks on save loading. 