### PR TITLE
Debug tooltip helper

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -64,7 +64,7 @@
   <CE_Settings_RealisticCookOff_Desc>Ammunition stacks won't spawn damaging projectiles on cooking off.</CE_Settings_RealisticCookOff_Desc>
 
   <CE_Settings_ShowExtraTooltips_Desc>Enables extra tooltips for the cell under the mouse pointer (hold left-shift to view).</CE_Settings_ShowExtraTooltips_Desc>
-  <CE_Settings_ShowExtraTooltips_Title>Show Extra Tooltios</CE_Settings_ShowExtraTooltips_Title>
+  <CE_Settings_ShowExtraTooltips_Title>Show Extra Tooltips</CE_Settings_ShowExtraTooltips_Title>
   
 
 </LanguageData>

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -63,4 +63,8 @@
   <CE_Settings_RealisticCookOff_Title>Realistic cook-off</CE_Settings_RealisticCookOff_Title>
   <CE_Settings_RealisticCookOff_Desc>Ammunition stacks won't spawn damaging projectiles on cooking off.</CE_Settings_RealisticCookOff_Desc>
 
+  <CE_Settings_ShowExtraTooltips_Desc>Enables extra tooltips for the cell under the mouse pointer (hold left-shift to view).</CE_Settings_ShowExtraTooltips_Desc>
+  <CE_Settings_ShowExtraTooltips_Title>Show Extra Tooltios</CE_Settings_ShowExtraTooltips_Title>
+  
+
 </LanguageData>

--- a/Make.py
+++ b/Make.py
@@ -37,6 +37,7 @@ def parseArgs(argv):
     argParser.add_argument("--verbose", "-v", action="count", default=0, help="Increase verbosity, specify more times for more verbosity")
     argParser.add_argument("--download-libs", action="store_true", default=False, help=f"Automatically download referenced packages to {tdir}/downloads and unpack them to $reference")
     argParser.add_argument("--publicizer", type=str, metavar="PATH", help="Location of AssemblyPublicizer source code or parent directory of AssemblyPublicizer.exe")
+    argParser.add_argument("--debug", action="store_true", default=False, help="Define `DEBUG` when calling csc")
 
     options = argParser.parse_args(argv[1:])
     if not options.download_libs and options.reference is None:
@@ -263,6 +264,8 @@ def main(argv=sys.argv):
 
     libraries = [l for l in set(libraries) if not os.path.basename(l) in removed_libraries]
     args.extend([f'-out:{options.output}', *sources, *[f'-r:{r}' for r in libraries]])
+    if options.debug:
+        args.append('-define:DEBUG')
     if verbose > 2:
         print(libraries)
     if verbose > 6:

--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltip.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltip.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using UnityEngine;
+
+namespace CombatExtended
+{
+    /// <summary>
+    /// Important: the return type should be string.
+    /// Used to allow for access to debug information anywhere via a tooltip.
+    /// This will be called when the left shift button is down or incase alternative key is not none, it will one will be required.
+    /// A call to this function should return a string to be added to the tooltip.
+    /// Usage:
+    /// Requires that the function has (Map map, IntVec3 pos) as input parameters for usage within maps.
+    /// Requires that the function has (World map, int tile) as input parameters for usage within the world map.
+    /// Requires that the flaged function has a return type of string.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class CE_DebugTooltip : Attribute
+    {
+        public readonly CE_DebugTooltipType tooltipType;
+        public readonly KeyCode altKey;
+
+        /// <summary>
+        /// Important: the return type should be string.
+        /// Used to allow for access to debug information anywhere via a tooltip.
+        /// This will be called when the left shift button is down or incase alternative key is not none, it will one will be required.
+        /// A call to this function should return a string to be added to the tooltip.
+        /// Usage:
+        /// Requires that the function has (Map map, IntVec3 pos) as input parameters for usage within maps.
+        /// Requires that the function has (World map, int tile) as input parameters for usage within the world map.        
+        /// Requires that the flaged function has a return type of string.
+        /// </summary>
+        /// <param name="tooltipType">Where to call this function</param>
+        /// <param name="altKey">alternative key instead of left shift</param>        
+        public CE_DebugTooltip(CE_DebugTooltipType tooltipType, KeyCode altKey = KeyCode.None)
+        {
+            this.tooltipType = tooltipType;
+            this.altKey = altKey;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
@@ -55,10 +55,10 @@ namespace CombatExtended
         public CE_DebugTooltipHelper(Game game)
         {          
         }
-      
-        public override void GameComponentTick()
+               
+        public override void GameComponentUpdate()
         {
-            base.GameComponentTick();
+            base.GameComponentUpdate();
             if (!Controller.settings.DebuggingMode || !Input.anyKey || Find.CurrentMap == null || Current.ProgramState != ProgramState.Playing)
             {
                 return;

--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
@@ -59,7 +59,7 @@ namespace CombatExtended
         public override void GameComponentUpdate()
         {
             base.GameComponentUpdate();
-            if (!Controller.settings.DebuggingMode || !Input.anyKey || Find.CurrentMap == null || Current.ProgramState != ProgramState.Playing)
+            if (!Controller.settings.ShowExtraTooltips || !Input.anyKey || Find.CurrentMap == null || Current.ProgramState != ProgramState.Playing)
             {
                 return;
             }
@@ -97,7 +97,16 @@ namespace CombatExtended
                 Pair<Func<Map, IntVec3, string>, KeyCode> callback = mapCallbacks[i];                
                 if (Input.GetKey(callback.Second == KeyCode.None ? KeyCode.LeftShift : callback.Second))
                 {
-                    string message = callback.First(Find.CurrentMap, mouseCell);
+		    string message;
+		    try
+		    {
+			message = callback.First(Find.CurrentMap, mouseCell);
+		    }
+		    catch (Exception e)
+		    {
+			Log.Error(e.ToString());
+			message = "Debug Callback failed (see log for details)";
+		    }
                     if (!message.NullOrEmpty())
                     {
                         DoTipSignal(mouseRect, message);

--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltipHelper.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Verse;
+using UnityEngine;
+using System.Collections.Generic;
+using RimWorld.Planet;
+using System.Linq;
+using HarmonyLib;
+using System.Reflection;
+using System.Text;
+using RimWorld;
+
+namespace CombatExtended
+{    
+    public class CE_DebugTooltipHelper : GameComponent
+    {
+        private StringBuilder builder = new StringBuilder();
+
+        private static List<Pair<Func<Map, IntVec3, string>, KeyCode>> mapCallbacks = new List<Pair<Func<Map, IntVec3, string>, KeyCode>>();
+        private static List<Pair<Func<World, int, string>, KeyCode>> worldCallbacks = new List<Pair<Func<World, int, string>, KeyCode>>();
+        
+        private static readonly Rect MouseRect = new Rect(0, 0, 50, 50);
+
+        static CE_DebugTooltipHelper()
+        {            
+            var functions = typeof(CE_DebugTooltipHelper).Assembly
+                .GetTypes()
+                .SelectMany(t => t.GetMethods(AccessTools.all))
+                .Where(m => m.HasAttribute<CE_DebugTooltip>() && m.IsStatic);
+            foreach (MethodBase m in functions)
+            {
+                CE_DebugTooltip attribute = m.TryGetAttribute<CE_DebugTooltip>();
+                if (attribute.tooltipType == CE_DebugTooltipType.World)
+                {
+                    ParameterInfo[] param = m.GetParameters();
+                    if (param[0].ParameterType != typeof(World) || param[1].ParameterType != typeof(int))
+                    {
+                        Log.Error($"CE: Error processing debug tooltip {m.GetType().Name}:{m.Name} {m.FullDescription()} need to have (World, int) as parameters, skipped");
+                        continue;
+                    }
+                    worldCallbacks.Add(new Pair<Func<World, int, string>, KeyCode>((world, tile) => (string)m.Invoke(null, new object[] { world, tile }), attribute.altKey));                                        
+                }
+                else if (attribute.tooltipType == CE_DebugTooltipType.Map)
+                {
+                    ParameterInfo[] param = m.GetParameters();
+                    if (param[0].ParameterType != typeof(Map) || param[1].ParameterType != typeof(IntVec3))
+                    {
+                        Log.Error($"CE: Error processing debug tooltip {m.GetType().Name}:{m.Name} {m.FullDescription()} need to have (Map, IntVec3) as parameters, skipped");
+                        continue;
+                    }
+                    mapCallbacks.Add(new Pair<Func<Map, IntVec3, string>, KeyCode>((map, cell) => (string)m.Invoke(null, new object[] { map, cell }), attribute.altKey));                    
+                }                
+            }
+        }
+
+        public CE_DebugTooltipHelper(Game game)
+        {          
+        }
+      
+        public override void GameComponentTick()
+        {
+            base.GameComponentTick();
+            if (!Controller.settings.DebuggingMode || !Input.anyKey || Find.CurrentMap == null || Current.ProgramState != ProgramState.Playing)
+            {
+                return;
+            }
+            Rect mouseRect;
+
+            mouseRect = MouseRect;
+            mouseRect.center = Event.current.mousePosition;
+            Camera worldCamera = Find.WorldCamera;
+            
+            if (!worldCamera.gameObject.activeInHierarchy)
+            {
+                IntVec3 mouseCell = UI.MouseCell();
+
+                if (mouseCell.InBounds(Find.CurrentMap))
+                {                    
+                    TryMapTooltips(mouseRect, mouseCell);                                    
+                }
+            }
+            else
+            {
+                int tile = GenWorld.MouseTile();
+
+                if (tile != -1)
+                {
+                    TryWorldTooltips(mouseRect, tile);
+                }
+            }           
+        }
+
+        private void TryMapTooltips(Rect mouseRect, IntVec3 mouseCell)
+        {
+            bool bracketShown = false;
+            for(int i = 0;i < mapCallbacks.Count; i++)
+            {
+                Pair<Func<Map, IntVec3, string>, KeyCode> callback = mapCallbacks[i];                
+                if (Input.GetKey(callback.Second == KeyCode.None ? KeyCode.LeftShift : callback.Second))
+                {
+                    string message = callback.First(Find.CurrentMap, mouseCell);
+                    if (!message.NullOrEmpty())
+                    {
+                        DoTipSignal(mouseRect, message);
+                    }
+                    if (!bracketShown)
+                    {
+                        GenUI.RenderMouseoverBracket();
+                        bracketShown = true;
+                    }
+                }                                
+            }                      
+        }
+
+        private void TryWorldTooltips(Rect mouseRect, int tile)
+        {                                
+            for (int i = 0; i < worldCallbacks.Count; i++)
+            {
+                Pair<Func<World, int, string>, KeyCode> callback = worldCallbacks[i];
+                if (Input.GetKey(callback.Second == KeyCode.None ? KeyCode.LeftShift : callback.Second))
+                {
+                    string message = callback.First(Find.World, tile);
+                    if (!message.NullOrEmpty())
+                    {
+                        DoTipSignal(mouseRect, message);
+                    }
+                }                          
+            }            
+        }
+
+        private TipSignal DoTipSignal(Rect rect, string message)
+        {
+            builder.Clear();
+            builder.Append("<color=orange>CE_DEBUG_TIP:</color>. ");
+            builder.Append(message);
+            TipSignal tip = new TipSignal();
+            tip.text = message;            
+            tip.priority = (TooltipPriority)3;
+            TooltipHandler.TipRegion(rect, tip);
+            return tip;
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/CE_DebugTooltipType.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugTooltipType.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace CombatExtended
+{
+    public enum CE_DebugTooltipType
+    {        
+        World = 1,
+        Map = 2,        
+    }
+}

--- a/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_DebugUtility.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using RimWorld.Planet;
+using Verse;
+
+namespace CombatExtended
+{
+    public static class CE_DebugUtility
+    {
+        [CE_DebugTooltip(CE_DebugTooltipType.Map)]
+        public static string CellPositionTip(Map map, IntVec3 cell)
+        {
+            return $"Cell: ({cell.x}, {cell.z})";
+        }
+
+        [CE_DebugTooltip(CE_DebugTooltipType.World)]
+        public static string TileIndexTip(World world, int tile)
+        {
+            return $"Tile index: {tile}";
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -23,6 +23,8 @@ namespace CombatExtended
         private bool showBackpacks = true;
         private bool showTacticalVests = true;
 
+	private bool showExtraTooltips = false;
+
         public bool ShowCasings => showCasings;
         public bool ShowTaunts => showTaunts;
         public bool AllowMeleeHunting => allowMeleeHunting;
@@ -31,6 +33,7 @@ namespace CombatExtended
         public bool TurretsBreakShields => turretsBreakShields;
         public bool ShowBackpacks => showBackpacks;
         public bool ShowTacticalVests => showTacticalVests;
+	public bool ShowExtraTooltips => showExtraTooltips;
 
         public bool ShowTutorialPopup = true;
 
@@ -93,6 +96,8 @@ namespace CombatExtended
             Scribe_Values.Look(ref showBackpacks, "showBackpacks", true);
             Scribe_Values.Look(ref showTacticalVests, "showTacticalVests", true);
 
+	    Scribe_Values.Look(ref showExtraTooltips, "showExtraTooltips", false);
+
 #if DEBUG
             // Debug settings
             Scribe_Values.Look(ref debuggingMode, "debuggingMode", false);
@@ -137,6 +142,7 @@ namespace CombatExtended
             list.CheckboxLabeled("CE_Settings_SmokeEffects_Title".Translate(), ref smokeEffects, "CE_Settings_SmokeEffects_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_MergeExplosions_Title".Translate(), ref mergeExplosions, "CE_Settings_MergeExplosions_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
+	    list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
 
             // Only Allow these settings to be changed in the main menu since doing while a
             // map is loaded will result in rendering issues.


### PR DESCRIPTION
## Additions

Added a simple system that should allow us to implement tool tips for debugging purposes both in maps and on the world view. This system works by:
1. Finds all functions that have the `CE_DebugTooltip` attribute.
2. If debugging is enabled in CE settings, these functions will be called when the input requirements are met. (by default holding shift, it can be changed)
3. If it's a map, the map and the cell directly under the cursor is passed. If it's a planet (world view), the world and the tile index are passed.
4. The resulting string is used in a new `TipSignal`. 

### Notes
This system doesn't change anything in CE. The new code can only run if debugging is enabled, so no risk is involved in this

## Example
A simple example:
```cs
[CE_DebugTooltip(CE_DebugTooltipType.Map)]
public static string CellPositionTip(Map map, IntVec3 cell)
{
    return $"Cell: ({cell.x}, {cell.z})";
}
```
Holding shift will results in:

<img width="124" alt="Screen Shot 2021-10-17 at 12 00 01 PM" src="https://user-images.githubusercontent.com/6241020/137641166-d977f994-f8a7-40b6-92b3-de98d8f77d85.png">

