### PR TITLE
explicitly disallow fast-forward

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         git config --global user.email "actions@github.com"
         git config --global user.name "GitHub Actions"
-        git pull --no-commit --allow-unrelated-histories -X theirs origin pull/${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}/head:
+        git pull --no-ff --no-commit --allow-unrelated-histories -X theirs origin pull/${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}/head:
         git status
         wget https://raw.githubusercontent.com/CombatExtended-Continued/CombatExtended/Development/Make.py -O Make.py
         mkdir -p Assemblies


### PR DESCRIPTION
## Changes

Explicitly disabled fast-forward pull when automatically building PRs.

## Reasoning

The pull request auto-builder clones Development, then hard pulls the PR.  If the two have diverged, it fails with an error about not knowing how to reconcile the differences.  Passing `--no-ff` to `git pull` explicitly disables fast-forward merge, which allows it to successfully pull the PR's changes.


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
