### PR TITLE
Patch Anthro Race

### DIFF
--- a/Patches/Anthro Race/Anthro_Bodytype.xml
+++ b/Patches/Anthro Race/Anthro_Bodytype.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Anthro Race</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+						
+			<!--Outside Squishy-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName = "Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+				<value>
+				  <li>OutsideSquishy</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName = "Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+				<value>
+				  <li>OutsideSquishy</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName = "Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+				<value>
+				  <li>OutsideSquishy</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName = "Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+				<value>
+				  <li>OutsideSquishy</li>
+				</value>
+			</li>
+			
+			<!--Arm Groups-->
+		
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
+				<value>
+				  <li>LeftArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
+				<value>
+				  <li>RightArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+				<value>
+				  <li>LeftShoulder</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+				<value>
+				  <li>RightShoulder</li>
+				</value>
+			</li>
+		
+			<!--Natural Armor-->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Neck"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Leg"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="Anthro"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/parts/li[def="Toe"]/groups</xpath>
+				<value>
+						<li>CoveredByNaturalArmor</li>
+				</value>
+			</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Anthro Race/PawnKinds_Anthro.xml
+++ b/Patches/Anthro Race/PawnKinds_Anthro.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Anthro Race</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to pawns ========== -->
+
+      <li Class="PatchOperationAddModExtension">
+        <xpath>
+          /Defs/PawnKindDef[@Name="AnthroOutlanderBase"]
+        </xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>5</min>
+              <max>7</max>
+            </primaryMagazineCount>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Anthro Race/Race_Anthro.xml
+++ b/Patches/Anthro Race/Race_Anthro.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Anthro Race</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]</xpath>
+          <value>
+            <li Class="CombatExtended.RacePropertiesExtensionCE">
+              <bodyShape>Humanoid</bodyShape>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationSequence">
+          <success>Always</success>
+          <operations>
+            <li Class="PatchOperationTest">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]/comps</xpath>
+              <success>Invert</success>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]</xpath>
+              <value>
+                <comps />
+              </value>
+            </li>
+          </operations>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]/statBases/MeleeDodgeChance</xpath>
+          <value>
+            <MeleeDodgeChance>1</MeleeDodgeChance>
+            <MeleeCritChance>1</MeleeCritChance>
+            <MeleeParryChance>1</MeleeParryChance>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>left fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>right fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>4.49</cooldownTime>
+                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                <chanceFactor>0.2</chanceFactor>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Anthro"]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Anthro Race/Scenarios_Anthro.xml
+++ b/Patches/Anthro Race/Scenarios_Anthro.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Anthro Race</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ScenarioDef[defName="AnthroScenarioClassic"]/scenario/parts</xpath>
+        <value>
+          <li Class="ScenPart_StartingThing_Defined">
+            <def>StartingThing_Defined</def>
+            <thingDef>Ammo_44Magnum_FMJ</thingDef>
+            <count>180</count>
+          </li>
+        </value>
+      </li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[defName="AnthroScenarioClassic"]/scenario/parts/li[thingDef="Apparel_FlakVest"]</xpath>
+			</li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>
+

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -76,6 +76,7 @@ Anima Gear  |
 AnimalCollabProj	|
 Animal Armor: Vanilla	|
 Animal Equipment	|
+Anthro Race |
 Anty the War Ant Race |
 Apparello 2	|
 Arachne Race	|


### PR DESCRIPTION
## Additions
Patches the Anthro Race. In vanilla, the anthro pawns are statistically identical to baseline humans, simply having different heads. They likewise have the normal human stats here. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
