### PR TITLE
Pawnkind autopatcher

### DIFF
--- a/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
@@ -16,14 +16,14 @@ namespace CombatExtended.Compatibility
         static PawnKindPatcher()
         {
            
-            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefs.ToList().FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false);
+            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefsListForReading.FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false);
             foreach (PawnKindDef thin in stuff)
             {
 
 
                 thin.modExtensions = new List<DefModExtension>();
                 thin.modExtensions.Add(new LoadoutPropertiesExtension { primaryMagazineCount = new FloatRange { min = 2, max = 5 } });
-                LoadoutPropertiesExtension aadada = thin.modExtensions.Find(tt => tt is LoadoutPropertiesExtension) as LoadoutPropertiesExtension;
+                
 
             }
         }


### PR DESCRIPTION
Because I still understand github very little I had to remake the PR
## Additions

Automatically adds CE LoadoutPropertiesModExtension to all human ( and soon mechanoids) which lack it using C# on save loading



## Reasoning

Xml patching all pawnkinds would probably be less reliable and breakable, so I wanted to see whether it could work this  way. And well, it did.

## Alternatives

Static contructor could probably be used instead of FinalizeInit in WorldComp 
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
