### PR TITLE
Fix shield belts stopping shooting when offline

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
@@ -11,7 +11,7 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(ShieldBelt), nameof(ShieldBelt.AllowVerbCast))]
     internal static class ShieldBelt_PatchAllowVerbCast
     {
-        internal static bool Prefix(ref bool __result, Verb verb)
+        internal static bool Prefix(ref bool __result, Verb verb, ShieldBelt __instance)
         {
             __result = (__instance.ShieldState != ShieldState.Active) || verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
             return false;


### PR DESCRIPTION

## Changes

Inactive Shield belts do not stop pawns from shooting.

## References

#1082 

## Reasoning

The linked PR made shield belts properly prevent firing while active under RW 1.3.  However, prior to RW 1.2, inactive shield belts did not interfere with a pawns ability to fire.  This restores that behavior.

## Alternatives

Make players micro removing shield belts once they are disabled.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (hours)
