### PR TITLE
Remove some reflection calls in favor of direct calls (new)

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -102,61 +102,14 @@
 		<Folder Include="CombatExtended\GUI\Tabs\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3087" GeneratePathProperty="true" />
-		<PackageReference Include="Lib.Harmony" Version="2.1.1" ExcludeAssets="runtime" />
-		<PackageReference Include="TaskPubliciser" Version="1.0.3" />
-		<PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.2" />
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
+		<PackageReference Include="Krafs.Publicizer" Version="1.0.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3159" GeneratePathProperty="true" />
+		<PackageReference Include="Lib.Harmony" Version="2.1.1" ExcludeAssets="runtime" />
 	</ItemGroup>
-	<Target Name="Publicise" BeforeTargets="UpdateReferences">
-		<!-- Set our variables -->
-		<PropertyGroup>
-			<AssemblyCSharp>$(PkgKrafs_Rimworld_Ref)\ref\net472\Assembly-CSharp.dll</AssemblyCSharp>
-			<Unity_CoreModule>$(PkgKrafs_Rimworld_Ref)\ref\net472\UnityEngine.CoreModule.dll</Unity_CoreModule>
-			<PubliciseOutputPath>$(PkgKrafs_Rimworld_Ref)\ref\net472\</PubliciseOutputPath>
-			<AssemblyCSharp_Publicised>$(PubliciseOutputPath)Assembly-CSharp_publicised.dll</AssemblyCSharp_Publicised>
-			<Unity_CoreModule_Publicised>$(PubliciseOutputPath)UnityEngine.CoreModule_publicised.dll</Unity_CoreModule_Publicised>
-		</PropertyGroup>
-		<!-- Publicise the dlls (if required) -->
-		<Message Importance="High" Text="Publicising Rimworld Assembly ..." />
-		<Publicise TargetAssemblyPath="$(AssemblyCSharp)" OutputPath="$(PubliciseOutputPath)" Condition="Exists('$(AssemblyCSharp)')" />
-		<Publicise TargetAssemblyPath="$(Unity_CoreModule)" OutputPath="$(PubliciseOutputPath)" Condition="Exists('$(Unity_CoreModule)')" />
-		<!-- Add references to the new publicised dlls -->
-		<Message Importance="High" Text="Replacing reference to un-publicised assemblies with publicised equivalents ..." />
-	</Target>
-	<Target Name="AddRefrences" BeforeTargets="UpdateReferences" AfterTargets="Publicise">
-		<!-- Set our variables -->
-		<PropertyGroup>
-			<AssemblyCSharp>$(PkgKrafs_Rimworld_Ref)\ref\net472\Assembly-CSharp.dll</AssemblyCSharp>
-			<Unity_CoreModule>$(PkgKrafs_Rimworld_Ref)\ref\net472\UnityEngine.CoreModule.dll</Unity_CoreModule>
-			<PubliciseOutputPath>$(PkgKrafs_Rimworld_Ref)\ref\net472\</PubliciseOutputPath>
-			<AssemblyCSharp_Publicised>$(PubliciseOutputPath)Assembly-CSharp_publicised.dll</AssemblyCSharp_Publicised>
-			<Unity_CoreModule_Publicised>$(PubliciseOutputPath)UnityEngine.CoreModule_publicised.dll</Unity_CoreModule_Publicised>
-		</PropertyGroup>
-		<!-- Publicise the dlls (if required) -->
-		<ItemGroup>
-			<Reference Include="$(AssemblyCSharp_Publicised)">
-				<SpecificVersion>false</SpecificVersion>
-				<HintPath>$(AssemblyCSharp_Publicised)</HintPath>
-				<Implicit>true</Implicit>
-				<Private>false</Private>
-			</Reference>
-			<Reference Include="$(Unity_CoreModule_Publicised)">
-				<SpecificVersion>false</SpecificVersion>
-				<HintPath>$(Unity_CoreModule_Publicised)</HintPath>
-				<Implicit>true</Implicit>
-				<Private>false</Private>
-			</Reference>
-		</ItemGroup>
-	</Target>
-	<Target Name="UpdateReferences" AfterTargets="ResolveLockFileReferences">
-		<Message Importance="High" Text="Remove References at ($(PkgKrafs_Rimworld_Ref))" />
-		<ItemGroup>
-			<Reference Remove="$(PkgKrafs_Rimworld_Ref)\ref\net472\Assembly-CSharp.dll" />
-			<Reference Remove="$(PkgKrafs_Rimworld_Ref)\ref\net472\UnityEngine.CoreModule.dll" />
-		</ItemGroup>
-	</Target>
+  <ItemGroup>
+    <Publicize Include="Assembly-CSharp" />
+  </ItemGroup>
 </Project>

--- a/Source/CombatExtended/CombatExtended/Lasers/Building_LaserGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Lasers/Building_LaserGunCE.cs
@@ -15,7 +15,6 @@ namespace CombatExtended.Lasers
     // AdeptusMechanicus.Building_LaserGunCE
     public class Building_LaserGunCE : Building_TurretGunCE, IBeamColorThing
     {
-	private static MethodInfo ChangeStoredEnergy = typeof(PowerNet).GetMethod("ChangeStoredEnergy", BindingFlags.Instance | BindingFlags.NonPublic);
         public bool isCharged = false;
         public int previousBurstCooldownTicksLeft = 0;
 
@@ -86,8 +85,7 @@ namespace CombatExtended.Lasers
         {
             if (amount <= 0) return true;
             if (AvailablePower() < amount) return false;
-
-	    ChangeStoredEnergy.Invoke(powerComp.PowerNet, new object[]{-amount});
+            powerComp.PowerNet.ChangeStoredEnergy(-amount);
             return true;
         }
 

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker_AddInjury.cs
@@ -108,22 +108,8 @@ namespace CombatExtended.HarmonyCE
     static class Patch_CheckDuplicateDamageToOuterParts
     {
         public static float lastHitPartHealth = 0;
-	static MethodInfo FinalizeAndAddInjury = null;
 
-	static Patch_CheckDuplicateDamageToOuterParts()
-	{
-	    FinalizeAndAddInjury = typeof(DamageWorker_AddInjury).GetMethod("FinalizeAndAddInjury",
-									    BindingFlags.Instance | BindingFlags.NonPublic,
-									    null,
-									    new Type[] {
-										typeof(Pawn),
-										typeof(Hediff_Injury),
-										typeof(DamageInfo),
-										typeof(DamageWorker.DamageResult) },
-									    null);
-	}
-	
-	[HarmonyPrefix]
+    [HarmonyPrefix]
 	static bool Prefix(DamageWorker_AddInjury __instance, DamageInfo dinfo, Pawn pawn, float totalDamage, DamageWorker.DamageResult result)
 	{
 	    var hitPart = dinfo.HitPart;
@@ -151,7 +137,7 @@ namespace CombatExtended.HarmonyCE
 			{
 			    hediff_Injury.Severity = 1f;
 			}
-			FinalizeAndAddInjury.Invoke(__instance, new object[]{pawn, hediff_Injury, dinfo, result});
+            __instance.FinalizeAndAddInjury(pawn, hediff_Injury, dinfo, result);
 		    }
 		}
 	    }

--- a/Source/CombatExtended/Harmony/Harmony_Hediff_MissingPart.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Hediff_MissingPart.cs
@@ -16,11 +16,10 @@ namespace CombatExtended.HarmonyCE
     {
         public static bool Prefix(Hediff_MissingPart __instance, ref bool __result)
         {
-            var hediff = Traverse.Create(__instance);
             __result = Current.ProgramState != ProgramState.Entry
                 && __instance.IsFresh
                 && !__instance.Part.def.IsSolid(__instance.Part, __instance.pawn.health.hediffSet.hediffs) 
-                && !hediff.Property("ParentIsMissing").GetValue<bool>()
+                && !__instance.ParentIsMissing
                 && __instance.lastInjury != HediffDefOf.SurgicalCut;
             return false;
         }

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -229,8 +229,6 @@ namespace CombatExtended.HarmonyCE
                 return true;
             }
 
-            private static MethodBase mOverrideMaterialIfNeeded = AccessTools.Method(typeof(PawnRenderer), "OverrideMaterialIfNeeded");
-
             private static void DrawHeadApparel(PawnRenderer renderer, Pawn pawn, Vector3 rootLoc, Vector3 headLoc, Vector3 headOffset, Rot4 bodyFacing, Quaternion quaternion, PawnRenderFlags flags, Rot4 headFacing, ref bool hideHair)
             {
                 if (flags.FlagSet(PawnRenderFlags.Portrait) && Prefs.HatsOnlyOnMap)
@@ -284,8 +282,7 @@ namespace CombatExtended.HarmonyCE
             {
                 Material mat = record.graphic.MatAt(bodyFacing);
                 if (flags.FlagSet(PawnRenderFlags.Cache)) return mat;
-
-                return (Material)mOverrideMaterialIfNeeded.Invoke(renderer, new object[] { mat, pawn, flags.FlagSet(PawnRenderFlags.Portrait) });
+                return renderer.OverrideMaterialIfNeeded(mat, pawn, flags.FlagSet(PawnRenderFlags.Portrait));
             }
 
             /// <summary>

--- a/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
@@ -32,7 +32,7 @@ namespace CombatExtended.HarmonyCE
             {
                 if (__instance.ShieldState == ShieldState.Active)
                 {
-                    Traverse.Create(__instance).Method("Break").GetValue();
+                    __instance.Break();
                     ___ticksToReset = SHORT_SHIELD_RECHARGE_TIME;
                 }
                 if (___ticksToReset < SHORT_SHIELD_RECHARGE_TIME)


### PR DESCRIPTION
## Additions

No new functionality

## Changes

Replaced some slow reflection calls with direct calls instead, which should be faster
Replaced Wiri's publicizer in favor of Kraf's publicizer so it won't mess with external files. Also much less dependency - 5 nuget packages squashed to 3 nuget packages.

## Reasoning

I noticed one high consuming patch on PawnRenderer Head mat method and it turned out that it used a slow invoke call. I replaced it and then I searced for other slow reflection calls and replaced them

## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
