### PR TITLE
Xenohumans Expanded patch fixes

### DIFF
--- a/Patches/Xenohumans Expanded/Races_Radman_XH.xml
+++ b/Patches/Xenohumans Expanded/Races_Radman_XH.xml
@@ -5,7 +5,7 @@
 		<mods>
 			<li>Xenohumans Expanded</li>
 		</mods>
-		<match Class="PatchOperationSequence">	
+		<match Class="PatchOperationSequence">
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
@@ -17,16 +17,10 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/statBases/ArmorRating_Blunt</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/statBases</xpath>
 					<value>
 						<ArmorRating_Blunt>0.05</ArmorRating_Blunt>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
 						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 					</value>
 				</li>
@@ -34,7 +28,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/statBases/ToxicSensitivity</xpath>
 					<value>
-	  					<ToxicSensitivity>0.6</ToxicSensitivity>
+						<ToxicSensitivity>0.6</ToxicSensitivity>
 						<SmokeSensitivity>0.7</SmokeSensitivity>
 						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<MeleeCritChance>1</MeleeCritChance>

--- a/Patches/Xenohumans Expanded/Races_Vatgrown_XH.xml
+++ b/Patches/Xenohumans Expanded/Races_Vatgrown_XH.xml
@@ -5,11 +5,11 @@
 		<mods>
 			<li>Xenohumans Expanded</li>
 		</mods>
-		<match Class="PatchOperationSequence">	
+		<match Class="PatchOperationSequence">
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]</xpath>
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
@@ -18,7 +18,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/statBases</xpath>
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<MeleeCritChance>1</MeleeCritChance>
@@ -27,7 +27,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/tools</xpath>
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -70,11 +70,11 @@
 					<success>Always</success>
 					<operations>
 						<li Class="PatchOperationTest">
-							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/comps</xpath>
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]/comps</xpath>
 							<success>Invert</success>
 						</li>
 						<li Class="PatchOperationAdd">
-							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]</xpath>
+							<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]</xpath>
 							<value>
 								<comps />
 							</value>
@@ -83,7 +83,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="RadWorlderRace"]/comps</xpath>
+					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="VatgrownHumanRace"]/comps</xpath>
 					<value>
 						<li>
 							<compClass>CombatExtended.CompPawnGizmo</compClass>


### PR DESCRIPTION
## Changes

- Fixed incorrect defName for VatgrownHumanRace;
- Switched operation from Replace to Add for RadWorlderRace's armor ratings - it doesn't have them prior to the patch.

## Reasoning

Initial implementation was throwing XML patch operation errors on load, and upon inspection issues became visible.

## Alternatives

Cutting out the armor values for radworlders? I didn't find the reason they have them - the mod in question only references their resistance to disease and toxic hazards.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (briefly, to make sure patches are applied)
