### PR TITLE
Changed More Utility Packs' name to PackageID in loadAfter

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -48,6 +48,6 @@
 		<li>Ryflamer.Rimcraft.Scenarios</li>
 		<li>DankPyon.Medieval.Overhaul</li>
 		<li>RimOfMadness.Vampires</li>
-		<li>More Utility Packs</li>
+		<li>sgc.moreutilitypacks</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
## Changes

RimPy's autosorting would not place CE after More Utility Packs, which resulted in patch errors on Royalty-dependent apparel. That was due to MUP being referenced in loadAfter by name, not PackageID. That was fixed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
