### PR TITLE
Update CompSuppressable.cs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -66,8 +66,8 @@ namespace CombatExtended
                 if (pawn != null)
                 {
                     //Get morale
-                    float hardBreakThreshold = pawn.mindState?.mentalBreaker?.BreakThresholdMajor ?? 0;
-                    float currentMood = pawn.needs?.mood?.CurLevel ?? 0.5f;
+                    float hardBreakThreshold = BreakThresholdMajorCached(pawn);
+                    float currentMood = CurrentMoodCached(pawn);
                     threshold = Mathf.Sqrt(Mathf.Max(0, currentMood - hardBreakThreshold)) * maxSuppression * 0.125f;
                 }
                 else
@@ -76,6 +76,30 @@ namespace CombatExtended
                 }
                 return threshold;
             }
+        }
+
+        private float breakThresholdMajorCached;
+        private int breakThresholdMajorTickCheck;
+        private float BreakThresholdMajorCached(Pawn pawn)
+        {
+            if (breakThresholdMajorTickCheck == 0 || Find.TickManager.TicksGame > (breakThresholdMajorTickCheck + 30))
+            {
+                breakThresholdMajorCached = pawn.mindState?.mentalBreaker?.BreakThresholdMajor ?? 0;
+                breakThresholdMajorTickCheck = Find.TickManager.TicksGame;
+            }
+            return breakThresholdMajorCached;
+        }
+
+        private float currentMoodCached;
+        private int currentMoodTickCheck;
+        private float CurrentMoodCached(Pawn pawn)
+        {
+            if (currentMoodTickCheck == 0 || Find.TickManager.TicksGame > (currentMoodTickCheck + 30))
+            {
+                currentMoodCached = pawn.needs?.mood?.CurLevel ?? 0.5f;
+                currentMoodTickCheck = Find.TickManager.TicksGame;
+            }
+            return currentMoodCached;
         }
 
         private CompInventory _compInventory = null;


### PR DESCRIPTION
## Additions
- No new additions
## Changes
- Cache and fetch BreakThresholdMajor every 30 tick instead of 1 tick.
## References
## Reasoning
- As seen SuppressionThreshold is getting called every tick by IsHunkering and it contains retrieval of BreakThresholdMajor which is a bit heavy method, especially if every humanlike pawn will call it every tick. This is changed to cache and update it every 30 tick which is 0.5 second at normal speed and thus makes basically no difference, but makes the performance impact lighter in 30 times. 
## Alternatives
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
