### PR TITLE
Remove BenchBase overwrition 

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -3,30 +3,6 @@
 
   <!-- ========================= Work tables ==========================-->
 
-  <ThingDef Name="BenchBase" ParentName="BuildingBase" Abstract="True">
-    <canOverlapZones>false</canOverlapZones>
-    <minifiedDef>MinifiedThing</minifiedDef>
-    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
-    <thingCategories>
-      <li>BuildingsProduction</li>
-    </thingCategories>
-    <statBases>
-      <Mass>20</Mass>
-    </statBases>
-    <building>
-      <forceShowRoomStats>true</forceShowRoomStats>
-    </building>
-    <interactionCellIcon>DiningChair</interactionCellIcon>
-    <comps>
-      <li>
-        <compClass>CompReportWorkSpeed</compClass>
-      </li>
-    </comps>
-    <placeWorkers>
-      <li>PlaceWorker_ReportWorkSpeedPenalties</li>
-    </placeWorkers>
-  </ThingDef>
-
   <ThingDef ParentName="BenchBase">
     <defName>AmmoBench</defName>
     <label>loading bench</label>


### PR DESCRIPTION
## Additions
No new changes
## Changes
Removed BenchBase overwrition, which isn't clear why it's here at all. No mods should overwrite vanilla bases.

Here is the screenshot of xml bases comparison. Left is CE, right is Vanilla.
![image](https://user-images.githubusercontent.com/24846741/139563009-e51c8672-7d5b-49d1-b419-9cb3c4bee771.png)

## References
## Reasoning
No mod should overwrite vanilla bases, for changes use xml patches, so they inject the changes in the right place, not overwriting the whole thing.
## Alternatives
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
