### PR TITLE
Fix recipe labels

### DIFF
--- a/Defs/Ammo/Advanced/12x70mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x70mmCharged.xml
@@ -235,8 +235,8 @@
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
     <defName>MakeAmmo_12x65mmCharged_Ion</defName>
-    <label>make 12x65mm Charged (Ion) cartridge x500</label>
-    <description>Craft 500 12x65mm Charged (Ion) cartridges.</description>
+    <label>make 12x65mm Charged (Ion) cartridge x200</label>
+    <description>Craft 200 12x65mm Charged (Ion) cartridges.</description>
     <jobString>Making 12x65mm Charged (Ion) cartridges.</jobString>
     <ingredients>
       <li>


### PR DESCRIPTION
A very minor fix for 12x70 charge recipe label being incorrect.