### PR TITLE
implicitly exclude libraries which have publicized alternatives

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -166,6 +166,7 @@ def parse_sources(csproj, base_dir, verbose):
 
 def parse_publicize(csproj):
     publicized_libraries = []
+    removed_libraries = []
     publicize_task = [i for i in csproj.getElementsByTagName("Target")
                           if 'Name' in i.attributes and i.attributes['Name'].value.startswith('Publi')]
     variables = {}
@@ -198,9 +199,9 @@ def parse_publicize(csproj):
                           if 'Include' in i.attributes]
         for pub in publicize_task:
             publicized_libraries.append(PublicizeTarget(pub+'.dll', pub+'_publicized.dll'))
-            
+            removed_libraries.append(pub+'.dll')
     
-    return publicized_libraries
+    return publicized_libraries, removed_libraries
 
 def parse_csproj(csproj_path, verbose):
     
@@ -216,7 +217,8 @@ def parse_csproj(csproj_path, verbose):
 
         sources = parse_sources(csproj, base_dir, verbose)
 
-        publicized_libraries = parse_publicize(csproj)
+        publicized_libraries, removed_libraries_2 = parse_publicize(csproj)
+        removed_libraries.extend(removed_libraries_2)
 
         
 


### PR DESCRIPTION
## Changes

Implicitly exclude the original libraries when they are publicized


## Reasoning

The new publicizer format in the `.csproj` doesn't expliticly exclude the un-published assemblies.  If the compiler finds the un-published version before the published version, it causes the build to fail.  This is why PRs have failed building sometimes, but the same branch in a new PR builds successfully.

## Alternatives

Explicitly exclude the pre-publicized libraries.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
