### PR TITLE
Rebalance Ratkin race melee tools

### DIFF
--- a/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rakinlike.xml
@@ -70,25 +70,23 @@
 				  <li Class="CombatExtended.ToolCE">
 						<label>left fist</label>
 						<capacities>
-							<li>Scratch</li>
+							<li>Blunt</li>
 						</capacities>
-						<power>3</power>
-						<cooldownTime>1.11</cooldownTime>
+						<power>1</power>
+						<cooldownTime>1.26</cooldownTime>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>0.081</armorPenetrationBlunt>
-						<armorPenetrationSharp>0.02</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
 
 				  </li>
 				  <li Class="CombatExtended.ToolCE">
 						<label>right fist</label>
 						<capacities>
-							<li>Scratch</li>
+							<li>Blunt</li>
 						</capacities>
-						<power>3</power>
-						<cooldownTime>1.11</cooldownTime>
+						<power>1</power>
+						<cooldownTime>1.26</cooldownTime>
 						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-						<armorPenetrationBlunt>0.081</armorPenetrationBlunt>
-						<armorPenetrationSharp>0.02</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
 				   </li>
 					<li Class="CombatExtended.ToolCE">
 						<label>teeth</label>
@@ -108,7 +106,7 @@
 							<li>Blunt</li>
 						</capacities>
 						<power>2</power>
-						<cooldownTime>4.24</cooldownTime>
+						<cooldownTime>4.49</cooldownTime>
 						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 						<chanceFactor>0.1</chanceFactor>
 						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>


### PR DESCRIPTION
## Changes

- Changed Ratkin fist damage capacity type to `Blunt`
- Rebalanced power, cooldown time and blunt armor penetration to baseline human levels

## Reasoning

Aside from having rat ears and tails, Ratkins are functionally identical to 140~150 cm tall teenage human girls, and do not have rodent claws on their fingers. The proposed rebalance brings them more in line with baseline humans.

## Alternatives

Retaining the current patches would give Ratkins an unfair advantage over humans and most other humanoid races.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) with patched mod loaded
- [x] Playtested a colony (20 minutes, over 10+ instances of unarmed combat between a naked Ratkin and a naked human, to ensure a fair comparison without armor buffs from any race-specific apparel)
