### PR TITLE
Increase explosion armor penetration

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -7,6 +7,11 @@ namespace CombatExtended
     public static class AmmoUtility
     {
         /// <summary>
+        /// Multiplier used to scale the armor penetration of a given projectile's explosion
+        /// </summary>
+        private const float ExplosiveArmorPenetrationMultiplier = 0.25f;
+
+        /// <summary>
         ///     Generates a readout text for a projectile with the damage amount, type, secondary explosion and other CE stats for
         ///     display in info-box
         /// </summary>
@@ -56,7 +61,7 @@ namespace CombatExtended
                     && props.damageDef != DamageDefOf.Extinguish
                     && props.damageDef != DamageDefOf.Smoke)
                 {
-                    stringBuilder.AppendLine("   " + "CE_DescBluntPenetration".Translate() + ": " + GenExplosionCE.GetExplosionAP(props) + " " + "CE_MPa".Translate());
+                    stringBuilder.AppendLine("   " + "CE_DescBluntPenetration".Translate() + ": " + props.GetExplosionArmorPenetration() + " " + "CE_MPa".Translate());
                 }
             }
             else
@@ -103,6 +108,16 @@ namespace CombatExtended
 
             return stringBuilder.ToString();
         }
+
+        /// <summary>
+        /// Determine the armor penetration value of a given projectile type's explosion.
+        /// </summary>
+        public static float GetExplosionArmorPenetration(this ProjectileProperties props) => props.damageAmountBase * ExplosiveArmorPenetrationMultiplier;
+
+        /// <summary>
+        /// Determine the armor penetration value of a given explosive type's explosion.
+        /// </summary>
+        public static float GetExplosionArmorPenetration(this CompProperties_ExplosiveCE props) => props.damageAmountBase * ExplosiveArmorPenetrationMultiplier;
 
         public static bool IsShell(ThingDef def)
         {

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -39,7 +39,7 @@ namespace CombatExtended
             {
                 //Call GenExplosionCE for main explosion
                 GenExplosionCE.DoExplosion(posIV, map, Props.explosiveRadius, Props.explosiveDamageType, instigator,
-                    GenMath.RoundRandom(Props.damageAmountBase), Props.damageAmountBase * 0.1f,
+                    GenMath.RoundRandom(Props.damageAmountBase), Props.GetExplosionArmorPenetration(),
                     Props.explosionSound, null, parent.def, null,
                     Props.postExplosionSpawnThingDef, Props.postExplosionSpawnChance, Props.postExplosionSpawnThingCount,
                     Props.applyDamageToExplosionCellsNeighbors, Props.preExplosionSpawnThingDef, Props.preExplosionSpawnChance,

--- a/Source/CombatExtended/CombatExtended/GenExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/GenExplosionCE.cs
@@ -151,9 +151,5 @@ namespace CombatExtended
                 }
             }
         }
-        public static float GetExplosionAP(ProjectileProperties props)
-        {
-            return props.GetDamageAmount(1) * 0.1f;
-        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1078,7 +1078,7 @@ namespace CombatExtended
                 if (def.projectile.explosionRadius > 0)
                 {
                     GenExplosionCE.DoExplosion(explodePos.ToIntVec3(), Map, def.projectile.explosionRadius,
-                        def.projectile.damageDef, launcher, def.projectile.GetDamageAmount(1), GenExplosionCE.GetExplosionAP(def.projectile),
+                        def.projectile.damageDef, launcher, def.projectile.GetDamageAmount(1), def.projectile.GetExplosionArmorPenetration(),
                         def.projectile.soundExplode, equipmentDef,
                         def, null, def.projectile.postExplosionSpawnThingDef, def.projectile.postExplosionSpawnChance, def.projectile.postExplosionSpawnThingCount,
                         def.projectile.applyDamageToExplosionCellsNeighbors, def.projectile.preExplosionSpawnThingDef, def.projectile.preExplosionSpawnChance,

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -120,7 +120,7 @@ namespace CombatExtended
                     if (detProps != null)
                     {
                         GenExplosionCE.DoExplosion(Position, Map, detProps.explosionRadius, detProps.damageDef,
-                            this, detProps.GetDamageAmount(1), GenExplosionCE.GetExplosionAP(detProps),
+                            this, detProps.GetDamageAmount(1), detProps.GetExplosionArmorPenetration(),
                             detProps.soundExplode,
                             null, def, null, detProps.postExplosionSpawnThingDef, detProps.postExplosionSpawnChance,
                             detProps.postExplosionSpawnThingCount, detProps.applyDamageToExplosionCellsNeighbors,


### PR DESCRIPTION



## Changes

Bump the armor penetration factor of explosion damage to 0.25, up from
0.1. This aims to make direct damage from explosions more dangerous.

Also factor out duplicated armor penetration calculations into helpers
in AmmoUtility so that it's easier to adjust the armor penetration
factor in the future.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
