### PR TITLE
Expanded Woodworking (Forked) Patch

### DIFF
--- a/Patches/Expanded Woodworking/Items_Resources.xml
+++ b/Patches/Expanded Woodworking/Items_Resources.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Expanded Woodworking (Forked)</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>0.99</cooldownTime>
+								<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.2</MeleeCritChance>
+							<MeleeParryChance>1</MeleeParryChance>
+							<MeleeDodgeChance>0.13</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases</xpath>
+					<value>
+						<Bulk>0.07</Bulk>
+						<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases/SharpDamageMultiplier</xpath>
+					<value>
+						<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/statBases/BluntDamageMultiplier</xpath>
+					<value>
+						<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="WoodLumberBase" or @Name="WoodLogBase"]/stuffProps/statFactors</xpath>
+					<value>
+						<Mass>0.3</Mass>
+						<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
Patched woodlogs and lumbers from Expanded Woodworking (Forked) mod to have the same stats as vanilla woodlog. All the stats were taken from woodlog patch, feel free to tweak if anything. 
## Changes
## References
## Reasoning
## Alternatives
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
