### PR TITLE
Check for invetory comp in pawnkind autopatcher

### DIFF
--- a/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
@@ -16,7 +16,7 @@ namespace CombatExtended.Compatibility
         static PawnKindPatcher()
         {
            
-            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefsListForReading.FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false);
+            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefsListForReading.FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false && i.race.comps.Any(t => t is CompProperties_Inventory));
             foreach (PawnKindDef thin in stuff)
             {
 

--- a/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/PawnKindAutoPatcher.cs
@@ -16,7 +16,7 @@ namespace CombatExtended.Compatibility
         static PawnKindPatcher()
         {
            
-            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefsListForReading.FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false && i.race.comps.Any(t => t is CompProperties_Inventory));
+            List<PawnKindDef> stuff = DefDatabase<PawnKindDef>.AllDefsListForReading.FindAll(i => i.modExtensions?.Any(tt => !(tt is LoadoutPropertiesExtension)) ?? true && i.RaceProps.Animal == false && (i.race?.comps?.Any(t => t is CompProperties_Inventory) ?? false));
             foreach (PawnKindDef thin in stuff)
             {
 


### PR DESCRIPTION
Very small change, requested by Hunstsman since the patcher seemed to have been adding the modextension to drones from rimfactory, which caused errors.
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
