### PR TITLE
Patch Rim-Effect Drell

### DIFF
--- a/Patches/Rimeffect Drell/Apparel_Drell.xml
+++ b/Patches/Rimeffect Drell/Apparel_Drell.xml
@@ -23,7 +23,7 @@
 				<value>
 					<Bulk>3</Bulk>
 					<WornBulk>1</WornBulk>
-					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>  
+					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 				</value>
 			</li>
 
@@ -31,6 +31,7 @@
 				<xpath>/Defs/ThingDef[defName="RE_AssassinsHood"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-0.6</SmokeSensitivity>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 				</value>
 			</li>
 

--- a/Patches/Rimeffect Drell/Apparel_Drell.xml
+++ b/Patches/Rimeffect Drell/Apparel_Drell.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Effect: Drell</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Assassin's Hood -->		
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_AssassinsHood"]/apparel/layers</xpath>
+				<value>
+					<layers Inherit="false">
+						<li>OnHead</li>
+						<li>MiddleHead</li>
+					</layers>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="RE_AssassinsHood"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>  
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="RE_AssassinsHood"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-0.6</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_AssassinsHood"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_AssassinsHood"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>9</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- Assassin's Jacket -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_AssassinsJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>1.75</WornBulk>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>	  
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimeffect Drell/Drell_Race.xml
+++ b/Patches/Rimeffect Drell/Drell_Race.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Effect: Drell</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Humanoid</bodyShape>
+					</li>
+				</value>
+			</li>
+			
+			<!-- Melee Tool & Basestats Defs -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1</MeleeCritChance>
+					<MeleeParryChance>1</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]/tools</xpath> 
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>1.26</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Checking if "RE_Drell" has a <comps> node and adding it if it doesn't exist -->
+			<li Class="PatchOperationSequence">
+				<success>Always</success>
+				<operations>
+					<li Class="PatchOperationTest">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]/comps</xpath>
+					<success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]</xpath>
+					<value>
+						<comps />
+					</value>
+					</li>
+				</operations>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="RE_Drell"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>
+
+			</operations>		
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Rimeffect Drell/PawnKinds_Drell.xml
+++ b/Patches/Rimeffect Drell/PawnKinds_Drell.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+ <Patch>
+
+	<Operation Class="PatchOperationFindMod">
+			<mods>
+				<li>Rim-Effect: Drell</li>
+			</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/PawnKindDef[defName="RE_DrellTraveller"]</xpath>
+			<value>
+				<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>5</max>
+				</primaryMagazineCount>
+				</li>
+			</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/PawnKindDef[defName="RE_DrellMercenary"]</xpath>
+			<value>
+				<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>7</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+					<magazineCount>
+					<min>1</min>
+					<max>5</max>
+					</magazineCount>			  
+					<generateChance>0.5</generateChance>
+					<sidearmMoney>
+						<min>100</min>
+						<max>450</max>
+					</sidearmMoney>
+					<weaponTags>
+						<li>CE_Sidearm_Melee</li>
+						<li>CE_Sidearm</li>			  
+					</weaponTags>				
+					</li>
+				</sidearms>
+				</li>
+			</value>
+			</li>
+			
+			</operations>		
+		</match>
+	</Operation>
+			  
+
+   
+  </Patch>

--- a/Patches/Rimeffect Drell/Projectiles_Drell.xml
+++ b/Patches/Rimeffect Drell/Projectiles_Drell.xml
@@ -1,0 +1,291 @@
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Rim-Effect: Drell</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>		
+
+		<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Viper</defName>
+		<label>Thermal Clip</label>
+		<ammoTypes>
+			<Ammo_ME>Bullet_Viper</Ammo_ME>
+			<Ammo_ME_AP>Bullet_Viper_AP</Ammo_ME_AP>
+			<Ammo_ME_Cryo>Bullet_Viper_Cryo</Ammo_ME_Cryo>
+			<Ammo_ME_HE>Bullet_Viper_HE</Ammo_ME_HE>
+			<Ammo_ME_FI>Bullet_Viper_FI</Ammo_ME_FI>
+			<Ammo_ME_Ion>Bullet_Viper_Ion</Ammo_ME_Ion>
+			<Ammo_ME_Toxic>Bullet_Viper_Toxic</Ammo_ME_Toxic>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Locust</defName>
+		<label>Thermal Clip</label>
+		<ammoTypes>
+			<Ammo_ME>Bullet_Locust</Ammo_ME>
+			<Ammo_ME_AP>Bullet_Locust_AP</Ammo_ME_AP>
+			<Ammo_ME_Cryo>Bullet_Locust_Cryo</Ammo_ME_Cryo>
+			<Ammo_ME_HE>Bullet_Locust_HE</Ammo_ME_HE>
+			<Ammo_ME_FI>Bullet_Locust_FI</Ammo_ME_FI>
+			<Ammo_ME_Ion>Bullet_Locust_Ion</Ammo_ME_Ion>
+			<Ammo_ME_Toxic>Bullet_Locust_Toxic</Ammo_ME_Toxic>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ================== Viper ================== -->
+
+	<ThingDef Name="BaseViperBullet" ParentName="Base6x24mmChargedBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Shot_MassAccelerated_Sniper</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>1.1</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageDef>Bullet</damageDef>
+		<speed>500</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>36</damageAmountBase>
+		<armorPenetrationSharp>28</armorPenetrationSharp>      
+		<armorPenetrationBlunt>180</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper_AP</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>24</damageAmountBase>
+		<armorPenetrationSharp>56</armorPenetrationSharp>      
+		<armorPenetrationBlunt>180</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper_Cryo</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>34</damageAmountBase>
+			<armorPenetrationSharp>30</armorPenetrationSharp>      
+			<armorPenetrationBlunt>180</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>ME_Cryo</def>
+				<amount>7</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper_HE</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>36</damageAmountBase>
+			<armorPenetrationSharp>28</armorPenetrationSharp>      
+			<armorPenetrationBlunt>180</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bomb_Secondary</def>
+				<amount>20</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper_Toxic</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>34</damageAmountBase>
+			<armorPenetrationSharp>28</armorPenetrationSharp>      
+			<armorPenetrationBlunt>180</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>ME_Toxin</def>
+				<amount>7</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseViperBullet">
+		<defName>Bullet_Viper_FI</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>36</damageAmountBase>
+		<armorPenetrationSharp>28</armorPenetrationSharp>      
+		<armorPenetrationBlunt>180</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			<def>ME_SickBurn</def>
+			<amount>5</amount>
+			</li>
+			<li>
+			<def>Flame</def>
+			<amount>1</amount>
+			</li>
+		  </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseViperBullet">
+    <defName>Bullet_Viper_Ion</defName>
+    <label>accelerated shot</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>27</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>EMP</def>
+          <amount>9</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationBlunt>180</armorPenetrationBlunt>
+      <empShieldBreakChance>1</empShieldBreakChance>
+    </projectile>
+  </ThingDef>
+
+	<!-- ================== Locust ================== -->
+
+  <ThingDef Name="BaseLocustBullet" ParentName="Base6x24mmChargedBullet" Abstract="true">
+    <graphicData>
+		<texPath>Things/Projectile/Shot_MassAccelerated_Small</texPath>
+		<graphicClass>Graphic_Single</graphicClass>
+		<shaderType>TransparentPostLight</shaderType>
+		<drawSize>1.1</drawSize>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>180</speed>
+    </projectile>
+  </ThingDef>
+
+	<ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>11</damageAmountBase>
+		<armorPenetrationSharp>10</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_AP</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>8</damageAmountBase>
+		<armorPenetrationSharp>20</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_HE</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>11</damageAmountBase>
+		<armorPenetrationSharp>10</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		<secondaryDamage>
+			<li>
+			<def>Bomb_Secondary</def>
+			<amount>5</amount>
+			</li>
+		</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_Cryo</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>11</damageAmountBase>
+		<armorPenetrationSharp>10</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		<secondaryDamage>
+			<li>
+			<def>ME_Cryo</def>
+			<amount>2</amount>
+			</li>
+		</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_Toxic</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>12</damageAmountBase>
+		<armorPenetrationSharp>10</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			<def>ME_Toxin</def>
+			<amount>2</amount>
+			</li>
+		  </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_FI</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>11</damageAmountBase>
+		<armorPenetrationSharp>10</armorPenetrationSharp>      
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			<def>ME_SickBurn</def>
+			<amount>2</amount>
+			</li>
+			<li>
+			<def>Flame</def>
+			<amount>1</amount>
+			<chance>0.25</chance>
+			</li>
+		</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseLocustBullet">
+		<defName>Bullet_Locust_Ion</defName>
+		<label>accelerated shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageAmountBase>7</damageAmountBase>
+		<secondaryDamage>
+			<li>
+			<def>EMP</def>
+			<amount>3</amount>
+			</li>
+		</secondaryDamage>
+		<armorPenetrationSharp>12</armorPenetrationSharp>
+		<armorPenetrationBlunt>30</armorPenetrationBlunt>
+		<empShieldBreakChance>0.30</empShieldBreakChance>
+		</projectile>
+	</ThingDef>
+
+
+		</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimeffect Drell/Scenarios_Drell.xml
+++ b/Patches/Rimeffect Drell/Scenarios_Drell.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Rim-Effect: Drell</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- === Add ammo to scenario === -->
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ScenarioDef[defName="RE_LoneDrellAssassin"]/scenario/parts</xpath>
+        <value>
+          <li Class="ScenPart_StartingThing_Defined">
+            <def>StartingThing_Defined</def>
+            <thingDef>Ammo_ME</thingDef>
+            <count>500</count>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Rimeffect Drell/Weapons_Drell.xml
+++ b/Patches/Rimeffect Drell/Weapons_Drell.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		  <li>Rim-Effect: Drell</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+    <!-- ========== Melee Tools ========== -->
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="RE_Gun_AllianceCompactSMG"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>grip</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>3</power>
+            <cooldownTime>1.54</cooldownTime>
+            <chanceFactor>1.5</chanceFactor>
+            <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>muzzle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>2</power>
+            <cooldownTime>1.54</cooldownTime>
+            <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="RE_Gun_AllianceRapidSniperRifle"]/tools</xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>stock</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>8</power>
+            <cooldownTime>1.55</cooldownTime>
+            <chanceFactor>1.5</chanceFactor>
+            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>barrel</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>5</power>
+            <cooldownTime>2.02</cooldownTime>
+            <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          </li>
+          <li Class="CombatExtended.ToolCE">
+            <label>muzzle</label>
+            <capacities>
+              <li>Poke</li>
+            </capacities>
+            <power>8</power>
+            <cooldownTime>1.55</cooldownTime>
+            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <!-- ========== M-12 Locust ========== -->
+    <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+      <defName>RE_Gun_AllianceCompactSMG</defName>
+      <statBases>
+        <SightsEfficiency>1.1</SightsEfficiency>
+        <ShotSpread>0.14</ShotSpread>
+        <SwayFactor>1.18</SwayFactor>
+        <Bulk>3.75</Bulk>
+        <Mass>1.8</Mass>
+        <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>True</hasStandardCommand>
+        <defaultProjectile>Bullet_Locust</defaultProjectile>
+        <warmupTime>0.6</warmupTime>
+        <range>32</range>
+        <burstShotCount>5</burstShotCount>
+        <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+        <soundCast>RE_Shot_Locust</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>9</muzzleFlashScale>
+        <recoilPattern>Regular</recoilPattern>
+        <recoilAmount>1.34</recoilAmount>
+      </Properties>
+      <costList>
+        <Steel>10</Steel>
+        <Plasteel>25</Plasteel>
+        <ComponentSpacer>1</ComponentSpacer>
+        <Chemfuel>5</Chemfuel>
+      </costList>
+      <AmmoUser>
+        <magazineSize>20</magazineSize>
+        <reloadTime>3.5</reloadTime>
+        <ammoSet>AmmoSet_Locust</ammoSet>
+      </AmmoUser>
+      <FireModes>
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aimedBurstShotCount>4</aimedBurstShotCount>
+      </FireModes>
+    </li>
+
+    <!-- Name -->
+    <li Class='PatchOperationReplace'>
+      <xpath>/Defs/ThingDef[defName='RE_Gun_AllianceCompactSMG']/label</xpath> 
+      <value>
+        <label>M-12 Locust</label>
+      </value>
+    </li>
+
+    <li Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="RE_Gun_AllianceCompactSMG"]/description</xpath>
+    <value>
+      <description>The Locust is an expensive but deadly addition to anyone's personal arsenal. This fully automatic submachine gun is punishing up close, while still capable of precise fire at long range.</description>
+    </value>
+    </li>
+
+    <!-- ========== M-97 Viper ========== -->
+    <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+      <defName>RE_Gun_AllianceRapidSniperRifle</defName>
+      <statBases>
+        <SightsEfficiency>2.5</SightsEfficiency>
+        <ShotSpread>0.05</ShotSpread>
+        <SwayFactor>1.46</SwayFactor>
+        <Bulk>10.0</Bulk>
+        <Mass>4.20</Mass>
+        <RangedWeapon_Cooldown>0.27</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>True</hasStandardCommand>
+        <defaultProjectile>Bullet_Viper</defaultProjectile>
+        <warmupTime>1.45</warmupTime>
+        <range>78</range>
+        <ammoConsumedPerShotCount>4</ammoConsumedPerShotCount>
+        <soundCast>RE_Shot_Viper</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>11</muzzleFlashScale>
+      </Properties>
+      <AmmoUser>
+        <magazineSize>24</magazineSize>
+        <reloadTime>1.1</reloadTime>
+        <ammoSet>AmmoSet_Viper</ammoSet>
+      </AmmoUser>
+      <FireModes>
+        <aiUseBurstMode>False</aiUseBurstMode>
+        <aiAimMode>AimedShot</aiAimMode>
+      </FireModes>
+    </li>
+
+    <!-- Name -->
+    <li Class='PatchOperationReplace'>
+      <xpath>/Defs/ThingDef[defName='RE_Gun_AllianceRapidSniperRifle']/label</xpath>
+      <value>
+        <label>M-97 Viper</label>
+      </value>
+    </li>
+
+    <li Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="RE_Gun_AllianceRapidSniperRifle"]/description</xpath>
+      <value>
+        <description>The Viper is a semi-automatic, rapid-fire sniper rifle capable of quickly engaging targets with follow-up shots.</description>
+      </value>
+    </li>
+
+		</operations>		
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -254,6 +254,7 @@ Rim of Madness - Bones	|
 Rim of Madness - Vampires	|
 Rim of Madness - Werewolves	|
 Rim-Effect: Core	|
+Rim-Effect: Drell	|
 Rim-Effect: Extended Cut	|
 Rim-Effect: N7	|
 Rimedieval - Medieval Royalty   |


### PR DESCRIPTION
## Additions
- Adds a patch for Rim-Effect: Drell. Viper is based off the Mantis, with higher rate of fire and lower damage. Locust is based off the tempest, with slightly higher rate of fire and longer range, and slightly less damage. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
