### PR TITLE
Ammo influencing recoil

### DIFF
--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -52,6 +52,7 @@
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_FMJ</cookOffProjectile>
+		<RecoilMult>1</RecoilMult>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
@@ -66,6 +67,7 @@
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_AP</cookOffProjectile>
+		<RecoilMult>1.2</RecoilMult>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
@@ -94,6 +96,7 @@
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
+		<RecoilMult>1.4</RecoilMult>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
@@ -108,6 +111,7 @@
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>
+		<RecoilMult>1.5</RecoilMult>
 	</ThingDef>
 	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
@@ -123,6 +127,7 @@
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_Sabot</cookOffProjectile>
+		<RecoilMult>1.5</RecoilMult>
 	</ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -140,10 +140,12 @@
     <description>How much will this weapon recoil upon firing.</description>
     <category>Weapon</category>    
     <defaultBaseValue>0</defaultBaseValue>
+    <toStringStyle>FloatTwo</toStringStyle>
     <showIfUndefined>false</showIfUndefined>
     <displayPriorityInCategory>898</displayPriorityInCategory>
     <parts>
       <li Class="CombatExtended.StatPart_Attachments" />
+      <li Class="CombatExtended.CombatExtended.StatParts.StatPart_Ammo" />
     </parts>
   </StatDef>
 

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -10,6 +10,10 @@ namespace CombatExtended
 {
     public class AmmoDef : ThingDef
     {
+        /// <summary>
+        /// Multiplier for recoil
+        /// </summary>
+        public float RecoilMult = 1f;
         public AmmoCategoryDef ammoClass;
         public int defaultAmmoCount = 1;
         public float cookOffSpeed = 1f;

--- a/Source/CombatExtended/CombatExtended/StatParts/AmmoRecoilStat.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/AmmoRecoilStat.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended.CombatExtended.StatParts
+{
+	public class StatPart_Ammo : StatPart
+	{
+		public override void TransformValue(StatRequest req, ref float val)
+		{
+			float num;
+
+			bool HasAmUser = req.Thing.TryGetComp<CompAmmoUser>() != null;
+
+			if (HasAmUser)
+			{
+				bool HasAmmo = req.Thing.TryGetComp<CompAmmoUser>().CurrentAmmo != null;
+				if (HasAmmo)
+				{
+					num = req.Thing.TryGetComp<CompAmmoUser>().CurrentAmmo.RecoilMult;
+					val *= num;
+					Log.Message(num.ToString());
+				}
+				
+			}
+		}
+
+		public override string ExplanationPart(StatRequest req)
+		{
+			float f;
+
+			bool HasAmUser = req.Thing.TryGetComp<CompAmmoUser>() != null;
+
+			if (HasAmUser)
+			{
+				bool HasAmmo = req.Thing.TryGetComp<CompAmmoUser>().CurrentAmmo != null;
+				if (HasAmmo)
+				{
+					f = req.Thing.TryGetComp<CompAmmoUser>().CurrentAmmo.RecoilMult;
+					return "Current ammunition: " + f.ToString();
+				}
+
+					
+			}
+			return null;
+		}
+
+	}
+}


### PR DESCRIPTION
## Additions

- Adds recoil multiplier to ammodefs

## Changes

Ammodefs now have a new field multiplying recoil when loaded into the gun.
Also recoil stat shown to player is no longer rounded

## Reasoning

- API ammo has very few downsides, so it just becomes the go to ammo in all situations
- Recoil overall seems to be pretty limited as a mechanic and it's values seems really small

## Alternatives

Instead of ammodefs it could be added to ammocategorydefs or ammosetdefs

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)

