### PR TITLE
Fractional damage has a chance to damage armor, and is applied as fra…

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -252,15 +252,14 @@ namespace CombatExtended
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
 		    float armorDamage2 = newDmgAmount * Mathf.Min(1.0f, penAmount / armorAmount);
-		    if (armorDamage2 <= 0.5f) {
+		    int armorDamage = (int) armorDamage2;
+		    armorDamage2 = armorDamage2 - armorDamage;
+		    if (armorDamage2 > 0) {
 			if (UnityEngine.Random.value < armorDamage2) {
-			    armorDamage2 = 1.0f;
-			}
-			else {
-			    armorDamage2 = 0.0f;
+			  armorDamage++;
 			}
 		    }
-                    int armorDamage = Mathf.RoundToInt(armorDamage2);
+                    
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -236,7 +236,7 @@ namespace CombatExtended
                     {
 			int armorDamage = 0;
 			if (dmgAmount <= 1.0f) {
-			    if (UnityEngine.Random.value < (penAmount / armorAmount) * dmgAmount) {
+			    if (Rand.Value < (penAmount / armorAmount) * dmgAmount) {
 				armorDamage = 1;
 			    }
 			}
@@ -256,7 +256,7 @@ namespace CombatExtended
 		    
 		    armorDamage2 = armorDamage2 - armorDamage;
 		    if (armorDamage2 > 0) {
-			if (UnityEngine.Random.value < armorDamage2) {
+			if (Rand.Value < armorDamage2) {
 			    armorDamage++;
 			}
 		    }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -189,12 +189,12 @@ namespace CombatExtended
             }
 
             // Applies blunt damage from partial penetrations.
-            if (isSharp && (dinfo.Amount > Mathf.CeilToInt(dmgAmount)))
+            if (isSharp && (dinfo.Amount > dmgAmount))
             {
                 pawn.TakeDamage(GetDeflectDamageInfo(dinfo, hitPart, ref dmgAmount, ref penAmount, true));
             }
             // Return damage info.
-            dinfo.SetAmount(Mathf.CeilToInt(dmgAmount));
+            dinfo.SetAmount(dmgAmount);
             return dinfo;
         }
 
@@ -234,14 +234,33 @@ namespace CombatExtended
                     // Soft armor takes absorbed damage from sharp and no damage from blunt
                     if (isSharpDmg)
                     {
-                        var armorDamage = Mathf.Max(dmgAmount * SoftArmorMinDamageFactor, dmgAmount - newDmgAmount);
-                        armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
+			int armorDamage = 0;
+			if (dmgAmount <= 1.0f) {
+			    if (UnityEngine.Random.value < (penAmount / armorAmount) * dmgAmount) {
+				armorDamage = 1;
+			    }
+			}
+			else {
+			    
+			    armorDamage = Mathf.CeilToInt(Mathf.Max(dmgAmount * SoftArmorMinDamageFactor, dmgAmount - newDmgAmount));
+			}
+			
+                        armor.TakeDamage(new DamageInfo(def, armorDamage));
                     }
                 }
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-                    var armorDamage = Mathf.Max(1, newDmgAmount);
+		    float armorDamage2 = newDmgAmount * Mathf.Min(1.0f, penAmount / armorAmount);
+		    if (armorDamage2 <= 0.5f) {
+			if (UnityEngine.Random.value < armorDamage2) {
+			    armorDamage2 = 1.0f;
+			}
+			else {
+			    armorDamage2 = 0.0f;
+			}
+		    }
+                    int armorDamage = Mathf.RoundToInt(armorDamage2);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -251,15 +251,15 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-		    float armorDamage2 = newDmgAmount * Mathf.Min(1.0f, penAmount / armorAmount);
+		    float armorDamage2 = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, penAmount / armorAmount);
 		    int armorDamage = (int) armorDamage2;
+		    
 		    armorDamage2 = armorDamage2 - armorDamage;
 		    if (armorDamage2 > 0) {
 			if (UnityEngine.Random.value < armorDamage2) {
-			  armorDamage++;
+			    armorDamage++;
 			}
 		    }
-                    
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }


### PR DESCRIPTION
## Changes
- Fractional damage rounds randomly.  If armor should take 0.5 damage from a hit, half the time it takes 0, half the time it takes 1.  If it should take 0.25 damage, 1/4 the time it takes 1 and 3/4 the time it takes 0.

## Reasoning

Why did you choose to implement things this way, e.g.
Currently, no matter how weak the damage source, and how strong the armor, the armor always takes at least 1 damage.  Given that even cataphract armor only has 600hp, this makes small arms fire too effective against hard targets.  

Also, once the armor is weak enough to let any non-zero amount through, the damage to the pawn is rounded up too, which makes small arms against armored targets too lethal.  

## Alternatives

Leave it as is.
Increase armor HP and rebalance other weapons to do *more* damage to armor. -- Same effect, but in fixed precision and much more work
Always round down.  -- causes opposite problem

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (months)
