### PR TITLE
Patch Bulgarian Imperial Uniforms

### DIFF
--- a/Patches/Bulgarian Imperial Uniforms/Apparel_Industrial.xml
+++ b/Patches/Bulgarian Imperial Uniforms/Apparel_Industrial.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Bulgarian Imperial Uniforms</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Uniform -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Uniform"]/statBases</xpath>
+				<value>
+					<Bulk>3.5</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Uniform"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+ 					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Uniform"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+ 					<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- Uniform Cap -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Cap"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+ 					<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Cap"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+ 					<ArmorRating_Blunt>0.03</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- Webbing -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+ 					<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
+					<Bulk>5</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+ 					<ArmorRating_Blunt>0.03</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/equippedStatOffsets/CarryingCapacity</xpath>
+				<value>
+ 					<CarryBulk>30</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/apparel/layers/li[.="Belt"]</xpath>
+				<value>
+ 					<li>Webbing</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/apparel/bodyPartGroups/li[.="Waist"]</xpath>
+				<value>
+ 					<li>Shoulders</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Bulgarian Imperial Uniforms/Apparel_Industrial.xml
+++ b/Patches/Bulgarian Imperial Uniforms/Apparel_Industrial.xml
@@ -67,7 +67,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Hessian_Bulgarian_Webbing"]/equippedStatOffsets/CarryingCapacity</xpath>
 				<value>
- 					<CarryBulk>30</CarryBulk>
+ 					<CarryBulk>45</CarryBulk>
 				</value>
 			</li>
 

--- a/Patches/Bulgarian Imperial Uniforms/RangedIndustrial.xml
+++ b/Patches/Bulgarian Imperial Uniforms/RangedIndustrial.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Bulgarian Imperial Uniforms</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="Gun_M1879_Peabody_Martini"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>stock</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <chanceFactor>1.5</chanceFactor>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>5</power>
+                <cooldownTime>2.02</cooldownTime>
+                <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>muzzle</label>
+                <capacities>
+                  <li>Poke</li>
+                </capacities>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="Gun_M1879_Peabody_Martini_Bayonet"]/tools</xpath>
+          <value>
+              <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>stock</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <chanceFactor>1.5</chanceFactor>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>bayonet</label>
+                <capacities>
+                  <li>Cut</li>
+                </capacities>
+                <power>17</power>
+                <cooldownTime>2.14</cooldownTime>
+                <armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.5</armorPenetrationSharp>	
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>bayonet</label>
+                <capacities>
+                  <li>Stab</li>
+                </capacities>
+                <power>6</power>
+                <cooldownTime>1.49</cooldownTime>
+                <armorPenetrationBlunt>2.16</armorPenetrationBlunt>
+                <armorPenetrationSharp>1.44</armorPenetrationSharp>				  
+                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+              </li>
+              </tools>
+          </value>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>Gun_M1879_Peabody_Martini</defName>
+          <statBases>
+            <Mass>3.83</Mass>
+            <Bulk>12.45</Bulk>
+            <ShotSpread>0.01</ShotSpread>
+            <SwayFactor>1.63</SwayFactor>
+            <SightsEfficiency>1</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.87</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+            <warmupTime>1.1</warmupTime>
+            <range>48</range>
+            <soundCast>Shot_BoltActionRifle</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>10</muzzleFlashScale>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>1</magazineSize>
+            <reloadTime>2</reloadTime>
+            <reloadOneAtATime>true</reloadOneAtATime>
+            <ammoSet>AmmoSet_303British</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+          </FireModes>
+          <weaponTags>
+            <li>SimpleGun</li>
+            <li>CE_AI_Rifle</li>
+          </weaponTags>
+          <AllowWithRunAndGun>false</AllowWithRunAndGun>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>Gun_M1879_Peabody_Martini_Bayonet</defName>
+          <statBases>
+            <Mass>4.40</Mass>
+            <Bulk>14.85</Bulk>
+            <ShotSpread>0.01</ShotSpread>
+            <SwayFactor>1.71</SwayFactor>
+            <SightsEfficiency>1</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.87</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+            <warmupTime>1.1</warmupTime>
+            <range>48</range>
+            <soundCast>Shot_BoltActionRifle</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>10</muzzleFlashScale>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>1</magazineSize>
+            <reloadTime>2</reloadTime>
+            <reloadOneAtATime>true</reloadOneAtATime>
+            <ammoSet>AmmoSet_303British</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+          </FireModes>
+          <weaponTags>
+            <li>SimpleGun</li>
+            <li>CE_AI_Rifle</li>
+          </weaponTags>
+          <AllowWithRunAndGun>false</AllowWithRunAndGun>
+        </li>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/ThingDef[defName="Gun_M1879_Peabody_Martini_Bayonet" or defName="Gun_M1879_Peabody_Martini"]</xpath>
+          <value>
+            <li Class="CombatExtended.GunDrawExtension">
+              <DrawSize>1.34,1.84</DrawSize>
+              <DrawOffset>0.12,-0.10</DrawOffset>
+            </li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -92,6 +92,7 @@ Beast Man Tribes  |
 Beeralope Squad	|
 Better Infestations	|
 Black Widows	|
+Bulgarian Imperial Uniforms |
 Carbon	|
 Censored Armory  |
 Clay Soldier Race |


### PR DESCRIPTION
## Additions
Patches the Bulgarian Imperial Uniforms mod.

The mod adds two weapons (both the same rifle, one with a bayonet), a hat, a uniform, and a webbing/backpack combo. The webbing combo has a base value of 45 carry bulk (versus 30 apiece for the backpack and tac vest), since it occupies both slots but the webbing itself is inferior to a tac vest in terms to actual capacity.

## Testing
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
