### PR TITLE
Patch FROG Suit Set

### DIFF
--- a/Patches/FROG Suit Set/Armor_Spacer.xml
+++ b/Patches/FROG Suit Set/Armor_Spacer.xml
@@ -8,43 +8,72 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-			<!-- === Trooper Armor === -->
+			<!-- === Frog Helmet === -->
+			<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="FROG_Helmet"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>1</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+			</li>
+
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/Mass</xpath>
+			<xpath>/Defs/ThingDef[defName="FROG_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>18</ArmorRating_Sharp>
+			</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="FROG_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>38</ArmorRating_Blunt>
+			</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="FROG_Helmet"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+			</li>
+
+			<!-- === Frog Suit === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="FROG_Suit"]/statBases</xpath>
 				<value>
 					<Bulk>40</Bulk>
-					<WornBulk>6</WornBulk>
-					<Mass>20</Mass>
+					<WornBulk>4</WornBulk>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>/Defs/ThingDef[defName="FROG_Suit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>/Defs/ThingDef[defName="FROG_Suit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>28</ArmorRating_Blunt>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/equippedStatOffsets/MentalBreakThreshold</xpath>
-				<value>
-					<CarryWeight>25</CarryWeight>
-					<CarryBulk>7.5</CarryBulk>
-					<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.3</ToxicSensitivity>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/apparel/bodyPartGroups</xpath>
+				<xpath>/Defs/ThingDef[defName="FROG_Suit"]/equippedStatOffsets</xpath>
 				<value>
+					<CarryWeight>25</CarryWeight>
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="FROG_Suit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
 					<li>Feet</li>
 				</value>
 			</li>

--- a/Patches/FROG Suit Set/Armor_Spacer.xml
+++ b/Patches/FROG Suit Set/Armor_Spacer.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>FROG Suit Set</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Trooper Armor === -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/Mass</xpath>
+				<value>
+					<Bulk>40</Bulk>
+					<WornBulk>6</WornBulk>
+					<Mass>20</Mass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/equippedStatOffsets/MentalBreakThreshold</xpath>
+				<value>
+					<CarryWeight>25</CarryWeight>
+					<CarryBulk>7.5</CarryBulk>
+					<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
+					<ToxicSensitivity>-0.3</ToxicSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/FROG Suit Set/Industrial_Ranged.xml
+++ b/Patches/FROG Suit Set/Industrial_Ranged.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>FROG Suit Set</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Tools === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName = "Gewehr3_Rifle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>stock</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- ========== Gewehr 3 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gewehr3_Rifle</defName>
+				<statBases>
+					<Mass>4.38</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.46</SwayFactor>
+					<Bulk>10.25</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.91</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+			  		<burstShotCount>4</burstShotCount>
+					<warmupTime>1.1</warmupTime>
+					<range>48</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -149,6 +149,7 @@ Forgotten Realms - Minotaur	|
 Forsakens	|
 Forsakens Fauna |  
 Fortifications - Industrial |
+FROG Suit Set   |
 Fuck it Unboomas Your Lope |
 Gas Traps And Shells	|
 Genetic Rim |


### PR DESCRIPTION
## Additions
Patches the FROG Suit Set mod, which adds a G3 rifle and two pieces of apparel, an armored bodysuit and accompanying helmet.

## References
Closes #1187

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (5 min.)
