### PR TITLE
Update VFE: Ancients Patch

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -906,7 +906,6 @@
     <xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
     <value>
       <tradeability>None</tradeability>
-      <destroyOnDrop>True</destroyOnDrop>
     </value>
   </Operation>
 

--- a/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
@@ -17,6 +17,31 @@
           <thing>Ammo_556x45mmNATO_Incendiary</thing>
         </KCSG.SymbolDef>
 
+        <KCSG.SymbolDef>
+          <defName>Ammo_12Gauge_Buck</defName>
+          <thing>Ammo_12Gauge_Buck</thing>
+        </KCSG.SymbolDef>
+
+        <KCSG.SymbolDef>
+          <defName>Ammo_45ACP_AP</defName>
+          <thing>Ammo_45ACP_AP</thing>
+        </KCSG.SymbolDef>
+
+        <KCSG.SymbolDef>
+          <defName>Ammo_762x51mmNATO_Incendiary</defName>
+          <thing>Ammo_762x51mmNATO_Incendiary</thing>
+        </KCSG.SymbolDef>
+
+        <KCSG.SymbolDef>
+          <defName>Ammo_762x54mmR_HE</defName>
+          <thing>Ammo_762x54mmR_HE</thing>
+        </KCSG.SymbolDef>
+
+        <KCSG.SymbolDef>
+          <defName>Ammo_6x24mmCharged</defName>
+          <thing>Ammo_6x24mmCharged</thing>
+        </KCSG.SymbolDef>
+
         </value>	
       </li>
 
@@ -39,7 +64,7 @@
       <li Class="PatchOperationReplace">
         <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
         <value>
-          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
@@ -47,6 +72,62 @@
         <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_12Gauge_Buck,Gun_ChainShotgun,Ammo_12Gauge_Buck,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
+        <value>
+              <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x51mmNATO_Incendiary,Ammo_762x54mmR_HE,Ammo_762x54mmR_HE,Gun_LMG,Ammo_45ACP_AP,Gun_Minigun,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,.,.,.,.,.,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
+        <value>
+              <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_ChargeRifle,Ammo_6x24mmCharged,Ammo_6x24mmCharged,Gun_HeavySMG,Ammo_45ACP_AP,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_MachinePistol,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,Apparel_PowerArmor,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
+        <value>
+          <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_MachinePistol,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
@@ -35,6 +35,13 @@
       </value>
     </li>
 
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
+      <value>
+        <fillPercent>0.95</fillPercent>
+      </value>
+    </li>
+
 	  <li Class="PatchOperationAdd">
 	  	<xpath>Defs/ThingDef[
 			defName = "VFEA_Turret_AncientSecurityTurret" or		
@@ -76,10 +83,11 @@
       </value>
     </li>
 
-    <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
+    <!-- Make turrets taller -->
+    <li Class="PatchOperationReplace">
+      <xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/statBases/MaxHitPoints</xpath>
       <value>
-        <fillPercent>0.95</fillPercent>
+        <MaxHitPoints>125</MaxHitPoints>
       </value>
     </li>
 


### PR DESCRIPTION
## Additions
- Add a bit more 5.56mm NATO ammo to most vaults, to supply turrets.
- Add ammo to new vaults added by VFE:A

## Changes
- Made the Minigun non-destroy on drop, so the one the spawns in one of the vaults is usable (the minigun is already patched within the files)
- Give the Ancient Sentry turret slightly more health, since it's not the makeshift piece of junk the miniturret explicitly is said to be. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
