### PR TITLE
Fix Raider mech's gun

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -108,6 +108,20 @@
         </tools>
       </value>
     </li>
+        <!-- === Label and Description === -->
+    <Operation Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VFE_Gun_RaiderMechanoidGun"]/label</xpath>
+      <value>
+          <label>handheld m240 turret</label>
+      </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VFE_Gun_RaiderMechanoidGun"]/description</xpath>
+      <value>
+          <description>A portable version of the m240 turret gun. Its intermediate-caliber rounds do moderate damage over medium ranges.</description>
+      </value>
+    </Operation>
 
     <!-- ========== Light Charge Blaster ========== -->
 	

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -62,7 +62,7 @@
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
       <defName>VFE_Gun_RaiderMechanoidGun</defName>
       <statBases>
-        <Mass>40</Mass>
+        <Mass>10</Mass>
         <Bulk>22</Bulk>
         <SwayFactor>8.80</SwayFactor>
         <ShotSpread>0.01</ShotSpread>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -83,11 +83,6 @@
         <muzzleFlashScale>10</muzzleFlashScale>
         <recoilPattern>Mounted</recoilPattern>
       </Properties>
-      <AmmoUser>
-        <magazineSize>80</magazineSize>
-        <reloadTime>7.8</reloadTime>
-        <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
-      </AmmoUser>
       <FireModes>
         <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiAimMode>SuppressFire</aiAimMode>


### PR DESCRIPTION
## Changes

Removed the AmmoUser node from the VFE_Gun_RaiderMechanoidGun
Tweaked the mass of the gun
Updated the label and description for the gun to match the weapon it's based on

## Reasoning

The gun for the raider mech has ammo capacity which currently breaks the weapon because the mech itself can't fetch ammo so just like the handheld mini-turret it should have infinite ammo for now until the ammo fetching issue gets resolved.
The weapon itself is balanced around a gun shooting 7.62x51 NATO namely the m240 machinegun so it probably should weigh around one and not 40kg making the slow moving mech even slower...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
