### PR TITLE
Rim-Effect: Asari & Reapers Final Patches

### DIFF
--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef ParentName="BaseBullet">
+  <ThingDef Name="Base12x64mmChargedBullet" ParentName="BaseBullet">
     <defName>Bullet_12x64mmCharged</defName>
     <label>12x64mm Charged bullet</label>
     <graphicData>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -63,7 +63,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef ParentName="BaseBullet">
+  <ThingDef Name="Base80x256mmFuelThermobaricBullet" ParentName="BaseBullet">
     <defName>Bullet_80x256mmFuel_Thermobaric</defName>
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <label>80x256mm fuel shell (Thermobaric)</label>

--- a/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
@@ -111,7 +111,7 @@
 			<defName>AmmoSet_Goliath</defName>
 			<label>Reaper tech</label>
 			<ammoTypes>
-				<Ammo_Reapers>Bullet_12x64mmCharged</Ammo_Reapers>
+				<Ammo_Reapers>Bullet_Goliath</Ammo_Reapers>
 			</ammoTypes>
 		</CombatExtended.AmmoSetDef>
 
@@ -151,7 +151,7 @@
 			<defName>AmmoSet_Collossus</defName>
 			<label>Reaper tech</label>
 			<ammoTypes>
-				<Ammo_Reapers>Bullet_80x256mmFuel_Thermobaric</Ammo_Reapers>
+				<Ammo_Reapers>Bullet_Collosus</Ammo_Reapers>
 			</ammoTypes>
 		</CombatExtended.AmmoSetDef>
 
@@ -159,27 +159,14 @@
 
 		<!-- ================== Goliath ================== -->
 
-		<ThingDef ParentName="Base6x24mmChargedBullet">
+		<ThingDef ParentName="Base12x64mmChargedBullet">
 			<defName>Bullet_Goliath</defName>
-			<label>Goliath shot</label>
+			<label>goliath cannon shot</label>
 			<graphicData>
-			<texPath>Things/Projectiles/Shot_GoliathCannon</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
+				<texPath>Things/Projectiles/Shot_GoliathCannon</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
 			</graphicData>
-			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>38</damageAmountBase>
-			<speed>260</speed>
-			<secondaryDamage>
-				<li>
-				<def>Bomb_Secondary</def>
-				<amount>18</amount>
-				</li>
-			</secondaryDamage>
-			<armorPenetrationSharp>38</armorPenetrationSharp>
-			<armorPenetrationBlunt>334.6</armorPenetrationBlunt>
-			</projectile>
 		</ThingDef>
 
 		<!-- ================== Cannibal ================== -->
@@ -382,7 +369,7 @@
 		<comps>
 		<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-			<Fragment_ME>15</Fragment_ME>
+				<Fragment_ME>15</Fragment_ME>
 			</fragments>
 		</li>
 		</comps>
@@ -404,6 +391,22 @@
 		</ThingDef>
 
 		<!-- ================== Collossus ================== -->
+
+		<ThingDef ParentName="Base80x256mmFuelThermobaricBullet">
+			<defName>Bullet_Collosus</defName>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+			<label>colossus artillery shot</label>
+			<graphicData>
+				<texPath>Things/Projectiles/Shot_ColossusArtillery</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
+				<drawSize>2.5</drawSize>
+			</graphicData>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Bomb</damageDef>
+				<ai_IsIncendiary>false</ai_IsIncendiary>
+			</projectile>			
+		</ThingDef>
 
 		</value>
 		</li>

--- a/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-
 	<Operation Class="PatchOperationFindMod">
     <mods>
 		<li>Rim-Effect: Asari and Reapers</li>

--- a/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
@@ -400,12 +400,73 @@
 				<texPath>Things/Projectiles/Shot_ColossusArtillery</texPath>
 				<graphicClass>Graphic_Single</graphicClass>
 				<shaderType>TransparentPostLight</shaderType>
+				<drawSize>1.5</drawSize>
+			</graphicData>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Bomb</damageDef>
+				<ai_IsIncendiary>false</ai_IsIncendiary>
+			</projectile>			
+		</ThingDef>
+
+		<!-- ================== Bolter ================== -->
+
+		<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseMarauderBullet">
+			<defName>Bullet_ReaperBolter</defName>
+				<label>reaper bolter shot</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageAmountBase>16</damageAmountBase>
+				<armorPenetrationSharp>20</armorPenetrationSharp>      
+				<armorPenetrationBlunt>44</armorPenetrationBlunt>
+			</projectile>
+		</ThingDef>
+
+		<!-- ================== Heavy Bolter ================== -->
+
+		<ThingDef ParentName="Base12x64mmChargedBullet">
+			<defName>Bullet_ReaperHeavyBolter</defName>
+			<label>reaper heavy bolter shot</label>
+		<graphicData>
+			<texPath>Things/Projectiles/Shot_MarauderRifle</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		</ThingDef>
+
+		<!-- ================== Reaper Missile Launcher ================== -->
+
+		<ThingDef ParentName="Base80x256mmFuelThermobaricBullet">
+			<defName>Bullet_ReaperMissile</defName>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+			<label>reaper missile launcher rocket</label>
+			<graphicData>
+				<texPath>Things/Projectiles/ReaperMissileLauncher_Shot</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
 				<drawSize>2.5</drawSize>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Bomb</damageDef>
 				<ai_IsIncendiary>false</ai_IsIncendiary>
 			</projectile>			
+		</ThingDef>
+
+		<ThingDef ParentName="Base105mmHowitzerShell">
+			<defName>Bullet_ReaperKineticArtillery</defName>
+			<label>reaper kinetic artillery shot</label>
+			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+			<graphicData>
+				<texPath>Things/Projectiles/KineticArtillery_Shot</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
+				<drawSize>3.0</drawSize>
+			</graphicData>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Bomb</damageDef>
+				<damageAmountBase>350</damageAmountBase>
+				<explosionRadius>5</explosionRadius>
+				<soundExplode>MortarBomb_Explode</soundExplode>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</projectile>
 		</ThingDef>
 
 		</value>

--- a/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
@@ -23,7 +23,7 @@
 				<MarketValue>0.1</MarketValue>
 			</statBases>
 			<tradeTags>
-					<li>CE_AutoEnableTrade_Sellable</li>
+				<li>CE_AutoEnableTrade_Sellable</li>
 			</tradeTags>
 			<thingCategories>
 				<li>AmmoME</li>
@@ -33,7 +33,7 @@
 				<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 			</graphicData>
 			<ammoClass>ME_FMJ</ammoClass>
-				<generateAllowChance>0.1</generateAllowChance>
+			<generateAllowChance>0.1</generateAllowChance>
 		</ThingDef>
 
 		<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
@@ -445,10 +445,14 @@
 				<drawSize>2.5</drawSize>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<speed>0</speed>
 				<damageDef>Bomb</damageDef>
+				<explosionRadius>7.5</explosionRadius>
 				<ai_IsIncendiary>false</ai_IsIncendiary>
 			</projectile>			
 		</ThingDef>
+
+		<!-- ================== Reaper Kinetic Artillery ================== -->
 
 		<ThingDef ParentName="Base105mmHowitzerShell">
 			<defName>Bullet_ReaperKineticArtillery</defName>
@@ -458,7 +462,7 @@
 				<texPath>Things/Projectiles/KineticArtillery_Shot</texPath>
 				<graphicClass>Graphic_Single</graphicClass>
 				<shaderType>TransparentPostLight</shaderType>
-				<drawSize>3.0</drawSize>
+				<drawSize>2.5</drawSize>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Bomb</damageDef>

--- a/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Rim-Effect: Asari and Reapers</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<!-- ========== Traders ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="RE_Base_Asari_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+						<min>25</min>
+						<max>90</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+						<min>25</min>
+						<max>90</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>ME_Ammo</tradeTag>
+						<countRange>
+							<min>500</min>
+							<max>1800</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>1</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>50</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>6</max>
+						</thingDefCountRange>
+						</li>        
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="RE_Caravan_Asari_CombatSupplier"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+						<min>12</min>
+						<max>36</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+						<min>12</min>
+						<max>36</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>ME_Ammo</tradeTag>
+						<countRange>
+							<min>300</min>
+							<max>1200</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>1</min>
+							<max>3</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>20</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>3</max>
+						</thingDefCountRange>
+						</li>        
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="RE_Caravan_Asari_Exotic" or
+					defName="RE_Caravan_Asari_BulkGoods"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+						<min>15</min>
+						<max>45</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+						<min>15</min>
+						<max>45</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>ME_Ammo</tradeTag>
+						<countRange>
+							<min>120</min>
+							<max>400</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>1</min>
+							<max>2</max>
+						</thingDefCountRange>
+					</li>
+						<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>1</min>
+							<max>5</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>-1</min>
+							<max>3</max>
+						</thingDefCountRange>
+						</li>         
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="RE_Visitor_Asari_Standard"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>ME_Ammo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>60</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>-1</min>
+							<max>1</max>
+						</thingDefCountRange>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rim-Effect Asari and Reapers/Buildings_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Buildings_Reapers.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rim-Effect: Asari and Reapers</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<!-- ========== Light Bolter ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_Turret_ReaperBolter" or defName="RE_Turret_ReaperHeavyBolter"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="RE_Turret_ReaperBolter" or defName="RE_Turret_ReaperHeavyBolter"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.75</AimingAccuracy>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_Turret_ReaperBolter" or defName="RE_Turret_ReaperHeavyBolter"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+				</value>
+			</li>
+
+			<li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_ReaperBolter</defName>
+				<statBases>
+					<Mass>35.00</Mass>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>0.72</SwayFactor>
+					<RangedWeapon_Cooldown>0.66</RangedWeapon_Cooldown>					
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.28</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_ReaperBolter</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>55</range>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<burstShotCount>9</burstShotCount>
+					<soundCast>RE_Shot_ReaperBolter</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_Suppressive</li>
+					<li>TurretGun</li>
+				</weaponTags>
+			</li>
+
+			<li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_ReaperHeavyBolter</defName>
+				<statBases>
+					<Mass>35.00</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>1.33</SwayFactor>
+					<Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.28</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_ReaperHeavyBolter</defaultProjectile>
+					<warmupTime>1.30</warmupTime>
+					<range>75</range>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<burstShotCount>9</burstShotCount>
+					<soundCast>RE_Shot_HeavyBolter</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_Suppressive</li>
+					<li>TurretGun</li>
+				</weaponTags>
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Rim-Effect Asari and Reapers/Buildings_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Buildings_Reapers.xml
@@ -98,6 +98,123 @@
 				</weaponTags>
 			</li>
 
+			<!-- ========== Reaper Missile Launcher ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Turret_ReaperMissileLauncher"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Turret_ReaperMissileLauncher"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>10</turretBurstCooldownTime>
+				</value>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RE_Gun_ReaperMissileLauncher</defName>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+					<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_ReaperMissile</defaultProjectile>
+					<warmupTime>3.2</warmupTime>
+					<minRange>10</minRange>
+					<range>100</range>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>RE_Shot_ReaperKineticArtillery</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>55</muzzleFlashScale>
+					<circularError>1.2</circularError>
+					<requireLineOfSight>true</requireLineOfSight>
+					<indirectFirePenalty>0.4</indirectFirePenalty>
+					<targetParams>
+						<canTargetLocations>false</canTargetLocations>
+					</targetParams>
+				</Properties>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "RE_Gun_ReaperMissileLauncher"]</xpath>
+				<value>
+				<comps>
+					<li Class="CombatExtended.CompProperties_Charges">
+					<chargeSpeeds>
+					<li>90</li>
+					<li>100</li>
+					<li>150</li>
+					</chargeSpeeds>
+					</li>
+				</comps>	
+				</value>
+			</li>
+
+			<!-- ========== Reaper Beam ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_Bullet_ReaperBeam"]/projectile/armorPenetrationBase</xpath>
+				<value>
+					<armorPenetrationBase>1000</armorPenetrationBase>
+				</value>
+			</li>
+
+			<!-- ========== Kinetic Artillery ========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Turret_ReaperKineticArtillery"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Turret_ReaperKineticArtillery"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>10</turretBurstCooldownTime>
+				</value>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RE_Gun_ReaperKineticArtillery</defName>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+					<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_ReaperKineticArtillery</defaultProjectile>
+					<warmupTime>1.2</warmupTime>
+					<minRange>20</minRange>
+					<range>500</range>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>RE_Shot_ReaperKineticArtillery</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>55</muzzleFlashScale>
+					<circularError>2.5</circularError>
+					<requireLineOfSight>false</requireLineOfSight>
+					<indirectFirePenalty>0.6</indirectFirePenalty>
+					<targetParams>
+						<canTargetLocations>false</canTargetLocations>
+					</targetParams>
+				</Properties>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "RE_Gun_ReaperKineticArtillery"]</xpath>
+				<value>
+				<comps>
+					<li Class="CombatExtended.CompProperties_Charges">
+					<chargeSpeeds>
+					<li>50</li>
+					<li>70</li>
+					<li>90</li>
+					</chargeSpeeds>
+					</li>
+				</comps>	
+				</value>
+			</li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Rim-Effect Asari and Reapers/Races_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Races_Reapers.xml
@@ -7,6 +7,8 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+		<!-- ========== Body Shapes ========== -->
+
 		<li Class="PatchOperationAddModExtension">
 			<xpath>/Defs/ThingDef[
 			defName="RE_Husk_Banshee" or
@@ -56,11 +58,15 @@
 			</value>
 		</li>
 
+		<!-- ========== Stat Bases ========== -->
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[@Name="BaseHusk"]/statBases</xpath>
 			<value>
 				<NightVisionEfficiency>0.8</NightVisionEfficiency>
 				<SmokeSensitivity>0</SmokeSensitivity>
+				<PainShockThreshold>1</PainShockThreshold>
+				<Suppressability>0</Suppressability>
 			</value>
 		</li>
 

--- a/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
@@ -191,7 +191,7 @@
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_Collosus</defaultProjectile>
-          <burstShotCount>2</burstShotCount>
+          <burstShotCount>1</burstShotCount>
           <warmupTime>5.5</warmupTime>
           <ai_AvoidFriendlyFireRadius>5.9</ai_AvoidFriendlyFireRadius>
           <requireLineOfSight>false</requireLineOfSight>
@@ -203,8 +203,8 @@
           <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>          
         </Properties>
         <AmmoUser>
-          <magazineSize>2</magazineSize>
-          <reloadTime>8.6</reloadTime>
+          <magazineSize>1</magazineSize>
+          <reloadTime>7.6</reloadTime>
         </AmmoUser>
         <FireModes>
           <aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
@@ -70,6 +70,7 @@
         </value>
       </li>
 
+      <!-- ========== Goliath Cannnon ========== -->
       <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
         <defName>RE_Gun_GoliathCannon</defName>
         <statBases>
@@ -84,7 +85,7 @@
           <recoilAmount>1.28</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>true</hasStandardCommand>
-          <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+          <defaultProjectile>Bullet_Goliath</defaultProjectile>
           <warmupTime>1.30</warmupTime>
           <range>75</range>
           <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -104,91 +105,6 @@
         <weaponTags>
           <li>CE_AI_Suppressive</li>
         </weaponTags>
-      </li>
-
-      <li Class="PatchOperationAdd">
-      <xpath>Defs</xpath>
-      <value> 
-
-      <ThingDef ParentName="BaseGun">
-        <defName>Ravager_Launcher</defName>
-        <label>ravager cannon</label>
-        <graphicData>
-          <texPath>Things/Items/Weapons/AsariAssaultRifle</texPath>
-          <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
-        <statBases>
-          <SightsEfficiency>1</SightsEfficiency>
-          <ShotSpread>0.07</ShotSpread>
-          <SwayFactor>1.50</SwayFactor>
-          <Bulk>30</Bulk>
-          <Mass>20</Mass>
-          <RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
-        </statBases>
-        <verbs>
-          <li Class="CombatExtended.VerbPropertiesCE">
-            <recoilAmount>1.0</recoilAmount>
-            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-            <hasStandardCommand>true</hasStandardCommand>
-            <defaultProjectile>Bullet_Ravager</defaultProjectile>
-            <burstShotCount>3</burstShotCount>
-            <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-            <warmupTime>2.0</warmupTime>
-            <range>72</range>
-            <soundCast>RE_Shot_RavagerCannon</soundCast>
-            <soundCastTail>GunTail_Heavy</soundCastTail>
-            <muzzleFlashScale>9</muzzleFlashScale>
-          </li>
-        </verbs>
-        <comps>
-          <li Class="CombatExtended.CompProperties_AmmoUser">
-            <magazineSize>30</magazineSize>
-            <reloadTime>4</reloadTime>
-          </li>
-          <li Class="CombatExtended.CompProperties_FireModes">
-            <aiUseBurstMode>FALSE</aiUseBurstMode>
-            <aiAimMode>AimedShot</aiAimMode>
-          </li>
-        </comps>
-        <weaponTags>
-          <li>Ravager</li>
-        </weaponTags>
-        <tools>
-          <li Class="CombatExtended.ToolCE">
-            <label>stock</label>
-            <capacities>
-              <li>Blunt</li>
-            </capacities>
-            <power>8</power>
-            <cooldownTime>1.55</cooldownTime>
-            <chanceFactor>1.5</chanceFactor>
-            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-            <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-          </li>
-          <li Class="CombatExtended.ToolCE">
-            <label>barrel</label>
-            <capacities>
-              <li>Blunt</li>
-            </capacities>
-            <power>5</power>
-            <cooldownTime>2.02</cooldownTime>
-            <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-          </li>
-          <li Class="CombatExtended.ToolCE">
-            <label>muzzle</label>
-            <capacities>
-              <li>Poke</li>
-            </capacities>
-            <power>8</power>
-            <cooldownTime>1.55</cooldownTime>
-            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-            <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-          </li>
-        </tools>
-      </ThingDef>
-
-      </value>
       </li>
 
       <!-- ========== Cannibal Caster ========== -->
@@ -272,9 +188,9 @@
           <Bulk>20.00</Bulk>
         </statBases>
         <Properties>
-          <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
-          <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+          <defaultProjectile>Bullet_Collosus</defaultProjectile>
           <burstShotCount>2</burstShotCount>
           <warmupTime>5.5</warmupTime>
           <ai_AvoidFriendlyFireRadius>5.9</ai_AvoidFriendlyFireRadius>


### PR DESCRIPTION
## Additions
A handful of final content patches I forgot to add with the previous PR.
- Patches for Reaper turrets.
- Patches for Asari traders.
- Gave Reaper Husks appropriate stats such that they don't feel pain or fear of incoming fire.

## Changes
- Gave Names to some Mechanoid ammo, so it can be used as a Parent for some reaper ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
