### PR TITLE
Fix trenches missing VFE class when VFE-sec not loaded

### DIFF
--- a/Source/CombatExtended/Compatibility/Trenches.cs
+++ b/Source/CombatExtended/Compatibility/Trenches.cs
@@ -18,6 +18,28 @@ namespace CombatExtended.Compatibility
         {
             vfeInstalled = ModLister.HasActiveModWithName(VFES_ModName);
         }
+
+	private static bool checkVFE(IntVec3 cell, Map map, out float heightAdjust)
+	{
+	    heightAdjust = 0f;
+	    List<Thing> thingList = GridsUtility.GetThingList(cell, map);
+	    foreach (Thing thing in thingList) 
+	    {
+		CompProperties_TerrainSetter compProperties = thing.def.GetCompProperties<CompProperties_TerrainSetter>();
+		if (compProperties == null)
+		{
+		    return false;
+		}
+		
+		TerrainDef terrainDef = compProperties.terrainDef;
+		TerrainDefExtension terrainDefExtension = TerrainDefExtension.Get(terrainDef);
+		heightAdjust = -terrainDefExtension.coverEffectiveness * CollisionVertical.WallCollisionHeight;
+		return true;
+		
+	    }
+	    return false;
+	}
+	
         public static float GetHeightAdjust(IntVec3 cell, Map map)
         {
             if (cell == null || map == null)
@@ -27,19 +49,10 @@ namespace CombatExtended.Compatibility
 	       
             if (vfeInstalled)
             {
-                List<Thing> thingList = GridsUtility.GetThingList(cell, map);
-                foreach (Thing thing in thingList) 
-                {
-		    CompProperties_TerrainSetter compProperties = thing.def.GetCompProperties<CompProperties_TerrainSetter>();
-                    if (compProperties == null)
-                    {
-                        return 0f;
-                    }
-		    
-                    TerrainDef terrainDef = compProperties.terrainDef;
-                    TerrainDefExtension terrainDefExtension = TerrainDefExtension.Get(terrainDef);
-                    return -terrainDefExtension.coverEffectiveness * CollisionVertical.WallCollisionHeight;
-		    
+		float heightAdjust = 0;
+		if (checkVFE(cell, map, out heightAdjust))
+		{
+		    return heightAdjust;
 		}
 	    }
 	    return 0f;


### PR DESCRIPTION

## Changes

Move the mod-specific height-adjust check into a private method so it doesn't try to resolve types in unused code paths.


## Reasoning

Otherwise Mono barfs on the missing types if VFE-security is not loaded.


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...without patched mod loaded
- [] (For compatibility patches) ...with patched mod loaded
- [X] Playtested a colony (seconds)
