### PR TITLE
Restore Androids Tiers - TX Series Patch

### DIFF
--- a/Patches/Android Tiers - TX Series/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers - TX Series/PawnkindDefs/PawnKinds_Android.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Android tiers - TX Series</li>
+			</mods>
+			<match Class="PatchOperationSequence">
+			<operations>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+					@Name="ATPP_AndroidTX2RaiderBase" or
+					@Name="ATPP_AndroidTX2KRaiderBase" or
+					@Name="ATPP_AndroidTX3RaiderBase" or
+					@Name="ATPP_AndroidTX4RaiderBase" or
+					@Name="ATPP_AndroidTX2CollectiveBase" or
+					@Name="ATPP_AndroidTX2KCollectiveBase" or
+					@Name="ATPP_AndroidTX3CollectiveBase" or
+					@Name="ATPP_AndroidTX4CollectiveBase"
+					]</xpath>
+				<value>	
+					<li Class="CombatExtended.LoadoutPropertiesExtension">	
+						<primaryMagazineCount>
+							<min>4</min>
+							<max>6</max>
+						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<generateChance>0.5</generateChance>
+								<sidearmMoney>
+									<min>20</min>
+									<max>120</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>CE_Sidearm_Melee</li>
+								</weaponTags>
+							</li>
+						</sidearms>
+					</li>
+				</value>
+			</li>
+			
+			</operations>
+			</match>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Android Tiers - TX Series/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers - TX Series/ThingDef_Races/AlienRace_Androids.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+	  <operations>
+		<li Class="PatchOperationFindMod">
+		  <mods>
+		  	<li>Android tiers - TX Series</li>
+		  </mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+
+				<!--Test for comps-->
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2ITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3ITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4ITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<!--Multiple-->
+				
+				<li Class="PatchOperationAddModExtension">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
+				  defName="ATPP_Android3TX" or
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX" or
+				  defName="ATPP_Android2KTX" or
+				  defName="ATPP_Android2KITX"
+				  ]</xpath>
+				  <value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+					  <bodyShape>Humanoid</bodyShape>
+					</li>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
+				  defName="ATPP_Android3TX" or
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX" or
+				  defName="ATPP_Android2KTX" or
+				  defName="ATPP_Android2KITX"
+				  ]/comps</xpath>
+				  <value>
+				    <li>
+					  <compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+				  </value>
+				</li>
+				
+				<!--2/3/4 are all complex enough to have at least some intrinsic self presevation. 
+				2KXT Are purpose built combat units and as such do not.-->
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
+				  defName="ATPP_Android3TX" or
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX"
+				  ]/comps</xpath>
+				  <value>
+				    <li Class="CombatExtended.CompProperties_Suppressable" />
+				  </value>
+				</li>
+				
+				<!--T2-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.95</MeleeDodgeChance>
+					<MeleeCritChance>0.95</MeleeCritChance>
+					<MeleeParryChance>0.95</MeleeParryChance>
+					<Suppressability>0.10</Suppressability>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--1mm Steel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>1</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.67</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.405</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.67</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.405</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>4.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--T3-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>1</MeleeDodgeChance>
+					<MeleeCritChance>1.1</MeleeCritChance>
+					<MeleeParryChance>1.1</MeleeParryChance>
+					<Suppressability>0.10</Suppressability>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--1mm plasteel/1.5mm steel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>4.75</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.67</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.67</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.8</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--T4-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>1.2</MeleeDodgeChance>
+					<MeleeCritChance>1.2</MeleeCritChance>
+					<MeleeParryChance>1.2</MeleeParryChance>
+					<Suppressability>0.25</Suppressability>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--2mm plasteel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>4</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.68</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.68</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>2.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--T2K-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.75</MeleeDodgeChance>
+					<MeleeCritChance>1.0</MeleeCritChance>
+					<MeleeParryChance>1.2</MeleeParryChance>
+					<Suppressability>0</Suppressability>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--4mm Steel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>4</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.05</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.05</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>5.29</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+			  </operations>
+			</match>
+	    </li>
+		
+	  </operations>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -73,7 +73,7 @@ Ancient Fallout Armory  |
 Ancient Humans   |
 Android Tiers	|
 Android Tiers SM7 Overhaul (Continued)  |
-Android TX Series   |
+Android - TX Series   |
 Androids	|
 Androids Expanded	|
 Anima Animals  |


### PR DESCRIPTION
## Additions
- Restores the Android Tiers TX Series patch from prior to version 1.3.4.4.

## References
Closes #1236 

## Reasoning
This patch folder was originally labeled as "Android Tiers++," a 1.0 mod whose content was integrated into Androids, and so these files were deleted as obsolete in the 1.3.4.4 release. This PR restores those files and the correct mod name.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
