### PR TITLE
Patch Feles Race Mod + Small Patch Updates

### DIFF
--- a/Patches/Feles - Felines of the Rim [1.3]/Bodies_Feles.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Bodies_Feles.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+    	<li>Feles - Felines of the Rim [1.3]</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- ========== Add groups ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+			<value>
+				<li>OutsideSquishy</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+			<value>
+				<li>OutsideSquishy</li>
+			</value>
+		</li> 
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+			<value>
+				<li>OutsideSquishy</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+			<value>
+				<li>OutsideSquishy</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName = "Feles"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+			<value>
+				<li>CoveredByNaturalArmor</li>
+			</value>
+		</li> 
+
+      </operations>
+    </match>
+  </Operation> 
+</Patch>
+
+

--- a/Patches/Feles - Felines of the Rim [1.3]/Feles_Leather.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Feles_Leather.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Feles - Felines of the Rim [1.3]</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[
+			defName="Leo_leather" or
+			defName="Tigris_leather" or
+			defName="Jaguar_leather" or
+			defName="Cheetah_leather" or
+			defName="Panther_leather"
+			]/statBases/StuffPower_Armor_Sharp</xpath>
+			<value>
+				<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[
+			defName="Leo_leather" or
+			defName="Tigris_leather" or
+			defName="Jaguar_leather" or
+			defName="Cheetah_leather" or
+			defName="Panther_leather"
+			]/statBases/StuffPower_Armor_Blunt</xpath>
+			<value>
+				<StuffPower_Armor_Blunt>0.03</StuffPower_Armor_Blunt>
+			</value>
+		</li>
+			
+		</operations>
+	</match>
+	</Operation>
+</Patch>

--- a/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Feles - Felines of the Rim [1.3]</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+          defName="YanzihkoJaguar" or
+          defName="YanzihkoLeo" or
+          defName="YanzihkoPanther" or
+          defName="YanzihkoTigris" or
+          defName="YanzihkoCheetah"
+          ]</xpath>
+          <value>
+            <li Class="CombatExtended.RacePropertiesExtensionCE">
+              <bodyShape>Humanoid</bodyShape>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+          defName="YanzihkoJaguar" or
+          defName="YanzihkoLeo" or
+          defName="YanzihkoPanther" or
+          defName="YanzihkoTigris" or
+          defName="YanzihkoCheetah"         
+          ]/statBases</xpath>
+          <value>
+            <MeleeDodgeChance>1</MeleeDodgeChance>
+            <MeleeCritChance>1</MeleeCritChance>
+            <MeleeParryChance>1</MeleeParryChance>
+            <Suppressability>1</Suppressability>
+            <SmokeSensitivity>1</SmokeSensitivity>
+            <NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel>
+            <CarryWeight>40</CarryWeight>
+            <CarryBulk>30</CarryBulk>            
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+          defName="YanzihkoJaguar" or
+          defName="YanzihkoLeo" or
+          defName="YanzihkoPanther" or
+          defName="YanzihkoTigris" or
+          defName="YanzihkoCheetah"
+          ]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>left fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>right fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>4.49</cooldownTime>
+                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                <chanceFactor>0.2</chanceFactor>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationSequence">
+          <success>Always</success>
+          <operations>
+            <li Class="PatchOperationTest">
+              <xpath>Defs/AlienRace.ThingDef_AlienRace[
+              defName="YanzihkoJaguar" or
+              defName="YanzihkoLeo" or
+              defName="YanzihkoPanther" or
+              defName="YanzihkoTigris" or
+              defName="YanzihkoCheetah"              
+              ]/comps</xpath>
+              <success>Invert</success>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>Defs/AlienRace.ThingDef_AlienRace[
+              defName="YanzihkoJaguar" or
+              defName="YanzihkoLeo" or
+              defName="YanzihkoPanther" or
+              defName="YanzihkoTigris" or
+              defName="YanzihkoCheetah"              
+              ]</xpath>
+              <value>
+                <comps />
+              </value>
+            </li>
+          </operations>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+          defName="YanzihkoJaguar" or
+          defName="YanzihkoLeo" or
+          defName="YanzihkoPanther" or
+          defName="YanzihkoTigris" or
+          defName="YanzihkoCheetah"
+          ]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
@@ -32,8 +32,8 @@
           defName="YanzihkoCheetah"         
           ]/statBases</xpath>
           <value>
-            <MeleeDodgeChance>1</MeleeDodgeChance>
-            <MeleeCritChance>1</MeleeCritChance>
+            <MeleeDodgeChance>1.1</MeleeDodgeChance>
+            <MeleeCritChance>0.85</MeleeCritChance>
             <MeleeParryChance>1</MeleeParryChance>
             <Suppressability>1</Suppressability>
             <SmokeSensitivity>1</SmokeSensitivity>

--- a/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Races_Feles.xml
@@ -54,36 +54,47 @@
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
-                <label>left fist</label>
+                <label>left claw</label>
                 <capacities>
-                  <li>Blunt</li>
+                  <li>Scratch</li>
                 </capacities>
-                <power>1</power>
-                <cooldownTime>1.26</cooldownTime>
+                <power>2</power>
+                <cooldownTime>0.91</cooldownTime>
                 <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+                <armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.07</armorPenetrationSharp>
               </li>
               <li Class="CombatExtended.ToolCE">
-                <label>right fist</label>
+                <label>right claw</label>
                 <capacities>
-                  <li>Blunt</li>
+                  <li>Scratch</li>
                 </capacities>
-                <power>1</power>
-                <cooldownTime>1.26</cooldownTime>
+                <power>2</power>
+                <cooldownTime>0.91</cooldownTime>
                 <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+                <armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.07</armorPenetrationSharp>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <capacities>
+                  <li>Bite</li>
+                </capacities>
+                <power>3</power>
+                <cooldownTime>1.49</cooldownTime>
+                <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>1.640</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.12</armorPenetrationSharp>
               </li>
               <li Class="CombatExtended.ToolCE">
                 <label>head</label>
                 <capacities>
                   <li>Blunt</li>
                 </capacities>
-                <power>2</power>
-                <cooldownTime>4.49</cooldownTime>
+                <power>1</power>
+                <cooldownTime>4.29</cooldownTime>
                 <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
                 <chanceFactor>0.2</chanceFactor>
-                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+                <armorPenetrationBlunt>0.525</armorPenetrationBlunt>
               </li>
             </tools>
           </value>

--- a/Patches/Feles - Felines of the Rim [1.3]/Scenarios_Feles.xml
+++ b/Patches/Feles - Felines of the Rim [1.3]/Scenarios_Feles.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Feles - Felines of the Rim [1.3]</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ScenarioDef[defName="FelesScenario1"]/scenario/parts</xpath>
+			<value>
+				<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_45ACP_FMJ</thingDef>
+				<count>350</count>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ScenarioDef[defName="FelesScenario2"]/scenario/parts</xpath>
+			<value>
+				<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_Arrow_Stone</thingDef>
+				<count>100</count>
+				</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ScenarioDef[defName="FelesScenario2"]/scenario/parts/li[thingDef="Pila"]</xpath>
+			<value>
+				<count>20</count>
+			</value>
+		</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>
+
+

--- a/Patches/Warhammer - Dryad/Race_Dryad.xml
+++ b/Patches/Warhammer - Dryad/Race_Dryad.xml
@@ -10,7 +10,7 @@
         <!-- Base Dryad -->
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[@Name="DryadAnimalThingBase"]</xpath>
+          <xpath>/Defs/ThingDef[@Name="KTDryadAnimalThingBase"]</xpath>
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
               <bodyShape>Humanoid</bodyShape>
@@ -22,11 +22,11 @@
           <success>Always</success>
           <operations>
             <li Class="PatchOperationTest">
-              <xpath>/Defs/ThingDef[@Name="DryadAnimalThingBase"]/comps</xpath>
+              <xpath>/Defs/ThingDef[@Name="KTDryadAnimalThingBase"]/comps</xpath>
               <success>Invert</success>
             </li>
             <li Class="PatchOperationAdd">
-              <xpath>/Defs/ThingDef[@Name="DryadAnimalThingBase"]</xpath>
+              <xpath>/Defs/ThingDef[@Name="KTDryadAnimalThingBase"]</xpath>
               <value>
                 <comps />
               </value>
@@ -35,7 +35,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[@Name="DryadAnimalThingBase"]/comps</xpath>
+          <xpath>/Defs/ThingDef[@Name="KTDryadAnimalThingBase"]/comps</xpath>
           <value>
             <li>
               <compClass>CombatExtended.CompPawnGizmo</compClass>

--- a/Patches/Xenohumans - Anthromorphs/Races_Vulpinemorph.xml
+++ b/Patches/Xenohumans - Anthromorphs/Races_Vulpinemorph.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Xenohumans - Anthromorphs</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]</xpath>
+          <value>
+            <li Class="CombatExtended.RacePropertiesExtensionCE">
+              <bodyShape>Humanoid</bodyShape>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]/statBases</xpath>
+          <value>
+            <MeleeDodgeChance>1</MeleeDodgeChance>
+            <MeleeCritChance>1</MeleeCritChance>
+            <MeleeParryChance>1</MeleeParryChance>
+            <Suppressability>1</Suppressability>
+            <SmokeSensitivity>1</SmokeSensitivity>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>left fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>right fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>4.49</cooldownTime>
+                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                <chanceFactor>0.2</chanceFactor>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationSequence">
+          <success>Always</success>
+          <operations>
+            <li Class="PatchOperationTest">
+              <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]/comps</xpath>
+              <success>Invert</success>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]</xpath>
+              <value>
+                <comps />
+              </value>
+            </li>
+          </operations>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATK_Vulpinemorph"]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/PawnKindDef[defName="ATK_Villager_Vulpinemorph"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+              <min>2</min>
+              <max>4</max>
+            </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -154,6 +154,7 @@ Fate Grand Order - Styles Apparel Pack	|
 FCP Makeshift Weapons Pack	|
 FCP Minuteman Equipment Teaser	|
 FCP Raider Armor and Apparel Teaser	|
+Feles - Felines of the Rim [1.3]    |
 Fell Tribes	|
 Ferrex Race	|
 FFGermanShepherd    |


### PR DESCRIPTION
## Additions
- Patch the Feles Race mod. They're smaller than humans, with less carry weight and bulk, lower crit chance, higher dodge, and some night vision.

## Changes
- Updated Warhammer Dryads race. The defName was changed without any other changes.
- Patch Xenohumans Vulpinemorphs. As with the other races, they're completely statistically identical to normal humans.

## References
Close #1233 

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
