### PR TITLE
Fix .25 ACP ballistics

### DIFF
--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Defs>
 
 	<ThingCategoryDef>
@@ -16,7 +16,7 @@
 		<ammoTypes>
 			<Ammo_25ACP_FMJ>Bullet_25ACP_FMJ</Ammo_25ACP_FMJ>
 			<Ammo_25ACP_AP>Bullet_25ACP_AP</Ammo_25ACP_AP>
-			<Ammo_25ACP_HP>Bullet_25ACP_HP</Ammo_25ACP_HP>			
+			<Ammo_25ACP_HP>Bullet_25ACP_HP</Ammo_25ACP_HP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
@@ -88,7 +88,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>152</speed>
+			<speed>50</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -97,9 +97,9 @@
 		<defName>Bullet_25ACP_FMJ</defName>
 		<label>.25 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>2.67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -107,9 +107,9 @@
 		<defName>Bullet_25ACP_AP</defName>
 		<label>.25 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>2.67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,9 +117,9 @@
 		<defName>Bullet_25ACP_HP</defName>
 		<label>.25 ACP bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>2.67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Additions

No new functionality.

## Changes

Altered the ballistic statistics of the .25 ACP round.

## Reasoning

I'd like to create a CE-only Rimworld mod for .25 pocket pistols, but found the .25 ACP to be way over powered for a "Low caliber handgun cartridge lacking in stopping power."
- I reduced the projectile speed from 152 to 50. A speed of 152 is faster than some rifle rounds! Typical velocity for a .25 ACP is 750-800 feet per second.
- I reduced the damage to make it closer to .22 LR, which has similar ballistics.
- I reduced blunt penetration to something between .22 short and .32 ACP.

Looks like the only weapon that uses .25 ACP currently is the Volcanic Pistol from Vanilla Weapons Expanded: Frontier. This change reduces the effectiveness of the Volcanic, but is historically accurate. The "rocket ball" ammo of the Volcanic repeaters had terrible ballistics.

## Alternatives
- Patch to override the ammo stats defined in CE core, if possible.
- Create a new ammo type for pocket pistols.