### PR TITLE
Correct .25 ACP Velocity

### DIFF
--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -88,7 +88,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>152</speed>
+			<speed>46</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -97,9 +97,9 @@
 		<defName>Bullet_25ACP_FMJ</defName>
 		<label>.25 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -107,9 +107,9 @@
 		<defName>Bullet_25ACP_AP</defName>
 		<label>.25 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,9 +117,9 @@
 		<defName>Bullet_25ACP_HP</defName>
 		<label>.25 ACP bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>17.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
As kindly pointed out by @mgoldstein, .25 ACP is too high velocity. A glance at the sheet has discovered that the velocity was erroneously entered in ft/s instead of m/s. The error has been fixed, and these are the new stats from the projectile spreadsheet.