### PR TITLE
SOS2: Added archotech hologram armor values

### DIFF
--- a/Patches/Save Our Ship 2/Hediffs_SOS2.xml
+++ b/Patches/Save Our Ship 2/Hediffs_SOS2.xml
@@ -45,6 +45,29 @@
 	</match>
 	</li>
 	
+	<li Class="PatchOperationConditional">
+	<xpath>Defs/HediffDef[defName="SoSHologramArchotech"]</xpath>
+	<match Class="PatchOperationSequence">
+	<operations>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoSHologramArchotech"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>12.0</ArmorRating_Sharp>
+			</value>
+		</li>
+
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoSHologramArchotech"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>16.0</ArmorRating_Blunt>
+			</value>
+		</li>
+	
+	</operations>
+	</match>
+	</li>
+	
 		</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions

- Added patched armor values for the archotech hologram hediff (`SoSHologramArchotech`) in the Save Our Ship 2 patch.

## Changes

## References

## Reasoning

The default SOS2 version of this wasn't patched and gave 0.75 sharp armor and 0.5 blunt armor, which is extremely low by CE standards. This patch should change it to be more in-line with SOS2 values and survivability. Since archotech holograms don't really have an IRL equivalent to refer to w.r.t material and penetration properties, I just chose the values to be comparable to a flak vest, which is approximately in-line with where the vanilla values fall.

## Alternatives

I could have not patched it and just dealt with it I guess

## Testing

Check tests you have performed:
- [ x ] Compiles without warnings
- [ x ] Game runs without errors
- [ x ] (For compatibility patches) ...with and without patched mod loaded
- [ x ] Playtested a colony (about 10 minutes)
