### PR TITLE
Hide Unnecessary Weapon Stats

### DIFF
--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -90,10 +90,9 @@
     <label>muzzle flash</label>
     <description>How bright the muzzle flash is.\n\nMuzzle flashes will illuminate a shooter's position in darkness, exposing them to more accurate return fire. Brighter muzzle flashes are easier to target.\n\nPawns will remember the position of the muzzle flash for 5-10 seconds.</description>
     <category>Weapon</category>
-    <showIfUndefined>true</showIfUndefined>
+    <showIfUndefined>false</showIfUndefined>
     <displayPriorityInCategory>898</displayPriorityInCategory>
     <defaultBaseValue>0</defaultBaseValue>
-    <hideAtValue>0</hideAtValue>
     <parts>
       <li Class="CombatExtended.StatPart_Attachments" />
     </parts>
@@ -183,7 +182,7 @@
     <label>ammo consumed per shot</label>
     <description>How many units of ammunition this gun consumes for each individual shot.\n\nThis applies to guns with multiple barrels that fire simultaneously with each pull of the trigger, or exotic energy weapons that use up different amounts of energy from a power cell.</description>
     <category>Weapon</category>
-      <showIfUndefined>true</showIfUndefined>
+    <showIfUndefined>true</showIfUndefined>
 	  <displayPriorityInCategory>877</displayPriorityInCategory>
   </StatDef>
 

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -10,6 +10,7 @@
     <minValue>0.01</minValue>
     <toStringStyle>PercentZero</toStringStyle>
     <showIfUndefined>false</showIfUndefined>
+    <hideAtValue>0</hideAtValue>
     <parts>
       <li Class="StatPart_Quality">
         <factorAwful>0.7</factorAwful>
@@ -92,6 +93,7 @@
     <showIfUndefined>true</showIfUndefined>
     <displayPriorityInCategory>898</displayPriorityInCategory>
     <defaultBaseValue>0</defaultBaseValue>
+    <hideAtValue>0</hideAtValue>
     <parts>
       <li Class="CombatExtended.StatPart_Attachments" />
     </parts>
@@ -141,6 +143,7 @@
     <category>Weapon</category>    
     <defaultBaseValue>0</defaultBaseValue>
     <showIfUndefined>false</showIfUndefined>
+    <hideAtValue>0</hideAtValue>
     <displayPriorityInCategory>898</displayPriorityInCategory>
     <parts>
       <li Class="CombatExtended.StatPart_Attachments" />
@@ -166,7 +169,7 @@
     <label>reload time</label>
     <description>How long should this weapon take to reload.</description>
     <category>Weapon</category>
-    <showIfUndefined>true</showIfUndefined>
+    <showIfUndefined>false</showIfUndefined>
     <displayPriorityInCategory>897</displayPriorityInCategory>
     <defaultBaseValue>1</defaultBaseValue>
     <parts>


### PR DESCRIPTION
## Changes
- Hide the `Sight Efficiency` stat if the value is zero. Realistically, only melee weapons have 0 SE, so there should be no harm in hiding it.
-  Hide `Recoil` if the value is zero. Since recoil only applies to weapons capable of automatic fire, it's meaningless in other cases. This could theoretically hide the info from the player in the case of an automatic weapon whose defined recoil is zero, but I don't know that this is meaningful information in that case any way.
- Hide `Reload Time` if it doesn't have a defined value. This way, it will no longer appear for melee weapons or ranged weapons that don't reload (like single-use rockets).
- Hide the `Muzzle Flash` stat if the value is undefined. This should hide that stat on weapons where it's not useful info (like melee weapons) without interfering with weapons that have a Muzzle Flash of 0 (like a suppressed weapon, for instance).

## Reasoning
In their current formatting, the info panels of Melee weapons and some ranged weapons are cluttered with useless information for stats that don't apply to them. Hiding these in some cases cleans up the panel and makes it more informative for the player.

**The only chief concern I have is potentially unforeseen edge cases where these changes unintentionally hide useful information from the player, which will need to be tested for.**

## Alternatives
Could leave it as it.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
