### PR TITLE
20mm cannon buffs

### DIFF
--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -115,7 +115,7 @@
       <label>20x102mm NATO bullet (FMJ)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <damageAmountBase>70</damageAmountBase>
-        <armorPenetrationSharp>13</armorPenetrationSharp>
+        <armorPenetrationSharp>28</armorPenetrationSharp>
         <armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
       </projectile>
     </ThingDef>
@@ -124,8 +124,8 @@
 		<defName>Bullet_20x102mmNATO_Incendiary</defName>
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>26</armorPenetrationSharp>
+			<damageAmountBase>42</damageAmountBase>
+			<armorPenetrationSharp>36</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -141,7 +141,7 @@
 		<label>20x102mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -157,7 +157,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>46</armorPenetrationSharp>
+			<armorPenetrationSharp>64</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -126,7 +126,7 @@
     <label>20mm Hispano bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>31</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>254</speed>
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>70</armorPenetrationSharp>
+      <armorPenetrationSharp>60</armorPenetrationSharp>
       <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>
     </projectile>
   </ThingDef> 

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -115,7 +115,7 @@
     <label>20x128mm Oerlikon bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>75</damageAmountBase>
-      <armorPenetrationSharp>18</armorPenetrationSharp>
+      <armorPenetrationSharp>22</armorPenetrationSharp>
       <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -125,7 +125,7 @@
 		<label>20mm Oerlikon bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>47</damageAmountBase>
-			<armorPenetrationSharp>36</armorPenetrationSharp>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
 			<armorPenetrationBlunt>1280.120</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -140,7 +140,7 @@
 		<defName>Bullet_20x128mmOerlikon_HE</defName>
 		<label>20mm Oerlikon bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>75</damageAmountBase>
+			<damageAmountBase>63</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>1280.120</armorPenetrationBlunt>
 			<secondaryDamage>


### PR DESCRIPTION
Rebalanced cannon ammo to more accurately reflect real world ammo based on 
https://cdn.discordapp.com/attachments/735025023550750752/934986056623857724/21ec14139aa784e8846d8d84d5280bef.png
and
http://www.wwiiequipment.com/index.php?option=com_content&view=article&id=96:hispano-20mm-armour-piercing-ammunition&catid=44:gunsrockets&Itemid=60
and 
https://apps.dtic.mil/sti/pdfs/ADA140367.pdf
also was bothered that 50bmg was outpeforming 20mm cannon ammo in penetration, which doesnt really make sense

## Additions

spreadsheet edits here 
https://docs.google.com/spreadsheets/d/1IPCE7Uh5DcznrqFc69aRV4InFTuHDh-X-5OI6QBoGA0/edit#gid=1393347070

## Changes

20mm Cannon buffs to reflect real world cannons and reduce their underperformance when compared to 50bmg

## References

nil

## Reasoning

50bmg outpeforms 20mm cannon in almost all departments, making 20mm cannon shells obsolete with such a high cost in manafacturing, edited the values slightly to give 20mm a smaller edge over 50bmg in terms of penetration

## Alternatives


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
