### PR TITLE
VFE - Mechanoids Auto Tesla Turret fix

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -495,6 +495,13 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/projectile/damageAmountBase</xpath>
+				<value>
+					<damageAmountBase>10</damageAmountBase>
+				</value>
+			</li>
+ 
+			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 				<value>
 					<damageDef>Electrical</damageDef>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -469,14 +469,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/statBases/RangedWeapon_Cooldown</xpath>
 				<value>
-					<RangedWeapon_Cooldown>4</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/warmupTime</xpath>
 				<value>
-					<warmupTime>2.0</warmupTime>
+					<warmupTime>4.0</warmupTime>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -239,13 +239,6 @@
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
-				<value>
-					<turretBurstCooldownTime>1</turretBurstCooldownTime>
-				</value>
-			</li>
 			
 			<!-- Price increase because CE Inferno cannon is not an equivalent weapon to most other options : Reduced compared to sheet inferno since it bloats the cost too much-->
 			
@@ -469,14 +462,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>2.4</turretBurstCooldownTime>
+					<turretBurstCooldownTime>2</turretBurstCooldownTime>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/statBases/RangedWeapon_Cooldown</xpath>
 				<value>
-					<RangedWeapon_Cooldown>2.4</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>4</RangedWeapon_Cooldown>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -453,14 +453,7 @@
 				</value>
 			</li>
 			
-			<!-- ========== Auto Charge Lance ========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]</xpath>
-				<value>
-					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-				</value>
-			</li>
+			<!-- ========== Auto Tesla Turret ========== -->
 
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
@@ -476,39 +469,45 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>0.9</turretBurstCooldownTime>
+					<turretBurstCooldownTime>2.4</turretBurstCooldownTime>
 				</value>
 			</li>
-			
-			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>VFE_Gun_AutoTesla</defName>
-				<statBases>
-				  <Mass>40</Mass>
-				  <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-				  <SightsEfficiency>1</SightsEfficiency>
-				  <ShotSpread>0.01</ShotSpread>
-				  <SwayFactor>0.44</SwayFactor>
-				  <Bulk>13.00</Bulk>
-				</statBases>
-				<Properties>
-				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-				  <hasStandardCommand>true</hasStandardCommand>
-				  <defaultProjectile>VFE_Bullet_TeslaProjectileCE</defaultProjectile>
-				  <warmupTime>1.3</warmupTime>
-				  <range>45</range>
-				  <burstShotCount>5</burstShotCount>
-				  <ticksBetweenBurstShots>15</ticksBetweenBurstShots>
-				  <soundCast>Shot_ChargeBlaster</soundCast>
-				  <soundCastTail>GunTail_Heavy</soundCastTail>
-				  <muzzleFlashScale>9</muzzleFlashScale>
-				  <minRange>6</minRange>
-				</Properties>
-				<FireModes>
-				  <aiAimMode>AimedShot</aiAimMode>
-				  <noSnapshot>true</noSnapshot>
-				</FireModes>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/statBases/RangedWeapon_Cooldown</xpath>
+				<value>
+					<RangedWeapon_Cooldown>2.4</RangedWeapon_Cooldown>
+				</value>
 			</li>
-			
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/warmupTime</xpath>
+				<value>
+					<warmupTime>2.0</warmupTime>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/range</xpath>
+				<value>
+					<range>45</range>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/minRange</xpath>
+				<value>
+					<minRange>6</minRange>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
+				<value>
+					<damageDef>Electrical</damageDef>
+				</value>
+			</li>
+
       </operations>
     </match>
   </Operation>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -68,16 +68,16 @@
       <statBases>
         <Mass>12</Mass>
         <Bulk>22</Bulk>
-        <SwayFactor>8.80</SwayFactor>
+        <SwayFactor>4.40</SwayFactor>
         <ShotSpread>0.01</ShotSpread>
-        <SightsEfficiency>0.66</SightsEfficiency>
+        <SightsEfficiency>1.0</SightsEfficiency>
         <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
       </statBases>
       <Properties>
         <recoilAmount>1.16</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+        <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
         <warmupTime>1.3</warmupTime>
         <range>54</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -68,19 +68,19 @@
       <statBases>
         <Mass>12</Mass>
         <Bulk>22</Bulk>
-        <SwayFactor>4.40</SwayFactor>
+        <SwayFactor>4.00</SwayFactor>
         <ShotSpread>0.01</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>
         <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
       </statBases>
       <Properties>
-        <recoilAmount>1.16</recoilAmount>
+        <recoilAmount>1.66</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
         <warmupTime>1.6</warmupTime>
         <range>54</range>
-        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
         <soundCast>MediumMG</soundCast>
         <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -14,7 +14,7 @@
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
       <defName>VFE_Gun_CombatMechanoidGun</defName>
       <statBases>
-        <RangedWeapon_Cooldown>3.5</RangedWeapon_Cooldown>
+        <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
         <SightsEfficiency>1</SightsEfficiency>
         <ShotSpread>0.07</ShotSpread>
         <SwayFactor>0.82</SwayFactor>
@@ -71,14 +71,14 @@
         <SwayFactor>4.40</SwayFactor>
         <ShotSpread>0.01</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>
-        <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+        <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
       </statBases>
       <Properties>
         <recoilAmount>1.16</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
-        <warmupTime>1.3</warmupTime>
+        <warmupTime>1.6</warmupTime>
         <range>54</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -80,7 +80,7 @@
         <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
         <warmupTime>1.6</warmupTime>
         <range>54</range>
-        <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+        <ticksBetweenBurstShots>11</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
         <soundCast>MediumMG</soundCast>
         <soundCastTail>GunTail_Medium</soundCastTail>


### PR DESCRIPTION
## Changes

Closes https://github.com/CombatExtended-Continued/CombatExtended/issues/1238

- Fixed the auto tesla turret from VFE - Mechanoids. Since it uses a custom thingClass, changing it to the CE's turret thingClass wouldn't let it fire its special chain projectile. Changed range values, warmup and cooldown times to match CE values better along with its damage type from Burn to Electrical.
- Tweaked Raider mech's weapon sway and SightsEfficiency to reflect its new caliber better since it's not using 20x110mm cartridges anymore and the values seem to have been unchanged when switched from 20x110mm to 7.62NATO.
- Change its weapon's projectile from 7.62NATO to .338 Norma Magnum to make it less useless for the cost of the mech itself.
- Tweaked and fixed some of the warmup and cooldown times on the Raider mech and Combat mech's guns
- Removed a duplicate patch

## Alternatives

- Leave the tesla turret as is and change its projectile which defeats its purpose to a certain degree.
- Leave Raider mech's weapon as is which is very inaccurate and uses a semi-useless cartridge when in FMJ form for the stage of it's used in.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Did a full colony run with this changes and encountered no issues)
