### PR TITLE
Fix Nearmare Race AlienRace_Nearmare

### DIFF
--- a/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
+++ b/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
@@ -221,7 +221,7 @@
 			</li>
 
     		<li Class="PatchOperationAdd">
-				<xpath>Defs/HediffDef[defName="RE_TargetingVI"]</xpath>
+				<xpath>Defs/HediffDef[defName="RE_TargetingVI"]/stages</xpath>
 				<value>
 					<li>
 					<statOffsets>

--- a/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
+++ b/Patches/Rimeffect Core/Turrets_and_Misc_ME.xml
@@ -216,20 +216,18 @@
 			</value>
 			</li>
 
-    			<li Class="PatchOperationRemove">
+    		<li Class="PatchOperationRemove">
 				<xpath>Defs/HediffDef[defName="RE_TargetingVI"]/hediffClass</xpath>
 			</li>
 
-    			<li Class="PatchOperationAdd">
+    		<li Class="PatchOperationAdd">
 				<xpath>Defs/HediffDef[defName="RE_TargetingVI"]</xpath>
 				<value>
-    					<stages>
-        					<li>
-            						<statOffsets>
-							<AimingDelayFactor>-0.08</AimingDelayFactor>
-            						</statOffsets>
-        					</li>
-    					</stages>
+					<li>
+					<statOffsets>
+						<AimingDelayFactor>-0.08</AimingDelayFactor>
+					</statOffsets>
+					</li>
 				</value>
 			</li>
 


### PR DESCRIPTION
## Additions

Build in support for the new version of Nearmare Race

## Changes
Fix some bugs 

## References

no

## Reasoning

The old patch of Nearmar Race can not make it compatibility with CE.
## Alternatives

Some weapons and clothes will be compatible with CE soon.

## Testing

Except for some weapons and clothes, Nearmare Race is compatible with CE again.
