### PR TITLE
Pulsefire Turret Balance

### DIFF
--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -121,7 +121,7 @@
                   <recoilAmount>0.79</recoilAmount>
                   <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                   <hasStandardCommand>true</hasStandardCommand>
-                  <defaultProjectile>Bullet_600NitroExpress_Incendiary</defaultProjectile>
+                  <defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
                   <warmupTime>1.25</warmupTime>
                   <range>75</range>
                   <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -138,7 +138,7 @@
                 <li Class="CombatExtended.CompProperties_AmmoUser">
                   <magazineSize>60</magazineSize>
                   <reloadTime>8.5</reloadTime>
-                  <ammoSet>AmmoSet_600NitroExpress</ammoSet>
+                  <ammoSet>AmmoSet_8x50mmCharged</ammoSet>
                 </li>
                 <li Class="CombatExtended.CompProperties_FireModes">
                   <aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -272,14 +272,14 @@
               </weaponTags>
               <verbs>
                 <li Class="CombatExtended.VerbPropertiesCE">
-                  <recoilAmount>0.69</recoilAmount>
+                  <recoilAmount>0.71</recoilAmount>
                   <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                   <hasStandardCommand>true</hasStandardCommand>
-                  <defaultProjectile>Bullet_303British_AP</defaultProjectile>
-                  <warmupTime>1.25</warmupTime>
+                  <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+                  <warmupTime>0.75</warmupTime>
                   <range>65</range>
                   <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-                  <burstShotCount>12</burstShotCount>
+                  <burstShotCount>10</burstShotCount>
                   <soundCast>Shot_TurretSniper</soundCast>
                   <muzzleFlashScale>18</muzzleFlashScale>
                   <targetParams>
@@ -290,9 +290,9 @@
               </verbs>
               <comps>
                 <li Class="CombatExtended.CompProperties_AmmoUser">
-                  <magazineSize>50</magazineSize>
+                  <magazineSize>100</magazineSize>
                   <reloadTime>7.9</reloadTime>
-                  <ammoSet>AmmoSet_303British</ammoSet>
+                  <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
                 </li>
                 <li Class="CombatExtended.CompProperties_FireModes">
                   <aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -79,7 +79,7 @@
               <rotatable>true</rotatable>
               <building>
                 <ai_combatDangerous>true</ai_combatDangerous>
-                <turretGunDef>Gun_PulsefireTurret</turretGunDef>
+                <turretGunDef>InfernoCannon_Fire</turretGunDef>
                 <turretBurstCooldownTime>6.0</turretBurstCooldownTime>
               </building>
               <placeWorkers>
@@ -280,7 +280,7 @@
                   <range>65</range>
                   <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
                   <burstShotCount>10</burstShotCount>
-                  <soundCast>Shot_TurretSniper</soundCast>
+                  <soundCast>Shot_ChargeBlaster</soundCast>
                   <muzzleFlashScale>18</muzzleFlashScale>
                   <targetParams>
                     <canTargetLocations>false</canTargetLocations>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -79,7 +79,7 @@
               <rotatable>true</rotatable>
               <building>
                 <ai_combatDangerous>true</ai_combatDangerous>
-                <turretGunDef>ChargeLance_Fire</turretGunDef>
+                <turretGunDef>Gun_PulsefireTurret</turretGunDef>
                 <turretBurstCooldownTime>6.0</turretBurstCooldownTime>
               </building>
               <placeWorkers>
@@ -126,7 +126,7 @@
                   <range>75</range>
                   <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
                   <burstShotCount>1</burstShotCount>
-                  <soundCast>PulsefireTurretRound</soundCast>
+                  <soundCast>ChargeLance_Fire</soundCast>
                   <muzzleFlashScale>9</muzzleFlashScale>
                   <targetParams>
                     <canTargetLocations>false</canTargetLocations>

--- a/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
+++ b/Patches/Pulsefire Turret/PulsefireTurret_CombatExtendedPatch.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Patch>
   <!-- Mod Support for Combat Extended -->
   <Operation Class="PatchOperationFindMod">
@@ -79,7 +79,7 @@
               <rotatable>true</rotatable>
               <building>
                 <ai_combatDangerous>true</ai_combatDangerous>
-                <turretGunDef>InfernoCannon_Fire</turretGunDef>
+                <turretGunDef>ChargeLance_Fire</turretGunDef>
                 <turretBurstCooldownTime>6.0</turretBurstCooldownTime>
               </building>
               <placeWorkers>
@@ -121,7 +121,7 @@
                   <recoilAmount>0.79</recoilAmount>
                   <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                   <hasStandardCommand>true</hasStandardCommand>
-                  <defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+                  <defaultProjectile>Bullet_12x65mmCharged</defaultProjectile>
                   <warmupTime>1.25</warmupTime>
                   <range>75</range>
                   <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -138,7 +138,7 @@
                 <li Class="CombatExtended.CompProperties_AmmoUser">
                   <magazineSize>60</magazineSize>
                   <reloadTime>8.5</reloadTime>
-                  <ammoSet>AmmoSet_8x50mmCharged</ammoSet>
+                  <ammoSet>AmmoSet_12x65mmCharged</ammoSet>
                 </li>
                 <li Class="CombatExtended.CompProperties_FireModes">
                   <aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -272,14 +272,14 @@
               </weaponTags>
               <verbs>
                 <li Class="CombatExtended.VerbPropertiesCE">
-                  <recoilAmount>0.71</recoilAmount>
+                  <recoilAmount>0.69</recoilAmount>
                   <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                   <hasStandardCommand>true</hasStandardCommand>
                   <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
-                  <warmupTime>0.75</warmupTime>
+                  <warmupTime>1.25</warmupTime>
                   <range>65</range>
                   <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-                  <burstShotCount>10</burstShotCount>
+                  <burstShotCount>12</burstShotCount>
                   <soundCast>Shot_ChargeBlaster</soundCast>
                   <muzzleFlashScale>18</muzzleFlashScale>
                   <targetParams>
@@ -290,7 +290,7 @@
               </verbs>
               <comps>
                 <li Class="CombatExtended.CompProperties_AmmoUser">
-                  <magazineSize>100</magazineSize>
+                  <magazineSize>150</magazineSize>
                   <reloadTime>7.9</reloadTime>
                   <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
                 </li>


### PR DESCRIPTION
## Additions

Adds proper ammunition to pulsefire turrets.

## Changes

Increased magazine size for twinfire turrets now using Charge SMG ammo
Single shot pulsefire now using 8x50mm

## References

nil

## Reasoning

Why did you choose to implement things this way, e.g.
- Pulsefire turrets were considered spacer tech and speaking with the original mod author, the original CE patch was a quick fix and not meant to be anything permanent 

## Alternatives

Describe alternative implementations you have considered, e.g.
- I am considering different ammo types 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 4 hours
