### PR TITLE
Allow men in black to spawn with backpacks

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -793,11 +793,18 @@
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>3</min>
-          <max>6</max>
+          <min>5</min>
+          <max>8</max>
         </primaryMagazineCount>
       </li>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+   <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]/apparelRequired</xpath>
+     <value>
+       <li>Apparel_Backpack</li>
+     </value>
   </Operation>
 
 </Patch>


### PR DESCRIPTION
## Additions

- Added backpacks to required apparel for men in black

## Changes

- Increased the amount of ammo men in black can spawn with

## Reasoning

- Men in black spawn with the default carry bulk which is low for the apparel they wear and usually don't spawn with additional ammo for their weapon.
- The amount of ammo they spawn with is quite low for a pawn who is supposed to arrive and save the colony from danger.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
