### PR TITLE
Update ApexRimworldLegends_Weapons_MachineGuns.xml

### DIFF
--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_MachineGuns.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_MachineGuns.xml
@@ -68,7 +68,7 @@
               </li>
               <li Class="CombatExtended.ToolCE">
                 <label>barrel</label>
-                <capacities>63/3
+                <capacities>
                   <li>Blunt</li>
                 </capacities>
                 <power>8</power>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_MachineGuns.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_MachineGuns.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Patch>
   <Operation Class="PatchOperationFindMod">
     <mods>
@@ -24,8 +24,8 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
-            <burstShotCount>18</burstShotCount>
-            <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+            <burstShotCount>21</burstShotCount>
+            <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
             <warmupTime>1.25</warmupTime>
             <range>60</range>
             <soundCast>Shot_Minigun</soundCast>
@@ -33,7 +33,7 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>36</magazineSize>
+            <magazineSize>63</magazineSize>
             <reloadTime>3.33</reloadTime>
             <ammoSet>AmmoSet_762x54mmR</ammoSet>
           </AmmoUser>
@@ -68,7 +68,7 @@
               </li>
               <li Class="CombatExtended.ToolCE">
                 <label>barrel</label>
-                <capacities>
+                <capacities>63/3
                   <li>Blunt</li>
                 </capacities>
                 <power>8</power>
@@ -108,7 +108,7 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
-            <burstShotCount>35</burstShotCount>
+            <burstShotCount>20</burstShotCount>
             <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
             <warmupTime>1.25</warmupTime>
             <range>64</range>
@@ -117,7 +117,7 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>35</magazineSize>
+            <magazineSize>80</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
           </AmmoUser>
@@ -195,7 +195,7 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
-            <burstShotCount>44</burstShotCount>
+            <burstShotCount>15</burstShotCount>
             <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
             <warmupTime>1.8</warmupTime>
             <range>58</range>
@@ -204,12 +204,12 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>44</magazineSize>
+            <magazineSize>60</magazineSize>
             <reloadTime>2.8</reloadTime>
             <ammoSet>AmmoSet_8x35mmCharged</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>12</aimedBurstShotCount>
+            <aimedBurstShotCount>10</aimedBurstShotCount>
           </FireModes>
           <weaponTags>
             <li>SpacerGun</li>
@@ -293,7 +293,7 @@
             </targetParams>
           </Properties>
           <AmmoUser>
-            <magazineSize>30</magazineSize>
+            <magazineSize>60</magazineSize>
             <reloadTime>4.9</reloadTime>
             <ammoSet>AmmoSet_ARL_127x39mmCharged</ammoSet>
           </AmmoUser>


### PR DESCRIPTION
Gave greater capacity to Apex Legend Machine guns to reflect actual in game performance(apex legends) 
as well as reflect their roles as machine guns rather than assault rifles.

## Additions
nil

## Changes

Adjusted ARL LMG magazine capacity, didnt change anything else

## Reasoning

Why did you choose to implement things this way, e.g.
- Current performance mimics that of Assault rifles with 36-40 round magazines, changed the capacity to reflect both Apex legends performance and in game balance

## Alternatives

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
