### PR TITLE
Turrets Tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -182,31 +182,27 @@
       <SightsEfficiency>2.3</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.14</SwayFactor>
-      <RangedWeapon_Cooldown>10.7</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_90mmCannonShell_HEAT</defaultProjectile>
-        <warmupTime>6.55</warmupTime>
-        <minRange>16</minRange>
+        <defaultProjectile>Bullet_30x173mmNATO_FMJ</defaultProjectile>
+        <warmupTime>4.5</warmupTime>
+        <minRange>5</minRange>
         <range>86</range>
-        <burstShotCount/>
-        <soundCast>120mm</soundCast>
+        <soundCast>Shot_TurretSniper</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>20</muzzleFlashScale>
-        <targetParams>
-          <canTargetLocations>true</canTargetLocations>
-        </targetParams>
         <recoilPattern>Mounted</recoilPattern>
       </li>
     </verbs>
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
-        <magazineSize>3</magazineSize>
-        <reloadTime>9.8</reloadTime>
-        <ammoSet>AmmoSet_90mmCannonShell</ammoSet>
+        <magazineSize>30</magazineSize>
+        <reloadTime>7.8</reloadTime>
+        <ammoSet>AmmoSet_30x173mmNATO</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
         <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -202,7 +202,7 @@
 		<xpath>Defs/ThingDef[defName = "Turret_Sniper"]/researchPrerequisites</xpath>
 		<value>
 			<researchPrerequisites>
-				<li>CE_TurretHeavyWeapons</li>
+				<li>CE_HeavyTurret</li>
 			</researchPrerequisites>
 		</value>
 	</Operation>
@@ -284,7 +284,7 @@
 		<xpath>Defs/ThingDef[defName = "Turret_Autocannon"]/researchPrerequisites</xpath>
 		<value>
 			<researchPrerequisites>
-				<li>CE_TurretHeavyWeapons</li>
+				<li>CE_HeavyTurret</li>
 			</researchPrerequisites>
 		</value>
 	</Operation>


### PR DESCRIPTION
## Changes

- Changed the research project required for autocannon and uranium slug turrets to the proper one.
- Changed the ammo type the uranium slug turret uses to 30mmNATO for consistency's sake and more usefulness.

## Reasoning

- Autocannon and uranium slug turrets are heavy auto-turrets and should be coupled with the heavy auto turret added by CE, not manned turrets
- Uranium slug turrets currently use the 90mm shell which is a bit silly considering their name and use-case. Also there is a manned 90mm flak turret which is enough for 90mm shell usage. Also the switch from 90mm shells to 30mm rounds is more consistent with other weapons patched for CE.

## Alternatives

- Leave the research projects be as is
- Leave the uranium slug turret untouched

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
