### PR TITLE
Apex rimworld legends AR tweaks

### DIFF
--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -24,7 +24,7 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-            <burstShotCount>4</burstShotCount>
+            <burstShotCount>5</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
             <warmupTime>1.1</warmupTime>
             <range>52</range>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_AssaultRifles.xml
@@ -33,7 +33,7 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>20</magazineSize>
+            <magazineSize>30</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
           </AmmoUser>
@@ -106,7 +106,7 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
-            <burstShotCount>2</burstShotCount>
+            <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>5.66</ticksBetweenBurstShots>
             <warmupTime>1.0</warmupTime>
             <range>50</range>
@@ -188,8 +188,8 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
-            <burstShotCount>18</burstShotCount>
-            <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+            <burstShotCount>14</burstShotCount>
+            <ticksBetweenBurstShots>4.2</ticksBetweenBurstShots>
             <warmupTime>1</warmupTime>
             <range>46</range>
             <soundCast>Shot_AssaultRifle</soundCast>
@@ -197,7 +197,7 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>18</magazineSize>
+            <magazineSize>28</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_FN57x28mm</ammoSet>
           </AmmoUser>
@@ -272,8 +272,8 @@
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
-            <burstShotCount>2</burstShotCount>
-            <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+            <burstShotCount>6</burstShotCount>
+            <ticksBetweenBurstShots>5.2</ticksBetweenBurstShots>
             <warmupTime>1</warmupTime>
             <range>58</range>
             <soundCast>Shot_ChargeRifle</soundCast>
@@ -281,7 +281,7 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>26</magazineSize>
+            <magazineSize>36</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
           </AmmoUser>


### PR DESCRIPTION
Tweaked to ad

## Additions

nil

## Changes

Adjusted RoF to mimic gun performance in Apex Legends, 
Increased magazine size to make the guns more feasible, using their extended mag variants from Apex Legends

## References

nil

## Reasoning

nil

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
