### PR TITLE
Add patch for More Psycasts mod

### DIFF
--- a/Patches/More Psycasts/AbilitiesPatch.xml
+++ b/Patches/More Psycasts/AbilitiesPatch.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>More Psycasts</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="MorePsycasts_HaulSkip"]/verbProperties/range</xpath>
+					<value>
+						<range>6</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="MorePsycasts_Ignite"]/verbProperties/range</xpath>
+					<value>
+						<range>12</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="MorePsycasts_Mending"]/verbProperties/range</xpath>
+					<value>
+						<range>17</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="MorePsycasts_FertilitySkip"]/verbProperties/range</xpath>
+					<value>
+						<range>17</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[
+						defName="MorePsycasts_ArcticPinhole" or
+						defName="MorePsycasts_CleanSkip"]/verbProperties/range</xpath>
+					<value>
+						<range>28</range>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="MorePsycasts_FlashHeal"]/verbProperties/range</xpath>
+					<value>
+						<range>32</range>
+					</value>
+				</li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>
+


### PR DESCRIPTION
## Additions

- Added a patch for More Psycasts mod (https://steamcommunity.com/sharedfiles/filedetails/?id=2460833332)

## Changes

- Increase the range on psycasts added by More Psycasts

## Reasoning

- Ranged psycasts are patched to have more range in CE so patched psycasts added by More Psycasts to have more range

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Been using it since installed More Psycasts)
