### PR TITLE
Craftable Miniguns

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -880,7 +880,7 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Gun_Minigun"]/statBases</xpath>
     <value>
-      <MarketValue>1500</MarketValue>
+      <MarketValue>1700</MarketValue>
     </value>
   </Operation>
 
@@ -894,7 +894,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/ComponentIndustrial</xpath>
     <value>
-      <ComponentIndustrial>10</ComponentIndustrial>
+      <ComponentIndustrial>14</ComponentIndustrial>
     </value>
   </Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -877,27 +877,29 @@
     </value>
   </Operation>
 
-  <!-- Disable for player -->
-
-  <Operation Class="PatchOperationAttributeSet">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]</xpath>
-    <attribute>ParentName</attribute>
-    <value>BaseGunWithQuality</value>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList</xpath>
-  </Operation>
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/recipeMaker</xpath>
-  </Operation>
-
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Gun_Minigun"]/statBases</xpath>
     <value>
-      <MarketValue>2200</MarketValue>
+      <MarketValue>1500</MarketValue>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/Steel</xpath>
+    <value>
+      <Steel>200</Steel>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/ComponentIndustrial</xpath>
+    <value>
+      <ComponentIndustrial>10</ComponentIndustrial>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/equippedStatOffsets</xpath>
   </Operation>
 
   <!-- ========== Doomsday launcher ========== -->


### PR DESCRIPTION
## Changes

- Made Miniguns craftable with a balanced crafting recipe and removed the move speed offset

## Reasoning

- Other mods have craftable versions of Miniguns so why not?

## Alternatives

- Leave the miniguns uncraftable and buyable or quest reward only

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
