### PR TITLE
Magical Menagerie & Witcher Monster Hunter Patch Tweaks

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -25,6 +25,7 @@
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>
 		<li>Rah.RVTE</li>
+		<li>sarg.magicalmenagerie</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>

--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -10,7 +10,9 @@
     <li>1541287769</li> <!-- Field Medic -->
     <li>1729446857</li> <!-- Mortar Accuracy -->
   </incompatibleWith>
-  <loadBefore></loadBefore>
+  <loadBefore>
+    <li>1821617793</li> <!-- Magical Menagerie -->
+  </loadBefore>
   <loadAfter>
     <li>2009463077</li> <!-- Harmony -->
     <li>1542254108</li> <!-- TheInfinityIQ.Halo.UNSC -->

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
@@ -8,7 +8,7 @@
 			<operations>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Quill"]/projectile</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Quill"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -18,26 +18,25 @@
 							<!-- Roughly equal to steel neolithic arrows -->
 							<armorPenetrationSharp>0.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>3.02</armorPenetrationBlunt>
-
 						</projectile>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Tremor"]/projectile</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Tremor"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>Blunt</damageDef>
 							<damageAmountBase>20</damageAmountBase>
-							<speed>8</speed>
+							<speed>12</speed>
 							<armorPenetrationBlunt>100</armorPenetrationBlunt>
 						</projectile>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_WispProjectile"]/projectile</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WispProjectile"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -49,19 +48,19 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_AcidicBreath"]/projectile</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_AcidicBreath"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>20</speed>
 							<damageDef>MM_AcidicBreath</damageDef>
-							<damageAmountBase>2</damageAmountBase>
+							<damageAmountBase>5</damageAmountBase>
 							<flyOverhead>false</flyOverhead>
 						</projectile>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.ExpandableProjectileDef[defName="MM_GazeAttack"]/projectile</xpath>
+					<xpath>/Defs/VFECore.ExpandableProjectileDef[defName="MM_GazeAttack"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>MM_PetrifyingGaze</damageDef>
@@ -73,19 +72,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.ExpandableProjectileDef[defName="MM_CenteredGazeAttack"]/projectile</xpath>
-					<value>
-						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<damageDef>MM_PetrifyingGaze</damageDef>
-							<flyOverhead>false</flyOverhead>
-							<damageAmountBase>2</damageAmountBase>
-							<speed>20</speed>
-						</projectile>
-					</value>
-				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.ExpandableProjectileDef[defName="MM_GreenStreamBreath"]/projectile</xpath>
+					<xpath>/Defs/VFECore.ExpandableProjectileDef[defName="MM_GreenStreamBreath"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>ToxicBite</damageDef>
@@ -97,7 +84,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/VFECore.ExpandableProjectileDef[defName="MM_FlameBreathAnimated"]/projectile</xpath>
+					<xpath>/Defs/VFECore.ExpandableProjectileDef[defName="MM_FlameBreathAnimated"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>40</speed>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
@@ -97,6 +97,73 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseBullet">
+							<defName>MM_GazeAttack_CE</defName>
+							<label>petrifying gaze</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Things/Projectiles/MM_GazeAttack</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<flyOverhead>false</flyOverhead>
+								<damageDef>MM_PetrifyingGaze</damageDef>
+								<damageAmountBase>5</damageAmountBase>
+								<speed>20</speed>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseBullet">
+							<defName>MM_GreenStreamBreath_CE</defName>
+							<label>poison breath</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Things/Projectiles/MM_PoisonBreath</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<flyOverhead>false</flyOverhead>
+								<damageDef>ToxicBite</damageDef>
+								<damageAmountBase>15</damageAmountBase>
+								<speed>20</speed>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseBullet">
+							<defName>MM_FlameBreathAnimated_CE</defName>
+							<label>flame breath</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Things/Projectiles/MM_Firebreath</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<flyOverhead>false</flyOverhead>
+								<damageDef>Flame</damageDef>
+								<damageAmountBase>2</damageAmountBase>
+								<speed>40</speed>
+								<explosionRadius>1.1</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+								<soundExplode>Interact_Ignite</soundExplode>
+							</projectile>
+						</ThingDef>
+
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+				<xpath>/Defs/DamageDef[defName="MM_PetrifyingGaze"]/additionalHediffs/li[hediff="MM_Petrification"]/severityPerDamageDealt</xpath>
+					<value>
+						<severityPerDamageDealt>0.035</severityPerDamageDealt>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
@@ -53,7 +53,7 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>20</speed>
-							<damageDef>MM_ToxicBreath</damageDef>
+							<damageDef>MM_AcidicBreath</damageDef>
 							<damageAmountBase>2</damageAmountBase>
 							<flyOverhead>false</flyOverhead>
 						</projectile>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Projectiles.xml
@@ -51,9 +51,9 @@
 					<xpath>/Defs/ThingDef[defName="MM_AcidicBreath"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>20</speed>
+							<speed>15</speed>
 							<damageDef>MM_AcidicBreath</damageDef>
-							<damageAmountBase>5</damageAmountBase>
+							<damageAmountBase>1</damageAmountBase>
 							<flyOverhead>false</flyOverhead>
 						</projectile>
 					</value>
@@ -147,8 +147,7 @@
 								<flyOverhead>false</flyOverhead>
 								<damageDef>Flame</damageDef>
 								<damageAmountBase>2</damageAmountBase>
-								<speed>40</speed>
-								<explosionRadius>1.1</explosionRadius>
+								<speed>25</speed>
 								<ai_IsIncendiary>true</ai_IsIncendiary>
 								<soundExplode>Interact_Ignite</soundExplode>
 							</projectile>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -224,9 +224,22 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/verbs</xpath>
 					<value>
-						<range>12</range>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_GazeAttack_CE</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>1</warmupTime>
+								<range>12</range>
+								<minRange>1</minRange>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>1</commonality>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 
@@ -295,6 +308,26 @@
 								<armorPenetrationBlunt>3.92</armorPenetrationBlunt>
 							</li>
 						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_GazeAttack_CE</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>1</warmupTime>
+								<range>20</range>
+								<minRange>1</minRange>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>1</commonality>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 
@@ -547,9 +580,26 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/verbs</xpath>
 					<value>
-						<range>18</range>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_FlameBreathAnimated_CE</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>2.5</warmupTime>
+								<range>18</range>
+								<minRange>2</minRange>
+								<soundCast>MM_FireBreathSound</soundCast>
+								<muzzleFlashScale>2</muzzleFlashScale>
+								<commonality>0.8</commonality>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 
@@ -847,9 +897,26 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/verbs</xpath>
 					<value>
-						<range>10</range>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_FlameBreathAnimated_CE</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>1.5</warmupTime>
+								<range>10</range>
+								<minRange>2</minRange>
+								<soundCast>MM_FireBreathSound</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>1.0</commonality>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 
@@ -1664,11 +1731,29 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs</xpath>
 					<value>
-						<range>14</range>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_GreenStreamBreath_CE</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>1.5</warmupTime>
+								<range>14</range>
+								<minRange>1</minRange>
+								<soundCast>MM_PoisonBreathSound</soundCast>
+								<muzzleFlashScale>1</muzzleFlashScale>
+								<commonality>1.0</commonality>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
+
 
 				<!-- ========== Unicorn ========== -->
 
@@ -1856,6 +1941,30 @@
 								<armorPenetrationBlunt>2</armorPenetrationBlunt>
 							</li>
 						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_Tremor</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<warmupTime>1</warmupTime>
+								<range>15</range>
+								<minRange>5</minRange>
+								<soundCast>MM_Tremor</soundCast>
+								<muzzleFlashScale>0</muzzleFlashScale>
+								<commonality>1</commonality>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -587,7 +587,8 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>MM_FlameBreathAnimated_CE</defaultProjectile>
-								<burstShotCount>1</burstShotCount>
+								<burstShotCount>2</burstShotCount>
+								<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 								<warmupTime>2.5</warmupTime>
 								<range>18</range>
 								<minRange>2</minRange>
@@ -1146,9 +1147,9 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>MM_AcidicBreath</defaultProjectile>
-								<burstShotCount>1</burstShotCount>
-								<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
-								<warmupTime>1.5</warmupTime>
+								<burstShotCount>6</burstShotCount>
+								<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+								<warmupTime>2.0</warmupTime>
 								<range>18</range>
 								<minRange>2</minRange>
 								<soundCast>MM_PoisonBreathSound</soundCast>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -10,7 +10,22 @@
 				<!-- Shared bodyShape patches -->
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath> Defs/ThingDef[ defName="MM_Ahuizotl" or defName="MM_Catoblepas" or defName="MM_Cerberus" or defName="MM_CeryneianHind" or defName="MM_Chimera" or defName="MM_ErymanthianBoar" or defName="MM_Griffin" or defName="MM_Kitsune" or defName="MM_LernaeanHydra" or defName="MM_Manticore" or defName="MM_Pegasus" or defName="MM_Qilin" or defName="MM_Unicorn" or defName="MM_Xiezhi"]</xpath>
+					<xpath>/Defs/ThingDef[
+					defName="MM_Ahuizotl" or 
+					defName="MM_Catoblepas" or 
+					defName="MM_Cerberus" or 
+					defName="MM_CeryneianHind" or 
+					defName="MM_Chimera" or 
+					defName="MM_ErymanthianBoar" or 
+					defName="MM_Griffin" or 
+					defName="MM_Kitsune" or 
+					defName="MM_LernaeanHydra" or 
+					defName="MM_Manticore" or 
+					defName="MM_Pegasus" or 
+					defName="MM_Qilin" or 
+					defName="MM_Unicorn" or 
+					defName="MM_Xiezhi"
+					]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +34,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath> Defs/ThingDef[defName="MM_WillOWisp" or defName="MM_LesserWyvern"]</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -28,7 +43,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath> Defs/ThingDef[defName="MM_Basilisk" or defName="MM_Tlilcoatl" or defName="MM_Salamander"]</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Basilisk" or defName="MM_Tlilcoatl" or defName="MM_Salamander"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Serpentine</bodyShape>
@@ -37,7 +52,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath> Defs/ThingDef[defName="MM_WildMinotaur" or defName="MM_Kappa"]</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur" or defName="MM_Kappa"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
@@ -46,7 +61,12 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath> Defs/ThingDef[defName="MM_Phoenix" or defName="MM_Fenghuang" or defName="MM_Ieltxu"]</xpath>
+					<xpath>/Defs/ThingDef[
+					defName="MM_Phoenix" or 
+					defName="MM_Fenghuang" or 
+					defName="MM_Ieltxu" or 
+					defName="MM_LesserWyvern"
+					]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -57,7 +77,7 @@
 				<!-- ========== Ahuizotl ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Ahuizotl"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ahuizotl"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.26</MeleeCritChance>
@@ -66,7 +86,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Ahuizotl"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ahuizotl"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -154,7 +174,7 @@
 				<!-- ========== Basilisk ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.19</MeleeDodgeChance>
 						<MeleeCritChance>0.18</MeleeCritChance>
@@ -165,7 +185,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -204,7 +224,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/verbs/li/range</xpath>
 					<value>
 						<range>12</range>
 					</value>
@@ -213,7 +233,7 @@
 				<!-- ========== Catoblepas ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Catoblepas"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.35</MeleeCritChance>
@@ -224,7 +244,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Catoblepas"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -281,7 +301,7 @@
 				<!-- ========== Cerberus ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Cerberus"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Cerberus"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.28</MeleeCritChance>
@@ -290,7 +310,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Cerberus"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Cerberus"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -345,7 +365,7 @@
 				<!-- ========== Ceryneian Hind ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_CeryneianHind"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_CeryneianHind"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.14</MeleeDodgeChance>
 						<MeleeCritChance>0.27</MeleeCritChance>
@@ -354,7 +374,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_CeryneianHind"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_CeryneianHind"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -419,7 +439,7 @@
 				<!-- ========== Chimera ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Chimera"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.09</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
@@ -430,7 +450,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Chimera"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -527,7 +547,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Chimera"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/verbs/li/range</xpath>
 					<value>
 						<range>18</range>
 					</value>
@@ -536,7 +556,7 @@
 				<!-- ========== Erymanthian Boar ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_ErymanthianBoar"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_ErymanthianBoar"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
@@ -545,7 +565,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_ErymanthianBoar"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_ErymanthianBoar"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -601,7 +621,7 @@
 				<!-- ========== Fenghuang ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Fenghuang"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Fenghuang"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.17</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
@@ -610,7 +630,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Fenghuang"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Fenghuang"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -670,7 +690,7 @@
 				<!-- ========== Griffin ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Griffin"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Griffin"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.17</MeleeDodgeChance>
 						<MeleeCritChance>0.17</MeleeCritChance>
@@ -679,7 +699,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Griffin"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Griffin"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -759,7 +779,7 @@
 				<!-- ========== Ieltxu ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.06</MeleeCritChance>
@@ -769,7 +789,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -827,7 +847,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/verbs/li/range</xpath>
 					<value>
 						<range>10</range>
 					</value>
@@ -836,7 +856,7 @@
 				<!-- ========== Kappa ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Kappa"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Kappa"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
@@ -845,7 +865,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Kappa"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Kappa"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -917,7 +937,7 @@
 				<!-- ========== Kitsune ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Kitsune"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Kitsune"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.07</MeleeCritChance>
@@ -926,7 +946,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Kitsune"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Kitsune"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1004,7 +1024,7 @@
 				<!-- ========== Lernaean Hydra ========== --> <!-- Note: Hydra's projectile didn't work so it requires a fix -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.22</MeleeCritChance>
@@ -1015,7 +1035,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1052,7 +1072,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs/li/range</xpath>
 					<value>
 						<range>18</range>
 					</value>
@@ -1061,7 +1081,7 @@
 				<!-- ========== Lesser Wyvern ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.25</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
@@ -1070,7 +1090,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1132,14 +1152,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 					</value>
@@ -1149,7 +1169,7 @@
 				<!-- ========== Manticore ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Manticore"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.31</MeleeCritChance>
@@ -1159,7 +1179,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Manticore"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1254,7 +1274,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Manticore"]/verbs</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1281,7 +1301,7 @@
 				<!-- ========== Pegasus ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Pegasus"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Pegasus"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
@@ -1290,7 +1310,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Pegasus"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Pegasus"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1360,7 +1380,7 @@
 				<!-- ========== Phoenix ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.36</MeleeDodgeChance>
 						<MeleeCritChance>0.17</MeleeCritChance>
@@ -1369,7 +1389,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1427,14 +1447,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/statBases/MoveSpeed</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/statBases/MoveSpeed</xpath>
 					<value>
 						<MoveSpeed>4.7</MoveSpeed>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Phoenix"]</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]</xpath>
 					<value>
 						<butcherProducts>
 							<Prometheum>10</Prometheum>
@@ -1445,7 +1465,7 @@
 				<!-- ========== Qilin ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Qilin"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Qilin"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.23</MeleeCritChance>
@@ -1454,7 +1474,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Qilin"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Qilin"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1538,7 +1558,7 @@
 				<!-- ========== Salamander ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Salamander"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Salamander"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.29</MeleeCritChance>
@@ -1547,7 +1567,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Salamander"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Salamander"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1588,7 +1608,7 @@
 				<!-- ========== Tlilcoatl ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.23</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
@@ -1599,7 +1619,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1626,7 +1646,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs/li/range</xpath>
 					<value>
 						<range>14</range>
 					</value>
@@ -1635,7 +1655,7 @@
 				<!-- ========== Unicorn ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Unicorn"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Unicorn"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.41</MeleeCritChance>
@@ -1644,7 +1664,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Unicorn"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Unicorn"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1736,7 +1756,7 @@
 				<!-- ========== Wild Minotaur ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_WildMinotaur"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
@@ -1745,7 +1765,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_WildMinotaur"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1824,7 +1844,7 @@
 				<!-- ========== Will-O'-Wisp ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.00</MeleeCritChance>
@@ -1833,7 +1853,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1859,7 +1879,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/verbs</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1886,7 +1906,7 @@
 				<!-- ========== Xiezhi ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="MM_Xiezhi"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Xiezhi"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.25</MeleeDodgeChance>
 						<MeleeCritChance>0.18</MeleeCritChance>
@@ -1895,7 +1915,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="MM_Xiezhi"]/tools</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_Xiezhi"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -1021,7 +1021,7 @@
 					</value>
 				</li>
 
-				<!-- ========== Lernaean Hydra ========== --> <!-- Note: Hydra's projectile didn't work so it requires a fix -->
+				<!-- ========== Lernaean Hydra ========== -->
 
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/statBases</xpath>
@@ -1072,9 +1072,27 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs/li/range</xpath>
+					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs</xpath>
 					<value>
-						<range>18</range>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>MM_AcidicBreath</defaultProjectile>
+								<burstShotCount>1</burstShotCount>
+								<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+								<warmupTime>1.5</warmupTime>
+								<range>18</range>
+								<minRange>2</minRange>
+								<soundCast>MM_PoisonBreathSound</soundCast>
+								<muzzleFlashScale>0</muzzleFlashScale>
+								<commonality>1</commonality>
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+								<recoilAmount>0.4</recoilAmount>
+							</li>
+						</verbs>
 					</value>
 				</li>
 

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -1154,14 +1154,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>25</ArmorRating_Blunt>
+						<ArmorRating_Blunt>20</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -1154,14 +1154,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+						<ArmorRating_Blunt>25</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -1904,7 +1904,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>MM_WispProjectile</defaultProjectile>
-								<burstShotCount>50</burstShotCount>
+								<burstShotCount>25</burstShotCount>
 								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 								<warmupTime>2</warmupTime>
 								<range>15</range>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Resources.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Resources.xml
@@ -18,14 +18,14 @@
                 </li>
 
                 <!-- ===== Heavy Magical Leather ===== -->
-                <li Class="PatchOperationAdd">
+                <li Class="PatchOperationReplace">
                     <xpath>/Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
                     <value>
                         <StuffPower_Armor_Sharp>0.65</StuffPower_Armor_Sharp>
                     </value>
                 </li>
 
-                <li Class="PatchOperationAdd">
+                <li Class="PatchOperationReplace">
                     <xpath>/Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
                     <value>
                         <StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Resources.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Resources.xml
@@ -12,8 +12,8 @@
                 <li Class="PatchOperationReplace">
                     <xpath>/Defs/ThingDef[defName="MM_LightMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
                     <value>
-                        <StuffPower_Armor_Sharp>0.55</StuffPower_Armor_Sharp>
-                        <StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
+                        <StuffPower_Armor_Sharp>0.45</StuffPower_Armor_Sharp>
+                        <StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
                     </value>
                 </li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
@@ -40,14 +40,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>1</ArmorRating_Blunt>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
@@ -32,14 +32,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
@@ -37,14 +37,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FogletCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FogletCE.xml
@@ -28,14 +28,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+			<ArmorRating_Blunt>1</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_KikimoreCE.xml
@@ -94,14 +94,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+			<ArmorRating_Blunt>6</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMAux_KikimoreWarrior"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
@@ -13,7 +13,7 @@
 				<xpath>Defs/ThingDef[defName="WMH_Wyvern"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>QuadrupedLow</bodyShape>
+						<bodyShape>Birdlike</bodyShape>
 					</li>
 				</value>
 			</li>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WyvernCE.xml
@@ -39,14 +39,14 @@
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+			<ArmorRating_Blunt>25</ArmorRating_Blunt>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="WMH_Wyvern"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/WH_ProjectileShoot.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/WH_ProjectileShoot.xml
@@ -16,15 +16,15 @@
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-											<hasStandardCommand>true</hasStandardCommand>
-											<defaultProjectile>WMH_WyvernAcidSpit</defaultProjectile>
-											<warmupTime>1.5</warmupTime>
-											<burstShotCount>1</burstShotCount>
-											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-											<minRange>1</minRange>
-											<range>30</range>
-											<muzzleFlashScale>0</muzzleFlashScale>
-											<commonality>0.5</commonality>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>WMH_WyvernAcidSpit</defaultProjectile>
+										<warmupTime>1.5</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+										<minRange>1</minRange>
+										<range>30</range>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<commonality>0.5</commonality>
 									</li>
 								</verbs>
 							</value>
@@ -38,15 +38,15 @@
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-											<hasStandardCommand>true</hasStandardCommand>
-											<defaultProjectile>WMH_LeshyWave</defaultProjectile>
-											<warmupTime>1</warmupTime>
-											<burstShotCount>1</burstShotCount>
-											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-											<minRange>2</minRange>
-											<range>50</range>
-											<muzzleFlashScale>0</muzzleFlashScale>
-											<commonality>1</commonality>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>WMH_LeshyWave</defaultProjectile>
+										<warmupTime>1</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+										<minRange>2</minRange>
+										<range>50</range>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<commonality>1</commonality>
 									</li>
 								</verbs>
 							</value>
@@ -60,15 +60,15 @@
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-											<hasStandardCommand>true</hasStandardCommand>
-											<defaultProjectile>WMH_WispProjectile</defaultProjectile>
-											<warmupTime>0.3</warmupTime>
-											<burstShotCount>50</burstShotCount>
-											<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-											<minRange>1</minRange>
-											<range>36</range>
-											<muzzleFlashScale>0</muzzleFlashScale>
-											<commonality>1</commonality>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>WMH_WispProjectile</defaultProjectile>
+										<warmupTime>0.3</warmupTime>
+										<burstShotCount>50</burstShotCount>
+										<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+										<minRange>1</minRange>
+										<range>36</range>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<commonality>1</commonality>
 									</li>
 								</verbs>
 							</value>
@@ -82,17 +82,17 @@
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-											<hasStandardCommand>true</hasStandardCommand>
-											<defaultProjectile>WMH_Rock</defaultProjectile>
-											<warmupTime>3</warmupTime>
-											<burstShotCount>1</burstShotCount>
-											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-											<minRange>6</minRange>
-											<range>32</range>
-											<soundCast>WMH_RockThrow</soundCast>
-											<muzzleFlashScale>0</muzzleFlashScale>
-											<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-											<commonality>0.4</commonality>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>WMH_Rock</defaultProjectile>
+										<warmupTime>3</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+										<minRange>6</minRange>
+										<range>32</range>
+										<soundCast>WMH_RockThrow</soundCast>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+										<commonality>0.4</commonality>
 									</li>
 								</verbs>
 							</value>

--- a/Patches/Vanilla Animals Expanded/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Caves_Animals.xml
@@ -50,6 +50,20 @@
     </li>
 
     <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Blunt</xpath>
+      <value>
+        <ArmorRating_Blunt>2</ArmorRating_Blunt>
+      </value>
+    </li>
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Sharp</xpath>
+      <value>
+        <ArmorRating_Sharp>1</ArmorRating_Sharp>
+      </value>
+    </li>
+
+    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/tools</xpath>
       <value>
         <tools>
@@ -144,14 +158,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+        <ArmorRating_Blunt>8</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>1</ArmorRating_Sharp>
+        <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
     
@@ -224,14 +238,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+        <ArmorRating_Blunt>2</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+        <ArmorRating_Sharp>1</ArmorRating_Sharp>
       </value>
     </li>
     
@@ -295,14 +309,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>1</ArmorRating_Blunt>
+        <ArmorRating_Blunt>8</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+        <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
     
@@ -383,14 +397,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>5</ArmorRating_Blunt>
+        <ArmorRating_Blunt>12</ArmorRating_Blunt>
       </value>
     </li>
     
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>3</ArmorRating_Sharp>
+        <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
     
@@ -473,8 +487,8 @@
       <value>
         <statBases>
           <MoveSpeed>4.0</MoveSpeed>
-          <ArmorRating_Blunt>12</ArmorRating_Blunt>
-          <ArmorRating_Sharp>6</ArmorRating_Sharp>
+          <ArmorRating_Blunt>16</ArmorRating_Blunt>
+          <ArmorRating_Sharp>8</ArmorRating_Sharp>
           <ComfyTemperatureMin>-40</ComfyTemperatureMin>
           <MarketValue>1000</MarketValue>
           <LeatherAmount>0</LeatherAmount>
@@ -637,14 +651,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/race/baseBodySize</xpath>
       <value>
-        <baseBodySize>2</baseBodySize>
+        <baseBodySize>20</baseBodySize>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/race/baseHealthScale</xpath>
       <value>
-        <baseHealthScale>2.4</baseHealthScale>
+        <baseHealthScale>6</baseHealthScale>
       </value>
     </li>
 

--- a/Patches/Vanilla Animals Expanded/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Caves_Animals.xml
@@ -52,14 +52,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>2</ArmorRating_Blunt>
+        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>1</ArmorRating_Sharp>
+        <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
       </value>
     </li>
 
@@ -145,13 +145,6 @@
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
         </li>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2</baseHealthScale>
       </value>
     </li>
     
@@ -483,21 +476,25 @@
     </li>
 
     <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Blunt</xpath>
+      <value>
+        <ArmorRating_Blunt>16</ArmorRating_Blunt>
+      </value>
+    </li>
+    
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Sharp</xpath>
+      <value>
+        <ArmorRating_Sharp>8</ArmorRating_Sharp>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases</xpath>
       <value>
-        <statBases>
-          <MoveSpeed>4.0</MoveSpeed>
-          <ArmorRating_Blunt>16</ArmorRating_Blunt>
-          <ArmorRating_Sharp>8</ArmorRating_Sharp>
-          <ComfyTemperatureMin>-40</ComfyTemperatureMin>
-          <MarketValue>1000</MarketValue>
-          <LeatherAmount>0</LeatherAmount>
-          <ToxicSensitivity>0</ToxicSensitivity>
-          <ComfyTemperatureMax>60</ComfyTemperatureMax>
           <MeleeDodgeChance>0.25</MeleeDodgeChance>
           <MeleeCritChance>0.75</MeleeCritChance>
           <MeleeParryChance>0.5</MeleeParryChance>
-        </statBases>
       </value>
     </li>
 
@@ -648,20 +645,6 @@
     </li>
 
     <!-- === Wyrm === -->
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>20</baseBodySize>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>6</baseHealthScale>
-      </value>
-    </li>
-
     <li Class="PatchOperationAddModExtension">
       <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]</xpath>
       <value>
@@ -672,22 +655,25 @@
     </li>
 
     <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Blunt</xpath>
+      <value>
+        <ArmorRating_Blunt>8</ArmorRating_Blunt>
+      </value>
+    </li>
+    
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Sharp</xpath>
+      <value>
+        <ArmorRating_Sharp>6</ArmorRating_Sharp>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases</xpath>
       <value>
-      <statBases>
-        <MoveSpeed>5.8</MoveSpeed>
-        <ComfyTemperatureMin>-40</ComfyTemperatureMin>			
-        <Flammability>0</Flammability>
-        <MarketValue>2400</MarketValue>
-        <ArmorRating_Blunt>.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>.45</ArmorRating_Sharp>
-        <ArmorRating_Heat>1.5</ArmorRating_Heat>
-        <FilthRate>8</FilthRate>
-        <CaravanRidingSpeedFactor>1.8</CaravanRidingSpeedFactor>
         <MeleeDodgeChance>0.4</MeleeDodgeChance>
         <MeleeCritChance>0.33</MeleeCritChance>
         <MeleeParryChance>0.25</MeleeParryChance>
-      </statBases>
       </value>
     </li>
 


### PR DESCRIPTION
## Changes
- Misc. formatting and housekeeping to improve readability.
- Change Wyverns from QuadrupedLow to Birdlike bodyshape.
- Fix damage type for Acid Spit projectile.

Closes #1257 

## Reasoning
Wyverns separate front legs, ambling around on two back legs and the "elbows" of their wings when on the ground, but are still generally laid-out similar to other dragons.

## Alternatives
Could leave it all as-is, I suppose.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
