### PR TITLE
RimAtomics Patch

### DIFF
--- a/Patches/Dubs Rimatomics/Apparel_Atomic.xml
+++ b/Patches/Dubs Rimatomics/Apparel_Atomic.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Armour Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Radiation Suits === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[@Name="RadSuitBodyBase" or defName = "Apparel_RadiationSuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase" or defName = "Apparel_RadiationSuit"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>4</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.65</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- === Radiation Masks === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[@Name="RadSuitMaskBase"]/equippedStatOffsets</xpath>
+				<value>
+					<AimingAccuracy>-0.1</AimingAccuracy>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[@Name="RadSuitMaskBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.ApparelHediffExtension">
+						<hediff>WearingGasMask</hediff>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
+					<Bulk>4</Bulk>
+					<WornBulk>1.5</WornBulk>						
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+					<Bulk>7</Bulk>
+					<WornBulk>2</WornBulk>	
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1.25</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Dubs Rimatomics/Apparel_Atomic.xml
+++ b/Patches/Dubs Rimatomics/Apparel_Atomic.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Vanilla Armour Expanded</li>
+			<li>Dubs Rimatomics</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
@@ -28,14 +28,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2.65</ArmorRating_Sharp>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -69,14 +69,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					<Bulk>7</Bulk>
 					<WornBulk>2</WornBulk>	
 				</value>
@@ -85,7 +85,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>1.25</ArmorRating_Blunt>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Dubs Rimatomics/Atomics_Trader.xml
+++ b/Patches/Dubs Rimatomics/Atomics_Trader.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		  <li>Dubs Rimatomics</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<li Class="PatchOperationAdd">
+        <xpath>Defs/TraderKindDef[defName="Orbital_Rimatomics"]/stockGenerators</xpath>
+        <value>
+          <li Class="StockGenerator_SingleDef">
+            <thingDef>FSX</thingDef>
+            <countRange>
+              <min>75</min>
+              <max>300</max>
+            </countRange>
+          </li>
+          <li Class="StockGenerator_SingleDef">
+            <thingDef>Prometheum</thingDef>
+            <countRange>
+              <min>75</min>
+              <max>300</max>
+            </countRange>
+          </li>
+          <li Class="StockGenerator_Tag">
+            <tradeTag>CE_Ammo</tradeTag>
+            <countRange>
+              <min>500</min>
+              <max>2000</max>
+            </countRange>
+            <thingDefCountRange>
+              <min>6</min>
+              <max>11</max>
+            </thingDefCountRange>
+          </li>
+          <li Class="StockGenerator_Tag">
+            <tradeTag>CE_HeavyAmmo</tradeTag>
+            <countRange>
+              <min>20</min>
+              <max>250</max>
+            </countRange>
+            <thingDefCountRange>
+              <min>4</min>
+              <max>7</max>
+            </thingDefCountRange>
+          </li>      
+          <li Class="StockGenerator_Category">
+            <categoryDef>Ammo</categoryDef>
+            <thingDefCountRange>
+              <min>0</min>
+              <max>0</max>
+            </thingDefCountRange>
+          </li>
+          <li Class="StockGenerator_Tag">
+            <tradeTag>CE_Turret</tradeTag>
+            <thingDefCountRange>
+              <min>-2</min>
+              <max>4</max>
+            </thingDefCountRange>
+            <countRange>
+              <min>1</min>
+              <max>2</max>
+            </countRange>
+          </li>
+          <li Class="StockGenerator_Category">
+            <categoryDef>WeaponsTurrets</categoryDef>
+            <thingDefCountRange>
+              <min>0</min>
+              <max>0</max>
+            </thingDefCountRange>
+          </li>
+        </value>
+			</li>
+      
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Dubs Rimatomics</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+			<!--Sabots : Damage Stuff-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultDamage</xpath>
+				<value>
+					<defaultDamage>200</defaultDamage>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultArmorPenetration</xpath>
+				<value>
+					<defaultArmorPenetration>120000</defaultArmorPenetration>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultDamage</xpath>
+				<value>
+					<defaultDamage>800</defaultDamage>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultArmorPenetration</xpath>
+				<value>
+					<defaultArmorPenetration>240000</defaultArmorPenetration>
+				</value>
+			</li>
+			
+			<!--Sabots : Projectile Tweaks-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bullet_Sabot"]/projectile/speed</xpath>
+				<value>
+					<speed>700</speed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bullet_Sabot_DU"]/projectile/speed</xpath>
+				<value>
+					<speed>650</speed>
+				</value>
+			</li>
+			
+			<!--Sabots : Fire Mission Tweaks-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
+				<value>
+					<explosionDamage>Bomb_Sabot</explosionDamage>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DUSabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
+				<value>
+					<explosionDamage>Bomb_DUSabot</explosionDamage>
+				</value>
+			</li>
+			
+			<!--Marauder : Damage Stuff-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultDamage</xpath>
+				<value>
+					<defaultDamage>70</defaultDamage>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultArmorPenetration</xpath>
+				<value>
+					<defaultArmorPenetration>80</defaultArmorPenetration>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/speed</xpath>
+				<value>
+					<speed>800</speed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/damageAmountBase</xpath>
+			</li>
+			
+			<!--Marauder : Range-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/verbs/li/range</xpath>
+				<value>
+					<range>90</range>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/EnergyWep/range</xpath>
+				<value>
+					<range>90</range>
+				</value>
+			</li>
+			
+			<!--Turrets : Stats-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="PPCMarauder" or defName="PPCRailgun"]/statBases</xpath>
+				<value>
+					<ShootingAccuracyTurret>5</ShootingAccuracyTurret>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PPCMarauder"]/specialDisplayRadius</xpath>
+				<value>
+					<specialDisplayRadius>90</specialDisplayRadius>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

Patches apparel and traders of Rimatomics,
The turrets use special code to function which isn't supported by CE so, they behave like vanilla turrets but with tweaked damage values to mimic CE turrets.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (1 IRL year)
