### PR TITLE
Autocannon ammo type switch

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -140,7 +140,7 @@
         <recoilAmount>1.67</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_20x110mmHispano_FMJ</defaultProjectile>
+        <defaultProjectile>Bullet_20x102mmNATO_FMJ</defaultProjectile>
         <warmupTime>4.3</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
@@ -155,7 +155,7 @@
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>80</magazineSize>
         <reloadTime>7.8</reloadTime>
-        <ammoSet>AmmoSet_20x110mmHispano</ammoSet>
+        <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
         <aiAimMode>AimedShot</aiAimMode>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -131,8 +131,8 @@
     <statBases>
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.2</ShotSpread>
-      <SwayFactor>1.61</SwayFactor>
+      <ShotSpread>0.1</ShotSpread>
+      <SwayFactor>1.42</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
     </statBases>
     <verbs>
@@ -141,7 +141,7 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_FMJ</defaultProjectile>
-        <warmupTime>4.3</warmupTime>
+        <warmupTime>3.2</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -137,7 +137,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.67</recoilAmount>
+        <recoilAmount>1.61</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_FMJ</defaultProjectile>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -76,7 +76,7 @@
             <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
-            <recoilAmount>1.78</recoilAmount>
+            <recoilAmount>1.72</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_20x102mmNATO_FMJ</defaultProjectile>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -79,7 +79,7 @@
             <recoilAmount>1.78</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_20x110mmHispano_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_20x102mmNATO_FMJ</defaultProjectile>
             <burstShotCount>10</burstShotCount>
             <ticksBetweenBurstShots>12</ticksBetweenBurstShots>
             <warmupTime>1</warmupTime>
@@ -92,7 +92,7 @@
           <AmmoUser>
             <magazineSize>50</magazineSize>
             <reloadTime>6.5</reloadTime>
-            <ammoSet>AmmoSet_20x110mmHispano</ammoSet>
+            <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>AimedShot</aiAimMode>


### PR DESCRIPTION
## Changes

- Changed the ammo type the Autocannon uses to 20mmn NATO

## Reasoning

- Consistency

## Alternatives

- Leave the ammo type be as is


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
