### PR TITLE
Patching WindowBase

### DIFF
--- a/Patches/Windows/Openvindows.xml
+++ b/Patches/Windows/Openvindows.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Windows</li>
+		</mods>
+			<match Class="PatchOperationSequence">
+				<operations>
+					<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name = "WindowBase"]/fillPercent</xpath>
+						<value>
+							<fillPercent>0.6</fillPercent>
+						</value>
+					</li>
+				</operations>
+			</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Applying the same patch CE already does to the original mod to the Windows fork mod

## Additions

Applies the same patch CE already does for the original "[JPT] Open The Windows" to the "Windows" fork  by Owlchemist.

## Changes

Changing the fillPercent to 0.6

## Reasoning

Allow pawns to use windows to shoot. I actually thought the temperature would equalize when messing with the fillpercent, but it doesn't, respecting the mods own windows gizmo that controls wether air should pass or not.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony  for some days
