### PR TITLE
Vanilla Ideology Expanded - Dryads Patch

### DIFF
--- a/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
@@ -18,7 +18,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>VDE_AcidBolt</defaultProjectile>
-								<warmupTime>3.4</warmupTime>
+								<warmupTime>1.8</warmupTime>
 								<burstShotCount>1</burstShotCount>
 								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 								<minRange>1.9</minRange>
@@ -38,7 +38,7 @@
 								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 								<hasStandardCommand>true</hasStandardCommand>
 								<defaultProjectile>VDE_AcidBolt</defaultProjectile>
-								<warmupTime>3.2</warmupTime>
+								<warmupTime>2.0</warmupTime>
 								<burstShotCount>1</burstShotCount>
 								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 								<minRange>1.9</minRange>

--- a/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Ideology Expanded - Dryads</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ================= Setting it so that the Animal is shooting using CE code ================= -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>VDE_AcidBolt</defaultProjectile>
+								<warmupTime>3.4</warmupTime>
+								<burstShotCount>1</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<minRange>1.9</minRange>
+								<range>32</range>
+								<soundCast>VDE_AcidBolt</soundCast>
+								<muzzleFlashScale>0</muzzleFlashScale>
+								<commonality>0.8</commonality>
+							</li>
+						</verbs>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VDE_Dryad_Spitter"]/verbs</xpath>
+					<value>
+						<verbs>
+							<li Class="CombatExtended.VerbPropertiesCE">
+								<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+								<hasStandardCommand>true</hasStandardCommand>
+								<defaultProjectile>VDE_AcidBolt</defaultProjectile>
+								<warmupTime>3.2</warmupTime>
+								<burstShotCount>1</burstShotCount>
+								<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+								<minRange>1.9</minRange>
+								<range>22</range>
+								<soundCast>VDE_AcidBolt</soundCast>
+								<muzzleFlashScale>0</muzzleFlashScale>
+								<commonality>0.8</commonality>
+							</li>
+						</verbs>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectiles.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectiles.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Ideology Expanded - Dryads</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ================= Setting it so that the Animal is shooting using CE code ================= -->
+	
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="VDE_AcidBolt"]</xpath>
+							<value>
+								<thingClass>CombatExtended.BulletCE</thingClass>
+							</value>				
+						</li>
+					
+				
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VDE_AcidBolt"]/projectile</xpath>
+					<value>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<flyOverhead>false</flyOverhead>
+							<damageDef>VDE_AcidSpit</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<speed>21</speed>
+							<armorPenetrationSharp>2</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.4</armorPenetrationBlunt>
+						</projectile>
+					</value>
+				</li>
+			</operations>
+		</match>
+		
+	</Operation>
+	
+</Patch>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Ideology Expanded - Dryads</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.62</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.85</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.75</StuffPower_Armor_Heat>
+					</value>
+				</li>
+			</operations>
+		</match>
+	
+	</Operation>
+			
+</Patch>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -11,13 +11,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.62</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.4</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.85</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.085</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -23,7 +23,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
-						<StuffPower_Armor_Heat>0.3</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.01</StuffPower_Armor_Heat>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -17,7 +17,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.085</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.075</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -26,6 +26,14 @@
 						<StuffPower_Armor_Heat>0.01</StuffPower_Armor_Heat>
 					</value>
 				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/stuffProps/statFactors/MaxHitPoints</xpath>
+					<value>
+						<MaxHitPoints>1</MaxHitPoints>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Items/Items_Resource_Stuff.xml
@@ -23,7 +23,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VDE_Gaubric"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
-						<StuffPower_Armor_Heat>0.75</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.3</StuffPower_Armor_Heat>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Animal_AwakenedDryads.xml
@@ -1,0 +1,1161 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Ideology Expanded - Dryads</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Carrier"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+			
+						<!-- ======================== Awakened Carrier ========================  -->
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Carrier"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Carrier"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+			
+				<!-- ======================== Awakened Clawer ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Clawer"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Clawer"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
+						<ArmorRating_Sharp>1.12</ArmorRating_Sharp>
+						<MeleeDodgeChance>0.8</MeleeDodgeChance>
+						<MeleeCritChance>0.45</MeleeCritChance>
+						<MeleeParryChance>0.50</MeleeParryChance>
+					</value>
+				</li>
+
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Clawer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>0.96</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>24</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>5.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>8</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>0.96</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>24</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>5.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>8</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>28</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>10</armorPenetrationBlunt>
+								<armorPenetrationSharp>15</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+
+				<!-- ======================== Awakened Barkskin ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Barkskin"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Barkskin"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Barkskin"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Barkskin"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Barkskin"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+				<!-- ======================== Awakened WoodMaker ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Woodmaker"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Birdlike</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Woodmaker"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Woodmaker"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>15</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>15</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>8</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<!-- ======================== Awakened Medicinemaker ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Medicinemaker"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Medicinemaker"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Medicinemaker"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+
+				<!-- ======================== Awakened Berrymaker ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Berrymaker"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Berrymaker"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Berrymaker"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+				<!-- ======================== Awakened Stonedigger ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Stonedigger"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Stonedigger"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Stonedigger"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+				<!-- ======================== Awakened Nectarmaker ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Nectarmaker"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Nectarmaker"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Nectarmaker"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+				<!-- ======================== Awakened Spitter ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Serpentine</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]/statBases</xpath>
+					<value>
+						<AimingAccuracy>1.0</AimingAccuracy>
+						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+
+				<!-- ======================== Awakened Gaubricmaker ========================  -->
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Gaubricmaker"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+
+				<!-- Adding stats to the pawn to make sure they have them -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Gaubricmaker"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.25</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.04</MeleeParryChance>
+					</value>
+				</li>
+
+
+				<!-- Adds the combat stats that CE needs in order to work-->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Gaubricmaker"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>10</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+							</li>
+
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>2</cooldownTime>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>5</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+							</li>
+						</tools>
+					</value>
+				</li>		
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Spitter_RangedAttack.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Spitter_RangedAttack.xml
@@ -12,8 +12,6 @@
 					<value>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-						<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-						<ArmorRating_Sharp>1.12</ArmorRating_Sharp>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Spitter_RangedAttack.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/ThingDefs_Races/Races_Spitter_RangedAttack.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Ideology Expanded - Dryads</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="VDE_Dryad_Spitter"]/statBases</xpath>
+					<value>
+						<AimingAccuracy>1.0</AimingAccuracy>
+						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+						<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
+						<ArmorRating_Sharp>1.12</ArmorRating_Sharp>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions
- Made the Awakened Dryads functional in CE 
- Added range and accuracy to both ranged 'spitter' Dryads
- Changed the acid projectile to CE Projectile

## Changes

- Altered the stats of Gaubric (Fur/Leather) to bring it more in line with other materials in CE


## Reasoning

Why did you choose to implement things this way, e.g.
- Brought the mod in line with other similar mods and made it so that the new features and creatures added worked in CE

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) (About 20 Days, with both artifically spawned in and naturally spawned Dryads)
