### PR TITLE
Caulaflower melee targetting tweaks

### DIFF
--- a/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Languages/English/Keyed/Misc_Gameplay.xml
@@ -4,5 +4,6 @@
 	<DormantCompAmmoBeacon>Ready to resupply turrets</DormantCompAmmoBeacon>
 	<CE_MeleeTargetting_CurPart>Targeted bodypart:</CE_MeleeTargetting_CurPart>
 	<CE_MeleeTargetting_CurHeight>Melee attacked area</CE_MeleeTargetting_CurHeight>
+	<CE_NoBP>None</CE_NoBP>
 	
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -103,6 +103,7 @@ namespace CombatExtended
                     if (neckApparel != null && maxWeaponPen < neckApparel.GetStatValue(StatDefOf.ArmorRating_Sharp))
                     {
                         targetBodyPart = null;
+                        return BodyPartHeight.Bottom;
                     }
                     else
                     {
@@ -194,7 +195,7 @@ namespace CombatExtended
                     defaultLabel = "CE_MeleeTargetting_CurHeight".Translate() + " " + heightString,
                 };
             }
-            if (SkillReqBP)
+            if (SkillReqBP && heightInt != BodyPartHeight.Undefined)
             {
                 yield return new Command_Action
                 {

--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -180,15 +180,19 @@ namespace CombatExtended
                         {
                             case BodyPartHeight.Bottom:
                                 heightInt = BodyPartHeight.Middle;
+                                targetBodyPart = null;
                                 break;
                             case BodyPartHeight.Middle:
                                 heightInt = BodyPartHeight.Top;
+                                targetBodyPart = null;
                                 break;
                             case BodyPartHeight.Top:
                                 heightInt = BodyPartHeight.Undefined;
+                                targetBodyPart = null;
                                 break;
                             case BodyPartHeight.Undefined:
                                 heightInt = BodyPartHeight.Bottom;
+                                targetBodyPart = null;
                                 break;
                         }
                     },
@@ -200,7 +204,7 @@ namespace CombatExtended
                 yield return new Command_Action
                 {
                     icon = ContentFinder<Texture2D>.Get("UI/Buttons/TargettingMelee/Undefined"),
-                    defaultLabel = "CE_MeleeTargetting_CurPart".Translate() + " " + targetBodyPart,
+                    defaultLabel = "CE_MeleeTargetting_CurPart".Translate() + " " + (targetBodyPart?.label ?? "CE_NoBP".Translate()),
                     action = delegate
                     {
                         List<FloatMenuOption> options = new List<FloatMenuOption>();
@@ -234,6 +238,8 @@ namespace CombatExtended
                                    }
                                    ));
                         }
+
+                        options.Add(new FloatMenuOption("CE_NoBP".Translate(), delegate { targetBodyPart = null; }));
 
                         Find.WindowStack.Add(new FloatMenu(options));
                     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -435,14 +435,14 @@ namespace CombatExtended
                 switch (GetAttackedPartHeightCE())
                 {
                     case BodyPartHeight.Bottom:
-                        chance *= 0.5f;
+                        chance *= 0.8f;
                         break;
                     case BodyPartHeight.Middle:
                         break;
                     case BodyPartHeight.Undefined:
                         break;
                     case BodyPartHeight.Top:
-                        chance *= 0.3f;
+                        chance *= 0.7f;
                         break;
                 }
 


### PR DESCRIPTION
## Changes

Increased base height hit chances and improved automatic targetting


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
