### PR TITLE
Useless Clothes compatibility

### DIFF
--- a/Patches/uselessclothes/uselessclothespatch.xml
+++ b/Patches/uselessclothes/uselessclothespatch.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Useless clothes</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="woola" or defName="woolschoolpants" or defName="woolschoolskirt" or defName="woolshirtpants" or defName="wooluniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- == VAE_Apparel_Shorts, VAE_Apparel_Skirt and VAE_Apparel_TankTop == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="woolnecktie" or defName="woolbow"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>0.1</Bulk>
+						<StuffEffectMultiplierArmor>0.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<!-- == useless SuitJacket == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="woolsuitpants"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+				<!-- == useless school uniform == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="woolschooluniform_Thin"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<WornBulk>1</WornBulk>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/uselessclothes/uselessclothespatch.xml
+++ b/Patches/uselessclothes/uselessclothespatch.xml
@@ -13,7 +13,7 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Apparel_Shorts, VAE_Apparel_Skirt and VAE_Apparel_TankTop == -->
+				<!-- == Useless nooses == -->
 				<!-- statBases -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="woolnecktie" or defName="woolbow"]/statBases/StuffEffectMultiplierArmor</xpath>


### PR DESCRIPTION
## Additions

Adds compatibility with Useless Clothes which adds a bunch of useless clothes to the game, by pulling up their armor stuff value up to VE apparel standards. 

## Changes

Only adjusted stuff effect value. No other changes. 


## Reasoning

Why did you choose to implement things this way, e.g.
- I just like useless clothes. 

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
Full in game year have passed with everyone using useless clothes. No errors associated with useless clothes. 
