### PR TITLE
Compatibility for Archotech+(Continued) and Archotech Expanded

### DIFF
--- a/Patches/Archotech Expanded/AE_Hediffs_BodyParts_Prosthetics.xml
+++ b/Patches/Archotech Expanded/AE_Hediffs_BodyParts_Prosthetics.xml
@@ -35,7 +35,7 @@
 					</capacities>
 					<power>1</power>
 					<cooldownTime>0.01</cooldownTime>
-					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+					<armorPenetrationBlunt>21.5</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -46,8 +46,8 @@
 		<value>
 			<statOffsets>
 				<MeleeDodgeChance>10</MeleeDodgeChance>
-				<ArmorRating_Sharp>10</ArmorRating_Sharp>
-				<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				<ArmorRating_Blunt>21</ArmorRating_Blunt>
 				<ArmorRating_Heat>1.5</ArmorRating_Heat>
 				<GeneralLaborSpeed>10</GeneralLaborSpeed>
 			</statOffsets>

--- a/Patches/Archotech Expanded/AE_Hediffs_BodyParts_Prosthetics.xml
+++ b/Patches/Archotech Expanded/AE_Hediffs_BodyParts_Prosthetics.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Archotech Expanded</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+		
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="AdvancedArchotechArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="ArchotechObliterator"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>0.01</cooldownTime>
+					<armorPenetrationBlunt>4</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="ArchotechMembrane"]/stages/li/statOffsets</xpath>
+		<value>
+			<statOffsets>
+				<MeleeDodgeChance>10</MeleeDodgeChance>
+				<ArmorRating_Sharp>10</ArmorRating_Sharp>
+				<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				<ArmorRating_Heat>1.5</ArmorRating_Heat>
+				<GeneralLaborSpeed>10</GeneralLaborSpeed>
+			</statOffsets>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="ArchotechDeathClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>claw</label>
+					<capacities>
+						<li>Scratch</li>
+					</capacities>
+					<power>21</power>
+					<cooldownTime>0.89</cooldownTime>
+					<armorPenetrationSharp>10</armorPenetrationSharp>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</li>
+	
+		</operations>
+	</match>
+</Operation>
+</Patch>

--- a/Patches/Archotech Expanded/AE_Items_Resource_Stuff.xml
+++ b/Patches/Archotech Expanded/AE_Items_Resource_Stuff.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Archotech Expanded</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+	<!-- Atto -->
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Attomachinery"]/statBases</xpath>
+		<value>
+			<Bulk>0.03</Bulk>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Attomachinery"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Attomachinery"]/stuffProps/statFactors</xpath>
+		<value>
+			<MeleePenetrationFactor>50</MeleePenetrationFactor>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Attomachinery"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>50</StuffPower_Armor_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Attomachinery"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>50</StuffPower_Armor_Blunt>
+		</value>
+	</li>
+	
+	<!-- Pico -->
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Picomachinery"]/statBases</xpath>
+		<value>
+			<Bulk>0.03</Bulk>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Picomachinery"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Picomachinery"]/stuffProps/statFactors</xpath>
+		<value>
+			<MeleePenetrationFactor>25</MeleePenetrationFactor>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Picomachinery"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>25</StuffPower_Armor_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Picomachinery"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>25</StuffPower_Armor_Blunt>
+		</value>
+	</li>
+	
+	<!-- Nano -->
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Nanomachinery"]/statBases</xpath>
+		<value>
+			<Bulk>0.03</Bulk>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Nanomachinery"]/stuffProps/categories</xpath>
+		<value>
+			<li>Metallic_Weapon</li>
+			<li>Steeled</li>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Nanomachinery"]/stuffProps/statFactors</xpath>
+		<value>
+			<MeleePenetrationFactor>2.5</MeleePenetrationFactor>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Nanomachinery"]/statBases/StuffPower_Armor_Sharp</xpath>
+		<value>
+			<StuffPower_Armor_Sharp>2.5</StuffPower_Armor_Sharp>
+		</value>
+	</li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Nanomachinery"]/statBases/StuffPower_Armor_Blunt</xpath>
+		<value>
+			<StuffPower_Armor_Blunt>2.5</StuffPower_Armor_Blunt>
+		</value>
+	</li>
+
+		</operations>
+	</match>
+</Operation>
+</Patch>

--- a/Patches/Archotech+/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
+++ b/Patches/Archotech+/ArchotechPlus_Hediffs_BodyParts_Archotech.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Archotech+ (Continued)</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="ArchotechSubdermalArmor"]/stages</xpath>
+		<value>
+			<stages>
+				<li>
+					<minSeverity>1</minSeverity>
+					<statOffsets>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.2</ArmorRating_Heat>
+					</statOffsets>
+					<totalBleedFactor>0.8</totalBleedFactor>
+				</li>
+				<li>
+					<minSeverity>2</minSeverity>
+					<statOffsets>
+						<ArmorRating_Sharp>3</ArmorRating_Sharp>
+						<ArmorRating_Blunt>3</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.30</ArmorRating_Heat>
+					</statOffsets>
+					<totalBleedFactor>0.6</totalBleedFactor>
+					<statFactors>
+						<IncomingDamageFactor>0.9</IncomingDamageFactor>
+					</statFactors>
+				</li>
+				<li>
+					<minSeverity>3</minSeverity>
+					<statOffsets>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
+						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+						<ArmorRating_Heat>0.4</ArmorRating_Heat>
+					</statOffsets>
+					<totalBleedFactor>0.4</totalBleedFactor>
+					<statFactors>
+						<IncomingDamageFactor>0.75</IncomingDamageFactor>
+					</statFactors>
+				</li>
+			</stages>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="ArchotechCortex"]/stages/li[minSeverity=1]/statOffsets</xpath>
+		<value>
+			<Suppressability>-0.05</Suppressability>
+		</value>
+	</li>	
+	
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/HediffDef[defName="ArchotechCortex"]/stages/li[minSeverity=2]/statOffsets</xpath>
+		<value>
+			<Suppressability>-0.1</Suppressability>
+		</value>
+	</li>
+
+		</operations>
+	</match>
+</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

- Compatibility for Archotech+(Continued)
- Compatibility for Archotech Expanded

## Reasoning

- Archotech Membrane from Archotech Expanded provides comparatively less armor than in vanilla, in order to not make pawns immortal.
- Archotech Obliterator and Deathclaw arms from Archotech expanded have relatively high armor penetration in order to be viable in combat and I feel like they should be, considering their tech level.

## Alternatives

- Make the membrane as OP as vanilla.
- Make materials from Archotech Expanded unfit for making melee weapons and armor.

## Testing

- [x] Game runs without errors with and without patched mod loaded (At least any that seem related)
- [x] Tested every prosthetic and implant
- [x] Playtested a colony (~2 hours while testing materials and implants)
