### PR TITLE
Small fix for Horse Mask

### DIFF
--- a/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
+++ b/Patches/Vanilla Ideology Expanded - Hats and Rags/Apparel_Headgear.xml
@@ -67,7 +67,7 @@
         </li>
 	      
 
-        <li Class="PatchOperationAdd">
+        <li Class="PatchOperationReplace">
           <xpath>Defs/ThingDef[defName="VIEHAR_Apparel_HorseMask"]/apparel/layers</xpath>
           <value>
             <layers>


### PR DESCRIPTION
From Aquiles#4265 on discord:

> After many hours of testing, I found the error in the patch for Vanilla Ideology Expanded - Hats and Rags. The CE patch seems OK at first glance, but to make the error disappear a small change is needed: in the Apparel_Headgear file, the PatchOperation for the HorseMask should be Replace, not Add. Just in case you want to merge it to the github version.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
