### PR TITLE
.410 realism and other projectile changes

### DIFF
--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -32,6 +32,17 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45Colt410Bore_SB</defName>
+		<label>.45 Colt/.410 bore</label>
+		<ammoTypes>
+			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
+			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
+			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="45ColtBase" ParentName="SmallAmmoBase" Abstract="True">

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -98,8 +98,8 @@
 		<defName>Bullet_9x18mmMakarov_FMJ</defName>
 		<label>9mm Makarov bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -108,8 +108,8 @@
 		<defName>Bullet_9x18mmMakarov_AP</defName>
 		<label>9mm Makarov bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -118,7 +118,7 @@
 		<defName>Bullet_9x18mmMakarov_HP</defName>
 		<label>9mm Makarov bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -145,7 +145,7 @@
 		<label>.303 British bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>19</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>.303 British bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>.303 British bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>.303 British bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
 		  <armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -145,7 +145,7 @@
 		<label>5.56mm NATO bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>34.18</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>5.56mm NATO bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>34.18</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>5.56mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>9</damageAmountBase>
-		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>34.18</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -191,7 +191,7 @@
 		<label>5.56mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
-		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>34.18</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>5.56mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>7</damageAmountBase>
-		  <armorPenetrationSharp>18</armorPenetrationSharp>
+		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>44.18</armorPenetrationBlunt>
 		  <speed>277</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -145,7 +145,7 @@
 		<label>7.92mm Mauser bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>7.92mm Mauser bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>7.92mm Mauser bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>7.92x57mm Mauser bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
 		  <armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -54,7 +54,7 @@
   </ThingDef>
 
   <ThingDef ParentName="Base410BoreBullet">
-    <defName>Bullet_410Bore_Buck</defName>
+    <defName>Bullet_410Bore_Buck_SB</defName>
     <label>buckshot pellet</label>
     <graphicData>
       <texPath>Things/Projectile/Shotgun_Pellet</texPath>
@@ -66,6 +66,22 @@
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>2</armorPenetrationBlunt>
       <spreadMult>35.6</spreadMult>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Buck</defName>
+    <label>buckshot pellet</label>
+    <graphicData>
+      <texPath>Things/Projectile/Shotgun_Pellet</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>9</damageAmountBase> 
+      <pelletCount>5</pelletCount>
+      <armorPenetrationSharp>3</armorPenetrationSharp>
+      <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
+      <spreadMult>17.8</spreadMult>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -61,11 +61,11 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>9</damageAmountBase> 
+      <damageAmountBase>4</damageAmountBase> 
       <pelletCount>5</pelletCount>
-      <armorPenetrationSharp>3</armorPenetrationSharp>
-      <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
-      <spreadMult>17.8</spreadMult>
+      <armorPenetrationSharp>1</armorPenetrationSharp>
+      <armorPenetrationBlunt>2</armorPenetrationBlunt>
+      <spreadMult>35.6</spreadMult>
     </projectile>
   </ThingDef>
 

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -37,6 +37,9 @@
   <CE_Settings_ShowWebbing_Title>Show Tactical Vests</CE_Settings_ShowWebbing_Title>
   <CE_Settings_ShowWebbing_Desc>Enables / Disables the rendering of tactical vests (all pawns)</CE_Settings_ShowWebbing_Desc>
 
+  <CE_Settings_PartialStats_Title>Turn on partial armor</CE_Settings_PartialStats_Title>
+  <CE_Settings_PartialStats_Desc>When turned on some armor might have different stats on different body parts</CE_Settings_PartialStats_Desc>
+
   <!-- ========== Ammo settings ========== -->
 
   <CE_Settings_EnableAmmoSystem_Title>Enable ammunition system</CE_Settings_EnableAmmoSystem_Title>


### PR DESCRIPTION
## Additions

- Makes .410 bore garbage as it should be from a short barrel of stuff like Taurus judge. 
- Fixes one setting

## Reasoning

- .410 works like a shotgun in a pisol package in CE considering how next to no mods add .410 guns other than the Taurus Judge, while in real life it is just a bad pistol, working best with standard .45 Colt

## Alternatives

Putting up with killing bears with a taurus judge

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
