### PR TITLE
Apparel rebalanced and various tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Various.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Various.xml
@@ -24,7 +24,7 @@
       <MaxHitPoints>75</MaxHitPoints>
       <ArmorRating_Sharp>14</ArmorRating_Sharp>
       <ArmorRating_Blunt>21</ArmorRating_Blunt>
-      <Mass>12</Mass>
+      <Mass>10</Mass>
       <Bulk>5</Bulk>
       <WornBulk>3</WornBulk>
       <EquipDelay>5</EquipDelay>

--- a/Patches/Core/Storyteller/RaidStrategies.xml
+++ b/Patches/Core/Storyteller/RaidStrategies.xml
@@ -31,7 +31,7 @@
 		</value>
 	</Operation>
 -->
-	<!-- Make advanced tactics drop-in only -->
+	<!-- Make advanced tactics drop-in only
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RaidStrategyDef[defName="ImmediateAttackSmart"]/selectionWeightPerPointsCurve/points</xpath>
@@ -51,7 +51,7 @@
 				<li>0,1</li>
 			</points>
 		</value>
-	</Operation>
+	</Operation> -->
 <!--
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RaidStrategyDef[defName="ImmediateAttackSmart"]/arriveModes</xpath>
@@ -62,7 +62,7 @@
 		</value>
 	</Operation>
 -->
-	<!-- Unnerf sapper points -->
+	<!-- Unnerf sapper points 
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/RaidStrategyDef[defName="ImmediateAttackSappers"]/pointsFactorCurve/points</xpath>
@@ -71,7 +71,7 @@
 				<li>0,1</li>
 			</points>
 		</value>
-	</Operation>
+	</Operation> -->
 
 </Patch>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -166,7 +166,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakVest"]/statBases/Mass</xpath>
 		<value>
-			<Mass>13</Mass>
+			<Mass>11</Mass>
 		</value>
 	</Operation>
 
@@ -234,7 +234,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_FlakJacket"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<Bulk>5</Bulk>
-			<WornBulk>5</WornBulk>
+			<WornBulk>2.5</WornBulk>
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>
@@ -320,10 +320,17 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/statBases/Mass</xpath>
+		<value>
+			<Mass>2.5</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<Bulk>4</Bulk>
-			<WornBulk>4</WornBulk>
+			<WornBulk>2.5</WornBulk>
 			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 			<ArmorRating_Sharp>2</ArmorRating_Sharp>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -431,14 +431,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.1</baseBodySize>
+			<baseBodySize>1.8</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>1</baseHealthScale>
+			<baseHealthScale>1.6</baseHealthScale>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -431,14 +431,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseBodySize</xpath>
 		<value>
-			<baseBodySize>1.8</baseBodySize>
+			<baseBodySize>1.1</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseHealthScale</xpath>
 		<value>
-			<baseHealthScale>1.6</baseHealthScale>
+			<baseHealthScale>1</baseHealthScale>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -805,7 +805,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Horse"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>5</MoveSpeed>
+			<MoveSpeed>6</MoveSpeed>
 			<MeleeDodgeChance>0.11</MeleeDodgeChance>
 			<MeleeCritChance>0.30</MeleeCritChance>
 			<MeleeParryChance>0.19</MeleeParryChance>

--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -112,6 +112,30 @@
 				</value>
 			</li>
 
+			<!-- == Ranged Shield Pack == -->
+
+			<Operation Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</Operation>
+
+			<Operation Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases/EnergyShieldRechargeRate</xpath>
+				<value>
+					<EnergyShieldRechargeRate>0.195</EnergyShieldRechargeRate>
+				</value>
+			</Operation>
+
+			<Operation Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases/EnergyShieldEnergyMax</xpath>
+				<value>
+					<EnergyShieldEnergyMax>1.35</EnergyShieldEnergyMax>
+				</value>
+			</Operation>
+
 			<!-- == Mini-Turret Pack == -->
 
 			<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -114,27 +114,27 @@
 
 			<!-- == Ranged Shield Pack == -->
 
-			<Operation Class="PatchOperationAdd">
+			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases</xpath>
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>2</WornBulk>
 				</value>
-			</Operation>
+			</li>
 
-			<Operation Class="PatchOperationReplace">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases/EnergyShieldRechargeRate</xpath>
 				<value>
 					<EnergyShieldRechargeRate>0.195</EnergyShieldRechargeRate>
 				</value>
-			</Operation>
+			</li>
 
-			<Operation Class="PatchOperationReplace">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAEA_Apparel_RangedShieldBelt"]/statBases/EnergyShieldEnergyMax</xpath>
 				<value>
 					<EnergyShieldEnergyMax>1.35</EnergyShieldEnergyMax>
 				</value>
-			</Operation>
+			</li>
 
 			<!-- == Mini-Turret Pack == -->
 


### PR DESCRIPTION
## Additions

- Patched the ranged shield belts from VAE-Accessories that were somehow left out in the process, based on the patched vanilla shield belts

## Changes

- Rebalanced weight and worn bulk of flak pants, worn bulk of flak jackets and weight of composite and armor vests
- Adjusted the move speed of horses to make em more useful
- Removed the raid strategy tweaks made by CE, since 2 years ago there have been significant changes in raid strategy balance made in vanilla game which our patches screw with that.

## Reasoning

- Balance reasons.

## Alternatives

- None.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors