### PR TITLE
Added bipods to Kniper and Scoped Pistol from Cursed Guns mod

### DIFF
--- a/Patches/Cursed Guns/CursedGuns.xml
+++ b/Patches/Cursed Guns/CursedGuns.xml
@@ -1101,6 +1101,7 @@
 		<weaponTags>
 			<li>CE_Sidearm</li>
 			<li>CE_AI_BROOM</li>
+			<li>Bipod_DMR</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</li>
@@ -1330,6 +1331,7 @@
 			<aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
 		<weaponTags>
+			<li>Bipod_DMR</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 	</li>


### PR DESCRIPTION
## Changes

- The weapons that have bipods in the texture now have a functioning bipod

## Reasoning

- It is present in the sprite, so it probably should be present mechanically

## Testing

- [X] Game runs without errors
- [X] Tested that the bipods work
