### PR TITLE
Fix missing melee tools for grenades

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -27,6 +27,18 @@
     </comps>
     <alwaysHaulable>true</alwaysHaulable>
     <tickerType>Never</tickerType>
+    <tools>
+      <li Class="CombatExtended.ToolCE">
+        <label>Body</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>5</power>
+        <cooldownTime>1.75</cooldownTime>
+        <armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+        <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+      </li>
+    </tools>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="BaseGrenadeEquipment" ParentName="BaseEquipment" Abstract="True">

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -33,9 +33,9 @@
         <capacities>
           <li>Blunt</li>
         </capacities>
-        <power>5</power>
+        <power>2</power>
         <cooldownTime>1.75</cooldownTime>
-        <armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+        <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
         <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
       </li>
     </tools>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -16,6 +16,26 @@
 		</xpath>
 	</Operation> -->
 
+	<!-- ========== Melee tools ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]</xpath>
+		<value>
+			<tools>
+			  <li Class="CombatExtended.ToolCE">
+				<label>Body</label>
+				<capacities>
+				  <li>Blunt</li>
+				</capacities>
+				<power>5</power>
+				<cooldownTime>1.75</cooldownTime>
+				<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+			  </li>
+			</tools>
+		</value>
+	</Operation>
+
 	<!-- ========== Base Grenade Projectile ========== -->
 
 	<Operation Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -27,9 +27,9 @@
 				<capacities>
 				  <li>Blunt</li>
 				</capacities>
-				<power>5</power>
+				<power>2</power>
 				<cooldownTime>1.75</cooldownTime>
-				<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
 			  </li>
 			</tools>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -40,10 +40,10 @@
       </AmmoUser>      
       <FireModes>
         <aiAimMode>AimedShot</aiAimMode>
-		    <aimedBurstShotCount>5</aimedBurstShotCount>
+		<aimedBurstShotCount>5</aimedBurstShotCount>
       </FireModes>
     </li>
-	
+        <!-- === Tools === -->
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Gun_CombatMechanoidGun"]/tools</xpath>
       <value>
@@ -61,8 +61,9 @@
         </tools>
       </value>
     </li>
-      
-      <!-- === VFE Handheld Autocannon === -->
+
+    <!-- ========== VFE Handheld Autocannon ========== -->
+
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
       <defName>VFE_Gun_RaiderMechanoidGun</defName>
       <statBases>
@@ -95,7 +96,6 @@
         <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiAimMode>SuppressFire</aiAimMode>
       </FireModes>
-      <AllowWithRunAndGun>false</AllowWithRunAndGun>
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
@@ -111,6 +111,64 @@
             <power>10</power>
             <cooldownTime>2.44</cooldownTime>
             <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          </li>
+        </tools>
+      </value>
+    </li>
+
+    <!-- ========== VFE Small inferno spewer ========== -->
+	  
+    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+      <defName>VFE_Gun_InfernoSpewerSmall</defName>
+      <statBases>
+        <Mass>5</Mass>
+        <Bulk>8</Bulk>
+        <SwayFactor>1.00</SwayFactor>
+        <ShotSpread>0.5</ShotSpread>
+        <SightsEfficiency>1.0</SightsEfficiency>
+        <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <recoilAmount>0</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>15</range>
+        <minRange>2</minRange>
+        <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+        <burstShotCount>3</burstShotCount>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
+        <soundCast>HissFlamethrower</soundCast>
+        <muzzleFlashScale>2</muzzleFlashScale>
+      </Properties>
+      <AmmoUser>
+        <magazineSize>60</magazineSize>
+        <reloadTime>5</reloadTime>
+      </AmmoUser>
+      <FireModes>
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aiAimMode>SuppressFire</aiAimMode>
+        <noSingleShot>true</noSingleShot>
+      </FireModes>
+    </li>
+        <!-- === Tools === -->
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[@Name = "VFE_Gun_InfernoSpewerBase"]/tools
+      </xpath>
+      <value>
+        <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>barrel</label>
+            <capacities>
+              <li>Blunt</li>
+            </capacities>
+            <power>8</power>
+            <cooldownTime>2.24</cooldownTime>
+            <armorPenetrationBlunt>2.7</armorPenetrationBlunt>
             <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
           </li>
         </tools>


### PR DESCRIPTION
## Changes

- Fixed and gave melee tools to all grenade types to stop them from throwing red errors when used as a melee weapons in melee combat 
- Made Pyro Mech from VFE-Mechanoids use normal flamethrower projectile

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
