### PR TITLE
Doom factions patch tweaks

### DIFF
--- a/Patches/Doom Factions/DoomFactions_Weapons.xml
+++ b/Patches/Doom Factions/DoomFactions_Weapons.xml
@@ -162,30 +162,30 @@
             <Mass>6</Mass>
             <Bulk>12.20</Bulk>
             <SwayFactor>1.26</SwayFactor>
-            <ShotSpread>0.05</ShotSpread>
+            <ShotSpread>0.02</ShotSpread>
             <SightsEfficiency>1.1</SightsEfficiency>
-            <RangedWeapon_Cooldown>3.0</RangedWeapon_Cooldown>
+            <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
           </statBases>
           <costList>
             <Steel>200</Steel>
-            <ComponentIndustrial>5</ComponentIndustrial>
+            <ComponentIndustrial>7</ComponentIndustrial>
           </costList>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_556x45mmNATO_AP</defaultProjectile>
-            <burstShotCount>5</burstShotCount>
-            <ticksBetweenBurstShots>9</ticksBetweenBurstShots>
-            <warmupTime>1.0</warmupTime>
-            <range>60</range>
+            <defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+            <burstShotCount>10</burstShotCount>
+            <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+            <warmupTime>1.1</warmupTime>
+            <range>75</range>
             <soundCast>Fire_UACHeavyAssaultRifle</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>12</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>120</magazineSize>
+            <magazineSize>90</magazineSize>
             <reloadTime>7.8</reloadTime>
-            <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+            <ammoSet>AmmoSet_50BMG</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>SuppressFire</aiAimMode>

--- a/Patches/Doom Factions/DoomFactions_Weapons.xml
+++ b/Patches/Doom Factions/DoomFactions_Weapons.xml
@@ -234,10 +234,10 @@
           <AmmoUser>
             <magazineSize>300</magazineSize>
             <reloadTime>9.2</reloadTime>
-            <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+            <ammoSet>AmmoSet_338Norma</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aiAimMode>AimedShot</aiAimMode>
+            <aiAimMode>SuppressFire</aiAimMode>
           </FireModes>
           <weaponTags>
             <li>UAC_Sheperd</li>

--- a/Patches/Doom Factions/DoomFactions_Weapons.xml
+++ b/Patches/Doom Factions/DoomFactions_Weapons.xml
@@ -158,17 +158,18 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>UAC_HeavyAssaultRifle</defName>
           <statBases>
-            <WorkToMake>80000</WorkToMake>
-            <Mass>6</Mass>
-            <Bulk>12.20</Bulk>
-            <SwayFactor>1.26</SwayFactor>
-            <ShotSpread>0.02</ShotSpread>
-            <SightsEfficiency>1.1</SightsEfficiency>
-            <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+            <WorkToMake>59000</WorkToMake>
+            <Mass>10</Mass>
+            <Bulk>18.32</Bulk>
+            <SwayFactor>2.65</SwayFactor>
+            <ShotSpread>0.04</ShotSpread>
+            <SightsEfficiency>2.12</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
           </statBases>
           <costList>
-            <Steel>200</Steel>
-            <ComponentIndustrial>7</ComponentIndustrial>
+            <Steel>110</Steel>
+			<Plasteel>40</Plasteel>			  
+            <ComponentIndustrial>11</ComponentIndustrial>
           </costList>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -176,14 +177,15 @@
             <defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
             <burstShotCount>10</burstShotCount>
             <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-            <warmupTime>1.1</warmupTime>
+            <warmupTime>1.2</warmupTime>
             <range>75</range>
+			<recoilAmount>2.75</recoilAmount>						
             <soundCast>Fire_UACHeavyAssaultRifle</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
-            <muzzleFlashScale>12</muzzleFlashScale>
+            <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>90</magazineSize>
+            <magazineSize>100</magazineSize>
             <reloadTime>7.8</reloadTime>
             <ammoSet>AmmoSet_50BMG</ammoSet>
           </AmmoUser>

--- a/Patches/Doom Factions/DoomFactions_Weapons.xml
+++ b/Patches/Doom Factions/DoomFactions_Weapons.xml
@@ -15,10 +15,10 @@
                 <capacities>
                   <li>Blunt</li>
                 </capacities>
-                <power>2</power>
-                <cooldownTime>1.54</cooldownTime>
+                <power>6</power>
+                <cooldownTime>1.55</cooldownTime>
                 <chanceFactor>1.5</chanceFactor>
-                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
                 <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
               </li>
               <li Class="CombatExtended.ToolCE">
@@ -26,9 +26,9 @@
                 <capacities>
                   <li>Poke</li>
                 </capacities>
-                <power>2</power>
-                <cooldownTime>1.54</cooldownTime>
-                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                <power>8</power>
+                <cooldownTime>1.55</cooldownTime>
+                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
                 <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
               </li>
             </tools>


### PR DESCRIPTION
## Additions
- None

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Weapon stat changes to the UAC Heavy Assault Rifle
- UAC Heavy Assault Rifle (HAR) ammo type changed from 5.56 to .50BMG
- UAC Chaingun ammo type changed from 5.56 to .338 Norma 
- Weapon melee stats buffed

## Reasoning

Why did you choose to implement things this way, e.g.
- UAC HAR used to use .50BMG before the Doom Factions - Continued patch was merged
  - Out of game lore - the HAR fires .50BMG
- Chaingun ammo changed to .338 Norma to keep pace with HAR
- Melee stats in prior patches used to be split/separate by different weapon groups, which was simplified in the Doom Factions - Continued patch

## Alternatives

Describe alternative implementations you have considered, e.g.
- Chaingun ammo type changed back to .50BMG, but I wanted a pawn to be able to carry more ammo
- Chaingun firing 5.56 didn't feel as DOOM-like (overpowered)

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
