### PR TITLE
Flamethrower spread broadening

### DIFF
--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -64,7 +64,7 @@
 		<li>Incendiary mortar shells will airburst and set fire to large areas.</li>
 		<li>Prometheum is a self-igniting liquid that sticks to surfaces and is impossible to extinguish without firefoam.</li>
 		<li>It's not just carried items that count against your colonists' carry weight. Clothes and armor slow them down too.</li>
-		<li>Colonists wearing bulky clothing or carrying bulky equipment will work more slowly.</li>
+		<li>Colonists wearing bulky clothing or carrying bulky equipment will work more slowly and be less effective in melee combat.</li>
 		<li>Certain guns like machine guns and sniper rifles have bipods built into them for you to take advantage of. Beware that while guns can be fired without setting up their bipods, they will suffer a penalty to their accuracy.</li>
 
 	  <!-- Features -->

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -125,7 +125,7 @@
         <Mass>5</Mass>
         <Bulk>8</Bulk>
         <SwayFactor>1.00</SwayFactor>
-        <ShotSpread>0.5</ShotSpread>
+        <ShotSpread>5.0</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>
         <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
       </statBases>
@@ -138,7 +138,7 @@
         <range>15</range>
         <minRange>2</minRange>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-        <burstShotCount>3</burstShotCount>
+        <burstShotCount>5</burstShotCount>
         <targetParams>
           <canTargetLocations>true</canTargetLocations>
         </targetParams>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -221,13 +221,13 @@
           <statBases>
             <Bulk>20</Bulk>
             <SwayFactor>2.10</SwayFactor>
-            <ShotSpread>0.70</ShotSpread>
+            <ShotSpread>3.00</ShotSpread>
             <SightsEfficiency>0.65</SightsEfficiency>
             <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-            <recoilAmount>0.85</recoilAmount>
+            <recoilAmount>0.55</recoilAmount>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
             <burstShotCount>20</burstShotCount>


### PR DESCRIPTION
## Changes

- Increased the inherent projectile spread of Warcasket and Pyro mechanoid flamethrowers

## Reasoning

- Flamethrowers shoot a stream of fire currently which said stream can easily miss the intended target, increasing the spread of the fire that is shot enables flamethrowers to be more useful in area suppression and target immolation

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors