### PR TITLE
Fix melee targeting throwing errors for human-like animals

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -67,23 +67,27 @@ namespace CombatExtended
                 //just in case of attacking some weird creature
                 if (torso != null)
                 {
-                    var torsoApparel = target.apparel.WornApparel.FindAll(x => x.def.apparel.CoversBodyPart(torso));
-
-                    float overallRHA = 0f;
-
-                    if (!torsoApparel.NullOrEmpty())
+                    var apparelTracker = target.apparel;
+                    if (apparelTracker != null)
                     {
-                        foreach (Apparel apparel in torsoApparel)
+                        var torsoApparel = apparelTracker.WornApparel.FindAll(x => x.def.apparel.CoversBodyPart(torso));
+
+                        float overallRHA = 0f;
+
+                        if (!torsoApparel.NullOrEmpty())
                         {
-                            if (apparel != null)
+                            foreach (Apparel apparel in torsoApparel)
                             {
-                                overallRHA += apparel.GetStatValue(StatDefOf.ArmorRating_Sharp);
+                                if (apparel != null)
+                                {
+                                    overallRHA += apparel.GetStatValue(StatDefOf.ArmorRating_Sharp);
+                                }
                             }
                         }
-                    }
-                    if (maxWeaponPen < overallRHA)
-                    {
-                        return BodyPartHeight.Top;
+                        if (maxWeaponPen < overallRHA)
+                        {
+                            return BodyPartHeight.Top;
+                        }
                     }
                 }
 
@@ -98,16 +102,20 @@ namespace CombatExtended
 
                 if (neck != null)
                 {
-                    var neckApparel = target.apparel.WornApparel.Find(x => x.def.apparel.CoversBodyPart(neck));
+                    var apparelTracker = target.apparel;
+                    if (apparelTracker != null)
+                    {
+                        var neckApparel = apparelTracker.WornApparel.Find(x => x.def.apparel.CoversBodyPart(neck));
 
-                    if (neckApparel != null && maxWeaponPen < neckApparel.GetStatValue(StatDefOf.ArmorRating_Sharp))
-                    {
-                        targetBodyPart = null;
-                        return BodyPartHeight.Bottom;
-                    }
-                    else
-                    {
-                        targetBodyPart = neck.def;
+                        if (neckApparel != null && maxWeaponPen < neckApparel.GetStatValue(StatDefOf.ArmorRating_Sharp))
+                        {
+                            targetBodyPart = null;
+                            return BodyPartHeight.Bottom;
+                        }
+                        else
+                        {
+                            targetBodyPart = neck.def;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Additions
- Add two null checks for the apparel tracker of the target.

## Reasoning
- Animals don't have an apparel tracker, therefore when the code tries to check for worn apparel, it throws a "NullReferenceException" error.

## Testing
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
