### PR TITLE
Paniel the Automata Patch

### DIFF
--- a/Patches/Heyra the Horned/Bodydef/Heyra_Bodytype.xml
+++ b/Patches/Heyra the Horned/Bodydef/Heyra_Bodytype.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Heyra the Horned</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			<!--Arm Groups-->
+		
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="HeyraBody"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
+				<value>
+				  <li>LeftArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="HeyraBody"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
+				<value>
+				  <li>RightArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="HeyraBody"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+				<value>
+				  <li>LeftShoulder</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="HeyraBody"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+				<value>
+				  <li>RightShoulder</li>
+				</value>
+			</li>
+		
+			<!--Natural Armor-->
+			<li Class="PatchOperationAdd">
+			  <xpath>
+				/Defs/BodyDef[defName="HeyraBody"]//*[
+				def="Torso" or
+				def="Neck" or
+				def="Head" or
+				def="Heyra_Horn" or
+				def="Nose" or
+				def="Jaw" or
+				def="Ear" or
+				def="Shoulder" or
+				def="Arm" or
+				def="Hand" or
+				def="Finger" or
+				def="Leg" or
+				def="Foot" or
+				def="Toe"]/groups
+			  </xpath>
+
+			  <value>
+				<li>CoveredByNaturalArmor</li>
+			  </value>
+			</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -1,0 +1,827 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	  <Operation Class="PatchOperationFindMod">
+			
+		<mods><li>Paniel the Automata</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<!-- ==================== Shells ========================== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<ThingCategoryDef>
+						<defName>AmmoPanielHowitzerShells</defName>
+						<label>Paniel Howitzer shell</label>
+						<parent>AmmoShells</parent>
+						<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
+					</ThingCategoryDef>
+
+					<!-- ==================== AmmoSet ========================== -->
+
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_PanielHowitzerShell</defName>
+						<label>Paniel Howitzer shells</label>
+						<ammoTypes>
+							<Ammo_PanielHowitzerShell_HE>Bullet_PanielHowitzerShell_HE</Ammo_PanielHowitzerShell_HE>
+							<Ammo_PanielHowitzerShell_Incendiary>Bullet_PanielHowitzerShell_Incendiary</Ammo_PanielHowitzerShell_Incendiary>
+							<Ammo_PanielHowitzerShell_EMP>Bullet_PanielHowitzerShell_EMP</Ammo_PanielHowitzerShell_EMP>
+							<Ammo_PanielHowitzerShell_Smoke>Bullet_PanielHowitzerShell_Smoke</Ammo_PanielHowitzerShell_Smoke>
+							<Ammo_PanielHowitzerShell_Firefoam>Bullet_PanielHowitzerShell_Firefoam</Ammo_PanielHowitzerShell_Firefoam>
+							<Ammo_PanielHowitzerShell_AP>Bullet_PanielHowitzerShell_AP</Ammo_PanielHowitzerShell_AP>
+						</ammoTypes>
+						<isMortarAmmoSet>true</isMortarAmmoSet>		
+					</CombatExtended.AmmoSetDef>
+
+					<!-- ==================== Ammo ========================== -->
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_HE</defName>
+						<label>Paniel Howitzer shell (HE)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellHE</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>233.6</MarketValue>
+						</statBases>
+						<ammoClass>GrenadeHE</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_HE</detonateProjectile>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_Incendiary</defName>
+						<label>Paniel Howitzer shell (Incendiary)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellIN</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>187.76</MarketValue>
+						</statBases>
+						<ammoClass>GrenadeIncendiary</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_Incendiary</detonateProjectile>
+					</ThingDef>	
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_EMP</defName>
+						<label>Paniel Howitzer shell (EMP)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellEM</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>375.52</MarketValue>
+						</statBases>
+						<ammoClass>GrenadeEMP</ammoClass>
+					</ThingDef>
+
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_Smoke</defName>
+						<label>Paniel Howitzer shell (Smoke)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellSM</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>177.6</MarketValue>
+						</statBases>
+						<ammoClass>Smoke</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_Smoke</detonateProjectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_Firefoam</defName>
+						<label>Paniel Howitzer shell (Foam)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellFF</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>191.76</MarketValue>
+						</statBases>
+						<ammoClass>FoamFuel</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_Firefoam</detonateProjectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_AP</defName>
+						<label>Paniel Howitzer shell (AP)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellAP</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>144.04</MarketValue>
+						</statBases>
+						<ammoClass>GrenadeHE</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_AP</detonateProjectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielHowitzerShell_Anti</defName>
+						<label>Paniel Howitzer shell (Anti)</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellAG</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						  <li>CE_AutoEnableTrade_Sellable</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>1500</MarketValue>
+						</statBases>
+						<ammoClass>Antigrain</ammoClass>
+						<detonateProjectile>Bullet_PanielHowitzerShell_Anti</detonateProjectile>
+					</ThingDef>
+
+					<!-- ================== Projectiles ================== -->
+
+					<ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_HE</defName>
+						<label>Paniel Howitzer shell (HE)</label>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/HE</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Bullet_60mmMortarPaniel_HE>8</Bullet_60mmMortarPaniel_HE>
+								</fragments>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_Incendiary</defName>
+						<label>Paniel Howitzer shell (Incendiary)</label>
+						<graphicData>
+						  <texPath>Things/Projectile/Cannon/Howitzer/INC</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Bullet_60mmMortarPaniel_Incendiary>8</Bullet_60mmMortarPaniel_Incendiary>
+								</fragments>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_EMP</defName>
+						<label>Paniel Howitzer shell (EMP)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/EMP</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Bullet_60mmMortarPaniel_EMP>8</Bullet_60mmMortarPaniel_EMP>
+								</fragments>
+							</li>
+						</comps>
+					</ThingDef>
+
+					<ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_Smoke</defName>
+						<label>Paniel Howitzer shell (Smoke)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/SMK</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Bullet_60mmMortarPaniel_Smoke>8</Bullet_60mmMortarPaniel_Smoke>
+								</fragments>
+							</li>
+						</comps>
+					  </ThingDef>
+					  
+					  <ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_Firefoam</defName>
+						<label>Paniel Howitzer shell (Foam)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/SMK</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>5</damageAmountBase>
+							<explosionRadius>0.5</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Bullet_60mmMortarPaniel_Firefoam>8</Bullet_60mmMortarPaniel_Firefoam>
+								</fragments>
+							</li>
+						</comps>
+					  </ThingDef>
+					  
+					  <ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_AP</defName>
+						<label>Paniel Howitzer shell (AP)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/IILUM</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Bomb</damageDef>
+							<damageAmountBase>1050</damageAmountBase>
+							<explosionRadius>1</explosionRadius>
+							<soundExplode>MortarBomb_Explode</soundExplode>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						</projectile>
+						<comps>
+							<li Class="CombatExtended.CompProperties_Fragments">
+								<fragments>
+									<Fragment_Large>30</Fragment_Large>
+									<Fragment_Small>50</Fragment_Small>
+								</fragments>
+							</li>
+						</comps>
+					  </ThingDef>
+					  
+					  <ThingDef ParentName="Base105mmHowitzerShell">
+						<defName>Bullet_PanielHowitzerShell_Anti</defName>
+						<label>Paniel Howitzer shell (AP)</label>
+						<graphicData>
+							<texPath>Things/Projectile/Cannon/Howitzer/ANTI</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageDef>Bomb</damageDef>
+						  <damageAmountBase>800</damageAmountBase>
+						  <explosionRadius>50</explosionRadius>
+						  <explosionChanceToStartFire>0.22</explosionChanceToStartFire>
+						  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						  <flyOverhead>true</flyOverhead>
+						  <explosionEffect>GiantExplosion</explosionEffect>
+						  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+						  <soundExplode>Explosion_GiantBomb</soundExplode>
+						  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+						  <soundAmbient>MortarRound_Ambient</soundAmbient>
+						</projectile>
+					  </ThingDef>
+
+					<!-- ==================== Cluster ========================== -->
+					
+					<ThingDef ParentName="Base60mmMortarShell">
+					<defName>Bullet_60mmMortarPaniel_HE</defName>
+					<label>60mm mortar shell (HE)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/HE</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>9</speed>
+					  <gravityFactor>5</gravityFactor>
+					  <damageDef>Bomb</damageDef>
+					  <explosionRadius>2</explosionRadius>	  
+					  <damageAmountBase>76</damageAmountBase>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <flyOverhead>true</flyOverhead>
+					  <soundExplode>MortarBomb_Explode</soundExplode>
+					  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					  <ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+					<comps>
+					  <li Class="CombatExtended.CompProperties_Fragments">
+						<fragments>
+						  <Fragment_Large>6</Fragment_Large>
+						  <Fragment_Small>31</Fragment_Small>
+						</fragments>
+					  </li>
+					</comps>
+					</ThingDef>
+
+					<ThingDef ParentName="Base60mmMortarShell">
+					<defName>Bullet_60mmMortarPaniel_Incendiary</defName>
+					<label>60mm mortar shell (Incendiary)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/Incendiary</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>9</speed>
+					  <gravityFactor>5</gravityFactor>
+					  <damageDef>PrometheumFlame</damageDef>
+					  <damageAmountBase>0</damageAmountBase>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <explosionRadius>4.5</explosionRadius>
+					  <flyOverhead>true</flyOverhead>
+					  <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+					  <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+					  <soundExplode>MortarIncendiary_Explode</soundExplode>
+					</projectile>
+					</ThingDef>
+
+					<ThingDef ParentName="Base60mmMortarShell">
+					<defName>Bullet_60mmMortarPaniel_EMP</defName>
+					<label>60mm mortar shell (EMP)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/EMP</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>9</speed>
+					  <gravityFactor>5</gravityFactor>
+					  <damageDef>EMP</damageDef>
+					  <damageAmountBase>76</damageAmountBase>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <flyOverhead>true</flyOverhead>
+					  <explosionRadius>3.5</explosionRadius>
+					</projectile>
+					</ThingDef>
+
+					<ThingDef ParentName="Base60mmMortarShell">
+					<defName>Bullet_60mmMortarPaniel_Firefoam</defName>
+					<label>60mm mortar shell (Foam)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/Firefoam</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>9</speed>
+					  <gravityFactor>5</gravityFactor>
+					  <damageDef>Extinguish</damageDef>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <explosionRadius>7</explosionRadius>
+					  <flyOverhead>true</flyOverhead>
+					  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+					  <soundExplode>Explosion_EMP</soundExplode>
+					  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+					  <soundAmbient>MortarRound_Ambient</soundAmbient>
+					  <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
+					  <postExplosionSpawnChance>1</postExplosionSpawnChance>
+					  <postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
+					  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					  <explosionEffect>ExtinguisherExplosion</explosionEffect>
+					</projectile>
+					</ThingDef>
+
+					<ThingDef ParentName="Base60mmMortarShell">
+					<defName>Bullet_60mmMortarPaniel_Smoke</defName>
+					<label>60mm mortar shell (Smoke)</label>
+					<graphicData>
+					  <texPath>Things/Projectile/Mortar/Smoke</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>9</speed>
+					  <gravityFactor>5</gravityFactor>
+					  <damageDef>Smoke</damageDef>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <explosionRadius>4.5</explosionRadius>
+					  <flyOverhead>true</flyOverhead>
+					  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+					  <soundExplode>Explosion_EMP</soundExplode>
+					  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+					  <soundAmbient>MortarRound_Ambient</soundAmbient>
+					  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+					  <preExplosionSpawnChance>1</preExplosionSpawnChance>
+					  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					  <explosionEffect>ExtinguisherExplosion</explosionEffect>
+					</projectile>
+					</ThingDef>
+					
+					<!-- ==================== Railgun Projectile ========================== -->
+					
+					<ThingDef ParentName="Base90mmCannonShell">
+						<defName>Bullet_PanielRail</defName>
+						<label>Prototype Railgun Shot</label>
+						<graphicData>
+						  <texPath>Things/Projectile/ChargeLanceShot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <speed>400</speed>
+						  <damageDef>Bullet</damageDef>
+						  <damageAmountBase>600</damageAmountBase>
+						  <soundExplode>MortarBomb_Explode</soundExplode>
+						  <armorPenetrationSharp>500</armorPenetrationSharp>
+						  <armorPenetrationBlunt>12000</armorPenetrationBlunt>
+						</projectile>
+						<comps>
+						  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+							<damageAmountBase>250</damageAmountBase>
+							<explosiveDamageType>Bomb</explosiveDamageType>
+							<explosiveRadius>1.5</explosiveRadius>
+							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						  </li>
+						</comps>
+					</ThingDef>
+					
+					<!-- ==================== Recipes ========================== -->
+					
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_HE</defName>
+						<label>make Paniel HE Howitzer shells x2</label>
+						<description>Craft 2 Paniel HE Howitzer shells.</description>
+						<jobString>Making Paniel HE Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_60mmMortar_HE</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>Shell_60mmMortar_HE</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_HE>2</Ammo_PanielHowitzerShell_HE>
+						</products>
+					</RecipeDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_Incendiary</defName>
+						<label>make Paniel Incendiary Howitzer shells x2</label>
+						<description>Craft 2 Paniel Incendiary Howitzer shells.</description>
+						<jobString>Making Paniel Incendiary Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_60mmMortar_Incendiary</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>Shell_60mmMortar_Incendiary</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_Incendiary>2</Ammo_PanielHowitzerShell_Incendiary>
+						</products>
+					</RecipeDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_EMP</defName>
+						<label>make Paniel EMP Howitzer shells x2</label>
+						<description>Craft 2 Paniel EMP Howitzer shells.</description>
+						<jobString>Making Paniel EMP Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_60mmMortar_EMP</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>Shell_60mmMortar_EMP</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_EMP>2</Ammo_PanielHowitzerShell_EMP>
+						</products>
+					</RecipeDef>
+
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_Smoke</defName>
+						<label>make Paniel Smoke Howitzer shells x2</label>
+						<description>Craft 2 Paniel Smoke Howitzer shells.</description>
+						<jobString>Making Paniel Smoke Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_60mmMortar_Smoke</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>Shell_60mmMortar_Smoke</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_Smoke>2</Ammo_PanielHowitzerShell_Smoke>
+						</products>
+					</RecipeDef>
+					
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_Firefoam</defName>
+						<label>make Paniel Firefoam Howitzer shells x2</label>
+						<description>Craft 2 Paniel firefoam Howitzer shells.</description>
+						<jobString>Making Paniel firefoam Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_60mmMortar_Firefoam</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>Shell_60mmMortar_Firefoam</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_Firefoam>2</Ammo_PanielHowitzerShell_Firefoam>
+						</products>
+					</RecipeDef>
+					
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_AP</defName>
+						<label>make Paniel AP Howitzer shells x2</label>
+						<description>Craft 2 Paniel ap Howitzer shells.</description>
+						<jobString>Making Paniel ap Howitzer shells.</jobString>
+						<workAmount>11600</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>76</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentIndustrial</li>
+									</thingDefs>
+								</filter>
+								<count>2</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>FSX</li>
+									</thingDefs>
+								</filter>
+								<count>7</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>ComponentIndustrial</li>
+								<li>FSX</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_AP>2</Ammo_PanielHowitzerShell_AP>
+						</products>
+					</RecipeDef>
+					
+					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_Anti</defName>
+						<label>make Paniel Antigrain Howitzer shell</label>
+						<description>Craft Paniel antigrain Howitzer shell.</description>
+						<jobString>Making Paniel antigrain Howitzer shell.</jobString>
+						<workAmount>1200</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_AntigrainWarhead</li>
+									</thingDefs>
+								</filter>
+								<count>16</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Shell_AntigrainWarhead</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_Anti>1</Ammo_PanielHowitzerShell_Anti>
+						</products>
+					</RecipeDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@ParentName="PN_ShellBase"]</xpath>
+			</li>
+		</operations>
+		</match>	
+	  </Operation>
+</Patch>

--- a/Patches/Paniel the Automata/Bodies/Paniel_Bodytype.xml
+++ b/Patches/Paniel the Automata/Bodies/Paniel_Bodytype.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Paniel the Automata</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			<!--Arm Groups-->
+		
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="PanielBody"]/corePart/parts/li[def="PNShoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
+				<value>
+				  <li>LeftArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="PanielBody"]/corePart/parts/li[def="PNShoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
+				<value>
+				  <li>RightArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="PanielBody"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+				<value>
+				  <li>LeftShoulder</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="PanielBody"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+				<value>
+				  <li>RightShoulder</li>
+				</value>
+			</li>
+		
+			<!--Natural Armor-->
+			<li Class="PatchOperationAdd">
+			  <xpath>
+				/Defs/BodyDef[defName="PanielBody"]//*[
+				def="PNTorso" or
+				def="PNNeck" or
+				def="PNHead" or
+				def="PNNose" or
+				def="PNJaw" or
+				def="PNEar" or
+				def="PNShoulder" or
+				def="PNArm" or
+				def="PNHand" or
+				def="PNFinger" or
+				def="PNLeg" or
+				def="PNFoot" or
+				def="PNToe" or
+				def="PNTail"]/groups
+			  </xpath>
+
+			  <value>
+				<li>CoveredByNaturalArmor</li>
+			  </value>
+			</li>
+			
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Paniel the Automata/HediffDef/Hediff.xml
+++ b/Patches/Paniel the Automata/HediffDef/Hediff.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods><li>Paniel the Automata</li></mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[
+			defName="PN_RapidFireModuleHediff"
+			]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+			  <ShootingAccuracyPawn>-0.2</ShootingAccuracyPawn>
+			  <AimingAccuracy>-0.2</AimingAccuracy>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[
+			defName="PN_CQCModuleHediff"
+			]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+			  <ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+			  <AimingAccuracy>-0.2</AimingAccuracy>
+			</value>
+		</li>
+		
+		<!-- ==========  Abilities  =========== -->
+		
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/HediffDef[defName="PN_OfficerCommand"]</xpath>
+			<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[
+					defName="PN_OfficerCommand" or
+					defName="PN_OfficerCommandBuff"
+					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+					  <ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
+					  <AimingAccuracy>0.2</AimingAccuracy>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[
+					defName="PN_RapidFire"
+					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+					  <ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+					  <AimingAccuracy>-0.4</AimingAccuracy>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[
+					defName="PN_RapidFireOverload"
+					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+					  <ShootingAccuracyPawn>-0.6</ShootingAccuracyPawn>
+					  <AimingAccuracy>-0.6</AimingAccuracy>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[
+					defName="PN_CQC" or
+					defName="PN_CQCOverload"
+					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+					  <ShootingAccuracyPawn>-0.8</ShootingAccuracyPawn>
+					  <AimingAccuracy>-0.4</AimingAccuracy>
+					</value>
+				</li>
+			</operations>
+			</match>
+		</li>
+		
+
+		
+		
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Paniel the Automata</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Base_Core"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Base_Core"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Base_Core"]/statBases/Mass</xpath>
+				<value>
+					<Mass>1000</Mass>
+				</value>
+			</li>
+			<!--
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name="PN_BaseArtilleryBuilding" ]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+			-->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Base_Core"]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Base_Core"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<!-- ==========  Paniel Cannon  =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>PN_Artillery_Turret</defName>
+				<statBases>
+					<SightsEfficiency>1.0</SightsEfficiency>
+					<ShotSpread>0.12</ShotSpread>
+					<SwayFactor>0.80</SwayFactor>
+					<Bulk>22.00</Bulk>
+					<Mass>18.50</Mass>
+					<RangedWeapon_Cooldown>1.55</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.12</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_81mmMortarShell_HE</defaultProjectile>
+					<warmupTime>8</warmupTime>
+					<minRange>32</minRange>
+					<range>700</range>
+					<soundCast>PNCannonSound</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+					<circularError>1</circularError>
+					<indirectFirePenalty>0.2</indirectFirePenalty>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>1</magazineSize>
+				  <reloadTime>7.8</reloadTime>
+				  <reloadOneAtATime>true</reloadOneAtATime>
+				  <ammoSet>AmmoSet_PanielHowitzerShell</ammoSet>
+				</AmmoUser>
+			
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Turret" ]/building/fixedStorageSettings</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Turret" ]/building/defaultStorageSettings</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Artillery_Turret" ]/comps/li[@Class="CompProperties_ChangeableProjectile"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "PN_Artillery_Turret"]/comps</xpath>
+				<value>
+				  <li Class="CombatExtended.CompProperties_Charges">
+					<chargeSpeeds>
+					  <li>30</li>
+					  <li>50</li>
+					  <li>70</li>
+					  <li>90</li>
+					</chargeSpeeds>
+				  </li>
+				</value>
+			</li>
+			 
+			 
+				<!--<FireModes>
+				  <aiAimMode>AimedShot</aiAimMode>
+				  <noSnapshot>true</noSnapshot>
+				</FireModes>-->
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Items/Items_Resources.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Items/Items_Resources.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods><li>Nyaron race</li></mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<!-- ==========  Leather  =========== -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Leather_Automaton"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<value>
+			  <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+			</value>
+		</li>
+		
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -214,12 +214,22 @@
 		
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[
-			@ParentName="PN_HatBase" or 
-			@ParentName="PN_HatBase" or
-			@ParentName="PN_RoyalApparelBase" or
-			@ParentName="PN_RoyalHatBase"]/stuffCategories/li[.="Metallic"]</xpath>
+			defName="PN_ApparelMilitia" or 
+			defName="PN_ApparelMilitiaHat" or 
+			defName="PN_ApparelSoldier" or 
+			defName="PN_ApparelSoldierHat" or 
+			defName="PN_ApparelWorker" or 
+			defName="PN_ApparelWorkerHat" or 
+			defName="PN_ApparelMaid" or 
+			defName="PN_ApparelMaidHat" or 
+			defName="PN_ApparelRoyalguard" or 
+			defName="PN_ApparelRoyalguardHat" or 
+			defName="PN_ApparelRoyalmaid" or 
+			defName="PN_ApparelRoyalmaidHat"]/stuffCategories</xpath>
 			<value>
-				<li>Steeled</li>
+				<stuffCategories>
+				  <li>Steeled</li>
+				</stuffCategories>
 			</value>
 		</li>
 		

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -212,6 +212,17 @@
 			</value>
 		</li>
 		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[
+			@ParentName="PN_HatBase" or 
+			@ParentName="PN_HatBase" or
+			@ParentName="PN_RoyalApparelBase" or
+			@ParentName="PN_RoyalHatBase"]/stuffCategories/li[.="Metallic"]</xpath>
+			<value>
+				<li>Steeled</li>
+			</value>
+		</li>
+		
 		
 	</operations>
 	</match>	

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+		
+	<mods><li>Paniel the Automata</li></mods>
+		
+	<match Class="PatchOperationSequence">
+	<operations>
+	
+		<!--========= Stuffable =========-->
+		
+		<!--Fabric-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelBasic" or defName="PN_ApparelBasicHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_ApparelCape"]/statBases</xpath>
+			<value>
+				<Bulk>4</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelCape"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<!--Metallic-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[
+			defName="PN_ApparelMilitia" or
+			defName="PN_ApparelWorker" or
+			defName="PN_ApparelMaid"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[
+			defName="PN_ApparelMilitiaHat" or
+			defName="PN_ApparelWorkerHat" or
+			defName="PN_ApparelMaidHat"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelMilitia"]/statBases/Mass</xpath>
+			<value>
+				<Mass>8</Mass>
+				<Bulk>25</Bulk>
+				<WornBulk>10</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[
+			defName="PN_ApparelWorker" or
+			defName="PN_ApparelMaid"
+			]/statBases/Mass</xpath>
+			<value>
+				<Mass>6</Mass>
+				<Bulk>25</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+		
+		<!-- Advanced -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldier"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>9</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldier"]/statBases/Mass</xpath>
+			<value>
+				<Mass>12</Mass>
+				<Bulk>28</Bulk>
+				<WornBulk>20</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldier"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			<value>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<CarryBulk>20</CarryBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldierHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldierHat"]/statBases/Mass</xpath>
+			<value>
+				<Mass>2</Mass>
+				<Bulk>2</Bulk>
+				<WornBulk>1</WornBulk>
+				<NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelSoldierHat"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<AimingAccuracy>0.1</AimingAccuracy>
+			</value>
+		</li>
+		
+		<!-- Advanced -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguard"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>12</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguard"]/statBases/Mass</xpath>
+			<value>
+				<Mass>16</Mass>
+				<Bulk>28</Bulk>
+				<WornBulk>22</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguard"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			<value>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<CarryBulk>30</CarryBulk>
+				<CarryWeight>20</CarryWeight>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguardHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguardHat"]/statBases/Mass</xpath>
+			<value>
+				<Mass>5</Mass>
+				<Bulk>2.5</Bulk>
+				<WornBulk>1</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalguardHat"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<AimingAccuracy>0.3</AimingAccuracy>
+			</value>
+		</li>
+		
+		<!-- Advanced -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>8.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid"]/statBases/Mass</xpath>
+			<value>
+				<Mass>8</Mass>
+				<Bulk>25</Bulk>
+				<WornBulk>10</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat"]/statBases/Mass</xpath>
+			<value>
+				<Mass>2</Mass>
+				<Bulk>0.5</Bulk>
+				<WornBulk>0.5</WornBulk>
+			</value>
+		</li>
+		
+		
+	</operations>
+	</match>	
+  </Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
@@ -1,0 +1,760 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods><li>Paniel the Automata</li></mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<!-- ==========  Shovel  =========== -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_Shovel"]/tools</xpath>
+			<value>
+			  <tools>
+				<li Class="CombatExtended.ToolCE">
+				  <label>handle</label>
+				  <capacities>
+					<li>Poke</li>
+				  </capacities>
+				  <power>4</power>
+				  <cooldownTime>1.78</cooldownTime>
+				  <armorPenetrationBlunt>1</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+				  <label>head</label>
+				  <capacities>
+					<li>Blunt</li>
+				  </capacities>
+				  <power>22</power>
+				  <cooldownTime>2.38</cooldownTime>
+				  <armorPenetrationBlunt>9</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+				  <label>blade</label>
+				  <capacities>
+					<li>Stab</li>
+				  </capacities>
+				  <power>18</power>
+				  <cooldownTime>1.19</cooldownTime>
+				  <armorPenetrationSharp>1.5</armorPenetrationSharp>
+				  <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+				</li>
+			  </tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Shovel"]/statBases</xpath>
+			<value>
+				<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+				<Bulk>5.5</Bulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Shovel"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Shovel"]/equippedStatOffsets</xpath>
+			<value>
+			  <MeleeCritChance>0.42</MeleeCritChance>
+			  <MeleeParryChance>0.24</MeleeParryChance>
+			  <MeleeDodgeChance>0.2</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- ==========  PN_Chainsword  =========== -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_Chainsword"]/tools</xpath>
+			<value>
+			  <tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+					  <li>Poke</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.78</cooldownTime>
+					<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+					  <li>Stab</li>
+					</capacities>
+					<power>21</power>
+					<cooldownTime>1.19</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>3</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>edge</label>
+					<capacities>
+					  <li>Cut</li>
+					</capacities>
+					<power>39</power>
+					<cooldownTime>1</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.6</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				</li>
+			  </tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Chainsword"]/statBases</xpath>
+			<value>
+				<MeleeCounterParryBonus>0.39</MeleeCounterParryBonus>
+				<Bulk>6.5</Bulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Chainsword"]/equippedStatOffsets</xpath>
+			<value>
+			  <MeleeCritChance>0.08</MeleeCritChance>
+			  <MeleeParryChance>0.24</MeleeParryChance>
+			  <MeleeDodgeChance>1.07</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Chainsword"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+		
+		
+		<!-- ==========  Sword  =========== -->
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Chainlongsword"]/statBases</xpath>
+			<value>
+				<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+				<Bulk>13.5</Bulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Chainlongsword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				  <MeleeCritChance>0.63</MeleeCritChance>
+				  <MeleeParryChance>0.75</MeleeParryChance>
+				  <MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_Chainlongsword"]/tools</xpath>
+			<value>
+			  <tools>
+				  <li Class="CombatExtended.ToolCE">
+					<label>Point</label>
+					<capacities>
+					  <li>Stab</li>
+					</capacities>
+					<power>44</power>
+					<cooldownTime>1.57</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>6.75</armorPenetrationBlunt>
+					<armorPenetrationSharp>13.5</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				  </li>
+				  <li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+					  <li>Cut</li>
+					</capacities>
+					<power>100</power>
+					<cooldownTime>1.2</cooldownTime>
+					<chanceFactor>1</chanceFactor>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<armorPenetrationSharp>8.1</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+				  </li>
+				  <li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+					  <li>Poke</li>
+					</capacities>
+					<power>9</power>
+					<cooldownTime>2.35</cooldownTime>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>3</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				  </li>
+			  </tools>
+			</value>
+		</li>
+		
+		<!-- ========== Rifle =========== -->
+		
+		<li Class="PatchOperationRemove">
+		 <xpath>/Defs/ThingDef[defName="PN_Rifle"]/verbs</xpath>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.06</ShotSpread>
+				<SwayFactor>1.34</SwayFactor>
+				<Bulk>10.25</Bulk>
+				<Mass>3.19</Mass>
+				<RangedWeapon_Cooldown>0.78</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+				<warmupTime>1.1</warmupTime>
+				<range>62</range>
+				<soundCast>PNRifleSound</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>7</magazineSize>
+				<reloadTime>0.65</reloadTime>
+				<ammoSet>AmmoSet_303British</ammoSet>
+				<reloadOneAtATime>true</reloadOneAtATime>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Revolver =========== -->
+		
+		<li Class="PatchOperationRemove">
+		 <xpath>/Defs/ThingDef[defName="PN_Revolver"]/verbs</xpath>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_Revolver</defName>
+			<statBases>
+				<SightsEfficiency>0.7</SightsEfficiency>
+				<ShotSpread>0.14</ShotSpread>
+				<SwayFactor>0.47</SwayFactor>
+				<Bulk>3.25</Bulk>
+				<Mass>1.40</Mass>
+				<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>3.71</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+				<range>12</range>
+				<soundCast>Shot_Revolver</soundCast>
+				<soundCastTail>GunTail_Light</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>6</magazineSize>
+				<reloadTime>5.1</reloadTime>
+				<ammoSet>AmmoSet_44Magnum</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Machinegun =========== -->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_Machinegun</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.06</ShotSpread>
+				<SwayFactor>1.49</SwayFactor>
+				<Bulk>12.35</Bulk>
+				<Mass>10.00</Mass>
+				<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.24</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
+				<warmupTime>1.3</warmupTime>
+				<burstShotCount>10</burstShotCount>
+				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+				<range>59</range>
+				<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+				<soundCast>Shot_Minigun</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>80</magazineSize>
+				<reloadTime>7.8</reloadTime>
+				<ammoSet>AmmoSet_303British</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>5</aimedBurstShotCount>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Portable Cannon =========== -->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_Cannon</defName>
+			<statBases>
+				<SightsEfficiency>2.60</SightsEfficiency>
+				<ShotSpread>0.01</ShotSpread>
+				<SwayFactor>2.58</SwayFactor>
+				<Bulk>19.85</Bulk>
+				<Mass>18.00</Mass>
+				<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_20x110mmHispano_FMJ</defaultProjectile>
+				<warmupTime>2.8</warmupTime>
+				<range>41</range>
+				<soundCast>PNCannonSound</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>14</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>1</magazineSize>
+				<reloadTime>2.2</reloadTime>
+				<ammoSet>AmmoSet_20x110mmHispano</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Dual Royal Pistol =========== -->
+		
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="PN_TwinPistol"]/verbs</xpath>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_TwinPistol</defName>
+			<statBases>
+				<SightsEfficiency>0.60</SightsEfficiency>
+				<ShotSpread>1.70</ShotSpread>
+				<SwayFactor>1.14</SwayFactor>
+				<Bulk>5.50</Bulk>
+				<Mass>4.6</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.25</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<burstShotCount>12</burstShotCount>
+				<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+				<range>14</range>
+				<soundCast>Shot_Revolver</soundCast>
+				<soundCastTail>GunTail_Light</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>36</magazineSize>
+				<reloadTime>5.5</reloadTime>
+				<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>6</aimedBurstShotCount>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Royal Rifle =========== -->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_RoyalRifle</defName>
+			<statBases>
+				<SightsEfficiency>2.60</SightsEfficiency>
+				<ShotSpread>0.11</ShotSpread>
+				<SwayFactor>1.37</SwayFactor>
+				<Bulk>9.05</Bulk>
+				<Mass>4.60</Mass>
+				<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.89</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+				<warmupTime>1.1</warmupTime>
+				<burstShotCount>3</burstShotCount>
+				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+				<range>62</range>
+				<soundCast>PNRoyalRifleSound</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>36</magazineSize>
+				<reloadTime>5</reloadTime>
+				<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>2</aimedBurstShotCount>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Royal Launcher =========== -->
+		
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="PN_RoyalLSW"]/verbs</xpath>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_RoyalLSW</defName>
+			<statBases>
+				<SightsEfficiency>1.1</SightsEfficiency>
+				<ShotSpread>0.11</ShotSpread>
+				<SwayFactor>1.87</SwayFactor>
+				<Bulk>12.05</Bulk>
+				<Mass>5.70</Mass>
+				<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.89</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+				<warmupTime>1.1</warmupTime>
+				<range>55</range>
+				<soundCast>PNRoyalRifleSound</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>6</magazineSize>
+				<reloadTime>5.5</reloadTime>
+				<ammoSet>AmmoSet_25x59mmGrenade</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>PN_PrototypeRailGun</defName>
+			<statBases>
+			  <Mass>12.00</Mass>
+			  <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1.00</SightsEfficiency>
+			  <ShotSpread>0.2</ShotSpread>
+			  <SwayFactor>2.80</SwayFactor>
+			  <Bulk>13.0</Bulk>
+			</statBases>
+			<Properties>
+			  <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_PanielRail</defaultProjectile>
+			  <warmupTime>2.1</warmupTime>
+			  <range>53</range>
+			  <burstShotCount>1</burstShotCount>
+			  <soundAiming>PN_PrototypeRailGun_Warmup_Sound</soundAiming>
+			  <soundCast>PN_PrototypeRailGun_Fire_Sound</soundCast>
+			  <soundCastTail>GunTail_Heavy</soundCastTail>
+			  <onlyManualCast>true</onlyManualCast>
+			  <targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			  </targetParams>
+			  <muzzleFlashScale>14</muzzleFlashScale>
+			</Properties>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<AllowWithRunAndGun>false</AllowWithRunAndGun>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_PrototypeRailGun"]/tools</xpath>
+			<value>
+			  <tools>
+				<li Class="CombatExtended.ToolCE">
+				  <label>barrel</label>
+				  <capacities>
+					<li>Blunt</li>
+				  </capacities>
+				  <power>10</power>
+				  <cooldownTime>2.44</cooldownTime>
+				  <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+				  <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+			  </tools>
+			</value>
+		</li>
+		
+		<!-- ========== Melee Attacks =========== -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_Rifle" or 
+			defName="PN_Machinegun" or 
+			defName="PN_Cannon" or 
+			defName="PN_RoyalRifle" or 
+			defName="PN_RoyalLSW"
+			]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+					<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>barrel</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+						<capacities>
+						<li>Poke</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_Revolver" or
+			defName="PN_TwinPistol"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>grip</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.54</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+						<capacities>
+						<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.54</cooldownTime>
+						<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li> 
+		
+		<!-- ========== Royalty Equipment =========== -->
+		
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/ThingDef[defName="PN_RoyalSaber_Bladelink"]</xpath>
+			<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="PN_RoyalSaber_Bladelink"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.53</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>0.968</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>51</power>
+								<extraMeleeDamages>
+								<li>
+									<def>Flame</def>
+									<amount>8</amount>
+									<chance>0.3</chance>
+								</li>
+								</extraMeleeDamages>					
+								<cooldownTime>1.03</cooldownTime>
+								<chanceFactor>0.66</chanceFactor>
+								<armorPenetrationBlunt>5.576</armorPenetrationBlunt>
+								<armorPenetrationSharp>29.04</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+								<li>Stab</li>
+								</capacities>
+								<power>26</power>
+								<extraMeleeDamages>
+								<li>
+									<def>Flame</def>
+									<amount>5</amount>
+									<chance>0.2</chance>
+								</li>
+								</extraMeleeDamages>					
+								<cooldownTime>0.96</cooldownTime>
+								<armorPenetrationBlunt>2.478</armorPenetrationBlunt>
+								<armorPenetrationSharp>38.72</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_RoyalSaber_Bladelink"]/statBases</xpath>
+					<value>
+						<Bulk>8.5</Bulk>
+						<MeleeCounterParryBonus>0.90</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_RoyalSaber_Bladelink"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>1.10</MeleeCritChance>
+							<MeleeParryChance>0.70</MeleeParryChance>
+							<MeleeDodgeChance>0.50</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="PN_Chainsword_Bladelink"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>2</power>
+								<cooldownTime>1.36</cooldownTime>
+								<armorPenetrationBlunt>0.605</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>38</power>
+								<cooldownTime>0.74</cooldownTime>
+								<chanceFactor>1.33</chanceFactor>
+								<armorPenetrationBlunt>3.485</armorPenetrationBlunt>
+								<armorPenetrationSharp>21.78</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+								<li>Stab</li>
+								</capacities>
+								<power>16</power>					
+								<cooldownTime>0.85</cooldownTime>
+								<armorPenetrationBlunt>1.173</armorPenetrationBlunt>
+								<armorPenetrationSharp>30.24</armorPenetrationSharp>
+							</li>					
+						</tools>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+					  <DamageDef ParentName="Flame">
+						<defName>Flame_Nopenetration</defName>
+						<harmAllLayersUntilOutside>false</harmAllLayersUntilOutside>
+					  </DamageDef>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_Chainsword_Bladelink"]/statBases</xpath>
+					<value>
+						<Bulk>5.5</Bulk>
+						<MeleeCounterParryBonus>0.50</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_Chainsword_Bladelink"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>1.10</MeleeCritChance>
+							<MeleeParryChance>0.50</MeleeParryChance>
+							<MeleeDodgeChance>0.37</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+				
+			</operations>
+			</match>
+		</li>
+		
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Races/AlienRace_Paniel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Races/AlienRace_Paniel.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+		
+	<mods><li>Paniel the Automata</li></mods>
+		
+	<match Class="PatchOperationSequence">
+	<operations>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/comps</xpath>
+			<value>
+				<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+				</li>
+				<li Class="CombatExtended.CompProperties_Suppressable" />
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/statBases</xpath>
+			<value>
+			<MeleeCritChance>1</MeleeCritChance>
+			<MeleeParryChance>1</MeleeParryChance>
+			<Suppressability>0.5</Suppressability>
+			<SmokeSensitivity>0</SmokeSensitivity>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/tools</xpath> 
+			<value>
+				<tools>
+			<li Class="CombatExtended.ToolCE">
+			<label>left fist</label>
+			<capacities>
+				<li>Blunt</li>
+			</capacities>
+			<power>1</power>
+			<cooldownTime>1.26</cooldownTime>
+			<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+			<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+			<label>right fist</label>
+			<capacities>
+				<li>Blunt</li>
+			</capacities>
+			<power>1</power>
+			<cooldownTime>1.26</cooldownTime>
+			<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+			<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>head</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>4.49</cooldownTime>
+				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+				<chanceFactor>0.2</chanceFactor>
+				<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+			</li>
+		</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
+			  <value>
+				<li>Apparel_TacVest</li>
+				<li>Apparel_Backpack</li>
+				<li>Apparel_TribalBackpack</li>
+				<li>Apparel_BallisticShield</li>
+				<li>Apparel_MeleeShield</li>
+				<li>Apparel_GasMask</li>
+				<li>Apparel_ImprovGasMask</li>
+			  </value>
+		</li>
+		
+		
+	</operations>
+	</match>	
+  </Operation>
+</Patch>


### PR DESCRIPTION
## Additions

Stuff for Paniel the Automata.
Also a bodypatch for Heyra since I'm not sure whether it's needed any more, but the patch in the mod itself is missing bodydef stuff.

## Reasoning

For simplicity's sake, the paniel advanced weapons still use charge ammo despite having kinetic rounds in vanilla. Armor is stuffable but metallic. Originally the paniel clothing is all metallic options, but will probably switch to steelable to reduce the number of insanely heavy caravans from CE's alteration of stuff weight of gold/silver etc.

## Alternatives

Have considered either giving them very good ballistic weapon profiles instead, or making a custom ammodef but there's already quite a bit there for the shells, so it seems a little excessive, but I'm open to any suggestions.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
Running out of ammo in the current snapshot throws a red error if yo utry to shoot.
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
