### PR TITLE
Warhammer - Dryad patch fix

### DIFF
--- a/Patches/Warhammer - Dryad/Race_Dryad.xml
+++ b/Patches/Warhammer - Dryad/Race_Dryad.xml
@@ -46,6 +46,32 @@
 
         <!-- Dryad -->
 
+        <li Class="PatchOperationSequence">
+          <success>Always</success>
+          <operations>
+            <li Class="PatchOperationTest">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Dryad" or defName="Alien_DryadWild"]/comps</xpath>
+              <success>Invert</success>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Dryad" or defName="Alien_DryadWild"]</xpath>
+              <value>
+                <comps />
+              </value>
+            </li>
+          </operations>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Dryad" or defName="Alien_DryadWild"]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
         <li Class="PatchOperationReplace">
           <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Dryad" or defName="Alien_DryadWild"]/statBases/MeleeDodgeChance</xpath>
           <value>


### PR DESCRIPTION
## Additions
- Add a gizmo comp patch that directly targets the dryad alien races.

## Reasoning
- The alien races didn't previously have gizmos for weapon reload, fire and aim mode.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] ...with and without patched mod loaded;
- [ ] Playtested a colony.

## Additional material
- Warhammer - Dryad Steam Workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=1694750191
