### PR TITLE
Various flamethrower and grenades tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -183,6 +183,7 @@
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <range>7.0</range>
+        <minRange>3</minRange>
         <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -118,6 +118,7 @@
         <defaultProjectile>Proj_GrenadeFlashbang</defaultProjectile>
         <onlyManualCast>true</onlyManualCast>
         <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+        <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
       </li>
     </verbs>
     <comps>
@@ -192,6 +193,7 @@
         <defaultProjectile>Proj_GrenadeStickBomb</defaultProjectile>
         <onlyManualCast>true</onlyManualCast>
         <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+        <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
       </li>
     </verbs>
     <detonateProjectile>Proj_GrenadeStickBomb</detonateProjectile>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -182,8 +182,8 @@
         <label>throw stick bomb</label>
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <range>7.0</range>
-        <minRange>3</minRange>
+        <range>8.0</range>
+        <minRange>4</minRange>
         <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -182,8 +182,7 @@
         <label>throw stick bomb</label>
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <range>8.0</range>
-        <minRange>4</minRange>
+        <range>7.0</range>
         <warmupTime>1.8</warmupTime>
         <noiseRadius>4</noiseRadius>
         <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
@@ -194,7 +193,7 @@
         <defaultProjectile>Proj_GrenadeStickBomb</defaultProjectile>
         <onlyManualCast>true</onlyManualCast>
         <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-        <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+        <ai_AvoidFriendlyFireRadius>6</ai_AvoidFriendlyFireRadius>
       </li>
     </verbs>
     <detonateProjectile>Proj_GrenadeStickBomb</detonateProjectile>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -126,9 +126,6 @@
     <weaponTags>
       <li>GunHeavy</li>
     </weaponTags>
-    <thingCategories>
-      <li>WeaponsRanged</li>
-    </thingCategories>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -421,4 +421,3 @@
   </ThingDef>
 
 </Defs>
-

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -421,3 +421,4 @@
   </ThingDef>
 
 </Defs>
+

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -126,6 +126,9 @@
     <weaponTags>
       <li>GunHeavy</li>
     </weaponTags>
+    <thingCategories>
+      <li>WeaponsRanged</li>
+    </thingCategories>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -53,7 +53,7 @@
 			  <minRange>8</minRange>
 			  <soundCast>120mm</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
-				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+			  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 			</Properties>
 			<AmmoUser>
 			  <magazineSize>1</magazineSize>
@@ -93,13 +93,13 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
-			  <range>16</range>
+			  <range>12</range>
 			  <minRange>2.9</minRange>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 			  <burstShotCount>5</burstShotCount>
 			  <soundCast>HissFlamethrower</soundCast>
 			  <muzzleFlashScale>2</muzzleFlashScale>
-			  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+			  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
 			</Properties>
 			<AmmoUser>
 			  <magazineSize>100</magazineSize>

--- a/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -3,7 +3,7 @@
 
   <!-- ========== Patch raid point curves ========== -->
 
-  <Operation Class="PatchOperationReplace">
+  <!--<Operation Class="PatchOperationReplace">
     <xpath>Defs/FactionDef/maxPawnCostPerTotalPointsCurve</xpath>
     <value>
       <maxPawnCostPerTotalPointsCurve>
@@ -14,7 +14,7 @@
         </points>
       </maxPawnCostPerTotalPointsCurve>
     </value>
-  </Operation>
+  </Operation>-->
 
   <!-- ========== Patch mech raid delay and Centipede spawn weight ========== -->
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -234,6 +234,7 @@
 			<defaultProjectile>Proj_GrenadeFrag</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_AOE</li>
@@ -363,6 +364,7 @@
 			<defaultProjectile>Proj_GrenadeMolotov</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_AOE</li>
@@ -483,6 +485,7 @@
 			<defaultProjectile>Proj_GrenadeEMP</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_EMP</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -234,7 +234,7 @@
 			<defaultProjectile>Proj_GrenadeFrag</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+			<ai_AvoidFriendlyFireRadius>7</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_AOE</li>
@@ -353,7 +353,7 @@
 			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<range>10</range>
-			<minRange>4</minRange>
+			<minRange>2</minRange>
 			<warmupTime>0.8</warmupTime>
 			<noiseRadius>4</noiseRadius>
 			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
@@ -364,7 +364,7 @@
 			<defaultProjectile>Proj_GrenadeMolotov</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+			<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_AOE</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -37,6 +37,8 @@
 			<xpath>Defs/PawnKindDef[
 			defName="VFE_Mech_Knight" or 
 			defName="VFE_Mech_AdvancedKnight" or
+			defName="VFE_Mech_Inquisitor" or
+			defName="VFE_Mech_AdvancedInquisitor" or
 			defName="VFE_Mech_Pikeman"
 			]</xpath>
 			<value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -37,8 +37,6 @@
 			<xpath>Defs/PawnKindDef[
 			defName="VFE_Mech_Knight" or 
 			defName="VFE_Mech_AdvancedKnight" or
-			defName="VFE_Mech_Inquisitor" or
-			defName="VFE_Mech_AdvancedInquisitor" or
 			defName="VFE_Mech_Pikeman"
 			]</xpath>
 			<value>
@@ -50,7 +48,22 @@
 			  </li>
 			</value>
 		  </li>
-		  
+
+		  <li Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[
+			defName="VFE_Mech_Inquisitor" or
+			defName="VFE_Mech_AdvancedInquisitor"
+			]</xpath>
+			<value>
+			  <li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+				  <min>1</min>
+				  <max>2</max>
+				</primaryMagazineCount>
+			  </li>
+			</value>
+		  </li>
+
 		  <li Class="PatchOperationAddModExtension">
 			<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedPikeman"]</xpath>
 			<value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -77,16 +77,16 @@
 		  </li>
 		  
 		  <li Class="PatchOperationAddModExtension">
-  	        <xpath>Defs/PawnKindDef[defName="VFE_Mech_Termite" or defName="VFE_Mech_AdvTermite"]</xpath>
-  	        <value>
-              <li Class="CombatExtended.LoadoutPropertiesExtension">
-                <primaryMagazineCount>
-                  <min>8</min>
-                  <max>15</max>
-                </primaryMagazineCount>
-              </li>
-  	        </value>
-          </li>
+			<xpath>Defs/PawnKindDef[defName="VFE_Mech_Termite" or defName="VFE_Mech_AdvTermite"]</xpath>
+			<value>
+			  <li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+				  <min>8</min>
+				  <max>15</max>
+				</primaryMagazineCount>
+			  </li>
+			</value>
+		  </li>
 
       </operations>
     </match>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -307,8 +307,8 @@
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
       <defName>VFE_Gun_InfernoSpewer</defName>
       <statBases>
-        <Mass>10</Mass>
-        <Bulk>15</Bulk>
+        <Mass>6</Mass>
+        <Bulk>10</Bulk>
         <SwayFactor>1.00</SwayFactor>
         <ShotSpread>5.0</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>
@@ -348,8 +348,8 @@
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
       <defName>VFE_Gun_AdvancedInfernoSpewer</defName>
       <statBases>
-        <Mass>15</Mass>
-        <Bulk>15</Bulk>
+        <Mass>7</Mass>
+        <Bulk>12</Bulk>
         <SwayFactor>1.00</SwayFactor>
         <ShotSpread>5.0</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -9,6 +9,24 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+    <!-- ========== Forbid them from showing up in stockpiles ========== -->
+
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[@Name="VFE_Gun_InfernoSpewerBase" or defName="VFE_Gun_AdvancedInfernoCannon"]</xpath>
+      <value>
+        <destroyOnDrop>true</destroyOnDrop>
+      </value>
+    </li>
+
+    <!-- ========== Inferno spewer description change ========== -->
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[@Name="AA_FlamethrowerBase"]/description</xpath>
+      <value>
+        <description>A surprisingly lightweight flamethrower of mechanoid design, while idle the device seems cold as any other, but can immediately heat up to temperatures well above purely human technology. Two undermounted prometheum jelly tanks allow for an ammo capacity big enough for large plumes of liquid flame.</description>
+      </value>
+    </li>
+
     <!-- ========== VFE Handheld Mini Turret ========== -->
 
     <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -135,15 +153,16 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
         <warmupTime>1.3</warmupTime>
-        <range>15</range>
+        <range>14.9</range>
         <minRange>2</minRange>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-        <burstShotCount>5</burstShotCount>
+        <burstShotCount>3</burstShotCount>
         <targetParams>
           <canTargetLocations>true</canTargetLocations>
         </targetParams>
         <soundCast>HissFlamethrower</soundCast>
         <muzzleFlashScale>2</muzzleFlashScale>
+        <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
       </Properties>
       <AmmoUser>
         <magazineSize>60</magazineSize>
@@ -281,6 +300,94 @@
         <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiUseBurstMode>TRUE</aiUseBurstMode>
       </FireModes>
+    </li>
+
+    <!-- ========== Inferno spewer ========== -->
+	  
+    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+      <defName>VFE_Gun_InfernoSpewer</defName>
+      <statBases>
+        <Mass>10</Mass>
+        <Bulk>15</Bulk>
+        <SwayFactor>1.00</SwayFactor>
+        <ShotSpread>5.0</ShotSpread>
+        <SightsEfficiency>1.0</SightsEfficiency>
+        <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <recoilAmount>0</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>19.9</range>
+        <minRange>3</minRange>
+        <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+        <burstShotCount>5</burstShotCount>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
+        <soundCast>HissFlamethrower</soundCast>
+        <muzzleFlashScale>3</muzzleFlashScale>
+        <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+      </Properties>
+      <AmmoUser>
+        <magazineSize>80</magazineSize>
+        <reloadTime>8</reloadTime>
+        <ammoSet>AmmoSet_Flamethrower</ammoSet>
+      </AmmoUser>
+      <FireModes>
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aiAimMode>SuppressFire</aiAimMode>
+        <noSingleShot>true</noSingleShot>
+      </FireModes>
+      <weaponTags>
+        <li>VFE_MechanoidGunFlamer</li>
+      </weaponTags>
+    </li>
+
+    <!-- ========== Advanced inferno spewer ========== -->
+	  
+    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+      <defName>VFE_Gun_AdvancedInfernoSpewer</defName>
+      <statBases>
+        <Mass>15</Mass>
+        <Bulk>15</Bulk>
+        <SwayFactor>1.00</SwayFactor>
+        <ShotSpread>5.0</ShotSpread>
+        <SightsEfficiency>1.0</SightsEfficiency>
+        <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+      </statBases>
+      <Properties>
+        <recoilAmount>0</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
+        <warmupTime>1.6</warmupTime>
+        <range>24.9</range>
+        <minRange>4</minRange>
+        <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
+        <soundCast>HissFlamethrower</soundCast>
+        <muzzleFlashScale>5</muzzleFlashScale>
+        <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+      </Properties>
+      <AmmoUser>
+        <magazineSize>100</magazineSize>
+        <reloadTime>8</reloadTime>
+        <ammoSet>AmmoSet_Flamethrower</ammoSet>
+      </AmmoUser>
+      <FireModes>
+        <aiUseBurstMode>FALSE</aiUseBurstMode>
+        <aiAimMode>SuppressFire</aiAimMode>
+        <noSingleShot>true</noSingleShot>
+      </FireModes>
+      <weaponTags>
+        <li>VFE_AdvMechanoidGunFlamer</li>
+      </weaponTags>
     </li>
 	
     <!-- ========== Remove VFE Advanced Needle Gun and patch in replacement. ========== -->

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -341,9 +341,6 @@
         <aiAimMode>SuppressFire</aiAimMode>
         <noSingleShot>true</noSingleShot>
       </FireModes>
-      <weaponTags>
-        <li>VFE_MechanoidGunFlamer</li>
-      </weaponTags>
     </li>
 
     <!-- ========== Advanced inferno spewer ========== -->
@@ -385,9 +382,6 @@
         <aiAimMode>SuppressFire</aiAimMode>
         <noSingleShot>true</noSingleShot>
       </FireModes>
-      <weaponTags>
-        <li>VFE_AdvMechanoidGunFlamer</li>
-      </weaponTags>
     </li>
 	
     <!-- ========== Remove VFE Advanced Needle Gun and patch in replacement. ========== -->

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -153,7 +153,7 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
         <warmupTime>1.3</warmupTime>
-        <range>14.9</range>
+        <range>15</range>
         <minRange>2</minRange>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
         <burstShotCount>3</burstShotCount>
@@ -320,7 +320,7 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
         <warmupTime>1.3</warmupTime>
-        <range>19.9</range>
+        <range>20</range>
         <minRange>3</minRange>
         <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
         <burstShotCount>5</burstShotCount>
@@ -361,7 +361,7 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
         <warmupTime>1.6</warmupTime>
-        <range>24.9</range>
+        <range>25</range>
         <minRange>4</minRange>
         <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -389,9 +389,9 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
-        <CarryBulk>20</CarryBulk>
+        <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
-        <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
+        <ShootingAccuracyPawn>2.8</ShootingAccuracyPawn>
         <MeleeDodgeChance>0.19</MeleeDodgeChance>
         <MeleeCritChance>0.22</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -391,7 +391,7 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
-        <CarryBulk>20</CarryBulk>
+        <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
         <MeleeDodgeChance>0.19</MeleeDodgeChance>
@@ -405,7 +405,7 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>12</ArmorRating_Blunt>
-		<ArmorRating_Heat>1</ArmorRating_Heat>
+        <ArmorRating_Heat>1</ArmorRating_Heat>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -241,7 +241,7 @@
             <targetParams>
               <canTargetLocations>true</canTargetLocations>
             </targetParams>
-            <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+            <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
           </Properties>
           <AmmoUser>
             <magazineSize>200</magazineSize>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -27,6 +27,13 @@
       <!-- Field Gun -->
 
       <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/fillPercent</xpath>
+        <value>
+            <fillPercent>0.65</fillPercent>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]/building/turretBurstWarmupTime</xpath>
         <value>
             <turretBurstWarmupTime>4.0</turretBurstWarmupTime>
@@ -101,7 +108,7 @@
               <defaultProjectile>Bullet_105mmHowitzerShell_HEAT_directfire</defaultProjectile>
               <warmupTime>4</warmupTime>
               <minRange>20</minRange>
-              <range>900</range>
+              <range>100</range>
               <burstShotCount>1</burstShotCount>
               <soundCast>VFEP_Shot_FieldCannon</soundCast>
               <muzzleFlashScale>16</muzzleFlashScale>
@@ -118,7 +125,7 @@
       <!-- Cannon - Based on the M1897 12-pounder -->
 
       <li Class="PatchOperationReplace">
-        <xpath>Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
+        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
         <value>
             <fillPercent>0.65</fillPercent>
         </value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -118,6 +118,13 @@
       <!-- Cannon - Based on the M1897 12-pounder -->
 
       <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
+        <value>
+            <fillPercent>0.65</fillPercent>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/building/turretBurstWarmupTime</xpath>
         <value>
             <turretBurstWarmupTime>3.3</turretBurstWarmupTime>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -26,13 +26,6 @@
 
       <!-- Field Gun -->
 
-      <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
-        <value>
-            <fillPercent>0.65</fillPercent>
-        </value>
-      </li>
-
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]/building/turretBurstWarmupTime</xpath>
         <value>
@@ -123,13 +116,6 @@
       </li>
 
       <!-- Cannon - Based on the M1897 12-pounder -->
-
-      <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
-        <value>
-            <fillPercent>0.65</fillPercent>
-        </value>
-      </li>
 
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/building/turretBurstWarmupTime</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -26,8 +26,8 @@
 
       <!-- Field Gun -->
 
-      <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/fillPercent</xpath>
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
         <value>
             <fillPercent>0.65</fillPercent>
         </value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -78,7 +78,7 @@
             <li Class="CombatExtended.CompProperties_AmmoUser">
               <magazineSize>1</magazineSize>
               <reloadTime>5</reloadTime>
-              <ammoSet>AmmoSet_105mmHowitzerShell</ammoSet>
+              <ammoSet>AmmoSet_105mmHowitzerShell_directfire</ammoSet>
             </li>
         </value>
       </li>
@@ -98,7 +98,7 @@
               <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
               <forceNormalTimeSpeed>false</forceNormalTimeSpeed>
               <hasStandardCommand>true</hasStandardCommand>
-              <defaultProjectile>Bullet_105mmHowitzerShell_HE</defaultProjectile>
+              <defaultProjectile>Bullet_105mmHowitzerShell_HEAT_directfire</defaultProjectile>
               <warmupTime>4</warmupTime>
               <minRange>20</minRange>
               <range>900</range>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -85,7 +85,7 @@
             <li Class="CombatExtended.CompProperties_AmmoUser">
               <magazineSize>1</magazineSize>
               <reloadTime>5</reloadTime>
-              <ammoSet>AmmoSet_105mmHowitzerShell_directfire</ammoSet>
+              <ammoSet>AmmoSet_105mmHowitzerShell</ammoSet>
             </li>
         </value>
       </li>
@@ -105,10 +105,10 @@
               <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
               <forceNormalTimeSpeed>false</forceNormalTimeSpeed>
               <hasStandardCommand>true</hasStandardCommand>
-              <defaultProjectile>Bullet_105mmHowitzerShell_HEAT_directfire</defaultProjectile>
+              <defaultProjectile>Bullet_105mmHowitzerShell_HE</defaultProjectile>
               <warmupTime>4</warmupTime>
               <minRange>20</minRange>
-              <range>100</range>
+              <range>900</range>
               <burstShotCount>1</burstShotCount>
               <soundCast>VFEP_Shot_FieldCannon</soundCast>
               <muzzleFlashScale>16</muzzleFlashScale>


### PR DESCRIPTION
## Changes

- Tweaked various flamethrower weapons' values
- Commented out raid point curves patch, it was messing with all the faction's raid curves be it mechanoid or modded factions
- Added "ai_AvoidFriendlyFireRadius" in a radius of 5 tiles to grenades that can cause friendly-fire and tweaked some of their minimum fire ranges to better suit their application

## Reasoning

- Changes to the grenades and flamethrowers were made to hopefully fix the dumb AI behavior of suicidal grenadiers and friendly-fire caused by improper use of said weapons

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors