### PR TITLE
4.5 hotfix stuff

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -126,6 +126,9 @@
     <weaponTags>
       <li>GunHeavy</li>
     </weaponTags>
+    <thingCategories>
+      <li>WeaponsRanged</li>
+    </thingCategories>    
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -26,6 +26,13 @@
 
       <!-- Field Gun -->
 
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
+        <value>
+            <fillPercent>0.65</fillPercent>
+        </value>
+      </li>
+
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]/building/turretBurstWarmupTime</xpath>
         <value>
@@ -116,6 +123,13 @@
       </li>
 
       <!-- Cannon - Based on the M1897 12-pounder -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
+        <value>
+            <fillPercent>0.65</fillPercent>
+        </value>
+      </li>
 
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/building/turretBurstWarmupTime</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -29,7 +29,7 @@
       <li Class="PatchOperationAdd">
         <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
         <value>
-            <fillPercent>0.65</fillPercent>
+            <fillPercent>0.90</fillPercent>
         </value>
       </li>
 
@@ -127,7 +127,7 @@
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
         <value>
-            <fillPercent>0.65</fillPercent>
+            <fillPercent>0.90</fillPercent>
         </value>
       </li>
 


### PR DESCRIPTION
- Fix the LAW stockpile issue.
- Increase the height of VFE: Pirates Cannons and Field Guns, so they can see over embrasures.