### PR TITLE
Fixed Censored Armory patch def reference typo

### DIFF
--- a/Patches/Censored Armory/Weapons_Turrets.xml
+++ b/Patches/Censored Armory/Weapons_Turrets.xml
@@ -530,7 +530,7 @@
 							<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
 							<hasStandardCommand>true</hasStandardCommand>
 							<requireLineOfSight>false</requireLineOfSight>
-							<defaultProjectile>AmmoSet_15cmNebelwerfer</defaultProjectile>
+							<defaultProjectile>Bullet_15cmNebelwerfer_HE</defaultProjectile>
 							<warmupTime>10</warmupTime>
 							<minRange>40</minRange>
 							<range>1000</range>


### PR DESCRIPTION
Changed ammo set name to projectile name in \<defaultProjectile\>.

## Additions

Nothing new added

## Changes

Replaced "AmmoSet_..." reference with "Bullet_..." reference in \<defaultProjectile\>.

## References

No relevant open issues found

## Reasoning

Wrong place for "AmmoSet_..". Also gives reference resolution error in log.

## Alternatives

N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings (no changes to code)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (tested in quickstart just to see if there's any problem with firing changed turret)
