### PR TITLE
Starship Troopers Arachnids Patch

### DIFF
--- a/Patches/Starship Troopers Arachnids/Bodies_Bugs.xml
+++ b/Patches/Starship Troopers Arachnids/Bodies_Bugs.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.3] Starship Troopers Arachnids Ver6.3</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Elytra"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Elytra"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Elytra"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="InsectLeg"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="Arachnid"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<!-- -->
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Elytra"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Elytra"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Elytra"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
+					<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="InsectLeg"]</xpath>
+							<value>
+								<groups>
+									<li>CoveredByNaturalArmor</li>
+								</groups>
+							</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="ArachnidScorpion"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</match>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Starship Troopers Arachnids/Races.xml
+++ b/Patches/Starship Troopers Arachnids/Races.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.3] Starship Troopers Arachnids Ver6.3</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+				<!-- BASE -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[@Name="BugsThingBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="BugsThingBase"]/statBases</xpath>
+					<value>
+						<PainShockThreshold>5</PainShockThreshold>
+					</value>
+				</li>
+			
+				<!-- Basic Warrior -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_WarriorBug" or defName="Arachnid_WarriorBugHive"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_WarriorBug" or defName="Arachnid_WarriorBugHive" or defName="Arachnid_FireFlyBug" or defName="Arachnid_HopperBug"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.09</MeleeDodgeChance>
+						<MeleeCritChance>0.53</MeleeCritChance>
+						<MeleeParryChance>0.02</MeleeParryChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_WarriorBug" or defName="Arachnid_WarriorBugHive" or defName="Arachnid_FireFlyBug" or defName="Arachnid_HopperBug"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>front left leg</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>1.0</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<armorPenetrationBlunt>24</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>front right leg</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>1.0</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>36</power>
+								<cooldownTime>1.33</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<armorPenetrationSharp>20</armorPenetrationSharp>
+								<armorPenetrationBlunt>68</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			
+				<!-- Bombardier -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_BombardierBug"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>1.6</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<armorPenetrationSharp>0.24</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			
+				<!-- Plasma Grenadier -->
+					
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>1.8</baseHealthScale>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.09</MeleeDodgeChance>
+						<MeleeCritChance>0.31</MeleeCritChance>
+						<MeleeParryChance>0.05</MeleeParryChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>front left leg</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>front right leg</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>1.33</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			
+				<!-- Large-class -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug" or defName="Arachnid_PlasmaBug"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>5.0</baseHealthScale>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>23</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_ScorpionBug"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>25</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaBug"]/statBases</xpath>
+					<value>
+						<ArmorRating_Sharp>30</ArmorRating_Sharp>
+						<ArmorRating_Blunt>14</ArmorRating_Blunt>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug" or defName="Arachnid_PlasmaBug"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.09</MeleeDodgeChance>
+						<MeleeCritChance>0.76</MeleeCritChance>
+						<MeleeParryChance>0.05</MeleeParryChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug" or defName="Arachnid_PlasmaBug"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>front left leg</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>33</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>front right leg</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>33</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightInsectLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>1.33</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationSharp>40</armorPenetrationSharp>
+								<armorPenetrationBlunt>20</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Starship Troopers Arachnids/Resources.xml
+++ b/Patches/Starship Troopers Arachnids/Resources.xml
@@ -10,7 +10,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="ArachnidLeg"]/statBases</xpath>
 					<value>
-						<Bulk>20.53</Bulk>
+						<Bulk>12</Bulk>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Starship Troopers Arachnids/Resources.xml
+++ b/Patches/Starship Troopers Arachnids/Resources.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.3] Starship Troopers Arachnids Ver6.3</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Arachnid Leg -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ArachnidLeg"]/statBases</xpath>
+					<value>
+						<Bulk>20.53</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidLeg"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Scratch</li>
+									<li>Stab</li>
+								</capacities>
+								<power>20</power>
+								<cooldownTime>2.6</cooldownTime>
+								<armorPenetrationSharp>20</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+			
+				<!-- Arachnid Carapace -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases</xpath>
+					<value>
+						<Bulk>0.05</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/SharpDamageMultiplier</xpath>
+					<value>
+						<MeleePenetrationFactor>3.0</MeleePenetrationFactor>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/stuffProps/categories</xpath>
+					<value>
+						<li>Metallic_Weapon</li>
+					</value>
+				</li>
+				
+				<!-- Arachnid Leather, made a bit worse than thrumbofur -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases</xpath>
+					<value>
+						<Bulk>0.05</Bulk>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.35</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.07</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Heat</xpath>
+					<value>
+						<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
+					</value>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Leather_Arachnids"]/stuffProps/categories</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Leather_Arachnids"]/stuffProps</xpath>
+						<value>
+							<categories>
+							  <li>SoftArmor</li>
+							</categories>
+						</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Leather_Arachnids"]/stuffProps/categories</xpath>
+						<value>
+							<li>SoftArmor</li>
+						</value>
+					</match>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
+++ b/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.3] Starship Troopers Arachnids Ver6.3</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- Tanker -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_TankerInfernoCannon</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_TankerInfernoCannon</defaultProjectile>
+						<warmupTime>1.2</warmupTime>
+						<range>27</range>
+						<burstShotCount>50</burstShotCount>
+						<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>0</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+				</li>
+			
+				<!-- Firefly -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_FireFlyInfernoCannon</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FireFlyInfernoCannon</defaultProjectile>
+						<warmupTime>0.36</warmupTime>
+						<range>20</range>
+						<burstShotCount>15</burstShotCount>
+						<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>0</muzzleFlashScale>
+						<recoilPattern>Mounted</recoilPattern>
+					</Properties>
+				</li>
+			
+				<!-- Plasma Bug -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_PlasmaBugPlasma</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>4.5</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.5</SightsEfficiency>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_PlasmaBugPlasma</defaultProjectile>
+						<warmupTime>4.5</warmupTime>
+						<range>700</range>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>100</muzzleFlashScale>
+						<indirectFirePenalty>0.2</indirectFirePenalty>
+						<requireLineOfSight>false</requireLineOfSight>
+					</Properties>
+				</li>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Gun_PlasmaBugPlasma"]</xpath>
+				<value>
+					<comps>
+						<li Class="CombatExtended.CompProperties_Charges">
+							<chargeSpeeds>
+								<li>30</li>
+								<li>50</li>
+								<li>70</li>
+								<li>90</li>
+							</chargeSpeeds>
+						</li>
+					</comps>
+				</value>
+				</li>
+			
+				<!-- Bombardier Bug -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_BombardierBugTrigger</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_BombardierBugTrigger</defaultProjectile>
+						<warmupTime>0.1</warmupTime>
+						<range>3</range>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>50</muzzleFlashScale>
+					</Properties>
+				</li>
+			
+				<!-- Plasma Grenadier Bug -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_PlasmaGrenadierBugPlasma</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.85</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_PlasmaGrenadierBugPlasma</defaultProjectile>
+						<warmupTime>0.5</warmupTime>
+						<range>40</range>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>12</muzzleFlashScale>
+					</Properties>
+				</li>
+			
+				<!-- Scorpion Bug -->
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_ScorpionBugPlasma</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.2</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>36</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>0.85</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_ScorpionBugPlasma</defaultProjectile>
+						<warmupTime>1.5</warmupTime>
+						<range>40</range>
+						<soundCast>InfernoCannon_Fire</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>12</muzzleFlashScale>
+					</Properties>
+				</li>
+				
+				<!-- Projectiles -->
+				<!-- Tanker -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseFlamethrowerBullet">
+							<defName>Bullet_TankerInfernoCannon</defName>
+							<label>flame stream</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Fireball</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<drawSize>2.5</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>PrometheumFlame</damageDef>
+								<damageAmountBase>10</damageAmountBase>
+								<speed>20</speed>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+								<soundExplode>CE_FlamethrowerExplosion</soundExplode>
+								<explosionRadius>1.5</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>
+				
+				<!-- Firefly -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseFlamethrowerBullet">
+							<defName>Bullet_FireFlyInfernoCannon</defName>
+							<label>flame stream</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Fireball</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<drawSize>1</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>PrometheumFlame</damageDef>
+								<damageAmountBase>5</damageAmountBase>
+								<speed>20</speed>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+								<soundExplode>CE_FlamethrowerExplosion</soundExplode>
+								<explosionRadius>1.0</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>
+				
+				<!-- Bombardier -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseFlamethrowerBullet">
+							<defName>Bullet_BombardierBugTrigger</defName>
+							<label>Bombardier Suicide</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Plasma</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+								<drawSize>0</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bomb</damageDef>
+								<damageAmountBase>120</damageAmountBase>
+								<speed>200</speed>
+								<explosionRadius>8.0</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>
+				
+				<!-- Plasma Grenadier -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseFlamethrowerBullet">
+							<defName>Bullet_PlasmaGrenadierBugPlasma</defName>
+							<label>plasma burst</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Plasma</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+								<drawSize>3</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bomb</damageDef>
+								<damageAmountBase>90</damageAmountBase>
+								<speed>20</speed>
+								<soundExplode>Explosion_EMP</soundExplode>
+								<explosionRadius>1.5</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>
+				
+				<!-- Scorpion Plasma -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="BaseFlamethrowerBullet">
+							<defName>Bullet_ScorpionBugPlasma</defName>
+							<label>plasma burst</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Plasma</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+								<drawSize>3</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bomb</damageDef>
+								<damageAmountBase>90</damageAmountBase>
+								<speed>30</speed>
+								<soundExplode>Explosion_EMP</soundExplode>
+								<explosionRadius>2.4</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+						</ThingDef>
+					</value>
+				</li>
+				
+				<!-- Plasma Bug -->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ThingDef ParentName="Base81mmMortarShell">
+							<defName>Bullet_PlasmaBugPlasma</defName>
+							<label>plasma burst</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Bugs_Plasma</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+								<drawSize>10</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Flame</damageDef>
+								<damageAmountBase>40</damageAmountBase>
+								<speed>1</speed>
+								<gravityFactor>5</gravityFactor>
+								<flyOverhead>true</flyOverhead>
+								<dropsCasings>false</dropsCasings>
+								<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+								<preExplosionSpawnChance>0.33</preExplosionSpawnChance>
+								<soundExplode>Explosion_EMP</soundExplode>
+								<explosionRadius>8.0</explosionRadius>
+								<ai_IsIncendiary>true</ai_IsIncendiary>
+							</projectile>
+							<comps>
+							  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+								<damageAmountBase>120</damageAmountBase>
+								<explosiveDamageType>Thermobaric</explosiveDamageType>
+								<explosiveRadius>4.4</explosiveRadius>
+								<explosionSound>MortarIncendiary_Explode</explosionSound>
+								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+							  </li>
+							</comps>
+						</ThingDef>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## References

Patch Request #1241 

## Reasoning

 - No recoil on Tanker bugs and Firefly to give them a more accurate flame stream
 - Warrior caste are made to be fast, deadly in melee but easily taken down.
 - Larger Arachnids are heavily armored and can resist small-arms fire.
 - Arachnids are fully armored except for outside organs in their head (eyes, mouth,etc)
 - The plasma projectiles casts shadows and sadly I don't know how to remove them. So some projectiles are really menacing like the Plasma Bugs'

## Alternatives

 - Change the flame thrower of the Tanker and Firefly to be flame damage instead of prometheum damage
 - Change the Plasma Bug's weapon to follow more of the Plasma Grenadier's plasma instead of an arc like a mortar
 - Remove the natural armor on the legs.
 - Make the Large Arachnids (or at least the incendiary arachnids) to be completely immune to fire

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
