### PR TITLE
Fortifications industrial update

### DIFF
--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -329,7 +329,6 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>7</explosionRadius>
-			<flyOverhead>true</flyOverhead>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
@@ -357,7 +356,6 @@
 		  <damageAmountBase>136</damageAmountBase>
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
-		  <flyOverhead>true</flyOverhead>
 		  <explosionRadius>6.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -374,7 +372,6 @@
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>7.5</explosionRadius>
-		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -252,7 +252,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		  </graphicData>
 		  <projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>150</speed>
+			<speed>154</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -213,7 +213,6 @@
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>10.5</explosionRadius>
-		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
@@ -277,7 +276,6 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>11.5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
@@ -305,7 +303,6 @@
 		  <damageAmountBase>452</damageAmountBase>
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
-		  <flyOverhead>true</flyOverhead>
 		  <explosionRadius>9.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -322,7 +319,6 @@
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>10.5</explosionRadius>
-		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -213,6 +213,7 @@
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>10.5</explosionRadius>
+		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
@@ -230,7 +231,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		  </graphicData>
 		  <projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>150</speed>
+			<speed>166</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -22,6 +22,18 @@
     	<isMortarAmmoSet>true</isMortarAmmoSet>		
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_155mmHowitzerShell_directfire</defName>
+		<label>155mm Howitzer shells</label>
+		<ammoTypes>
+			<Ammo_155mmHowitzerShell_HE>Bullet_155mmHowitzerShell_HE_directfire</Ammo_155mmHowitzerShell_HE>
+			<Ammo_155mmHowitzerShell_Incendiary>Bullet_155mmHowitzerShell_Incendiary_directfire</Ammo_155mmHowitzerShell_Incendiary>
+			<Ammo_155mmHowitzerShell_EMP>Bullet_155mmHowitzerShell_EMP_directfire</Ammo_155mmHowitzerShell_EMP>
+			<Ammo_155mmHowitzerShell_Smoke>Bullet_155mmHowitzerShell_Smoke_directfire</Ammo_155mmHowitzerShell_Smoke>
+		</ammoTypes>
+    	<isMortarAmmoSet>true</isMortarAmmoSet>		
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="155mmHowitzerShellBase" ParentName="HeavyAmmoBase" Abstract="True">
@@ -212,6 +224,115 @@
 		  <explosionEffect>ExtinguisherExplosion</explosionEffect>
 		</projectile>
 	  </ThingDef>
+
+	<!-- direct fire-->
+	<ThingDef Name="Base155mmHowitzerShellDirectfire" ParentName="BaseBullet" Abstract="true">
+		<graphicData>
+			<shaderType>TransparentPostLight</shaderType>
+		  </graphicData>
+		  <projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>150</speed>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base155mmHowitzerShellDirectfire">
+		<defName>Bullet_155mmHowitzerShell_HE_directfire</defName>
+		<label>155mm Howitzer shell (HE)</label>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/Cannon/Howitzer/HE</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>452</damageAmountBase>
+			<explosionRadius>10.5</explosionRadius>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>40</Fragment_Large>
+					<Fragment_Small>60</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base155mmHowitzerShellDirectfire">
+		<defName>Bullet_155mmHowitzerShell_Incendiary_directfire</defName>
+		<label>155mm Howitzer shell (Incendiary)</label>
+		<graphicData>
+		  <texPath>Things/Projectile/Cannon/Howitzer/INC</texPath>
+		  <graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>PrometheumFlame</damageDef>
+			<damageAmountBase>0</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<explosionRadius>11.5</explosionRadius>
+			<flyOverhead>true</flyOverhead>
+			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
+			<soundExplode>MortarIncendiary_Explode</soundExplode>
+		</projectile>
+		<comps>
+		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+			<damageAmountBase>104</damageAmountBase>
+			<explosiveDamageType>Thermobaric</explosiveDamageType>
+			<explosiveRadius>4</explosiveRadius>
+			<explosionSound>MortarIncendiary_Explode</explosionSound>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		  </li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="Base155mmHowitzerShellDirectfire">
+		<defName>Bullet_155mmHowitzerShell_EMP_directfire</defName>
+		<label>155mm Howitzer shell (EMP)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Cannon/Howitzer/EMP</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageDef>EMP</damageDef>
+		  <damageAmountBase>452</damageAmountBase>
+		  <armorPenetrationSharp>0</armorPenetrationSharp>
+		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+		  <flyOverhead>true</flyOverhead>
+		  <explosionRadius>9.5</explosionRadius>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base155mmHowitzerShellDirectfire">
+		<defName>Bullet_155mmHowitzerShell_Smoke_directfire</defName>
+		<label>155mm Howitzer shell (Smoke)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Cannon/Howitzer/SMK</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+	<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageDef>Smoke</damageDef>
+		  <armorPenetrationSharp>0</armorPenetrationSharp>
+		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+		  <explosionRadius>10.5</explosionRadius>
+		  <flyOverhead>true</flyOverhead>
+		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+		  <soundExplode>Explosion_EMP</soundExplode>
+		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+		  <soundAmbient>MortarRound_Ambient</soundAmbient>
+		  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		  <preExplosionSpawnChance>1</preExplosionSpawnChance>
+		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		  <explosionEffect>ExtinguisherExplosion</explosionEffect>
+		</projectile>
+	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 

--- a/Patches/Fortifications - Industrial/FT_Artillery.xml
+++ b/Patches/Fortifications - Industrial/FT_Artillery.xml
@@ -8,17 +8,63 @@
     <match Class="PatchOperationSequence">
       <operations>
         
-      <!-- === Mortar === -->
+      <!-- === Turret Bases === -->
       
-      <li Class="PatchOperationRemove">
-        <xpath>
-          /Defs/ThingDef[defName="FT_Turret_Mortar"]/comps |
-          /Defs/ThingDef[defName="FT_Turret_Mortar"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"] |
-          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/weaponTags/li[text()="Artillery_BaseDestroyer"] |
-          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/building |
-          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/comps/li[@Class="CompProperties_ChangeableProjectile"]
-        </xpath>
-      </li>
+	        <li Class="PatchOperationRemove">
+			<xpath>
+			  /Defs/ThingDef[defName="FT_Turret_Mortar"]/comps |
+			  /Defs/ThingDef[defName="FT_Turret_Mortar"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"] |
+			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/weaponTags/li[text()="Artillery_BaseDestroyer"] |
+			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/building |
+			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/comps/li[@Class="CompProperties_ChangeableProjectile"]
+			</xpath>
+	        </li>
+	  
+		<li Class="PatchOperationRemove">
+			<xpath>
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class = "CompProperties_Refuelable"] |
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/inspectorTabs |
+			Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"] |
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"]
+			</xpath>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/thingClass</xpath>
+			<value>
+				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/turretBurstCooldownTime</xpath>
+			<value>
+				<turretBurstCooldownTime>1</turretBurstCooldownTime>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/building/turretBurstCooldownTime</xpath>
+			<value>
+				<turretBurstCooldownTime>6</turretBurstCooldownTime>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/fillPercent</xpath>
+			<value>
+				<fillPercent>0.85</fillPercent>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building</xpath>
+			<value>
+				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
+			</value>
+		</li>
+		
+      <!-- === Infantry Mortar === -->
       
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName="FT_Artillery_Mortar"]/label</xpath>
@@ -149,78 +195,6 @@
 				</verbs>
 			</value>
 		</li>
-
-		<!-- Patch base -->
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/thingClass</xpath>
-			<value>
-				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/building/turretBurstCooldownTime</xpath>
-			<value>
-				<turretBurstCooldownTime>5</turretBurstCooldownTime>
-			</value>
-		</li>
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/building</xpath>
-			<value>
-				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
-			</value>
-		</li>
-
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/inspectorTabs</xpath>
-		</li>
-
-      <!-- === Heavy Artillery Common === -->
-	  
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/thingClass</xpath>
-			<value>
-				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/turretBurstCooldownTime</xpath>
-			<value>
-				<turretBurstCooldownTime>1</turretBurstCooldownTime>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/fillPercent</xpath>
-			<value>
-				<fillPercent>0.85</fillPercent>
-			</value>
-		</li>
-
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building</xpath>
-			<value>
-				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
-			</value>
-		</li>
-
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/inspectorTabs</xpath>
-		</li>
-
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"]</xpath>
-		</li>
         
       <!-- === 155mm Artillery / NK-33L "Prince" === -->
 
@@ -290,7 +264,7 @@
 				<ThingDef ParentName="BaseWeaponTurret">
 					<defName>FT_Gun_TurretEmpero</defName>
 					<label>155mm field cannon</label>
-					<description>A recoilless cannon designed to engage heavily-armed targets at range.</description>
+					<description>A powerful direct-firing cannon with high accuracy.</description>
 					<graphicData>
 						<texPath>Empero/Empero_Gun</texPath>
 						<drawOffset>(5,0,0)</drawOffset>
@@ -312,7 +286,7 @@
 							<defaultProjectile>Bullet_155mmHowitzerShell_HE_directfire</defaultProjectile>
 							<warmupTime>4</warmupTime>
 							<minRange>4.9</minRange>
-							<range>500</range>
+							<range>126</range>
 							<soundCast>FT_CannonLaunchC</soundCast>
 							<soundCastTail>GunTail_Heavy</soundCastTail>
 							<muzzleFlashScale>32</muzzleFlashScale>

--- a/Patches/Fortifications - Industrial/FT_Artillery.xml
+++ b/Patches/Fortifications - Industrial/FT_Artillery.xml
@@ -180,6 +180,162 @@
 			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar"]/inspectorTabs</xpath>
 		</li>
 
+      <!-- === Heavy Artillery Common === -->
+	  
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/thingClass</xpath>
+			<value>
+				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/turretBurstCooldownTime</xpath>
+			<value>
+				<turretBurstCooldownTime>1</turretBurstCooldownTime>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/fillPercent</xpath>
+			<value>
+				<fillPercent>0.85</fillPercent>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building</xpath>
+			<value>
+				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/inspectorTabs</xpath>
+		</li>
+
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"]</xpath>
+		</li>
+        
+      <!-- === 155mm Artillery / NK-33L "Prince" === -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="FT_Gun_TurretPrince"]/statBases</xpath>
+			<value>
+				<SightsEfficiency>0.5</SightsEfficiency>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_Gun_TurretPrince"]/label</xpath>
+			<value>
+				<label>155mm howitzer</label>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="FT_Gun_TurretPrince"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_Charges">
+				<chargeSpeeds>
+					<li>30</li>
+					<li>50</li>
+					<li>70</li>
+					<li>90</li>
+				</chargeSpeeds>
+				</li>
+				<li Class="CombatExtended.CompProperties_AmmoUser">
+					<magazineSize>1</magazineSize>
+					<reloadTime>10</reloadTime>
+					<ammoSet>AmmoSet_155mmHowitzerShell</ammoSet>
+				</li>				
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="FT_Gun_TurretPrince"]/verbs</xpath>
+			<value>
+				<verbs>
+					<li Class="CombatExtended.VerbPropertiesCE">
+						<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+						<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+						<hasStandardCommand>true</hasStandardCommand>
+						<requireLineOfSight>false</requireLineOfSight>
+						<defaultProjectile>Bullet_155mmHowitzerShell_HE</defaultProjectile>
+						<warmupTime>4</warmupTime>
+						<minRange>50</minRange>
+						<range>1000</range>
+						<soundCast>FT_CannonLaunchB</soundCast>
+						<muzzleFlashScale>16</muzzleFlashScale>
+						<circularError>1</circularError>
+						<indirectFirePenalty>0.4</indirectFirePenalty>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+					</li>
+				</verbs>
+			</value>
+		</li>
+        
+      <!-- === 155mm Field Cannon / NK-30 "Empero" === -->
+	  
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="FT_Gun_TurretEmpero"]</xpath>
+			<value>
+				<ThingDef ParentName="BaseWeaponTurret">
+					<defName>FT_Gun_TurretEmpero</defName>
+					<label>155mm field cannon</label>
+					<description>A recoilless cannon designed to engage heavily-armed targets at range.</description>
+					<graphicData>
+						<texPath>Empero/Empero_Gun</texPath>
+						<drawOffset>(5,0,0)</drawOffset>
+					</graphicData>
+					<soundInteract>Artillery_ShellLoaded</soundInteract>
+					<statBases>
+						<RangedWeapon_Cooldown>8.0</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.18</SightsEfficiency>
+						<ShotSpread>0.01</ShotSpread>
+						<SwayFactor>3.07</SwayFactor>
+						<DeteriorationRate>0</DeteriorationRate>
+						<Mass>205</Mass>
+						<Flammability>0</Flammability>     
+					</statBases>
+					<verbs>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<defaultProjectile>Bullet_155mmHowitzerShell_HE_directfire</defaultProjectile>
+							<warmupTime>4</warmupTime>
+							<minRange>4.9</minRange>
+							<range>500</range>
+							<soundCast>FT_CannonLaunchC</soundCast>
+							<soundCastTail>GunTail_Heavy</soundCastTail>
+							<muzzleFlashScale>32</muzzleFlashScale>
+							<targetParams>
+							  <canTargetLocations>true</canTargetLocations>
+							</targetParams>
+							<recoilPattern>Mounted</recoilPattern>
+						</li>
+					</verbs>
+					<comps>
+						<li Class="CombatExtended.CompProperties_AmmoUser">
+							<magazineSize>1</magazineSize>
+							<reloadTime>10</reloadTime>
+							<ammoSet>AmmoSet_155mmHowitzerShell_directfire</ammoSet>
+						</li>
+						<li Class="CombatExtended.CompProperties_FireModes">
+							<aiAimMode>AimedShot</aiAimMode>
+						</li>
+					</comps>
+			  </ThingDef>
+			</value>
+		</li>
+
       </operations>
     </match>
   </Operation>

--- a/Patches/Fortifications - Industrial/FT_Artillery.xml
+++ b/Patches/Fortifications - Industrial/FT_Artillery.xml
@@ -10,34 +10,34 @@
         
       <!-- === Turret Bases === -->
       
-	        <li Class="PatchOperationRemove">
-			<xpath>
-			  /Defs/ThingDef[defName="FT_Turret_Mortar"]/comps |
-			  /Defs/ThingDef[defName="FT_Turret_Mortar"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"] |
-			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/weaponTags/li[text()="Artillery_BaseDestroyer"] |
-			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/building |
-			  /Defs/ThingDef[defName="FT_Artillery_Mortar"]/comps/li[@Class="CompProperties_ChangeableProjectile"]
-			</xpath>
-	        </li>
+      <li Class="PatchOperationRemove">
+        <xpath>
+          /Defs/ThingDef[defName="FT_Turret_Mortar"]/comps |
+          /Defs/ThingDef[defName="FT_Turret_Mortar"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"] |
+          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/weaponTags/li[text()="Artillery_BaseDestroyer"] |
+          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/building |
+          /Defs/ThingDef[defName="FT_Artillery_Mortar"]/comps/li[@Class="CompProperties_ChangeableProjectile"]
+        </xpath>
+      </li>
 	  
 		<li Class="PatchOperationRemove">
 			<xpath>
-			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class = "CompProperties_Refuelable"] |
-			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/inspectorTabs |
-			Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"] |
-			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"]
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/comps/li[@Class = "CompProperties_Refuelable"] |
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/inspectorTabs |
+			Defs/ThingDef[defName="FT_TurretPrince"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"] |
+			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"]
 			</xpath>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/thingClass</xpath>
+			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/thingClass</xpath>
 			<value>
 				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building/turretBurstCooldownTime</xpath>
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince"]/building/turretBurstCooldownTime</xpath>
 			<value>
 				<turretBurstCooldownTime>1</turretBurstCooldownTime>
 			</value>
@@ -51,14 +51,14 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/fillPercent</xpath>
+			<xpath>Defs/ThingDef[defName="FT_TurretPrince"]/fillPercent</xpath>
 			<value>
 				<fillPercent>0.85</fillPercent>
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince" or defName="FT_TurretEmpero"]/building</xpath>
+			<xpath>Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/building</xpath>
 			<value>
 				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
 			</value>
@@ -257,59 +257,104 @@
 		</li>
         
       <!-- === 155mm Field Cannon / NK-30 "Empero" === -->
+		<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Furniture Expanded - Security</li>
+			</mods>
+			<match Class="PatchOperationSequence">
+				<operations>
 	  
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="FT_Gun_TurretEmpero"]</xpath>
-			<value>
-				<ThingDef ParentName="BaseWeaponTurret">
-					<defName>FT_Gun_TurretEmpero</defName>
-					<label>155mm field cannon</label>
-					<description>A powerful direct-firing cannon with high accuracy.</description>
-					<graphicData>
-						<texPath>Empero/Empero_Gun</texPath>
-						<drawOffset>(5,0,0)</drawOffset>
-					</graphicData>
-					<soundInteract>Artillery_ShellLoaded</soundInteract>
-					<statBases>
-						<RangedWeapon_Cooldown>8.0</RangedWeapon_Cooldown>
-						<SightsEfficiency>2.18</SightsEfficiency>
-						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>3.07</SwayFactor>
-						<DeteriorationRate>0</DeteriorationRate>
-						<Mass>205</Mass>
-						<Flammability>0</Flammability>     
-					</statBases>
-					<verbs>
-						<li Class="CombatExtended.VerbPropertiesCE">
-							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-							<hasStandardCommand>true</hasStandardCommand>
-							<defaultProjectile>Bullet_155mmHowitzerShell_HE_directfire</defaultProjectile>
-							<warmupTime>4</warmupTime>
-							<minRange>4.9</minRange>
-							<range>126</range>
-							<soundCast>FT_CannonLaunchC</soundCast>
-							<soundCastTail>GunTail_Heavy</soundCastTail>
-							<muzzleFlashScale>32</muzzleFlashScale>
-							<targetParams>
-							  <canTargetLocations>true</canTargetLocations>
-							</targetParams>
-							<recoilPattern>Mounted</recoilPattern>
-						</li>
-					</verbs>
-					<comps>
-						<li Class="CombatExtended.CompProperties_AmmoUser">
-							<magazineSize>1</magazineSize>
-							<reloadTime>10</reloadTime>
-							<ammoSet>AmmoSet_155mmHowitzerShell_directfire</ammoSet>
-						</li>
-						<li Class="CombatExtended.CompProperties_FireModes">
-							<aiAimMode>AimedShot</aiAimMode>
-						</li>
-					</comps>
-			  </ThingDef>
-			</value>
-		</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+				</li>
+	  
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/inspectorTabs</xpath>
+				</li>
+	  
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"]</xpath>
+				</li>
+	  
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/building/buildingTags</xpath>
+				</li>
 
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/thingClass</xpath>
+					<value>
+						<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/building/turretBurstCooldownTime</xpath>
+					<value>
+						<turretBurstCooldownTime>1</turretBurstCooldownTime>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/fillPercent</xpath>
+					<value>
+						<fillPercent>0.85</fillPercent>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="FT_Gun_TurretEmpero"]</xpath>
+					<value>
+						<ThingDef ParentName="BaseWeaponTurret">
+							<defName>FT_Gun_TurretEmpero</defName>
+							<label>155mm field cannon</label>
+							<description>A powerful direct-firing cannon with high accuracy.</description>
+							<graphicData>
+								<texPath>Empero/Empero_Gun</texPath>
+								<drawOffset>(5,0,0)</drawOffset>
+							</graphicData>
+							<soundInteract>Artillery_ShellLoaded</soundInteract>
+							<statBases>
+								<RangedWeapon_Cooldown>8.0</RangedWeapon_Cooldown>
+								<SightsEfficiency>2.18</SightsEfficiency>
+								<ShotSpread>0.01</ShotSpread>
+								<SwayFactor>3.07</SwayFactor>
+								<DeteriorationRate>0</DeteriorationRate>
+								<Mass>205</Mass>
+								<Flammability>0</Flammability>     
+							</statBases>
+							<verbs>
+								<li Class="CombatExtended.VerbPropertiesCE">
+									<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+									<hasStandardCommand>true</hasStandardCommand>
+									<defaultProjectile>Bullet_155mmHowitzerShell_HE_directfire</defaultProjectile>
+									<warmupTime>4</warmupTime>
+									<minRange>4.9</minRange>
+									<range>126</range>
+									<soundCast>FT_CannonLaunchC</soundCast>
+									<soundCastTail>GunTail_Heavy</soundCastTail>
+									<muzzleFlashScale>32</muzzleFlashScale>
+									<targetParams>
+									  <canTargetLocations>true</canTargetLocations>
+									</targetParams>
+									<recoilPattern>Mounted</recoilPattern>
+								</li>
+							</verbs>
+							<comps>
+								<li Class="CombatExtended.CompProperties_AmmoUser">
+									<magazineSize>1</magazineSize>
+									<reloadTime>10</reloadTime>
+									<ammoSet>AmmoSet_155mmHowitzerShell_directfire</ammoSet>
+								</li>
+								<li Class="CombatExtended.CompProperties_FireModes">
+									<aiAimMode>AimedShot</aiAimMode>
+								</li>
+							</comps>
+					  </ThingDef>
+					</value>
+				</li>
+				</operations>
+			</match>
+		</li>
       </operations>
     </match>
   </Operation>

--- a/Patches/Fortifications - Industrial/FT_Artillery.xml
+++ b/Patches/Fortifications - Industrial/FT_Artillery.xml
@@ -328,7 +328,7 @@
 									<hasStandardCommand>true</hasStandardCommand>
 									<defaultProjectile>Bullet_155mmHowitzerShell_HE_directfire</defaultProjectile>
 									<warmupTime>4</warmupTime>
-									<minRange>4.9</minRange>
+									<minRange>22</minRange>
 									<range>126</range>
 									<soundCast>FT_CannonLaunchC</soundCast>
 									<soundCastTail>GunTail_Heavy</soundCastTail>


### PR DESCRIPTION
## Additions

 - Added Direct-fire AmmoSet for 155mm
 - Compatibility for 155mm Howitzer and Field cannon

## Changes

- None

## References

- Contributes towards #1324 

## Reasoning

Why did you choose to implement things this way, e.g.
- 155mm Howitzer stats are based on VFE:S Heavy artillery but with a bit faster reload (12s vs 10s)
- 155mm Field cannon stats are similar to the 90mm Flak, with tweaks to make it similar to the 155mm Howitzer

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
