### PR TITLE
Handle zipfiles from nuget with 777 umask

### DIFF
--- a/Make.py
+++ b/Make.py
@@ -247,6 +247,7 @@ def main(argv=sys.argv):
             downloadLib(package.name, package.version, package.destination, verbose=verbose)
             unpackLib(package.destination, f"{tdir}/downloads/unpack", verbose=verbose)
             time.sleep(1)
+        os.system(f"chmod -R +r {tdir}/downloads/unpack")
         os.system(f"cp -r {tdir}/downloads/unpack/ref/net472/* {options.reference}")
         os.system(f"cp -r {tdir}/downloads/unpack/lib/net472/* {options.reference}")
 


### PR DESCRIPTION
## Changes

Apparently, nuget can host zip files whose contents are flagged unreadable, which prevents linking against them.
This marks all extracted files readable before trying to use the extracted files.

## References

Needed for #1380 

## Reasoning

Good idea to workaround the issue on our side as it may come up with future libraries too.  Sokyran has reported the issue to the Multiplayer devs, but this is more future proof, and cheap.

## Alternatives

Insist all referenced zip files are sane.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
