### PR TITLE
Replace reflection with direct calls or Harmony

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -21,8 +21,6 @@ namespace CombatExtended
      */
     internal static class AmmoInjector
     {
-        public static readonly FieldInfo _allRecipesCached = typeof(ThingDef).GetField("allRecipesCached", BindingFlags.Instance | BindingFlags.NonPublic);
-
         public const string destroyWithAmmoDisabledTag = "CE_Ammo";               // The trade tag which automatically deleted this ammo with the ammo system disabled
         private const string enableTradeTag = "CE_AutoEnableTrade";             // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
         private const string enableCraftingTag = "CE_AutoEnableCrafting";        // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
@@ -292,7 +290,7 @@ namespace CombatExtended
                     }
                 }
             }
-            _allRecipesCached.SetValue(benchDef, null);  // Set ammoCraftingStation.AllRecipes to null so it will reset
+            benchDef.allRecipesCached = null;  // Set ammoCraftingStation.AllRecipes to null so it will reset
         }
 
         public static bool gunRecipesShowCaliber = false;

--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -162,7 +162,7 @@ namespace CombatExtended
 				catch (Exception e) {	throw new Exception(def+".plant.immatureGraphic", e);	}
     		}
     		
-    		Graphic graphicSowing = (Graphic)(typeof(Plant).GetField("GraphicSowing", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null));
+    		Graphic graphicSowing = Plant.GraphicSowing;
     		
 			try {	if (graphicSowing != null)
 					BoundMap(graphicSowing, GraphicType.Plant);	}

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -451,12 +451,10 @@ namespace CombatExtended
 
         public static List<ThingDef> allWeaponDefs = new List<ThingDef>();
 
-        public static readonly FieldInfo cachedLabelCapInfo = typeof(Def).GetField("cachedLabelCap", BindingFlags.NonPublic | BindingFlags.Instance);
-
         public static void UpdateLabel(this Def def, string label)
         {
             def.label = label;
-            cachedLabelCapInfo.SetValue(def, new TaggedString(""));
+            def.cachedLabelCap = "";
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -24,7 +24,6 @@ namespace CombatExtended
         public bool IsActive => Controller.settings.EnableAmmoSystem && (parent.TryGetComp<CompCanBeDormant>()?.Awake ?? true);
 
         //FieldInfo thingsField = typeof(LordJob_MechanoidDefendBase).GetField("things");
-        FieldInfo mechClusterDefeatedField = typeof(LordJob_MechanoidDefendBase).GetField("mechClusterDefeated");
         LordJob_MechanoidDefendBase parentLordJob => ((parent as Building)?.GetLord()?.LordJob as LordJob_MechanoidDefendBase);
         public bool ClusterAlive
         {
@@ -35,7 +34,7 @@ namespace CombatExtended
                 if (lordJob == null)
                     return false;
 
-                return !(bool)mechClusterDefeatedField.GetValue(lordJob);
+                return !lordJob.mechClusterDefeated;
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -184,9 +184,6 @@ namespace CombatExtended
          * Current users are SmokepopBelt and BroadshieldPack, requiring bullet.def and bullet.Launcher.
          */
 
-        // todo: remove when moved to publicised assembly
-        private static readonly FieldInfo bulletLauncher = typeof(Bullet).GetField("launcher", BindingFlags.Instance | BindingFlags.NonPublic);
-
         private Bullet GenerateVanillaBullet()
         {
             var bullet = new Bullet
@@ -195,7 +192,7 @@ namespace CombatExtended
                 intendedTarget = this.intendedTargetThing,
             };
 
-            bulletLauncher.SetValue(bullet, this.launcher);  //Bad for performance, refactor if a more efficient solution is possible
+            bullet.launcher = launcher;
             return bullet;
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -345,8 +345,6 @@ namespace CombatExtended
         }
 
 
-        // Todo: When rimworld harmony updates to 2.0.4 use FieldRefAccess
-        private static readonly FieldInfo subGraphics = typeof(Graphic_Collection).GetField("subGraphics", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
 
         private Material[] shadowMaterial;
         private Material ShadowMaterial
@@ -562,8 +560,6 @@ namespace CombatExtended
         #endregion
 
         #region Collisions        
-        static readonly FieldInfo interceptDebug = typeof(CompProjectileInterceptor).GetField("debugInterceptNonHostileProjectiles", BindingFlags.NonPublic | BindingFlags.Instance);
-
         private bool CheckIntercept(Thing interceptorThing, CompProjectileInterceptor interceptorComp, bool withDebug = false)
         {
             Vector3 shieldPosition = interceptorThing.Position.ToVector3ShiftedWithAltitude(0.5f);
@@ -591,7 +587,7 @@ namespace CombatExtended
                 return false;
             }
 
-            if ((launcher == null || !launcher.HostileTo(interceptorThing)) && !((bool)interceptDebug.GetValue(interceptorComp)) && !interceptorComp.Props.interceptNonHostileProjectiles)
+            if ((launcher == null || !launcher.HostileTo(interceptorThing)) && !interceptorComp.debugInterceptNonHostileProjectiles && !interceptorComp.Props.interceptNonHostileProjectiles)
             {
                 return false;
             }
@@ -1165,7 +1161,7 @@ namespace CombatExtended
 
         private static Material[] GetShadowMaterial(Graphic_Collection g)
         {
-            var collection = (Graphic[])subGraphics.GetValue(g);
+            var collection = g.subGraphics;
             var shadows = collection.Select(item => item.GetColoredVersion(ShaderDatabase.Transparent, Color.black, Color.black).MatSingle).ToArray();
 
             return shadows;

--- a/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
+++ b/Source/CombatExtended/Harmony/Harmony_GenRadial.cs
@@ -40,7 +40,7 @@ namespace CombatExtended.HarmonyCE
 			ConstructorInfo constructor = typeof(GenRadial).GetConstructors(AccessTools.all).FirstOrDefault();
 			MethodInfo redoMethod = null;
 
-            defaultValue = (Int32)AccessTools.Field(typeof(GenRadial), "RadialPatternCount").GetValue(null);
+            defaultValue = GenRadial.RadialPatternCount;
 
 			// patch the constructor.
 			HarmonyBase.instance.Patch(constructor, null, null, new HarmonyMethod(typeof(Harmony_GenRadial_RadialPatternCount), "Transpiler_RadialPatternCount"));

--- a/Source/CombatExtended/Harmony/Harmony_TurretGunUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony_TurretGunUtility.cs
@@ -18,7 +18,7 @@ namespace CombatExtended.HarmonyCE
         const string className = "DisplayClass";
         const string methodName = "<TryFindRandomShellDef>";
 
-        public static void Postfix(object __instance, ThingDef x, ref bool __result)
+        public static void Postfix(object __instance, ThingDef x, ref bool __result, bool ___allowEMP, float ___maxMarketValue, bool ___mustHarmHealth)
         {
             // Ignore already true results.
             if (__result)
@@ -34,21 +34,8 @@ namespace CombatExtended.HarmonyCE
                 return;
             }
 
-            #region Get properties of parent of TryFindRandomShellDef
-            var type = __instance.GetType();
-
-            bool allowEMP;
-            bool.TryParse(AccessTools.Field(type, "allowEMP").GetValue(__instance)?.ToString(), out allowEMP);
-
-            float maxMarketValue;
-            float.TryParse(AccessTools.Field(type, "maxMarketValue").GetValue(__instance)?.ToString(), out maxMarketValue);
-
-            bool mustHarmHealth;
-            bool.TryParse(AccessTools.Field(type, "mustHarmHealth").GetValue(__instance)?.ToString(), out mustHarmHealth);
-            #endregion
-
             // Check if market value is within range.
-            if (maxMarketValue >= 0.0f && ammoDef.BaseMarketValue > maxMarketValue)
+            if (___maxMarketValue >= 0.0f && ammoDef.BaseMarketValue > ___maxMarketValue)
             {
                 return;
             }
@@ -68,13 +55,13 @@ namespace CombatExtended.HarmonyCE
             }
 
             // Ignore EMP if not allowed.
-            if (!allowEMP && (explosiveDamageDef == DamageDefOf.EMP || projectileDamageDef == DamageDefOf.EMP))
+            if (!___allowEMP && (explosiveDamageDef == DamageDefOf.EMP || projectileDamageDef == DamageDefOf.EMP))
             {
                 return;
             }
 
             // Check if shell harms health.
-            if (mustHarmHealth && explosiveDamageDef != null && !explosiveDamageDef.harmsHealth && projectileDamageDef != null && !projectileDamageDef.harmsHealth)
+            if (___mustHarmHealth && explosiveDamageDef != null && !explosiveDamageDef.harmsHealth && projectileDamageDef != null && !projectileDamageDef.harmsHealth)
             {
                 return;
             }


### PR DESCRIPTION
## Changes

- Wherever possible, use direct reference to fields
- If not possible, use `FieldRef`/`FieldRefAccess` from Harmony
- In one of the cases, used Harmony's functionality of accessing class fields in pre/postfixes
- Used `FastInvokeHandler`/`MethodInvoker` to replace `MethodInfo.Invoke()` call

## Reasoning

- Direct access with publicized assemblies should be much faster
- `FieldRef`/`FieldRefAccess` is much faster than reflection
- `FastInvokeHandler`/`MethodInvoker` is slightly faster than using reflection

## Alternatives

- Using slow reflection

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
