### PR TITLE
Add T's Samurai Faction to SupportedThirdPartyMods

### DIFF
--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -362,6 +362,7 @@ Tsar Armory	|
 Turk's Guns |
 Turret Collection	|
 Twi'lek Race    |
+T's Samurai Faction |
 Ultratech: Altered Carbon Remastered |
 Useless Clothes |
 Vanilla Animals Expanded |


### PR DESCRIPTION
## Additions

 - Add T's Samurai Faction to the list of Supported Third-Party Mods.

## Changes

## References

 - Support for T's Samurai Faction was added in #1067.

## Reasoning

## Alternatives

 - Unsure about Placement due to the `'` in the name. Could be placed at the start of Mods that start with a `T`.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
