### PR TITLE
Generic ammo for Taurus Judge and general generics cleanup

### DIFF
--- a/Defs/Ammo/Advanced/10x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/10x18mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_10x18mmCharged_AP>Bullet_10x18mmCharged_AP</Ammo_10x18mmCharged_AP>
       <Ammo_10x18mmCharged_Ion>Bullet_10x18mmCharged_Ion</Ammo_10x18mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedPistol</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_12GaugeCharged_Slug>Bullet_12GaugeCharged_Slug</Ammo_12GaugeCharged_Slug>
       <Ammo_12GaugeCharged_Ion>Bullet_12GaugeCharged_Ion</Ammo_12GaugeCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedShotgun</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_12x64mmCharged>Bullet_12x64mmCharged</Ammo_12x64mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedHeavy</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_12x72mmCharged_AP>Bullet_12x72mmCharged_AP</Ammo_12x72mmCharged_AP>
       <Ammo_12x72mmCharged_Ion>Bullet_12x72mmCharged_Ion</Ammo_12x72mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedHeavy</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_15x65mmDiffusingCharged_Buck>Bullet_15x65mmDiffusingCharged_Buck</Ammo_15x65mmDiffusingCharged_Buck>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedHeavy</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_5x35mmCharged>Bullet_5x35mmCharged</Ammo_5x35mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_6x18mmCharged_AP>Bullet_6x18mmCharged_AP</Ammo_6x18mmCharged_AP>
       <Ammo_6x18mmCharged_Ion>Bullet_6x18mmCharged_Ion</Ammo_6x18mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedPistol</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_6x22mmCharged>Bullet_6x22mmCharged</Ammo_6x22mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_6x24mmCharged_AP>Bullet_6x24mmCharged_AP</Ammo_6x24mmCharged_AP>
       <Ammo_6x24mmCharged_Ion>Bullet_6x24mmCharged_Ion</Ammo_6x24mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_8x35mmCharged_AP>Bullet_8x35mmCharged_AP</Ammo_8x35mmCharged_AP>
       <Ammo_8x35mmCharged_Ion>Bullet_8x35mmCharged_Ion</Ammo_8x35mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -18,6 +18,7 @@
       <Ammo_8x50mmCharged_AP>Bullet_8x50mmCharged_AP</Ammo_8x50mmCharged_AP>
       <Ammo_8x50mmCharged_Ion>Bullet_8x50mmCharged_Ion</Ammo_8x50mmCharged_Ion>
     </ammoTypes>
+    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/GENERIC/Charged.xml
+++ b/Defs/Ammo/GENERIC/Charged.xml
@@ -26,6 +26,55 @@
     <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
   </ThingCategoryDef>
 
+  <ThingCategoryDef>
+    <defName>AmmoShotgunCharged</defName>
+    <label>Charged Shotgun Ammo</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_ChargedPistol</defName>
+    <label>charged pistol</label>
+    <ammoTypes>
+      <Ammo_PistolCharged>Bullet_6x18mmCharged</Ammo_PistolCharged>
+      <Ammo_PistolCharged_AP>Bullet_6x18mmCharged_AP</Ammo_PistolCharged_AP>
+      <Ammo_PistolCharged_Ion>Bullet_6x18mmCharged_Ion</Ammo_PistolCharged_Ion>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_ChargedRifle</defName>
+    <label>charged rifle</label>
+    <ammoTypes>
+      <Ammo_RifleCharged>Bullet_6x24mmCharged</Ammo_RifleCharged>
+      <Ammo_RifleCharged_AP>Bullet_6x24mmCharged_AP</Ammo_RifleCharged_AP>
+      <Ammo_RifleCharged_Ion>Bullet_6x24mmCharged_Ion</Ammo_RifleCharged_Ion>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_ChargedHeavy</defName>
+    <label>heavy charged</label>
+    <ammoTypes>
+      <Ammo_HeavyCharged>Bullet_12x72mmCharged</Ammo_HeavyCharged>
+      <Ammo_HeavyCharged_AP>Bullet_12x72mmCharged_AP</Ammo_HeavyCharged_AP>
+      <Ammo_HeavyCharged_Ion>Bullet_12x72mmCharged_Ion</Ammo_HeavyCharged_Ion>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_ChargedShotgun</defName>
+    <label>charged shotgun</label>
+    <ammoTypes>
+      <Ammo_ShotgunCharged>Bullet_12GaugeCharged</Ammo_ShotgunCharged>
+      <Ammo_ShotgunCharged_Slug>Bullet_12GaugeCharged_Slug</Ammo_ShotgunCharged_Slug>
+      <Ammo_ShotgunCharged_Ion>Bullet_12GaugeCharged_Ion</Ammo_ShotgunCharged_Ion>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
 	<!-- ============= Ammo ============= -->
 
 <!-- Charged Pistol -->
@@ -178,5 +227,52 @@
     <generateAllowChance>0.25</generateAllowChance>
   </ThingDef>
 
+  <!-- Charge Shotgun -->
 
+  <ThingDef Class="CombatExtended.AmmoDef" Name="ChargeShotgunAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
+    <statBases>
+	  <Mass>0.034</Mass>
+	  <Bulk>0.07</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
+    </tradeTags>
+    <thingCategories>
+      <li>AmmoShotgunCharged</li>
+    </thingCategories>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="ChargeShotgunAmmo">
+    <defName>Ammo_ShotgunCharged</defName>
+    <label>Charged shotgun shell</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Regular</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <ammoClass>BuckShot</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="ChargeShotgunAmmo">
+    <defName>Ammo_ShotgunCharged_Slug</defName>
+    <label>Charged shotgun shell (Slug)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Concentrated</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <ammoClass>Slug</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="ChargeShotgunAmmo">
+    <defName>Ammo_ShotgunCharged_Ion</defName>
+    <label>Charged shotgun shell (Ion Shot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Ion</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <ammoClass>Ionized</ammoClass>
+    <generateAllowChance>0.25</generateAllowChance>
+  </ThingDef>
+  
 </Defs>

--- a/Defs/Ammo/GENERIC/Generics_Misc.xml
+++ b/Defs/Ammo/GENERIC/Generics_Misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
+
+    <!--For unique generic ammosets that don't fit in any existing category-->
+    <!-- ==================== Taurus Judge ========================== -->
     <CombatExtended.AmmoSetDef>
         <defName>AmmoSet_RevolverShotgun</defName>
         <label>revolver shotgun</label>

--- a/Defs/Ammo/GENERIC/Generics_Misc.xml
+++ b/Defs/Ammo/GENERIC/Generics_Misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <CombatExtended.AmmoSetDef>
+        <defName>AmmoSet_RevolverShotgun</defName>
+        <label>revolver shotgun</label>
+        <ammoTypes>
+            <Ammo_PistolMagnum_FMJ>Bullet_45Colt_FMJ</Ammo_PistolMagnum_FMJ>
+            <Ammo_PistolMagnum_AP>Bullet_45Colt_AP</Ammo_PistolMagnum_AP>
+            <Ammo_PistolMagnum_HP>Bullet_45Colt_HP</Ammo_PistolMagnum_HP>
+            <Ammo_Shotgun_Buck>Bullet_410Bore_Buck</Ammo_Shotgun_Buck>
+        </ammoTypes>
+    </CombatExtended.AmmoSetDef>
+</Defs>

--- a/Defs/Ammo/GENERIC/PistolMagnum.xml
+++ b/Defs/Ammo/GENERIC/PistolMagnum.xml
@@ -25,7 +25,7 @@
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoPistomMagnum" ParentName="SmallAmmoBase" Abstract="True">
-		<description>Powerful pistol cartridge designed for revolvers.</description>
+		<description>Powerful pistol cartridge designed primarily for revolvers.</description>
 		<statBases>
 			<Mass>0.023</Mass>
 			<Bulk>0.02</Bulk>

--- a/Defs/Ammo/GENERIC/Rifle.xml
+++ b/Defs/Ammo/GENERIC/Rifle.xml
@@ -29,7 +29,7 @@
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleBase" ParentName="SmallAmmoBase" Abstract="True">
-		<description>Large rifle bullet used in machine guns, sniper rifles and battle rifle.</description>
+		<description>Large rifle bullet used in machine guns, sniper rifles and battle rifles.</description>
 		<statBases>
 			<Mass>0.025</Mass>
 			<Bulk>0.03</Bulk>

--- a/Defs/Ammo/GENERIC/RifleMagnum.xml
+++ b/Defs/Ammo/GENERIC/RifleMagnum.xml
@@ -28,7 +28,7 @@
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleMagnumBase" ParentName="SmallAmmoBase" Abstract="True">
-        <description>high power rifle ammunition, used mainly by long range sniper rifles.</description>
+        <description>High power rifle ammunition, used mainly by long range sniper rifles.</description>
 		<statBases>
 			<Mass>0.05</Mass>
 			<Bulk>0.05</Bulk>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -19,7 +19,7 @@
 			<Ammo_408CheyenneTactical_HE>Bullet_408CheyenneTactical_HE</Ammo_408CheyenneTactical_HE>
 			<Ammo_408CheyenneTactical_Sabot>Bullet_408CheyenneTactical_Sabot</Ammo_408CheyenneTactical_Sabot>	         
     </ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
+		<similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -18,7 +18,7 @@
 			<Ammo_10mmAuto_AP>Bullet_10mmAuto_AP</Ammo_10mmAuto_AP>
 			<Ammo_10mmAuto_HP>Bullet_10mmAuto_HP</Ammo_10mmAuto_HP>
 		</ammoTypes>
-		<similarTo>AmmoSet_PistolMagnum</similarTo>
+		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -18,7 +18,7 @@
 			<Ammo_357SIG_AP>Bullet_357SIG_AP</Ammo_357SIG_AP>
 			<Ammo_357SIG_HP>Bullet_357SIG_HP</Ammo_357SIG_HP>
 		</ammoTypes>
-		<similarTo>AmmoSet_PistolMagnum</similarTo>
+		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -30,6 +30,7 @@
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck</Ammo_410Bore_Buck>
 		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
@@ -41,6 +42,7 @@
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
 		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -18,7 +18,7 @@
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
 		</ammoTypes>
-		<similarTo>AmmoSet_Pistol</similarTo>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -18,6 +18,7 @@
 			<Ammo_46x30mm_AP>Bullet_46x30mm_AP</Ammo_46x30mm_AP>
 			<Ammo_46x30mm_HP>Bullet_46x30mm_HP</Ammo_46x30mm_HP>
 		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -21,7 +21,7 @@
 			<Ammo_65x52mmCarcano_HE>Bullet_65x52mmCarcano_HE</Ammo_65x52mmCarcano_HE>
 			<Ammo_65x52mmCarcano_Sabot>Bullet_65x52mmCarcano_Sabot</Ammo_65x52mmCarcano_Sabot>								
 		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>	
+		<similarTo>AmmoSet_Rifle</similarTo>	
 	</CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -21,7 +21,7 @@
 			<Ammo_77x58mmArisaka_HE>Bullet_77x58mmArisaka_HE</Ammo_77x58mmArisaka_HE>
 			<Ammo_77x58mmArisaka_Sabot>Bullet_77x58mmArisaka_Sabot</Ammo_77x58mmArisaka_Sabot>			
 		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+		<similarTo>AmmoSet_Rifle</similarTo>
 	</CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->


### PR DESCRIPTION
## Additions

- Added generic charged ammosets to all current charge calibers
- Added the generic ammoset to the .45Colt + .410 bore ammoset
- New generic file to store all unique ammosets
- Added a generic ammoset to 4.6x30mm

## Changes

- Changed 10mm Auto generic: PistolMagnum => Pistol
- Changed .45 Colt generic: Pistol => PistolMagnum
- Changed .357 SIG generic: PistolMagnum => Pistol
- Changed .408 Cheyenne generic: AntiMateriel => RifleMagnum
- Changed 6.5x55mm Carcano generic: RifleIntermediate => Rifle
- Changed 7.7x58mm Arisaka generic: RifleIntermediate => Rifle
- Fixed some typos in generic descriptions

## Reasoning

- 10mm and .357SIG are too small for the Magnum category
- .45 Colt is too big for the Pistol category
- 6.5x55mm and 7.7x58mm are full power cartridges
- .408 is not quite Anti-Materiel



