### PR TITLE
Charged recipes and misc fixes

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -181,14 +181,14 @@
     <fixedIngredientFilter>
       <thingDefs>
         <li>Plasteel</li>
-        <li>Steel</li>         
+        <li>Steel</li>
         <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
       <Ammo_12GaugeCharged>200</Ammo_12GaugeCharged>
     </products>
-    <workAmount>20800</workAmount>		    
+    <workAmount>20800</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
@@ -237,9 +237,9 @@
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
     <defName>MakeAmmo_12GaugeCharged_Ion</defName>
-    <label>make 12 gauge Charged (Ion slug) shell x200</label>
-    <description>Craft 200 12 gauge Charged (Ion) shells.</description>
-    <jobString>Making 12 gauge Charged (Ion) shells.</jobString>
+    <label>make 12 gauge Charged (Ion Shot) shell x200</label>
+    <description>Craft 200 12 gauge Charged (Ion Shot) shells.</description>
+    <jobString>Making 12 gauge Charged (Ion Shot) shells.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -16,7 +16,6 @@
     <ammoTypes>
       <Ammo_12x64mmCharged>Bullet_12x64mmCharged</Ammo_12x64mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_ChargedHeavy</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -16,7 +16,6 @@
     <ammoTypes>
       <Ammo_15x65mmDiffusingCharged_Buck>Bullet_15x65mmDiffusingCharged_Buck</Ammo_15x65mmDiffusingCharged_Buck>
     </ammoTypes>
-    <similarTo>AmmoSet_ChargedHeavy</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -16,7 +16,6 @@
     <ammoTypes>
       <Ammo_5x35mmCharged>Bullet_5x35mmCharged</Ammo_5x35mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -16,7 +16,6 @@
     <ammoTypes>
       <Ammo_6x22mmCharged>Bullet_6x22mmCharged</Ammo_6x22mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_ChargedRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/GENERIC/Charged.xml
+++ b/Defs/Ammo/GENERIC/Charged.xml
@@ -274,5 +274,543 @@
     <ammoClass>Ionized</ammoClass>
     <generateAllowChance>0.25</generateAllowChance>
   </ThingDef>
-  
+
+  <!-- ==================== Recipes ========================== -->
+
+  <!-- Charged Pistol -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_PistolCharged</defName>
+    <label>make Charged pistol cartridge x500</label>
+    <description>Craft 500 Charged pistol cartridges.</description>
+    <jobString>Making Charged pistol cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_PistolCharged>500</Ammo_PistolCharged>
+    </products>
+    <workAmount>8400</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_PistolCharged_AP</defName>
+    <label>make Charged pistol (Conc.) cartridge x500</label>
+    <description>Craft 500 Charged pistol (Conc.) cartridges.</description>
+    <jobString>Making Charged pistol (Conc.) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_PistolCharged_AP>500</Ammo_PistolCharged_AP>
+    </products>
+    <workAmount>8400</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_PistolCharged_Ion</defName>
+    <label>make Charged pistol (Ion) cartridge x500</label>
+    <description>Craft 500 Charged pistol (Ion) cartridges.</description>
+    <jobString>Making Charged pistol (Ion) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_PistolCharged_Ion>500</Ammo_PistolCharged_Ion>
+    </products>
+    <workAmount>8400</workAmount>		
+  </RecipeDef>
+
+  <!-- Charged Rifle -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_RifleCharged</defName>
+    <label>make Charged rifle cartridge x500</label>
+    <description>Craft 500 Charged rifle cartridges.</description>
+    <jobString>Making Charged rifle cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_RifleCharged>500</Ammo_RifleCharged>
+    </products>
+    <workAmount>8600</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_RifleCharged_AP</defName>
+    <label>make Charged rifle (Conc.) cartridge x500</label>
+    <description>Craft 500 Charged rifle (Conc.) cartridges.</description>
+    <jobString>Making Charged rifle (Conc.) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_RifleCharged_AP>500</Ammo_RifleCharged_AP>
+    </products>
+    <workAmount>8600</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_RifleCharged_Ion</defName>
+    <label>make Charged rifle (Ion) cartridge x500</label>
+    <description>Craft 500 Charged rifle (Ion) cartridges.</description>
+    <jobString>Making Charged rifle (Ion) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_RifleCharged_Ion>500</Ammo_RifleCharged_Ion>
+    </products>
+    <workAmount>8600</workAmount>		
+  </RecipeDef>
+
+  <!-- Heavy Charged-->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_HeavyCharged</defName>
+    <label>make heavy Charged cartridge x500</label>
+    <description>Craft 500 heavy Charged cartridges.</description>
+    <jobString>Making heavy Charged cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_HeavyCharged>500</Ammo_HeavyCharged>
+    </products>
+    <workAmount>29800</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_HeavyCharged_AP</defName>
+    <label>make heavy Charged (Conc.) cartridge x500</label>
+    <description>Craft 500 heavy Charged (Conc.) cartridges.</description>
+    <jobString>Making heavy Charged (Conc.) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_HeavyCharged_AP>500</Ammo_HeavyCharged_AP>
+    </products>
+    <workAmount>29800</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_HeavyCharged_Ion</defName>
+    <label>make heavy Charged (Ion) cartridge x500</label>
+    <description>Craft 500 heavy Charged (Ion) cartridges.</description>
+    <jobString>Making heavy Charged (Ion) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>29</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_HeavyCharged_Ion>500</Ammo_HeavyCharged_Ion>
+    </products>
+    <workAmount>29800</workAmount>		
+  </RecipeDef>
+
+  <!-- Charged Shotgun -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_ShotgunCharged</defName>
+    <label>make Charged shotgun shell x200</label>
+    <description>Craft 200 Charged shotgun shells.</description>
+    <jobString>Making Charged shotgun shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	      
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_ShotgunCharged>200</Ammo_ShotgunCharged>
+    </products>
+    <workAmount>20800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_ShotgunCharged_Slug</defName>
+    <label>make Charged shotgun (Slug) shell x200</label>
+    <description>Craft 200 Charged shotgun (Slug) shells.</description>
+    <jobString>Making Charged shotgun (Slug) shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	      
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_ShotgunCharged_Slug>200</Ammo_ShotgunCharged_Slug>
+    </products>
+    <workAmount>20800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_ShotgunCharged_Ion</defName>
+    <label>make Charged shotgun (Ion Shot) shell x200</label>
+    <description>Craft 200 Charged shotgun (Ion Shot) shells.</description>
+    <jobString>Making Charged shotgun (Ion Shot) shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	      
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_ShotgunCharged_Ion>200</Ammo_ShotgunCharged_Ion>
+    </products>
+    <workAmount>20800</workAmount>
+  </RecipeDef>
+
 </Defs>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -200,8 +200,15 @@
 					</ItemProcessor.CombinationDef>
 				</value>
 			</li>
-			
-			
+
+			<li Class="PatchOperationReplace" MayRequire="sarg.alphabiomes">
+				<xpath>Defs/ItemProcessor.CombinationDef[defName="VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry_AB_Shell_Tar"]/result</xpath>
+				<value>
+					<result>Tar_shell_81mm</result>
+				</value>
+			</li>
+
+
       </operations>
     </match>
   </Operation>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -463,6 +463,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building</xpath>
+				<value>
+					<turretBurstWarmupTime>4.0</turretBurstWarmupTime>
+				</value>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building/turretBurstCooldownTime</xpath>
 				<value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -116,6 +116,13 @@
         </value>
       </li>
 
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[@Name = "VFEP_CrashedShip"]/building</xpath>
+        <value>
+          <turretBurstWarmupTime>3.0</turretBurstWarmupTime>
+        </value>
+      </li>
+
       <!-- Vanilla Gauntlet Charge Cannnon -->
       <li Class="PatchOperationAdd">
         <xpath>/Defs</xpath>


### PR DESCRIPTION
## Additions

- Added missing generic charged ammo recipes
- Fixed the Artillery Foundry from VFE-Mechs bug caused by removal of the tar shells from Alpha Biomes
- Fixed the crashed ship gauntlet turret and tesla turret warmup time from VE mechs and pirates mods
- **GOD DAMN IT SAM YOU'RE SUPPOSED TO TEST STUFF BEFORE APPROVING IT**
- PSA: load up the game with the changes in your PRs to make sure stuff's working as intended :D