### PR TITLE
Increase mag capacity of Orassan pistol

### DIFF
--- a/Patches/Orassans/ThingDefs_Weapons/Weapons.xml
+++ b/Patches/Orassans/ThingDefs_Weapons/Weapons.xml
@@ -140,7 +140,7 @@
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
 					<AmmoUser>
-						<magazineSize>10</magazineSize>
+						<magazineSize>20</magazineSize>
 						<reloadTime>2</reloadTime>
 						<ammoSet>AmmoSet_6mmRailgunOE</ammoSet>
 					</AmmoUser>


### PR DESCRIPTION
## Changes

- Increased magazine capacity of Orassan pistol from 10 to 20

## Reasoning

As requested by @DianaWinters.

The Orassan pistol is chambered in a custom 6mm OE railgun cartridge, which is similar in size to the real-life FN 5.7×28mm cartridge used in the FN Five-seven pistol, which in turn typically uses 20-round magazines as standard.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
