### PR TITLE
Compatibility for WarCasket Expanded and RimHammer40k -Dreadnought

### DIFF
--- a/Patches/RimHammer40k -Dreadnought/Apparel_Dreadnought.xml
+++ b/Patches/RimHammer40k -Dreadnought/Apparel_Dreadnought.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>RimHammer40k -Dreadnought</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+		<!-- ========== Remove Vanilla Carry Capacity ========== -->		
+		<li Class="PatchOperationRemove">
+			<xpath>/Defs/VFEPirates.WarcasketDef[
+			defName="Warcasket_Dreadnought"														
+			]/modExtensions/li/carryingCapacity</xpath>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Dreadnought"]/statBases</xpath>
+			<value>
+				<Bulk>350</Bulk>
+				<WornBulk>40</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Dreadnought"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>75</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Dreadnought"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>187.5</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Dreadnought"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>450</CarryWeight>
+				<CarryBulk>300</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- ========== Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Dreadnought"]/statBases</xpath>
+			<value>
+				<Bulk>45</Bulk>
+				<WornBulk>15</WornBulk>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Dreadnought"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>75</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Dreadnought"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>187.5</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- === Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Dreadnought"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>8</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+	
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Dreadnought"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Dreadnought"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>80</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Dreadnought"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>200</ArmorRating_Blunt>
+			</value>
+		</li>
+			
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>WarCasket Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+	<!-- ========== Remove Vanilla Carry Capacity ========== -->		
+		<li Class="PatchOperationRemove">
+			<xpath>/Defs/VFEPirates.WarcasketDef[
+			defName="Warcasket_Sentinel" or
+			defName="Warcasket_Guardian" or
+			defName="Warcasket_Tyrant"															
+			]/modExtensions/li/carryingCapacity</xpath>
+		</li>
+
+	<!-- ========== Sentinel Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Sentinel"]/statBases</xpath>
+			<value>
+				<Bulk>218.75</Bulk>
+				<WornBulk>18.75</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Sentinel"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>21.83</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Sentinel"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>54.575</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Sentinel"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>225</CarryWeight>
+				<CarryBulk>175</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- ========== Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>21.83</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>54.575</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- === Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/statBases</xpath>
+			<value>
+				<Bulk>12.5</Bulk>
+				<WornBulk>6.25</WornBulk>
+			</value>
+		</li>
+	
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>19.47</ArmorRating_Sharp>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>43.8</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+	<!-- Guardian Warcasket -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>230</Bulk>
+				<WornBulk>25</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>112</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Guardian"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>225</CarryWeight>
+				<CarryBulk>175</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- ========== Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>112</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- === Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>12.5</Bulk>
+				<WornBulk>6.25</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+	
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>30</ArmorRating_Sharp>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>120</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+	<!-- ========== Tyrant Warcasket ========== -->	
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Tyrant"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Tyrant"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>20</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Tyrant"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>48</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Tyrant"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>225</CarryWeight>
+				<CarryBulk>175</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- ========== Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>20</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>48</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+			<value>
+				<ammoDef>Ammo_40x53mmGrenade_Smoke</ammoDef>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+			<value>
+				<ammoCountPerCharge>1</ammoCountPerCharge>
+			</value>
+		</li>
+
+		<!-- === Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/statBases</xpath>
+			<value>
+				<Bulk>12.5</Bulk>
+				<WornBulk>6.25</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+	
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>22</ArmorRating_Sharp>
+			</value>
+		</li>
+
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>50</ArmorRating_Blunt>
+			</value>
+		</li>
+		</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

- Compatibility for WarCasket Expanded and RimHammer40k -Dreadnought mods by AOBA

## Reasoning

- The EMP ability of the Tyrant Warcasket helmet still reloads with components because it's not a gun, but rather a burst EMP device
- The armor values for WCE were calculated based on comments from the VFE Pirates patch and the relation between armor values
- Dreadnought has 75mm armor because that's what's stated in https://wh40k.lexicanum.com/wiki/Space_Marine_Dreadnought
- Dreadnought is considerably more bulky than other warcaskets because it looks that way

## Alternatives

Describe alternative implementations you have considered, e.g.
- Rework which warcaskets get nightvision
- Change things in regards to Tyrant's ammunition and projectiles

## Testing

Check tests you have performed:
- [x] All warcaskets work without errors
- [x] Game runs without errors with and without patched mod loaded
- [x] Playtested a colony (Around an hour)
