### PR TITLE
Autocannon shell generic ammo fix

### DIFF
--- a/Defs/Ammo/GENERIC/Autocannon.xml
+++ b/Defs/Ammo/GENERIC/Autocannon.xml
@@ -51,7 +51,7 @@
     <statBases>
       <MarketValue>1.04</MarketValue>
     </statBases>
-    <ammoClass>FullMetalJacket</ammoClass>
+    <ammoClass>ArmorPiercing</ammoClass>
     <cookOffProjectile>Bullet_20x110mmHispano_AP</cookOffProjectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- A small fix for the autocannon shell generic ammo set

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
