### PR TITLE
Patch Vanilla Factions Expanded - Classical

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -26,6 +26,7 @@
 		<li>Atlas.AndroidTiers</li>
 		<li>Rah.RVTE</li>
 		<li>sarg.magicalmenagerie</li>
+		<li>OskarPotocki.VFE.Classical</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>

--- a/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
+++ b/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
@@ -153,7 +153,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="CAL_Bronze"]/stuffProps/statFactors</xpath>
 				<value>
-					<MeleePenetrationFactor>0.96</MeleePenetrationFactor>
+					<MeleePenetrationFactor>0.80</MeleePenetrationFactor>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">

--- a/Patches/Expanded Materials - Metals/Items_Resource_Stuff.xml
+++ b/Patches/Expanded Materials - Metals/Items_Resource_Stuff.xml
@@ -102,6 +102,7 @@
 				<xpath>/Defs/ThingDef[defName="VMEu_Bronze"]/stuffProps/statFactors</xpath>
 				<value>
 					<Mass>1.1</Mass>
+					<MeleePenetrationFactor>0.80</MeleePenetrationFactor>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Vanilla Factions Expanded - Classical</li>
+    </mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
+				<CombatExtended.AmmoCategoryDef>
+					<defName>HeavyJavelin</defName>
+					<label>Heavy Javelin</label>
+					<description>A heavy javelin with an extended shank, making it ideal for punching through shields and armor.</description>
+				</CombatExtended.AmmoCategoryDef>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Javelins"]/ammoTypes</xpath>
+			<value>
+				<VFEC_Javelin>Classical_Javelin_Fired</VFEC_Javelin>
+			</value>
+		</li>	
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
+
+			<ThingDef ParentName="BasePilumProjectile">
+			<defName>Classical_Javelin_Thrown</defName>
+			<label>javelin</label>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageAmountBase>14</damageAmountBase>
+				<speed>16</speed>
+				<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+				<armorPenetrationSharp>5.5</armorPenetrationSharp>
+				<secondaryDamage>
+				<li>
+					<def>VFEC_ApparelDamage</def>
+					<amount>20</amount>
+				</li>
+				</secondaryDamage>
+				<preExplosionSpawnChance>0.40</preExplosionSpawnChance> <!-- Roman javelins/pila were designed to break or bend on impact, to prevent them being thrown back. -->
+				<preExplosionSpawnThingDef>VFEC_Javelin</preExplosionSpawnThingDef>
+			</projectile>
+			</ThingDef>
+
+			<ThingDef ParentName="BasePilumProjectile">
+				<defName>Classical_Javelin_Fired</defName>
+				<label>pilum (fired)</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageAmountBase>29</damageAmountBase>
+					<speed>44</speed>
+					<armorPenetrationBlunt>141.12</armorPenetrationBlunt>
+					<armorPenetrationSharp>14</armorPenetrationSharp>
+					<secondaryDamage>
+					<li>
+						<def>VFEC_ApparelDamage</def>
+						<amount>20</amount>
+					</li>
+					</secondaryDamage>					
+					<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
+					<preExplosionSpawnThingDef>VFEC_Javelin</preExplosionSpawnThingDef>
+				</projectile>
+			</ThingDef>
+
+			</value>
+		</li>
+		
+		</operations>
+	</match>
+	</Operation>
+</Patch>
+

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Classical</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Ammo === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs</xpath>
+          <value>
+
+          <CombatExtended.AmmoSetDef>
+            <defName>AmmoSet_ScorpionBolt</defName>
+            <label>scorpion bolts</label>
+            <ammoTypes>
+              <Ammo_CrossbowBolt_Stone>Projectile_ScorpionBolt_Stone</Ammo_CrossbowBolt_Stone>
+              <Ammo_CrossbowBolt_Steel>Projectile_ScorpionBolt_Steel</Ammo_CrossbowBolt_Steel>
+              <Ammo_CrossbowBolt_Plasteel>Projectile_ScorpionBolt_Plasteel</Ammo_CrossbowBolt_Plasteel>
+              <Ammo_CrossbowBolt_Venom>Projectile_ScorpionBolt_Venom</Ammo_CrossbowBolt_Venom>
+              <Ammo_CrossbowBolt_Flame>Projectile_ScorpionBolt_Flame</Ammo_CrossbowBolt_Flame>      
+            </ammoTypes>
+          </CombatExtended.AmmoSetDef>
+
+          <ThingDef ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_ScorpionBolt_Stone</defName>
+            <label>scorpion bolt (stone)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>8</damageAmountBase>
+              <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>1.85</armorPenetrationSharp>			
+              <preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Stone</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_ScorpionBolt_Steel</defName>
+            <label>scorpion bolt (steel)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>12</damageAmountBase>
+              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>2.85</armorPenetrationSharp>
+              <speed>22</speed>			
+              <preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_ScorpionBolt_Plasteel</defName>
+            <label>scorpion bolt (plasteel)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageAmountBase>10</damageAmountBase>
+              <armorPenetrationBlunt>8.12</armorPenetrationBlunt>
+              <armorPenetrationSharp>4</armorPenetrationSharp>
+              <speed>24</speed>				
+              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+
+          <ThingDef ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_ScorpionBolt_Venom</defName>
+            <label>scorpion bolt (venom)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>ArrowVenom</damageDef>
+              <damageAmountBase>12</damageAmountBase>
+              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
+              <armorPenetrationSharp>2.5</armorPenetrationSharp>
+              <speed>22</speed>	
+              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
+              <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
+            </projectile>
+          </ThingDef>
+          
+          <ThingDef ParentName="BaseCrossbowBoltProjectile">
+            <defName>Projectile_ScorpionBolt_Flame</defName>
+            <label>scorpion bolt (flame)</label>
+            <graphicData>
+              <texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+              <graphicClass>Graphic_Single</graphicClass>
+            </graphicData>
+            <projectile Class="CombatExtended.ProjectilePropertiesCE">
+              <damageDef>Flame</damageDef>
+              <damageAmountBase>5</damageAmountBase>
+              <armorPenetrationBlunt>3.28</armorPenetrationBlunt>
+              <armorPenetrationSharp>1.5</armorPenetrationSharp>
+              <speed>22</speed>	
+            </projectile>
+          </ThingDef>
+
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
@@ -34,10 +34,10 @@
               <graphicClass>Graphic_Single</graphicClass>
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <damageAmountBase>8</damageAmountBase>
-              <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-              <armorPenetrationSharp>1.85</armorPenetrationSharp>			
-              <preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
+              <damageAmountBase>9</damageAmountBase>
+              <armorPenetrationBlunt>1.65</armorPenetrationBlunt>
+              <armorPenetrationSharp>1.95</armorPenetrationSharp>			
+              <preExplosionSpawnChance>0.05</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Stone</preExplosionSpawnThingDef>
             </projectile>
           </ThingDef>
@@ -50,11 +50,11 @@
               <graphicClass>Graphic_Single</graphicClass>
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <damageAmountBase>12</damageAmountBase>
-              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
-              <armorPenetrationSharp>2.85</armorPenetrationSharp>
+              <damageAmountBase>14</damageAmountBase>
+              <armorPenetrationBlunt>6.85</armorPenetrationBlunt>
+              <armorPenetrationSharp>3.45</armorPenetrationSharp>
               <speed>22</speed>			
-              <preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
+              <preExplosionSpawnChance>0.233</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
           </ThingDef>
@@ -67,11 +67,11 @@
               <graphicClass>Graphic_Single</graphicClass>
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-              <damageAmountBase>10</damageAmountBase>
-              <armorPenetrationBlunt>8.12</armorPenetrationBlunt>
-              <armorPenetrationSharp>4</armorPenetrationSharp>
+              <damageAmountBase>12</damageAmountBase>
+              <armorPenetrationBlunt>8.82</armorPenetrationBlunt>
+              <armorPenetrationSharp>4.75</armorPenetrationSharp>
               <speed>24</speed>				
-              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
+              <preExplosionSpawnChance>0.5</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
             </projectile>
           </ThingDef>
@@ -85,11 +85,11 @@
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>ArrowVenom</damageDef>
-              <damageAmountBase>12</damageAmountBase>
-              <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
-              <armorPenetrationSharp>2.5</armorPenetrationSharp>
+              <damageAmountBase>14</damageAmountBase>
+              <armorPenetrationBlunt>6.85</armorPenetrationBlunt>
+              <armorPenetrationSharp>3.25</armorPenetrationSharp>
               <speed>22</speed>	
-              <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
+              <preExplosionSpawnChance>0.4</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
           </ThingDef>
@@ -103,9 +103,9 @@
             </graphicData>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>Flame</damageDef>
-              <damageAmountBase>5</damageAmountBase>
-              <armorPenetrationBlunt>3.28</armorPenetrationBlunt>
-              <armorPenetrationSharp>1.5</armorPenetrationSharp>
+              <damageAmountBase>7</damageAmountBase>
+              <armorPenetrationBlunt>3.68</armorPenetrationBlunt>
+              <armorPenetrationSharp>2.25</armorPenetrationSharp>
               <speed>22</speed>	
             </projectile>
           </ThingDef>

--- a/Patches/Vanilla Factions Expanded - Classical/Apparel_Classical.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Apparel_Classical.xml
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Factions Expanded - Classical</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Toga -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEC_Toga"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<Bulk>2</Bulk>
+				<WornBulk>2</WornBulk>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!-- Legionaire Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireArmor"]/statBases</xpath>
+			<value>
+				<Bulk>60</Bulk>
+				<WornBulk>10</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireArmor"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeDodgeChance>-0.05</MeleeDodgeChance>
+			</value>
+		</li>
+
+		<!-- Centurion Armor -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionArmor"]/statBases</xpath>
+			<value>
+				<Bulk>80</Bulk>
+				<WornBulk>12</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2.35</StuffEffectMultiplierArmor> <!-- Almost same thickness as plate armor. -->
+			</value>
+		</li>
+
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionArmor"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeDodgeChance>-0.10</MeleeDodgeChance>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/Apparel_Headgear.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Apparel_Headgear.xml
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Factions Expanded - Classical</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Wreath -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Wreath"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<WornBulk>0.5</WornBulk>
+			</value>
+		</li>
+
+		<!-- Legionnaire Helmet -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor> <!-- Most sources I can find put Roman helmets around this thickness. -->
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_LegionnaireHelmet"]/statBases</xpath>
+			<value>
+				<Bulk>3.5</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+
+		<!-- Centurion Helmet - 'Cedo Alterum!'  -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2.25</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEC_Apparel_CenturionHelmet"]/statBases</xpath>
+			<value>
+				<Bulk>3.5</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Classical</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Bronze -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases</xpath>
+				<value>
+					<Bulk>0.03</Bulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.83</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>1.24</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>1.1</Mass>
+				</value>
+			</li>
+
+			<!-- Tyrian -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.015</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
+				</value>
+			</li>
+
+			<Operation Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
+				<value>
+					<Bulk>0.05</Bulk>
+				</value>
+			</li>
+
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -46,7 +46,21 @@
 					<StuffPower_Armor_Blunt>1.24</StuffPower_Armor_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+					<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
+				<value>
+					<MeleePenetrationFactor>0.96</MeleePenetrationFactor>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
 				<value>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -55,9 +55,9 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
 				<value>
-					<MeleePenetrationFactor>0.96</MeleePenetrationFactor>
+					<MeleePenetrationFactor>0.80</MeleePenetrationFactor>
 				</value>
 			</li>
 
@@ -71,28 +71,28 @@
 			<!-- Tyrian -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.015</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
 				<value>
 					<Bulk>0.05</Bulk>
 				</value>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -67,13 +67,12 @@
 				</value>
 			</li>
 
-			<Operation Class="PatchOperationAdd">
+			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
 				<value>
 					<Bulk>0.05</Bulk>
 				</value>
 			</li>
-
 
 			</operations>
 		</match>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -7,6 +7,16 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
+			<!-- Opium -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/HediffDef[defName = "VFEC_OpiumHigh"]/stages/li</xpath>
+				<value>
+					<statFactors>
+						<Suppressability>0.50</Suppressability>
+					</statFactors>
+				</value>				
+			</li>
+
 			<!-- Bronze -->
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases</xpath>

--- a/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Classical</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- Give Auilaries some javelines. -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>
+          /Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]
+        </xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>2</min>
+              <max>6</max>
+            </primaryMagazineCount>
+            <sidearms>
+            <li>
+              <generateChance>0.70</generateChance>
+              <sidearmMoney>
+                <min>100</min>
+                <max>250</max>
+              </sidearmMoney>
+              <weaponTags>
+                <li>NeolithicMeleeBasic</li>
+                <li>ClassicalSimple</li>
+              </weaponTags>
+            </li>  
+            </sidearms>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
@@ -7,11 +7,17 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-      <!-- Give Auilaries some javelines. -->
+      <!-- Increase Legionaire weapon money slightly. -->
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/PawnKindDef[defName="VFEC_Legionnaire"]/weaponMoney</xpath>
+        <value>
+          <weaponMoney>140~300</weaponMoney>
+        </value>
+      </li>
+
+      <!-- Give Auxilaries some javelines. -->
       <li Class="PatchOperationAddModExtension">
-        <xpath>
-          /Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]
-        </xpath>
+        <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]</xpath>
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>

--- a/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
@@ -15,14 +15,14 @@
         </value>
       </li>
 
-      <!-- Give Auxilaries some javelines. -->
+      <!-- Give Auxilaries some javelins. -->
       <li Class="PatchOperationAddModExtension">
         <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]</xpath>
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>2</min>
-              <max>6</max>
+              <min>4</min>
+              <max>8</max>
             </primaryMagazineCount>
             <sidearms>
             <li>
@@ -38,6 +38,40 @@
             </li>  
             </sidearms>
           </li>
+        </value>
+      </li>
+
+      <!-- Give Archers some arrows. -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicArcher"]</xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>12</min>
+              <max>20</max>
+            </primaryMagazineCount>
+            <sidearms>
+            <li>
+              <generateChance>0.50</generateChance>
+              <sidearmMoney>
+                <min>100</min>
+                <max>250</max>
+              </sidearmMoney>
+              <weaponTags>
+                <li>NeolithicMeleeBasic</li>
+                <li>ClassicalSimple</li>
+              </weaponTags>
+            </li>  
+            </sidearms>
+          </li>
+        </value>
+      </li>
+
+      <!-- Give pawns some packs. -->
+      <li Class="PatchOperationAdd">
+      <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicArcher" or defName="VFEC_RepublicAuxilia"]/apparelRequired</xpath>
+        <value>
+          <li>Apparel_TribalBackpack</li>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Classical</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<li Class="PatchOperationRemove">
+		<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		</li>
+
+		<li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/thingClass</xpath>
+        <value>
+          <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+        </value>
+		</li>
+
+        <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/fillPercent</xpath>
+        <value>
+          <fillPercent>0.85</fillPercent>
+        </value>
+      </li>
+
+		<!-- ========== Scorpion - Weapon ========== -->
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>VFEC_TurretGun_Scorpion</defName>
+		  <statBases>
+		    <SightsEfficiency>1</SightsEfficiency>
+		    <ShotSpread>1</ShotSpread>
+		    <SwayFactor>1</SwayFactor>
+		    <Bulk>4.00</Bulk>
+		    <RangedWeapon_Cooldown>1.8</RangedWeapon_Cooldown>
+		  </statBases>
+		  <Properties>
+		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		    <hasStandardCommand>true</hasStandardCommand>
+		    <defaultProjectile>Pilum_Fired</defaultProjectile>
+		    <warmupTime>1.0</warmupTime>
+		    <range>32</range>
+		    <soundCast>Bow_Large</soundCast>
+		    <recoilPattern>Mounted</recoilPattern>
+		  </Properties>
+		  <AmmoUser>
+		    <magazineSize>1</magazineSize>
+		    <reloadTime>4</reloadTime>
+		    <ammoSet>AmmoSet_Javelins</ammoSet>
+		  </AmmoUser>
+		  <FireModes>
+		    <aiAimMode>AimedShot</aiAimMode>
+		    <noSnapshot>true</noSnapshot>
+		    <noSingleShot>false</noSingleShot>
+		  </FireModes>
+		</li>
+
+		<li Class="PatchOperationAdd">
+		  <xpath>/Defs/ThingDef[defName = "VFEC_TurretGun_Scorpion"]</xpath>
+		  <value>
+		  	<weaponTags>
+		    	<li>TurretGun</li>
+			</weaponTags>
+		  </value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>    

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
@@ -14,17 +14,17 @@
 
 		<li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/thingClass</xpath>
-        <value>
-          <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-        </value>
+			<value>
+				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+			</value>
 		</li>
 
         <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/fillPercent</xpath>
-        <value>
-          <fillPercent>0.85</fillPercent>
-        </value>
-      </li>
+        	<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/fillPercent</xpath>
+			<value>
+				<fillPercent>0.85</fillPercent>
+			</value>
+      	</li>
 
 		<!-- ========== Scorpion - Weapon ========== -->
 		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -39,16 +39,16 @@
 		  <Properties>
 		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		    <hasStandardCommand>true</hasStandardCommand>
-		    <defaultProjectile>Pilum_Fired</defaultProjectile>
+		    <defaultProjectile>Projectile_ScorpionBolt_Steel</defaultProjectile>
 		    <warmupTime>1.0</warmupTime>
-		    <range>32</range>
+		    <range>42</range>
 		    <soundCast>Bow_Large</soundCast>
 		    <recoilPattern>Mounted</recoilPattern>
 		  </Properties>
 		  <AmmoUser>
 		    <magazineSize>1</magazineSize>
 		    <reloadTime>4</reloadTime>
-		    <ammoSet>AmmoSet_Javelins</ammoSet>
+		    <ammoSet>AmmoSet_ScorpionBolt</ammoSet>
 		  </AmmoUser>
 		  <FireModes>
 		    <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Vanilla Factions Expanded - Classical</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>			
+
+				<!-- Kite Shield -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VFEC_Shield_Heavy"]</xpath>
+					<value>
+						 <ThingDef ParentName="ShieldBase">
+							<defName>VFEC_Shield_Heavy</defName>
+							<label>kite shield</label>
+							<description>A heavily fortified square shield that covers one's body from shin to shoulder, heavy enough to slow those weidling it at the benefit of incredible protection.</description>
+							<techLevel>Neolithic</techLevel>
+							<graphicData>
+								<texPath>Things/Item/Equipment/Shield/HeavyShield/HeavyShield</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<drawSize>0.88</drawSize>
+							</graphicData>
+							<thingCategories Inherit="False">
+								<li>Shields</li>
+							</thingCategories>
+							<costStuffCount>25</costStuffCount>							
+							<costList>
+								<WoodLog>60</WoodLog>
+								<Steel>35</Steel>
+							</costList>
+							<stuffCategories>
+								<li>Leathery</li>
+							</stuffCategories>
+							<recipeMaker>
+							  <researchPrerequisite>VFEC_HeavyShieldMaking</researchPrerequisite>		
+							  <recipeUsers>
+								<li>FueledSmithy</li>
+								<li>ElectricSmithy</li>		
+							  </recipeUsers>
+							</recipeMaker>		
+							<statBases>
+								<WorkToMake>3000</WorkToMake>
+								<MaxHitPoints>145</MaxHitPoints>
+								<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+								<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+								<ArmorRating_Blunt>6</ArmorRating_Blunt>	  
+								<Mass>8</Mass>
+								<Bulk>8</Bulk>
+								<WornBulk>6</WornBulk>
+							</statBases>
+							<equippedStatOffsets>
+							  <ReloadSpeed>-0.1</ReloadSpeed>
+							  <MeleeHitChance>-1</MeleeHitChance>
+							  <ShootingAccuracyPawn>-0.2</ShootingAccuracyPawn>
+							  <AimingAccuracy>-0.05</AimingAccuracy>
+							  <Suppressability>-0.25</Suppressability>
+							  <MeleeCritChance>-0.08</MeleeCritChance>
+							  <MeleeParryChance>1.0</MeleeParryChance>
+							</equippedStatOffsets>
+							<comps>
+								<li Class="CompOversizedWeapon.CompProperties_OversizedWeapon"/>							
+								<li>
+									<compClass>CompColorable</compClass>
+								</li>								
+							</comps>							
+							<modExtensions>
+							  <li Class="CombatExtended.ShieldDefExtension">
+								<shieldCoverage>
+								  <li>Hands</li>
+								  <li>Arms</li>
+								  <li>Shoulders</li>
+								  <li>Torso</li>
+								  <li>Neck</li>
+								  <li>Legs</li>		  
+								</shieldCoverage>
+								<drawAsTall>false</drawAsTall>
+							  </li>					  
+							</modExtensions>
+						  </ThingDef>					
+					</value>
+				</li>		
+										
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
@@ -9,79 +8,79 @@
 		<match Class="PatchOperationSequence">
 			<operations>			
 
-				<!-- Kite Shield -->
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEC_Shield_Heavy"]</xpath>
-					<value>
-						 <ThingDef ParentName="ShieldBase">
-							<defName>VFEC_Shield_Heavy</defName>
-							<label>kite shield</label>
-							<description>A heavily fortified square shield that covers one's body from shin to shoulder, heavy enough to slow those weidling it at the benefit of incredible protection.</description>
-							<techLevel>Neolithic</techLevel>
-							<graphicData>
-								<texPath>Things/Item/Equipment/Shield/HeavyShield/HeavyShield</texPath>
-								<graphicClass>Graphic_Single</graphicClass>
-								<drawSize>0.88</drawSize>
-							</graphicData>
-							<thingCategories Inherit="False">
-								<li>Shields</li>
-							</thingCategories>
-							<costStuffCount>25</costStuffCount>							
-							<costList>
-								<WoodLog>60</WoodLog>
-								<Steel>35</Steel>
-							</costList>
-							<stuffCategories>
-								<li>Leathery</li>
-							</stuffCategories>
-							<recipeMaker>
-							  <researchPrerequisite>VFEC_HeavyShieldMaking</researchPrerequisite>		
-							  <recipeUsers>
-								<li>FueledSmithy</li>
-								<li>ElectricSmithy</li>		
-							  </recipeUsers>
-							</recipeMaker>		
-							<statBases>
-								<WorkToMake>3000</WorkToMake>
-								<MaxHitPoints>145</MaxHitPoints>
-								<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
-								<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
-								<ArmorRating_Blunt>6</ArmorRating_Blunt>	  
-								<Mass>8</Mass>
-								<Bulk>8</Bulk>
-								<WornBulk>6</WornBulk>
-							</statBases>
-							<equippedStatOffsets>
-							  <ReloadSpeed>-0.1</ReloadSpeed>
-							  <MeleeHitChance>-1</MeleeHitChance>
-							  <ShootingAccuracyPawn>-0.2</ShootingAccuracyPawn>
-							  <AimingAccuracy>-0.05</AimingAccuracy>
-							  <Suppressability>-0.25</Suppressability>
-							  <MeleeCritChance>-0.08</MeleeCritChance>
-							  <MeleeParryChance>1.0</MeleeParryChance>
-							</equippedStatOffsets>
-							<comps>
-								<li Class="CompOversizedWeapon.CompProperties_OversizedWeapon"/>							
-								<li>
-									<compClass>CompColorable</compClass>
-								</li>								
-							</comps>							
-							<modExtensions>
-							  <li Class="CombatExtended.ShieldDefExtension">
-								<shieldCoverage>
-								  <li>Hands</li>
-								  <li>Arms</li>
-								  <li>Shoulders</li>
-								  <li>Torso</li>
-								  <li>Neck</li>
-								  <li>Legs</li>		  
-								</shieldCoverage>
-								<drawAsTall>false</drawAsTall>
-							  </li>					  
-							</modExtensions>
-						  </ThingDef>					
-					</value>
-				</li>		
+			<!-- Roman Shield (Scutum) -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Shield_Heavy"]</xpath>
+				<value>
+					<ThingDef ParentName="ShieldBase">
+					<defName>VFEC_Shield_Heavy</defName>
+					<label>kite shield</label>
+					<description>A heavily fortified square shield that covers one's body from shin to shoulder, heavy enough to slow those weidling it at the benefit of incredible protection.</description>
+					<techLevel>Neolithic</techLevel>
+					<graphicData>
+						<texPath>Things/Item/Equipment/Shield/HeavyShield/HeavyShield</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+						<drawSize>0.88</drawSize>
+					</graphicData>
+					<thingCategories Inherit="False">
+						<li>Shields</li>
+					</thingCategories>
+					<costStuffCount>25</costStuffCount>							
+					<costList>
+						<WoodLog>60</WoodLog>
+						<Steel>35</Steel>
+					</costList>
+					<stuffCategories>
+						<li>Leathery</li>
+					</stuffCategories>
+					<recipeMaker>
+						<researchPrerequisite>VFEC_HeavyShieldMaking</researchPrerequisite>		
+						<recipeUsers>
+						<li>FueledSmithy</li>
+						<li>ElectricSmithy</li>		
+						</recipeUsers>
+					</recipeMaker>		
+					<statBases>
+						<WorkToMake>3000</WorkToMake>
+						<MaxHitPoints>145</MaxHitPoints>
+						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+						<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+						<ArmorRating_Blunt>6</ArmorRating_Blunt>	  
+						<Mass>8</Mass>
+						<Bulk>8</Bulk>
+						<WornBulk>6</WornBulk>
+					</statBases>
+					<equippedStatOffsets>
+						<ReloadSpeed>-0.1</ReloadSpeed>
+						<MeleeHitChance>-1</MeleeHitChance>
+						<ShootingAccuracyPawn>-0.2</ShootingAccuracyPawn>
+						<AimingAccuracy>-0.05</AimingAccuracy>
+						<Suppressability>-0.25</Suppressability>
+						<MeleeCritChance>-0.08</MeleeCritChance>
+						<MeleeParryChance>1.0</MeleeParryChance>
+					</equippedStatOffsets>
+					<comps>
+						<li Class="CompOversizedWeapon.CompProperties_OversizedWeapon"/>							
+						<li>
+							<compClass>CompColorable</compClass>
+						</li>								
+					</comps>							
+					<modExtensions>
+						<li Class="CombatExtended.ShieldDefExtension">
+						<shieldCoverage>
+							<li>Hands</li>
+							<li>Arms</li>
+							<li>Shoulders</li>
+							<li>Torso</li>
+							<li>Neck</li>
+							<li>Legs</li>		  
+						</shieldCoverage>
+						<drawAsTall>false</drawAsTall>
+						</li>					  
+					</modExtensions>
+					</ThingDef>					
+				</value>
+			</li>		
 										
 			</operations>
 		</match>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsMelee.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsMelee.xml
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Factions Expanded - Classical</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!--One-handed Tags -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName = "VFEC_MeleeWeapon_Spatha" or defName="VFEC_MeleeWeapon_Dagger"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+
+		<!-- Spatha -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.57</cooldownTime>
+						<chanceFactor>0.10</chanceFactor>
+						<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.57</cooldownTime>
+						<chanceFactor>0.60</chanceFactor>
+						<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.2</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>31</power>
+						<cooldownTime>1.45</cooldownTime>
+						<chanceFactor>0.30</chanceFactor>
+						<armorPenetrationBlunt>1.944</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.44</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<MeleeCounterParryBonus>0.42</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.21</MeleeCritChance>
+					<MeleeParryChance>0.42</MeleeParryChance>
+					<MeleeDodgeChance>0.33</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li> 
+
+		<!-- Dagger (Pugio) -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/tools</xpath>
+			<value>
+				<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+					<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.29</cooldownTime>
+					<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+					<li>Cut</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.42</cooldownTime>
+					<armorPenetrationBlunt>0.396</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.35</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+					<li>Stab</li>
+					</capacities>
+					<power>21</power>
+					<cooldownTime>1.29</cooldownTime>
+					<chanceFactor>1.33</chanceFactor>
+					<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.31</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<MeleeCounterParryBonus>0.5</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.63</MeleeCritChance>
+				<MeleeParryChance>0.5</MeleeParryChance>
+				<MeleeDodgeChance>0.13</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -29,9 +29,6 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<value>
-					<thingCategories>
-						<li>WeaponsRanged</li>
-					</thingCategories>
           <techLevel>Neolithic</techLevel>			
 				</value>				
 			</li>		

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -8,7 +8,7 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-      <!-- === Javelin === -->
+			<!-- === Javelin === -->
 
 			<li Class="PatchOperationAttributeSet">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
@@ -16,11 +16,11 @@
 				<value>BaseWeaponAndAmmoNeolithic</value>				
 			</li>	
 
-        <li Class="PatchOperationAttributeAdd">
-          <xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
-          <attribute>Class</attribute>
-          <value>CombatExtended.AmmoDef</value>
-        </li>
+			<li Class="PatchOperationAttributeAdd">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<attribute>Class</attribute>
+				<value>CombatExtended.AmmoDef</value>
+			</li>
 
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/costList</xpath>
@@ -29,7 +29,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<value>
-          <techLevel>Neolithic</techLevel>			
+					<techLevel>Neolithic</techLevel>			
 				</value>				
 			</li>		
 
@@ -41,119 +41,120 @@
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/statBases</xpath>
 				<value>
 					<statBases>
-            <MarketValue>7.26</MarketValue>
-            <SightsEfficiency>0.45</SightsEfficiency>
-            <ShotSpread>1.5</ShotSpread>
-            <SwayFactor>2.5</SwayFactor>
-            <Bulk>3.5</Bulk>
-            <Mass>2</Mass>
-            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+						<MarketValue>7.26</MarketValue>
+						<SightsEfficiency>0.45</SightsEfficiency>
+						<ShotSpread>1.5</ShotSpread>
+						<SwayFactor>2.5</SwayFactor>
+						<Bulk>3.5</Bulk>
+						<Mass>2</Mass>
+						<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					</statBases>
 					<stackLimit>25</stackLimit>
-          <ammoClass>HeavyJavelin</ammoClass>				
+					<ammoClass>HeavyJavelin</ammoClass>				
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/verbs</xpath>
 				<value>
-				<verbs>
-					<li Class="CombatExtended.VerbPropertiesCE">
-						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
-						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Classical_Javelin_Thrown</defaultProjectile>
-						<warmupTime>0.8</warmupTime>
-						<range>12</range>
-						<soundCast>Interact_BeatFire</soundCast>
-					</li>
-				</verbs>
+					<verbs>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<defaultProjectile>Classical_Javelin_Thrown</defaultProjectile>
+							<warmupTime>0.8</warmupTime>
+							<range>12</range>
+							<soundCast>Interact_BeatFire</soundCast>
+						</li>
+					</verbs>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/tools</xpath>
 				<value>	
-						<tools>
-              <li Class="CombatExtended.ToolCE">
-                <label>shaft</label>
-                <capacities>
-                  <li>Blunt</li>
-                </capacities>
-                <power>7</power>
-                <cooldownTime>1.35</cooldownTime>
-                <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
-                <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
-              </li>
-              <li Class="CombatExtended.ToolCE">
-                <label>point</label>
-                <capacities>
-                  <li>Stab</li>
-                </capacities>
-                <power>15</power>
-                <cooldownTime>1.37</cooldownTime>
-                <chanceFactor>1.5</chanceFactor>
-                <armorPenetrationBlunt>1.69</armorPenetrationBlunt>
-                <armorPenetrationSharp>0.34</armorPenetrationSharp>
-                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-              </li>
-						</tools>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.35</cooldownTime>
+							<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>15</power>
+							<cooldownTime>1.37</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>1.69</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.34</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
 				</value>
 			</li>
 
-      <!-- === Add Projectiles and Recipes for the javelin. === -->
+			<!-- === Add Projectiles and Recipes for the javelin. === -->
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
 
-        <RecipeDef ParentName="AmmoRecipeNeolithicBase">
-          <defName>MakeAmmo_VFEC_Javelin</defName>
-          <label>make javelins x5</label>
-          <description>Craft 5 javelins.</description>
-        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-        <workSkill>Crafting</workSkill>
-        <recipeUsers>
-          <li>ElectricSmithy</li>
-          <li>FueledSmithy</li>
-          <li>CraftingSpot</li>
-        </recipeUsers>
-        <effectWorking>Smelt</effectWorking>
-        <unfinishedThingDef>UnfinishedWeapon</unfinishedThingDef>
-          <workAmount>2700</workAmount>	
-          <jobString>Making javelins.</jobString>
-          <ingredients>
-            <li>
-              <filter>
-                <thingDefs>
-                  <li>WoodLog</li>
-                </thingDefs>
-              </filter>
-              <count>6</count>
-            </li>
-            <li>
-              <filter>
-                <thingDefs>
-                  <li>Steel</li>
-                </thingDefs>
-              </filter>
-              <count>22</count>
-            </li>
-          </ingredients>
-          <fixedIngredientFilter>
-            <thingDefs>
-              <li>WoodLog</li>
-              <li>Steel</li>
-            </thingDefs>
-          </fixedIngredientFilter>
-          <products>
-            <VFEC_Javelin>5</VFEC_Javelin>
-          </products>
-        </RecipeDef>
+					<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+					  <defName>MakeAmmo_VFEC_Javelin</defName>
+					  <label>make javelins x5</label>
+					  <description>Craft 5 javelins.</description>
+					<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+					<workSkill>Crafting</workSkill>
+					<recipeUsers>
+					  <li>ElectricSmithy</li>
+					  <li>FueledSmithy</li>
+					  <li>CraftingSpot</li>
+					</recipeUsers>
+					<effectWorking>Smelt</effectWorking>
+					<unfinishedThingDef>UnfinishedWeapon</unfinishedThingDef>
+					  <workAmount>2700</workAmount>	
+					  <jobString>Making javelins.</jobString>
+					  <ingredients>
+					    <li>
+					      <filter>
+						<thingDefs>
+						  <li>WoodLog</li>
+						</thingDefs>
+					      </filter>
+					      <count>6</count>
+					    </li>
+					    <li>
+					      <filter>
+						<thingDefs>
+						  <li>Steel</li>
+						</thingDefs>
+					      </filter>
+					      <count>22</count>
+					    </li>
+					  </ingredients>
+					  <fixedIngredientFilter>
+					    <thingDefs>
+					      <li>WoodLog</li>
+					      <li>Steel</li>
+					    </thingDefs>
+					  </fixedIngredientFilter>
+					  <products>
+					    <VFEC_Javelin>5</VFEC_Javelin>
+					  </products>
+					</RecipeDef>
 
 				</value>				
 			</li>	
 
-      <!-- === Can't remove it entirely without causing errors, but make the mobile "Scorpion" weapon inaccessible. === -->
+			<!-- === Can't remove it entirely without causing errors, but make the mobile "Scorpion" weapon inaccessible. === -->
+
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]/weaponTags</xpath>
 			</li>
@@ -168,9 +169,9 @@
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion" or defName="VFEC_TurretGun_Scorpion"]/description</xpath>
-        <value>
-          <description>A ballista-like turret capable of firing rapidly when set up and manned. Very effective against enemy infantry.</description>
-        </value>
+				<value>
+				  <description>A ballista-like turret capable of firing rapidly when set up and manned. Very effective against enemy infantry.</description>
+				</value>
 			</li>
 
 		</operations>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -8,18 +8,19 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-      <!-- === Remove mobile "Scorpion". === -->
-			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]</xpath>
-			</li>
-
       <!-- === Javelin === -->
 
 			<li Class="PatchOperationAttributeSet">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<attribute>ParentName</attribute>
-				<value>BaseWeapon</value>				
+				<value>BaseWeaponAndAmmoNeolithic</value>				
 			</li>	
+
+        <li Class="PatchOperationAttributeAdd">
+          <xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+          <attribute>Class</attribute>
+          <value>CombatExtended.AmmoDef</value>
+        </li>
 
 			<li Class="PatchOperationRemove">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/costList</xpath>
@@ -51,7 +52,8 @@
             <Mass>2</Mass>
             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 					</statBases>
-					<stackLimit>25</stackLimit>				
+					<stackLimit>25</stackLimit>
+          <ammoClass>HeavyJavelin</ammoClass>				
 				</value>
 			</li>
 
@@ -107,25 +109,6 @@
 				<xpath>Defs</xpath>
 				<value>
 
-        <ThingDef ParentName="BasePilumProjectile">
-          <defName>Classical_Javelin_Thrown</defName>
-          <label>javelin</label>
-          <projectile Class="CombatExtended.ProjectilePropertiesCE">
-          <damageAmountBase>14</damageAmountBase>
-          <speed>16</speed>
-          <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
-          <armorPenetrationSharp>5</armorPenetrationSharp>
-            <secondaryDamage>
-              <li>
-                <def>VFEC_ApparelDamage</def>
-                <amount>20</amount>
-              </li>
-            </secondaryDamage>
-            <preExplosionSpawnChance>0.25</preExplosionSpawnChance> <!-- Roman javelins/pila were designed to break or bend on impact, to prevent them being thrown back. -->
-            <preExplosionSpawnThingDef>VFEC_Javelin</preExplosionSpawnThingDef>
-          </projectile>
-        </ThingDef>
-
         <RecipeDef ParentName="AmmoRecipeNeolithicBase">
           <defName>MakeAmmo_VFEC_Javelin</defName>
           <label>make javelins x5</label>
@@ -172,6 +155,26 @@
 
 				</value>				
 			</li>	
+
+      <!-- === Can't remove it entirely without causing errors, but make the mobile "Scorpion" weapon inaccessible. === -->
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]/weaponTags</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/minifiedDef</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/thingCategories</xpath>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion" or defName="VFEC_TurretGun_Scorpion"]/description</xpath>
+        <value>
+          <description>A ballista-like turret capable of firing rapidly when set up and manned. Very effective against enemy infantry.</description>
+        </value>
+			</li>
 
 		</operations>
 		</match>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Factions Expanded - Classical</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+      <!-- === Remove mobile "Scorpion". === -->
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]</xpath>
+			</li>
+
+      <!-- === Javelin === -->
+
+			<li Class="PatchOperationAttributeSet">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<attribute>ParentName</attribute>
+				<value>BaseWeapon</value>				
+			</li>	
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/costList</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<value>
+					<thingCategories>
+						<li>WeaponsRanged</li>
+					</thingCategories>
+          <techLevel>Neolithic</techLevel>			
+				</value>				
+			</li>		
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/recipeMaker</xpath>
+			</li>
+	
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/statBases</xpath>
+				<value>
+					<statBases>
+            <MarketValue>7.26</MarketValue>
+            <SightsEfficiency>0.45</SightsEfficiency>
+            <ShotSpread>1.5</ShotSpread>
+            <SwayFactor>2.5</SwayFactor>
+            <Bulk>3.5</Bulk>
+            <Mass>2</Mass>
+            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+					</statBases>
+					<stackLimit>25</stackLimit>				
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/verbs</xpath>
+				<value>
+				<verbs>
+					<li Class="CombatExtended.VerbPropertiesCE">
+						<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Classical_Javelin_Thrown</defaultProjectile>
+						<warmupTime>0.8</warmupTime>
+						<range>12</range>
+						<soundCast>Interact_BeatFire</soundCast>
+					</li>
+				</verbs>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/tools</xpath>
+				<value>	
+						<tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>shaft</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>7</power>
+                <cooldownTime>1.35</cooldownTime>
+                <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>point</label>
+                <capacities>
+                  <li>Stab</li>
+                </capacities>
+                <power>15</power>
+                <cooldownTime>1.37</cooldownTime>
+                <chanceFactor>1.5</chanceFactor>
+                <armorPenetrationBlunt>1.69</armorPenetrationBlunt>
+                <armorPenetrationSharp>0.34</armorPenetrationSharp>
+                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+              </li>
+						</tools>
+				</value>
+			</li>
+
+      <!-- === Add Projectiles and Recipes for the javelin. === -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+
+        <ThingDef ParentName="BasePilumProjectile">
+          <defName>Classical_Javelin_Thrown</defName>
+          <label>javelin</label>
+          <projectile Class="CombatExtended.ProjectilePropertiesCE">
+          <damageAmountBase>14</damageAmountBase>
+          <speed>16</speed>
+          <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+          <armorPenetrationSharp>5</armorPenetrationSharp>
+            <secondaryDamage>
+              <li>
+                <def>VFEC_ApparelDamage</def>
+                <amount>20</amount>
+              </li>
+            </secondaryDamage>
+            <preExplosionSpawnChance>0.25</preExplosionSpawnChance> <!-- Roman javelins/pila were designed to break or bend on impact, to prevent them being thrown back. -->
+            <preExplosionSpawnThingDef>VFEC_Javelin</preExplosionSpawnThingDef>
+          </projectile>
+        </ThingDef>
+
+        <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+          <defName>MakeAmmo_VFEC_Javelin</defName>
+          <label>make javelins x5</label>
+          <description>Craft 5 javelins.</description>
+        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+        <workSkill>Crafting</workSkill>
+        <recipeUsers>
+          <li>ElectricSmithy</li>
+          <li>FueledSmithy</li>
+          <li>CraftingSpot</li>
+        </recipeUsers>
+        <effectWorking>Smelt</effectWorking>
+        <unfinishedThingDef>UnfinishedWeapon</unfinishedThingDef>
+          <workAmount>2700</workAmount>	
+          <jobString>Making javelins.</jobString>
+          <ingredients>
+            <li>
+              <filter>
+                <thingDefs>
+                  <li>WoodLog</li>
+                </thingDefs>
+              </filter>
+              <count>6</count>
+            </li>
+            <li>
+              <filter>
+                <thingDefs>
+                  <li>Steel</li>
+                </thingDefs>
+              </filter>
+              <count>22</count>
+            </li>
+          </ingredients>
+          <fixedIngredientFilter>
+            <thingDefs>
+              <li>WoodLog</li>
+              <li>Steel</li>
+            </thingDefs>
+          </fixedIngredientFilter>
+          <products>
+            <VFEC_Javelin>5</VFEC_Javelin>
+          </products>
+        </RecipeDef>
+
+				</value>				
+			</li>	
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -159,12 +159,11 @@
 				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]/weaponTags</xpath>
 			</li>
 
-			<li Class="PatchOperationRemove">
+			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/minifiedDef</xpath>
-			</li>
-
-			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/thingCategories</xpath>
+				<value>
+					<minifiedDef>MinifiedThing</minifiedDef>			
+				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -381,7 +381,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Cut</damageDef>			
             <damageAmountBase>16</damageAmountBase>
-            <speed>12</speed>
+            <speed>14</speed>
             <armorPenetrationSharp>1.5</armorPenetrationSharp>
             <armorPenetrationBlunt>3</armorPenetrationBlunt>
             <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
@@ -394,7 +394,7 @@
           <label>thrown harpoon</label>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageAmountBase>13</damageAmountBase>
-            <speed>10</speed>
+            <speed>16</speed>
             <armorPenetrationBlunt>4.54</armorPenetrationBlunt>
             <armorPenetrationSharp>1.8</armorPenetrationSharp>
             <secondaryDamage>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -372,6 +372,7 @@ Vanilla Armour Expanded	|
 Vanilla Bionics Expansion	|
 Vanilla Brewing Expanded    |
 Vanilla Factions Expanded - Ancients    |
+Vanilla Factions Expanded - Classical   |
 Vanilla Factions Expanded - Insectoids |
 Vanilla Factions Expanded - Mechanoids	|
 Vanilla Factions Expanded - Medieval	|


### PR DESCRIPTION
## Additions
- Add a patch for Vanilla Factions Expanded - Classical.

## Reasoning
- The Legionnaire and Centurion armor thickness is somewhat less than plate armor, since the latter is later, more advanced medieval armor, but has less bulk and doesn't have the melee aiming penalties, since the helmets are open-faced. Even so, made of steel (I'm frankly not sure why they can be made of wood, but that's vanilla for you...), they provide satisfactory protection from typical sharp melee attacks.
- The Javelins are largely the same as the Pilum, but costs a bit more steel (for a longer shaft), and uses VFE's custom "apparel damage" type as an extra damage. They can also be fired from the VFE: Ballista.
- The Scorpion, while not impossibly heavy, was still too large to practically be used from the hip. In the patch, it fires a crossbow bolt at higher speed, with somewhat higher damage and AP, fulfilling its intended role as a faster firing, fairly long-range anti-personnel weapon.

## Changes
- Increase the projectile speed of harpoons and throwing axes from VFE: Vikings, since they were overlooked when some of the slower thrown weapons were sped up a while ago.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
