### PR TITLE
Rimsenal tag updates

### DIFF
--- a/Patches/Rimsenal Collection/Core/Weapons_GD_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_GD_CE.xml
@@ -521,6 +521,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>SniperRifle</li>
+					<li>Bipod_DMR</li>
 				</weaponTags>
 			</li>
 
@@ -564,6 +565,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_MachineGun</li>
+					<li>Bipod_LMG</li>
 				</weaponTags>
 			</li>
 

--- a/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
@@ -281,7 +281,13 @@
 					<DrawOffset>0,0</DrawOffset>
 				</li>
 				</value>
-			</li>	
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="JI_Gramr"]/weaponTags</xpath>
+				<value>
+				    <li>Bipod_DMR</li>
+				</value>
+			</li>				
 
 			<!-- ========== Grendel Rocket Launcher =========== -->  			
 			<li Class="PatchOperationReplace">

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
@@ -196,6 +196,34 @@
 		<workAmount>900</workAmount>
 	</RecipeDef>
 
+		<!-- ==================== Thumper Fuel Cell ammoset ========================== -->
+
+		<CombatExtended.AmmoSetDef>
+			<defName>AmmoSet_30x64mmFuel_RSThump</defName>
+			<label>30x64mm Fuel Cell (Thumper)</label>
+			<ammoTypes>
+				<Ammo_30x64mmFuel_Thermobaric>Bullet_30x64mmFuel_RSThump</Ammo_30x64mmFuel_Thermobaric>
+			</ammoTypes>
+		</CombatExtended.AmmoSetDef>
+
+		<!-- ================== Projectiles ================== -->
+
+	  <ThingDef ParentName="Base30x64mmFuelBullet">
+		<defName>Bullet_30x64mmFuel_RSThump</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>concussion bolt</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <explosionRadius>2.0</explosionRadius>
+		  <damageDef>Thump</damageDef>
+		  <damageAmountBase>24</damageAmountBase>
+		  <armorPenetrationSharp>0</armorPenetrationSharp>
+		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+		  <soundExplode>ThumpCannon_Impact</soundExplode>
+		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		  <ai_IsIncendiary>true</ai_IsIncendiary>
+		</projectile>
+	  </ThingDef>
+
 			</value>	
 		</li>
 

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -11,7 +11,7 @@
 
 			<!-- ========== Longgun Melee Tools =========== -->
 			  <li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Gun_RSBattleRifle" or defName="Gun_RSCarbine" or defName="Gun_RSAMRifle" or defName="Gun_AutomaticRifle" or defName="Gun_Repeater" or defName="Gun_MilitiaRifle" or defName="Gun_MarksmanRifle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="Gun_RSBattleRifle" or defName="Gun_RSCarbine" or defName="Gun_RSAMRifle" or defName="Gun_AutomaticRifle" or defName="Gun_Repeater" or defName="Gun_MilitiaRifle" or defName="Gun_MarksmanRifle" or defName="Gun_RSThumper"]/tools</xpath>
 				<value>
 				  <tools>
 					<li Class="CombatExtended.ToolCE">

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -246,6 +246,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
+					<li>Bipod_DMR</li>
 				</weaponTags>
 			</li>
 			
@@ -504,6 +505,52 @@
 				  <li>CE_AI_SR</li>
 				</weaponTags>
 				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_RSThumper</defName>
+				<statBases>
+					<Mass>8</Mass>
+					<RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.15</ShotSpread>
+					<SwayFactor>1.8</SwayFactor>
+					<Bulk>10</Bulk>
+					<WorkToMake>39500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>65</Steel>
+					<Plasteel>30</Plasteel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+					<Chemfuel>10</Chemfuel>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_30x64mmFuel_RSThump</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>40</range>
+					<burstShotCount>0</burstShotCount>
+					<soundCast>ThumpCannon_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>14</muzzleFlashScale>
+					<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>8</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_30x64mmFuel_RSThump</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AOE</li>
+				</weaponTags>
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 		</operations>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
@@ -378,6 +378,7 @@
             </FireModes>
             <weaponTags>
 				<li>FeralSniperRifle</li>
+				<li>Bipod_DMR</li>
             </weaponTags>
         </li>
 


### PR DESCRIPTION
## Additions

Added bipod tags where appropriate. Added stats for the vanilla enhanced thumper gun, uses 30x64 thermobaric and does half regular damage, but dealt as thump with 8 round mag.

## Changes
For bipod tags
Added DMR tag to the GD and JI sniper rifles. Added LMG tag to the GD LMG. Added DMR tag to the AM rifle from vanilla enhanced. Added DMR tag to Feral AM rifle.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
