### PR TITLE
Pawns' combatPower rebalanced

### DIFF
--- a/Patches/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
+++ b/Patches/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
@@ -51,6 +51,7 @@
 					</li>
 
 					<!-- === combatPower Patches === -->
+
 					<li Class="PatchOperationReplace">
 						<xpath>/Defs/PawnKindDef[defName="AA_Goliath"]/combatPower</xpath>
 						<value>

--- a/Patches/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
+++ b/Patches/Alpha Animals/PawnKindDefs_Mechanoids/AlphaAnimals_CE_Patch_PawnKind_Mechanoids.xml
@@ -50,6 +50,21 @@
 						</value>
 					</li>
 
+					<!-- === combatPower Patches === -->
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/PawnKindDef[defName="AA_Goliath"]/combatPower</xpath>
+						<value>
+							<combatPower>550</combatPower>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/PawnKindDef[defName="AA_Siegebreaker"]/combatPower</xpath>
+						<value>
+							<combatPower>500</combatPower>
+						</value>
+					</li>
+
 				</operations>
 			</match>
 	</Operation>

--- a/Patches/Alpha Animals/VFE_Mechs/AdvGoliath.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvGoliath.xml
@@ -97,7 +97,16 @@
 					</weaponTags>
 				</value>
 			</li>
-			
+
+			<!-- === combatPower Patch === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Advanced_Goliath"]/combatPower</xpath>
+				<value>
+					<combatPower>550</combatPower>
+				</value>
+			</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
@@ -84,7 +84,16 @@
 					</li>
 				</value>
 			</li>
-			
+
+			<!-- === combatPower Patch === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Advanced_Siegebreaker"]/combatPower</xpath>
+				<value>
+					<combatPower>500</combatPower>
+				</value>
+			</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/Alpha Animals/VFE_Mechs/VFEGoliath.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFEGoliath.xml
@@ -86,7 +86,16 @@
 					</li>
 				</value>
 			</li>
-			
+
+			<!-- === combatPower Patch === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Goliath"]/combatPower</xpath>
+				<value>
+					<combatPower>550</combatPower>
+				</value>
+			</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
@@ -84,7 +84,16 @@
 					</li>
 				</value>
 			</li>
-			
+
+			<!-- === combatPower Patch === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Siegebreaker"]/combatPower</xpath>
+				<value>
+					<combatPower>500</combatPower>
+				</value>
+			</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -11,7 +11,7 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName="Mech_Scyther"]/combatPower</xpath>
+    <xpath>Defs/PawnKindDef[defName="Mech_Scyther" or defName="Mech_Lancer"]/combatPower</xpath>
     <value>
       <combatPower>110</combatPower>
     </value>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -3,27 +3,6 @@
 
   <!-- ========== Mechanoid ========== -->
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/PawnKindDef[defName="Mech_Lancer"]</xpath>
-    <value>
-      <aiAvoidCover>false</aiAvoidCover>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName="Mech_Centipede"]/combatPower</xpath>
-    <value>
-      <combatPower>580</combatPower>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName="Mech_Scyther" or defName="Mech_Lancer"]/combatPower</xpath>
-    <value>
-      <combatPower>110</combatPower>
-    </value>
-  </Operation>
-
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
     <value>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -3,6 +3,20 @@
 
   <!-- ========== Mechanoid ========== -->
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="Mech_Centipede"]/combatPower</xpath>
+    <value>
+      <combatPower>580</combatPower>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="Mech_Scyther"]/combatPower</xpath>
+    <value>
+      <combatPower>110</combatPower>
+    </value>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
     <value>

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
@@ -77,42 +77,42 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Footsoldier"]/combatPower</xpath>
           <value>
-            <combatPower>250</combatPower>
+            <combatPower>275</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Veteran"]/combatPower</xpath>
           <value>
-            <combatPower>300</combatPower>
+            <combatPower>350</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform"]/combatPower</xpath>
           <value>
-            <combatPower>380</combatPower>
+            <combatPower>430</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Hussar"]/combatPower</xpath>
           <value>
-            <combatPower>350</combatPower>
+            <combatPower>400</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Pyro"]/combatPower</xpath>
           <value>
-            <combatPower>350</combatPower>
+            <combatPower>400</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Artillery"]/combatPower</xpath>
           <value>
-            <combatPower>400</combatPower>
+            <combatPower>450</combatPower>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
@@ -60,6 +60,62 @@
           </value>
         </li>
 
+        <!-- === Heavy Weapons Platform, Artillery === -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform" or defName="VFEP_Artillery"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>4</min>
+                <max>5</max>
+              </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+        <!-- === combatPower Patches === -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Footsoldier"]/combatPower</xpath>
+          <value>
+            <combatPower>250</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Veteran"]/combatPower</xpath>
+          <value>
+            <combatPower>300</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform"]/combatPower</xpath>
+          <value>
+            <combatPower>380</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Hussar"]/combatPower</xpath>
+          <value>
+            <combatPower>350</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Pyro"]/combatPower</xpath>
+          <value>
+            <combatPower>350</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Artillery"]/combatPower</xpath>
+          <value>
+            <combatPower>400</combatPower>
+          </value>
+        </li>
+
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
@@ -75,42 +75,42 @@
 
         <!-- === combatPower Patches === -->
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Footsoldier"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Footsoldier"]/combatPower</xpath>
           <value>
             <combatPower>250</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Veteran"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Veteran"]/combatPower</xpath>
           <value>
             <combatPower>300</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform"]/combatPower</xpath>
           <value>
             <combatPower>380</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Hussar"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Hussar"]/combatPower</xpath>
           <value>
             <combatPower>350</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Pyro"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Pyro"]/combatPower</xpath>
           <value>
             <combatPower>350</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Artillery"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Artillery"]/combatPower</xpath>
           <value>
             <combatPower>400</combatPower>
           </value>

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -63,14 +63,14 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
           <value>
-            <combatPower>350</combatPower>
+            <combatPower>400</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
           <value>
-            <combatPower>400</combatPower>
+            <combatPower>450</combatPower>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -59,6 +59,21 @@
           </value>
         </li>
 
+        <!-- === combatPower Patches === -->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
+          <value>
+            <combatPower>350</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
+          <value>
+            <combatPower>400</combatPower>
+          </value>
+        </li>
+
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -61,14 +61,14 @@
 
         <!-- === combatPower Patches === -->
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
           <value>
             <combatPower>350</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
           <value>
             <combatPower>400</combatPower>
           </value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -8,6 +8,14 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+        <!-- === Remove the added weapon tag from the Charge Lance === -->
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags</xpath>
+          <value>
+            <li>VFEP_Captain</li>
+          </value>
+        </li>
+
         <!-- === Research === -->
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ResearchProjectDef[defName="VFEP_WarcasketWeaponry"]/prerequisites/li[text()="MultibarrelWeapons"]</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -10,10 +10,7 @@
 
         <!-- === Remove the added weapon tag from the Charge Lance === -->
         <li Class="PatchOperationRemove">
-          <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags</xpath>
-          <value>
-            <li>VFEP_Captain</li>
-          </value>
+          <xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"VFEP_Captain")]</xpath>
         </li>
 
         <!-- === Research === -->


### PR DESCRIPTION
## Changes

- Removed the patch that adds cover usage behavior to Lancers
- Tweaked the combatPower of Warcasket pawns from VFE-Pirates
- Tweaked the combatPower of certain mechanoid pawns from Alpha Animals
- Removed the VFEP_Captain weapon tag from the Charge Lance which made it usable by Pirate Captains

## Reasoning

- Advanced mechs from VFE-Mechanoids have the cover usage behavior, adding a undocumented change to vanilla Lancers only causes confusions.
- Tweaked the combatPower of Warcasket pawns from VFE-Pirates to represent their strength a bit better
- No Human usable charge lances around here...

## Alternatives

- Leave stuff as is

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
