### PR TITLE
More Utility Packs qualitified

### DIFF
--- a/Patches/More Utility Packs/Apparel_Mechanoids.xml
+++ b/Patches/More Utility Packs/Apparel_Mechanoids.xml
@@ -53,6 +53,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName = "SGC_Apparel_INDMechPack"]/statBases</xpath>
+					<value>
+						<Bulk>9</Bulk>
+						<WornBulk>6</WornBulk>
+					</value>
+				</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/More Utility Packs/Apparel_Mechanoids.xml
+++ b/Patches/More Utility Packs/Apparel_Mechanoids.xml
@@ -12,6 +12,23 @@
 			<match Class="PatchOperationSequence">
 				<operations>
 
+				<!-- Quality Comp -->
+
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[
+					defName="SGC_Apparel_CombatMechPack" or
+					defName="SGC_Apparel_INDMechPack"
+					]/comps/li/compClass[.="CompQuality"]</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="SGC_Apparel_CombatMechPack" or defName="SGC_Apparel_INDMechPack"]/comps</xpath>
+						<value>
+							<li>
+								<compClass>CompQuality</compClass>
+							</li>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[
 					defName="SGC_Apparel_CombatMechPack" or
@@ -19,6 +36,20 @@
 					]/apparel/layers</xpath>
 					<value>
 						<li>Backpack</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "SGC_Apparel_CombatMechPack"]/statBases/EnergyShieldRechargeRate</xpath>
+					<value>
+						<EnergyShieldRechargeRate>0.225</EnergyShieldRechargeRate>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName = "SGC_Apparel_CombatMechPack"]/statBases/EnergyShieldEnergyMax</xpath>
+					<value>
+						<EnergyShieldEnergyMax>1.95</EnergyShieldEnergyMax>
 					</value>
 				</li>
 

--- a/Patches/More Utility Packs/Apparel_Packs.xml
+++ b/Patches/More Utility Packs/Apparel_Packs.xml
@@ -8,6 +8,33 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+		<!-- Add a parent with quality -->
+
+		<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/ThingDef[
+			defName="SGC_Apparel_RoboticRig" or
+			defName="SGC_Apparel_TraumaKit" or
+			defName="SGC_Apparel_RescueFrame" or
+			defName="SGC_Apparel_FieldMortar" or
+			defName="SGC_Apparel_Jetpack" or
+			defName="SGC_Apparel_CommandTower" or
+			defName="SGC_Apparel_CombatMechPack" or
+			defName="SGC_Apparel_INDMechPack" or
+			defName="SGC_Apparel_MechJet"
+			]</xpath>
+				<attribute>ParentName</attribute>
+				<value>ApparelBase</value>
+		</li>
+
+		<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[
+			defName="SGC_Apparel_SurvivalPack" or
+			defName="SGC_Apparel_Forklift"
+			]</xpath>
+				<attribute>ParentName</attribute>
+				<value>ApparelBase</value>
+		</li>
+
 		<!-- Change Layer -->
 
 		<li Class="PatchOperationAdd">
@@ -33,7 +60,8 @@
 			</value>
 		</li>
 
-		<!-- Robot Rig -->		
+		<!-- Robot Rig -->	
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_RoboticRig"]/statBases</xpath>
 			<value>
@@ -50,6 +78,7 @@
 		</li>
 
 		<!-- Medical Bag -->	
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_TraumaKit"]/statBases</xpath>
 			<value>
@@ -81,6 +110,7 @@
 		</li>
 
 		<!-- Rescue Frame -->
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_RescueFrame"]/statBases</xpath>
 			<value>
@@ -97,6 +127,7 @@
 		</li>
 
 		<!-- Forklift Rig -->
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName = "SGC_Apparel_Forklift"]/statBases</xpath>
 			<value>
@@ -113,68 +144,69 @@
 		</li>
 
 		<!-- Mortar Pack -->
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
-          <value>
-            <ammoDef>Shell_60mmMortar_HE</ammoDef>
-          </value>
-        </li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/maxCharges</xpath>
-          <value>
-            <maxCharges>3</maxCharges>
-          </value>
-        </li>
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+			<value>
+				<ammoDef>Shell_60mmMortar_HE</ammoDef>
+			</value>
+		</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
-          <value>
-            <ammoCountPerCharge>1</ammoCountPerCharge>
-          </value>
-        </li>
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/maxCharges</xpath>
+			<value>
+				<maxCharges>3</maxCharges>
+			</value>
+		</li>
 
-        <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps</xpath>
-          <value>
-            <li Class="CombatExtended.CompProperties_Charges">
-              <chargeSpeeds>
-                <li>30</li>
-                <li>50</li>
-                <li>70</li>
-                <li>90</li>
-              </chargeSpeeds>
-            </li>
-          </value>
-        </li>
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+			<value>
+				<ammoCountPerCharge>1</ammoCountPerCharge>
+			</value>
+		</li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/verbs</xpath>
-          <value>
-            <verbs>
-              <li Class="CombatExtended.VerbPropertiesCE">
-                <label>launch 60mm shell</label>
-                <verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
-                <hasStandardCommand>true</hasStandardCommand>
-                <onlyManualCast>True</onlyManualCast>
-                <warmupTime>2</warmupTime>
-                <range>40</range>
-                <minRange>5</minRange>
-                <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-        		<soundCast>Mortar_LaunchA</soundCast>
-                <soundCastTail>GunTail_Medium</soundCastTail>
-                <muzzleFlashScale>14</muzzleFlashScale>
-                <drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
-                <targetParams>
-                  <canTargetLocations>true</canTargetLocations>
-                </targetParams>
-                <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-                <defaultProjectile>Bullet_60mmMortarShell_HE</defaultProjectile>
-                <rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
-              </li>
-            </verbs>
-          </value>
-        </li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps</xpath>
+			<value>
+				<li Class="CombatExtended.CompProperties_Charges">
+					<chargeSpeeds>
+						<li>30</li>
+						<li>50</li>
+						<li>70</li>
+						<li>90</li>
+					</chargeSpeeds>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/verbs</xpath>
+			<value>
+				<verbs>
+					<li Class="CombatExtended.VerbPropertiesCE">
+						<label>launch 60mm shell</label>
+						<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<onlyManualCast>True</onlyManualCast>
+						<warmupTime>2</warmupTime>
+						<range>40</range>
+						<minRange>5</minRange>
+						<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+						<soundCast>Mortar_LaunchA</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>14</muzzleFlashScale>
+						<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+						<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+						<defaultProjectile>Bullet_60mmMortarShell_HE</defaultProjectile>
+						<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+					</li>
+				</verbs>
+			</value>
+		</li>
 
 		</operations>
 		</match>

--- a/Patches/More Utility Packs/Apparel_Packs.xml
+++ b/Patches/More Utility Packs/Apparel_Packs.xml
@@ -8,31 +8,78 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-		<!-- Add a parent with quality -->
+		<!-- Quality Comp -->
 
-		<li Class="PatchOperationAttributeSet">
-			<xpath>Defs/ThingDef[
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/ThingDef[
 			defName="SGC_Apparel_RoboticRig" or
 			defName="SGC_Apparel_TraumaKit" or
-			defName="SGC_Apparel_RescueFrame" or
-			defName="SGC_Apparel_FieldMortar" or
-			defName="SGC_Apparel_Jetpack" or
-			defName="SGC_Apparel_CommandTower" or
-			defName="SGC_Apparel_CombatMechPack" or
-			defName="SGC_Apparel_INDMechPack" or
-			defName="SGC_Apparel_MechJet"
-			]</xpath>
-				<attribute>ParentName</attribute>
-				<value>ApparelBase</value>
+			defName="SGC_Apparel_FieldMortar"
+			]/comps/li/compClass[.="CompQuality"]</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="SGC_Apparel_RoboticRig" or defName="SGC_Apparel_TraumaKit" or defName="SGC_Apparel_RescueFrame" or defName="SGC_Apparel_FieldMortar"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CompQuality</compClass>
+					</li>
+				</value>
+			</nomatch>
 		</li>
 
-		<li Class="PatchOperationAttributeSet">
-			<xpath>Defs/VAE_Accessories.CaravanCapacityApparelDef[
-			defName="SGC_Apparel_SurvivalPack" or
-			defName="SGC_Apparel_Forklift"
-			]</xpath>
-				<attribute>ParentName</attribute>
-				<value>ApparelBase</value>
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_RescueFrame"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="SGC_Apparel_RescueFrame"]</xpath>
+				<value>
+					<comps>
+						<li>
+							<compClass>CompQuality</compClass>
+						</li>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="SGC_Apparel_RescueFrame"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CompQuality</compClass>
+					</li>
+				</value>
+			</match>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="SGC_Apparel_Forklift"]/comps/li/compClass[.="CompQuality"]</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="SGC_Apparel_Forklift"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CompQuality</compClass>
+					</li>
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="SGC_Apparel_SurvivalPack"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="SGC_Apparel_SurvivalPack"]</xpath>
+				<value>
+					<comps>
+						<li>
+							<compClass>CompQuality</compClass>
+						</li>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName="SGC_Apparel_SurvivalPack"]/comps</xpath>
+				<value>
+					<li>
+						<compClass>CompQuality</compClass>
+					</li>
+				</value>
+			</match>
 		</li>
 
 		<!-- Change Layer -->
@@ -123,6 +170,20 @@
 			<value>
 				<CarryBulk>10</CarryBulk>
 				<CarryWeight>20</CarryWeight>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "SGC_Apparel_RescueFrame"]/statBases/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>0.75</EnergyShieldRechargeRate>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "SGC_Apparel_RescueFrame"]/statBases/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>9.0</EnergyShieldEnergyMax>
 			</value>
 		</li>
 

--- a/Patches/More Utility Packs/Apparel_Packs.xml
+++ b/Patches/More Utility Packs/Apparel_Packs.xml
@@ -113,6 +113,7 @@
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_RoboticRig"]/statBases</xpath>
 			<value>
 				<Bulk>10</Bulk>
+				<WornBulk>7</WornBulk>
 			</value>
 		</li>
 
@@ -130,6 +131,7 @@
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_TraumaKit"]/statBases</xpath>
 			<value>
 				<Bulk>8</Bulk>
+				<WornBulk>5</WornBulk>
 			</value>
 		</li>
 
@@ -146,6 +148,7 @@
 			<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName = "SGC_Apparel_SurvivalPack"]/statBases</xpath>
 			<value>
 				<Bulk>10</Bulk>
+				<WornBulk>5</WornBulk>
 			</value>
 		</li>
 
@@ -162,6 +165,7 @@
 			<xpath>/Defs/ThingDef[defName = "SGC_Apparel_RescueFrame"]/statBases</xpath>
 			<value>
 				<Bulk>12</Bulk>
+				<WornBulk>8</WornBulk>
 			</value>
 		</li>
 
@@ -193,6 +197,7 @@
 			<xpath>/Defs/VAE_Accessories.CaravanCapacityApparelDef[defName = "SGC_Apparel_Forklift"]/statBases</xpath>
 			<value>
 				<Bulk>10</Bulk>
+				<WornBulk>7</WornBulk>
 			</value>
 		</li>
 
@@ -205,6 +210,10 @@
 		</li>
 
 		<!-- Mortar Pack -->
+
+		<li Class="PatchOperationRemove">
+			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/equippedStatOffsets</xpath>
+		</li>
 
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="SGC_Apparel_FieldMortar"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>

--- a/Patches/More Utility Packs/Apparel_Packs.xml
+++ b/Patches/More Utility Packs/Apparel_Packs.xml
@@ -17,7 +17,7 @@
 			defName="SGC_Apparel_FieldMortar"
 			]/comps/li/compClass[.="CompQuality"]</xpath>
 			<nomatch Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="SGC_Apparel_RoboticRig" or defName="SGC_Apparel_TraumaKit" or defName="SGC_Apparel_RescueFrame" or defName="SGC_Apparel_FieldMortar"]/comps</xpath>
+				<xpath>/Defs/ThingDef[defName="SGC_Apparel_RoboticRig" or defName="SGC_Apparel_TraumaKit" or defName="SGC_Apparel_FieldMortar"]/comps</xpath>
 				<value>
 					<li>
 						<compClass>CompQuality</compClass>

--- a/Patches/More Utility Packs/Apparel_Royalty.xml
+++ b/Patches/More Utility Packs/Apparel_Royalty.xml
@@ -12,27 +12,91 @@
 			<match Class="PatchOperationSequence">
 				<operations>
 
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[
-				defName="SGC_Apparel_Jetpack" or
-				defName="SGC_Apparel_CommandTower"		
-				]/apparel/layers</xpath>
-				<value>
-					<li>Backpack</li>
-				</value>
-			</li>
+				<!-- Quality Comp -->
 
-			<li Class="PatchOperationFindMod">
-				<mods>
-					<li>Vanilla Factions Expanded - Mechanoids</li>
-				</mods>						
-				<match Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="SGC_Apparel_MechJet"]/apparel/layers</xpath>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[
+					defName="SGC_Apparel_Jetpack" or
+					defName="SGC_Apparel_CommandTower"
+					]/comps/li/compClass[.="CompQuality"]</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="SGC_Apparel_Jetpack" or defName="SGC_Apparel_CommandTower"]/comps</xpath>
+						<value>
+							<li>
+								<compClass>CompQuality</compClass>
+							</li>
+						</value>
+					</nomatch>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[
+					defName="SGC_Apparel_Jetpack" or
+					defName="SGC_Apparel_CommandTower"		
+					]/apparel/layers</xpath>
 					<value>
 						<li>Backpack</li>
 					</value>
-				</match>					
-			</li>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="SGC_Apparel_Jetpack"]/statBases/EnergyShieldRechargeRate</xpath>
+					<value>
+						<EnergyShieldRechargeRate>0.375</EnergyShieldRechargeRate>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="SGC_Apparel_Jetpack"]/statBases/EnergyShieldEnergyMax</xpath>
+					<value>
+						<EnergyShieldEnergyMax>3.75</EnergyShieldEnergyMax>
+					</value>
+				</li>
+
+				<li Class="PatchOperationFindMod">
+					<mods>
+						<li>Vanilla Factions Expanded - Mechanoids</li>
+					</mods>						
+					<match Class="PatchOperationSequence">
+						<operations>
+
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="SGC_Apparel_MechJet"]/apparel/layers</xpath>
+							<value>
+								<li>Backpack</li>
+							</value>
+						</li>
+
+						<!-- Quality Comp -->
+
+						<li Class="PatchOperationConditional">
+							<xpath>/Defs/ThingDef[defName="SGC_Apparel_MechJet"]/comps/li/compClass[.="CompQuality"]</xpath>
+							<nomatch Class="PatchOperationAdd">
+								<xpath>/Defs/ThingDef[defName="SGC_Apparel_MechJet"]/comps</xpath>
+								<value>
+									<li>
+										<compClass>CompQuality</compClass>
+									</li>
+								</value>
+							</nomatch>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName = "SGC_Apparel_MechJet"]/statBases/EnergyShieldRechargeRate</xpath>
+							<value>
+								<EnergyShieldRechargeRate>0.45</EnergyShieldRechargeRate>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>Defs/ThingDef[defName = "SGC_Apparel_MechJet"]/statBases/EnergyShieldEnergyMax</xpath>
+							<value>
+								<EnergyShieldEnergyMax>4.5</EnergyShieldEnergyMax>
+							</value>
+						</li>
+
+					</match>					
+				</li>
 
 				</operations>
 			</match>					

--- a/Patches/More Utility Packs/Apparel_Royalty.xml
+++ b/Patches/More Utility Packs/Apparel_Royalty.xml
@@ -95,6 +95,7 @@
 							</value>
 						</li>
 
+						</operations>
 					</match>					
 				</li>
 


### PR DESCRIPTION
## Changes

- Gave the CompQuality to the utility items from the More Utility Packs mod

## Reasoning

- The utility items added by the More Utility Packs have a ParentName which causes them to not have quality. Since in CE, those items add bulk and weight capacity and occupy the backpack layer and forbid wearing backpacks simultaneously with them, them not having quality means that the capacity increases don't scale.
- Items not having quality breaks the apparel restrictions. If you limit the quality of allowed apparel in any way, pawns stop auto-equipping the utility packs added by the mod and should be forced to equip them.

## Alternatives

- Leave them be as broken as they are

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Always play with these changes)
