### PR TITLE
pawnKind combat skill range tweaks

### DIFF
--- a/Ideology/Patches/AbilityDefs/Abilities.xml
+++ b/Ideology/Patches/AbilityDefs/Abilities.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- Combat Command -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="CombatCommand"]/verbProperties/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[defName="CombatCommand"]/statBases/Ability_EffectRadius</xpath>
+		<value>
+			<Ability_EffectRadius>14.9</Ability_EffectRadius>
+		</value>
+	</Operation>
+
+	<!-- Role Aura -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[@Name="RoleAuraBuffBase"]/verbProperties/range</xpath>
+		<value>
+			<range>14.9</range>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AbilityDef[@Name="RoleAuraBuffBase"]/statBases/Ability_EffectRadius</xpath>
+		<value>
+			<Ability_EffectRadius>14.9</Ability_EffectRadius>
+		</value>
+	</Operation>
+
+
+</Patch>
+

--- a/Ideology/Patches/Misc/Hediffs_Casts.xml
+++ b/Ideology/Patches/Misc/Hediffs_Casts.xml
@@ -4,20 +4,6 @@
 	<!-- Combat Command -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/AbilityDef[defName="CombatCommand"]/verbProperties/range</xpath>
-		<value>
-			<range>14.9</range>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/AbilityDef[defName="CombatCommand"]/statBases/Ability_EffectRadius</xpath>
-		<value>
-			<Ability_EffectRadius>14.9</Ability_EffectRadius>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mote_CombatCommand"]/graphicData/drawSize</xpath>
 		<value>
 			<drawSize>30</drawSize>
@@ -30,7 +16,6 @@
 			<range>14.9</range>
 		</value>
 	</Operation>
-
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CombatCommandBuff"]/comps/li[@Class="HediffCompProperties_Link"]/maxDistance</xpath>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -139,6 +139,18 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationReplace">
+   <xpath>/Defs/PawnKindDef[@Name="MercenaryGunnerBase"]/skills</xpath>
+   <value>
+     <skills>
+       <li>
+         <skill>Shooting</skill>
+         <range>6~16</range>
+       </li>
+     </skills>
+   </value>
+  </Operation>
+
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/PawnKindDef[defName="Mercenary_Gunner"]</xpath>
     <value>
@@ -190,6 +202,18 @@
         </sidearms>
       </li>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+   <xpath>/Defs/PawnKindDef[@Name="MercenarySniperBase"]/skills</xpath>
+   <value>
+     <skills>
+       <li>
+         <skill>Shooting</skill>
+         <range>8~18</range>
+       </li>
+     </skills>
+   </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
@@ -270,6 +294,21 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[@Name="MercenarySlasherBase"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[@Name="MercenarySlasherBase"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Melee</skill>
+           <range>4~12</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName = "Mercenary_Slasher" or defName="Mercenary_Slasher_Acidifier"]</xpath>
     <value>
@@ -284,6 +323,21 @@
         <shieldChance>0.9</shieldChance>
       </li>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>6~14</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
@@ -359,6 +413,21 @@
         </sidearms>
       </li>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="Town_Guard"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="Town_Guard"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>4~10</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
@@ -470,6 +539,25 @@
   </Operation>
 
   <!-- ========== Spacer ========== -->
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>6~12</range>
+         </li>
+         <li>
+           <skill>Melee</skill>
+           <range>4~12</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="AncientSoldier"]/weaponMoney</xpath>
@@ -662,6 +750,21 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="Tribal_HeavyArcher"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="Tribal_HeavyArcher"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>4~12</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Tribal_HeavyArcher"]</xpath>
     <value>
@@ -698,6 +801,21 @@
     <value>
       <combatPower>60</combatPower>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="Tribal_Berserker"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="Tribal_Berserker"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Melee</skill>
+           <range>4~12</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
@@ -739,6 +857,21 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefMelee"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefMelee"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Melee</skill>
+           <range>8~12</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Tribal_ChiefRanged"]</xpath>
     <value>
@@ -768,6 +901,21 @@
         </sidearms>
       </li>
     </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefRanged"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefRanged"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>6~14</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
@@ -812,6 +960,21 @@
      <value>
        <li>Apparel_Backpack</li>
      </value>
+  </Operation>
+
+  <Operation Class="PatchOperationConditional">
+   <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]/skills</xpath>
+   <nomatch Class="PatchOperationAdd">
+     <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]</xpath>
+     <value>
+       <skills>
+         <li>
+           <skill>Shooting</skill>
+           <range>8~14</range>
+         </li>
+       </skills>
+     </value>
+   </nomatch>
   </Operation>
 
 </Patch>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -138,7 +138,7 @@
      <skills>
        <li>
          <skill>Shooting</skill>
-         <range>6~16</range>
+         <range>4~16</range>
        </li>
      </skills>
    </value>
@@ -203,7 +203,7 @@
      <skills>
        <li>
          <skill>Shooting</skill>
-         <range>8~18</range>
+         <range>6~18</range>
        </li>
      </skills>
    </value>
@@ -858,7 +858,7 @@
        <skills>
          <li>
            <skill>Melee</skill>
-           <range>8~12</range>
+           <range>6~12</range>
          </li>
        </skills>
      </value>
@@ -904,7 +904,7 @@
        <skills>
          <li>
            <skill>Shooting</skill>
-           <range>6~14</range>
+           <range>6~12</range>
          </li>
        </skills>
      </value>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -408,21 +408,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="Town_Guard"]/skills</xpath>
-   <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="Town_Guard"]</xpath>
-     <value>
-       <skills>
-         <li>
-           <skill>Shooting</skill>
-           <range>4~10</range>
-         </li>
-       </skills>
-     </value>
-   </nomatch>
-  </Operation>
-
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Town_Guard"]</xpath>
     <value>
@@ -743,21 +728,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="Tribal_HeavyArcher"]/skills</xpath>
-   <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="Tribal_HeavyArcher"]</xpath>
-     <value>
-       <skills>
-         <li>
-           <skill>Shooting</skill>
-           <range>4~12</range>
-         </li>
-       </skills>
-     </value>
-   </nomatch>
-  </Operation>
-
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Tribal_HeavyArcher"]</xpath>
     <value>
@@ -794,21 +764,6 @@
     <value>
       <combatPower>60</combatPower>
     </value>
-  </Operation>
-
-  <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="Tribal_Berserker"]/skills</xpath>
-   <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="Tribal_Berserker"]</xpath>
-     <value>
-       <skills>
-         <li>
-           <skill>Melee</skill>
-           <range>4~12</range>
-         </li>
-       </skills>
-     </value>
-   </nomatch>
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -963,7 +963,7 @@
        <skills>
          <li>
            <skill>Shooting</skill>
-           <range>8~14</range>
+           <range>4~12</range>
          </li>
        </skills>
      </value>

--- a/Patches/Vanilla Factions Expanded - Ancients/PawnKinds_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/PawnKinds_Spacer.xml
@@ -9,7 +9,7 @@
       <operations>
         
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
+          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -29,25 +29,23 @@
           </value>
         </li>
 
-        <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
-          <value>
-            <li Class="CombatExtended.LoadoutPropertiesExtension">
-              <primaryMagazineCount>
-                <min>4</min>
-                <max>7</max>
-              </primaryMagazineCount>
-              <forcedSidearm>
-                <sidearmMoney>
-                  <min>175</min>
-                  <max>375</max>
-                </sidearmMoney>
-                <weaponTags>
-                  <li>CE_Sidearm_Melee</li>
-                </weaponTags>
-              </forcedSidearm>
-            </li>
-          </value>
+        <li Class="PatchOperationConditional">
+          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]/skills</xpath>
+          <nomatch Class="PatchOperationAdd">
+            <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
+            <value>
+              <skills>
+                <li>
+                  <skill>Shooting</skill>
+                  <range>8~14</range>
+                </li>
+                <li>
+                  <skill>Melee</skill>
+                  <range>6~14</range>
+                </li>
+              </skills>
+            </value>
+          </nomatch>
         </li>
 
       </operations>

--- a/Patches/Vanilla Factions Expanded - Pirates/AbilityDefs/Abilities.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/AbilityDefs/Abilities.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- Firing Frenzy -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AbilityDef[@Name="VFEP_RoleAuraBuffBase"]/verbProperties/range</xpath>
+			<value>
+				<range>14.9</range>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AbilityDef[@Name="VFEP_RoleAuraBuffBase"]/statBases/Ability_EffectRadius</xpath>
+			<value>
+				<Ability_EffectRadius>14.9</Ability_EffectRadius>
+			</value>
+		</li>
+
+      </operations>
+    </match>
+
+  </Operation>
+
+</Patch>
+

--- a/Patches/Vanilla Factions Expanded - Pirates/Misc/Hediffs_Casts.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Misc/Hediffs_Casts.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+		<!-- Firing Frenzy -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzy"]/comps/li[@Class="HediffCompProperties_GiveHediffsInRange"]/range</xpath>
+			<value>
+				<range>14.9</range>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzyBuff"]/stages/li/statOffsets</xpath>
+			<value>
+				<statOffsets>
+					<Suppressability>-0.25</Suppressability>
+				</statOffsets>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzyBuff"]/stages/li</xpath>
+			<value>
+				<statFactors>
+					<ReloadSpeed>1.20</ReloadSpeed>
+				</statFactors>
+			</value>
+		</li>
+
+      </operations>
+    </match>
+
+  </Operation>
+
+</Patch>
+

--- a/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
@@ -8,17 +8,17 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-	<!-- Pirate Captain -->
+		<!-- Pirate Captain -->
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
+			<xpath>/Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
 			<value>
 				<modifier>3</modifier>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="AimingDelayFactor"]</xpath>
+			<xpath>/Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="AimingDelayFactor"]</xpath>
 			<value>
 				<li Class="RoleEffect_PawnStatOffset">
 					<statDef>ReloadSpeed</statDef>

--- a/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+	<!-- Pirate Captain -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
+			<value>
+				<modifier>3</modifier>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="AimingDelayFactor"]</xpath>
+			<value>
+				<li Class="RoleEffect_PawnStatOffset">
+					<statDef>ReloadSpeed</statDef>
+					<modifier>0.15</modifier>
+				</li>
+			</value>
+		</li>
+
+      </operations>
+    </match>
+
+  </Operation>
+
+</Patch>
+

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -74,6 +74,22 @@
           </value>
         </li>
 
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/PawnKindDef[@Name="VFEP_MercenariesBase"]/skills</xpath>
+          <value>
+            <skills>
+              <li>
+                <skill>Shooting</skill>
+                <range>6~18</range>
+              </li>
+              <li>
+                <skill>Melee</skill>
+                <range>6~16</range>
+              </li>
+            </skills>
+          </value>
+        </li>
+
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -74,22 +74,6 @@
           </value>
         </li>
 
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[@Name="VFEP_MercenariesBase"]/skills</xpath>
-          <value>
-            <skills>
-              <li>
-                <skill>Shooting</skill>
-                <range>6~18</range>
-              </li>
-              <li>
-                <skill>Melee</skill>
-                <range>6~16</range>
-              </li>
-            </skills>
-          </value>
-        </li>
-
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -59,6 +59,22 @@
           </value>
         </li>
 
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/PawnKindDef[@Name="VFEP_MercenariesBase"]/skills</xpath>
+          <value>
+            <skills>
+              <li>
+                <skill>Shooting</skill>
+                <range>6~18</range>
+              </li>
+              <li>
+                <skill>Melee</skill>
+                <range>6~16</range>
+              </li>
+            </skills>
+          </value>
+        </li>
+
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -59,6 +59,21 @@
           </value>
         </li>
 
+        <!-- === combatPower Patches === -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
+          <value>
+            <combatPower>400</combatPower>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
+          <value>
+            <combatPower>450</combatPower>
+          </value>
+        </li>
+
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[@Name="VFEP_MercenariesBase"]/skills</xpath>
           <value>


### PR DESCRIPTION
## Changes

- Added and tweaked skill range values for vanilla and modded pawnKinds
- Fixed the Pirate Captain role bonuses from VFE-Pirates
- Some housekeeping for the combat oriented ideology abilities

## Reasoning

- Vanilla mercenary gunners and snipers had a shooting skill range of 4~20. Imperial pawns had various combat skill ranges as well which sparked the thought of tweaking and adding the melee and shooting skill range to certain high tier faction pawns to make them more reliable in their combat role.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors