### PR TITLE
Reverted the Lancer cover change

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -2,6 +2,13 @@
 <Patch>
 
   <!-- ========== Mechanoid ========== -->
+  
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[defName="Mech_Lancer"]</xpath>
+    <value>
+      <aiAvoidCover>false</aiAvoidCover>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="Mech_Centipede"]/combatPower</xpath>


### PR DESCRIPTION
## I recognize that the council has made a decision, but given that is a stupid-ass decision, I have elected to ignore it

But jokes aside, the Lancer cover change is not a good decision, Lancers are long range support mechs with very low stopping power and largely incredibly weak on their own. 
They are also lightly armored, are humanoid and have humanlike health scale, which doesn't allow for tanking shots like heavier mechs.
Removing the cover seeking behavior would also make static defenses the most effective strategy against them, which is exactly the strategy that mech raids discourage

And if you want to say that "it's an undocumented change", you do know that you can just document it, right?