### PR TITLE
Tweak VWE patch

### DIFF
--- a/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
@@ -402,6 +402,9 @@
         <FireModes>
           <aiAimMode>AimedShot</aiAimMode>     
         </FireModes>
+        <weaponTags>
+          <li>Bipod_DMR</li>
+        </weaponTags>
       </li>
 
       <!-- === Salvaged Laser Sniper Rifle === -->
@@ -433,6 +436,9 @@
         <FireModes>
           <aiAimMode>AimedShot</aiAimMode>     
         </FireModes>
+        <weaponTags>
+          <li>Bipod_DMR</li>
+        </weaponTags>
       </li>
 
       <!-- === Laser Minigun === -->

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -211,6 +211,7 @@
     </FireModes>
     <weaponTags>
       <li>SniperRifle</li>
+      <li>Bipod_DMR</li>
     </weaponTags>
     <!-- Required research rework -->
     <researchPrerequisite>PrecisionRifling</researchPrerequisite>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -657,6 +657,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
 					</weaponTags>
 					<!-- Required Research Rework -->
 					<researchPrerequisite>PrecisionRifling</researchPrerequisite>
@@ -701,6 +702,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
+						<li>Bipod_DMR</li>
 					</weaponTags>
 					<!-- Required Research Rework -->
 					<researchPrerequisite>PrecisionRifling</researchPrerequisite>
@@ -755,6 +757,7 @@
 						<li>IndustrialGunAdvanced</li>
 						<li>GunHeavy</li>
 						<li>CE_MachineGun</li>
+						<li>Bipod_LMG</li>
 					</weaponTags>
 					<!-- Required Research Rework -->
 					<researchPrerequisite>PrecisionRifling</researchPrerequisite>

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -241,18 +241,18 @@
           <defName>VWE_Gun_ChargeSniperRifle</defName>
           <statBases>
             <WorkToMake>50500</WorkToMake>
-            <Mass>6.5</Mass>
-            <Bulk>13.5</Bulk>
-            <SwayFactor>2.1</SwayFactor>
+            <Mass>8</Mass>
+            <Bulk>14.5</Bulk>
+            <SwayFactor>2.25</SwayFactor>
             <ShotSpread>0.05</ShotSpread>
             <SightsEfficiency>2.6</SightsEfficiency>
-            <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+            <RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
           </statBases>
           <costList>
-            <Steel>60</Steel>
-            <Plasteel>30</Plasteel>
+            <Steel>75</Steel>
+            <Plasteel>40</Plasteel>
             <Chemfuel>15</Chemfuel>
-            <ComponentIndustrial>10</ComponentIndustrial>
+            <ComponentIndustrial>12</ComponentIndustrial>
           </costList>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -262,7 +262,7 @@
             <range>75</range>
             <soundCast>VWE_Shot_ChargeSniperRifle</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
-            <muzzleFlashScale>10</muzzleFlashScale>
+            <muzzleFlashScale>11</muzzleFlashScale>
             <ammoConsumedPerShotCount>3</ammoConsumedPerShotCount>
           </Properties>
           <AmmoUser>

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -241,9 +241,9 @@
           <defName>VWE_Gun_ChargeSniperRifle</defName>
           <statBases>
             <WorkToMake>50500</WorkToMake>
-            <Mass>6.0</Mass>
-            <Bulk>12.0</Bulk>
-            <SwayFactor>1.9</SwayFactor>
+            <Mass>6.5</Mass>
+            <Bulk>13.5</Bulk>
+            <SwayFactor>2.1</SwayFactor>
             <ShotSpread>0.05</ShotSpread>
             <SightsEfficiency>2.6</SightsEfficiency>
             <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
@@ -276,6 +276,7 @@
           <weaponTags>
             <li>SniperRifle</li>
             <li>SpacerGun</li>
+            <li>Bipod_DMR</li>
           </weaponTags>
           <AllowWithRunAndGun>false</AllowWithRunAndGun>
         </li>
@@ -328,6 +329,7 @@
           <weaponTags>
             <li>SpacerGun</li>
             <li>CE_MachineGun</li>
+            <li>Bipod_SAW</li>
           </weaponTags>
           <AllowWithRunAndGun>false</AllowWithRunAndGun>
         </li>


### PR DESCRIPTION

## Additions

- Added bipods to base VWE, lasers and the quickdraw modules

## Changes

- Tweaked the stats on the charge sniper to balance out the change to triplet shot (could arguably be changed even further)
- Sway increased to simulate the shifted balance of having triple the barrel to deal with


## Reasoning

- Compared to 8x50, triple 8x35 has significantly higher stopping power, and so the weapon stats should reflect that
- Charge LMG was given a SAW bipod as it uses 6x24
- Only the snipers from the modules got bipods, as both lack a proper LMG/SAW

## Alternatives

- Leave them naked and bipodless =)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
