### PR TITLE
Fix Revia called shot gizmo

### DIFF
--- a/Patches/Revia Race/ThingDefs_Races/Race_Revia.xml
+++ b/Patches/Revia Race/ThingDefs_Races/Race_Revia.xml
@@ -32,16 +32,6 @@
 					</li>
 				</value>
 			</li>
-			
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ReviaRaceAlien"]/comps</xpath>
-				<value>
-					<li>
-					<compClass>CombatExtended.CompPawnGizmo</compClass>
-					</li>
-					<li Class="CombatExtended.CompProperties_Suppressable" />
-				</value>
-			</li>
 
       <!--
       Juanfrank


### PR DESCRIPTION
## Changes

Revia apparently doesn't need suppression and gizmo as they inherit it from somewhere. Adding gizmo the second time causes part selection to be toggled twice per click.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
