### PR TITLE
Fix Rabbie race patch failing

### DIFF
--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Races/AlienRace_Rabbielike.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Races/AlienRace_Rabbielike.xml
@@ -9,18 +9,19 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 			
-			<li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/inspectorTabs/li[.="ITab_Pawn_Gear"]</xpath>
-                    <value>
-                        <li>CombatExtended.ITab_Inventory</li>
-                    </value>
-			</li>
-
-            <li Class="PatchOperationAdd">
-                    <xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/comps</xpath>
-                    <value>
-                        <li Class="CombatExtended.CompProperties_Inventory" />
-                    </value>
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]</xpath>
+					<value>
+						<comps/>
+					</value>
+				</nomatch>
+				<match Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[@Name="RB_PawnBase"]</xpath>
+					<value>
+					</value>
+				</match>
 			</li>
 			
 			<li Class="PatchOperationAdd">


### PR DESCRIPTION


## Changes

Add comps, remove redundant Inventory (Rabbie inherits from BasePawn)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
