### PR TITLE
Rifle bipod tag

### DIFF
--- a/Defs/BipodCategoryDefs/BipodCategories.xml
+++ b/Defs/BipodCategoryDefs/BipodCategories.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
+
     <CombatExtended.BipodCategoryDef>
         <!--Same as in other defs -->
         <defName>bipodLMG</defName>
@@ -32,7 +33,7 @@
         <setuptime>180</setuptime>
         <recoil_mult_setup>0.7</recoil_mult_setup>
         <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
-        <warmup_mult_setup>0.76</warmup_mult_setup>
+        <warmup_mult_setup>0.75</warmup_mult_setup>
         <warmup_mult_NOT_setup>1</warmup_mult_NOT_setup>
          <!--when not specified just goes with blue, I just like making colorful logs tbh -->
         <logColor>(255, 0, 0)</logColor>
@@ -74,4 +75,21 @@
         <swayPenalty>1.25</swayPenalty>
         <useAutoSetMode>false</useAutoSetMode>
     </CombatExtended.BipodCategoryDef>
+
+    <CombatExtended.BipodCategoryDef>
+        <defName>bipodRifle</defName>
+        <label>Rifle</label>
+        <bipod_id>Bipod_Rifle</bipod_id>
+        <ad_Range>3</ad_Range>
+        <setuptime>150</setuptime>
+        <recoil_mult_setup>0.8</recoil_mult_setup>
+        <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
+        <warmup_mult_setup>0.85</warmup_mult_setup>
+        <warmup_mult_NOT_setup>1</warmup_mult_NOT_setup>
+        <logColor>(0, 0, 255)</logColor>
+        <swayMult>0.75</swayMult>
+        <swayPenalty>1</swayPenalty>
+        <useAutoSetMode>false</useAutoSetMode>
+    </CombatExtended.BipodCategoryDef>
+
 </Defs>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BullpupAR.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BullpupAR.xml
@@ -98,6 +98,10 @@
 					<aimedBurstShotCount>3</aimedBurstShotCount>
 				</FireModes>
 
+				<weaponTags>
+					<li>Bipod_Rifle</li>
+				</weaponTags>
+
 				<!-- No additional CE weaponTags needed -->
 			</li>
 

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -165,6 +165,7 @@
     </FireModes>
     <weaponTags>
       <li>IndustrialGunAdvanced</li>
+      <li>Bipod_Rifle</li>
     </weaponTags>
     <!-- Required research rework -->
     <researchPrerequisite>PrecisionRifling</researchPrerequisite>


### PR DESCRIPTION
## Additions

- Added a bipod tag to be used for appropriate assault and battle rifles with integrated bipods.

## Reasoning

- Certain rifles like the Galil and Famas have integrated bipods which don't fit in any of the existing bipod tag categories so, added a new rifle bipod tag to accommodate for that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
