### PR TITLE
Update Dependency Package versions

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -106,12 +106,12 @@
 		<Folder Include="CombatExtended\GUI\Tabs\" />
 	</ItemGroup>
 	<ItemGroup>
-    <PackageReference Include="Krafs.Publicizer" Version="1.0.1">
+    <PackageReference Include="Krafs.Publicizer" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3159" GeneratePathProperty="true" />
-    <PackageReference Include="Lib.Harmony" Version="2.1.1" ExcludeAssets="runtime" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3287" GeneratePathProperty="true" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.1" ExcludeAssets="runtime" />
 		<PackageReference Include="RimWorld.MultiplayerAPI" Version="0.4.0" />
 	</ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Changes

- What it says on the tin

## Reasoning

- The dependency package versions were outdated and VS forced an update on manual build each time a new unbuilt CE dev snapshot was downloaded for build

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
