### PR TITLE
Fix Winston Waves' raid modifier

### DIFF
--- a/Patches/Vanilla Storytellers Expanded - Winston Waves/Modifiers/Modifiers.xml
+++ b/Patches/Vanilla Storytellers Expanded - Winston Waves/Modifiers/Modifiers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Storytellers Expanded - Winston Waves</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Charge For Everyone === -->
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/VSEWW.ModifierDef[defName="VSEWW_ChargeForEveryone"]/allowedWeaponDef/li[contains(.,"Gun_ChargeLance")]</xpath>
+          <value>
+            <li MayRequire="CETeam.CombatExtendedGuns">CE_Gun_ChargeLMG</li>
+            <li MayRequire="CETeam.CombatExtendedGuns">CE_Gun_ChargeSniperRifle</li>
+            <li MayRequire="CETeam.CombatExtendedGuns">CE_Gun_ChargeSMG</li>
+          </value>
+        </li>
+        
+      </operations>
+    </match>
+
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- Fixed Winston Waves' "Charge weapons for everyone!" raid modifier that forced pawns to spawn with charge lances and replaced the lances with CE guns' charge weapons

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Works ingame)
