### PR TITLE
Pistol and rifle cartridge rebalanced

### DIFF
--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -119,7 +119,7 @@
 		<label>10mm Auto bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>2.64</armorPenetrationSharp>
 			<armorPenetrationBlunt>19.2</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -99,7 +99,7 @@
 		<label>.22 LR bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>2.25</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.22 LR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>4</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.22 LR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>1.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -97,7 +97,7 @@
 		<label>.32 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.980</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -107,7 +107,7 @@
 		<label>.32 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.980</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -99,7 +99,7 @@
 		<label>.357 Magnum bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.357 Magnum bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -99,7 +99,7 @@
     <label>.38 Special bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>9</damageAmountBase>
-      <armorPenetrationSharp>4</armorPenetrationSharp>
+      <armorPenetrationSharp>3</armorPenetrationSharp>
       <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -109,7 +109,7 @@
     <label>.38 Special bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>6</damageAmountBase>
-      <armorPenetrationSharp>8</armorPenetrationSharp>
+      <armorPenetrationSharp>6</armorPenetrationSharp>
       <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -99,7 +99,7 @@
 		<label>.40 SW bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.360</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.40 SW bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.360</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -119,7 +119,7 @@
 		<label>.44 Magnum bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>19</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>23.280</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -102,7 +102,7 @@
 		<label>.454 Casull bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6.75</armorPenetrationSharp>
 			<armorPenetrationBlunt>48.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -112,7 +112,7 @@
 		<label>.454 Casull bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>13.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>48.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -122,7 +122,7 @@
 		<label>.454 Casull bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>48.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -123,7 +123,7 @@
 		<label>.45 Colt bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.440</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -133,7 +133,7 @@
 		<label>.45 Colt bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.440</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -119,7 +119,6 @@
 		<label>4.6x30mm bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationBase>0.145</armorPenetrationBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.72</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -99,7 +99,7 @@
 		<label>.500 Smith Wessen Magnum bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.820</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.500 Smith Wessen Magnum bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.820</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.500 Smith Wessen Magnum bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.820</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -98,7 +98,7 @@
 		<label>.50 AE bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>19</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>38.480</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -108,7 +108,7 @@
 		<label>.50 AE bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>38.480</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -99,7 +99,7 @@
 		<label>7.62mm Tokarev bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.62mm Tokarev bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -99,7 +99,7 @@
 		<label>7.62mmR pistol bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.62mm Tokarev bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -106,7 +106,7 @@
 
 	<ThingDef ParentName="Base762x38mmRBullet">
 		<defName>Bullet_762x38mmR_AP</defName>
-		<label>7.62mm Tokarev bullet (AP)</label>
+		<label>7.62mm pistol bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>9</armorPenetrationSharp>
@@ -116,7 +116,7 @@
 
 	<ThingDef ParentName="Base762x38mmRBullet">
 		<defName>Bullet_762x38mmR_HP</defName>
-		<label>7.62mm Tokarev bullet (HP)</label>
+		<label>7.62mm pistol bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -99,7 +99,7 @@
 		<label>7.63mm Mauser bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.63mm Mauser bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -99,7 +99,7 @@
 		<label>7.63mm Longue bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.880</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.65x20mm Longue bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.880</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -96,7 +96,7 @@
 
 	<ThingDef ParentName="Base765x20mmLongueBullet">
 		<defName>Bullet_765x20mmLongue_FMJ</defName>
-		<label>7.63mm Longue bullet (FMJ)</label>
+		<label>7.65x20mm Longue bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -99,7 +99,7 @@
 		<label>9mm Makarov bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>9mm Makarov bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -123,7 +123,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<!--<armorPenetrationBase>0.31</armorPenetrationBase>-->
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -134,7 +134,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<!--<armorPenetrationBase>0.46</armorPenetrationBase>-->
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>9mm Para bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>3.3</armorPenetrationSharp>
+			<armorPenetrationSharp>2.475</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.70</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>9mm Para bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>6.6</armorPenetrationSharp>
+			<armorPenetrationSharp>4.95</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.70</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/127x55mmAR.xml
+++ b/Defs/Ammo/Rifle/127x55mmAR.xml
@@ -168,7 +168,7 @@
 		<label>12.7mm AR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>6.6</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -165,7 +165,7 @@
 		<label>.30-06 Springfield cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>26</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>5.33</armorPenetrationSharp>
 			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -17,7 +17,7 @@
 			<Ammo_300AACBlackout_FMJ>Bullet_300AACBlackout_FMJ</Ammo_300AACBlackout_FMJ>
 			<Ammo_300AACBlackout_AP>Bullet_300AACBlackout_AP</Ammo_300AACBlackout_AP>
 			<Ammo_300AACBlackout_HP>Bullet_300AACBlackout_HP</Ammo_300AACBlackout_HP>
-		    <Ammo_300AACBlackout_Incendiary>Bullet_300AACBlackout_Incendiary</Ammo_300AACBlackout_Incendiary>
+			<Ammo_300AACBlackout_Incendiary>Bullet_300AACBlackout_Incendiary</Ammo_300AACBlackout_Incendiary>
 			<Ammo_300AACBlackout_HE>Bullet_300AACBlackout_HE</Ammo_300AACBlackout_HE>
 			<Ammo_300AACBlackout_Sabot>Bullet_300AACBlackout_Sabot</Ammo_300AACBlackout_Sabot>			
 		</ammoTypes>
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -163,7 +163,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -177,7 +177,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>4.66</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -187,7 +187,7 @@
 		<label>.300 AAC Blackout bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -203,7 +203,7 @@
 		<label>.300 AAC Blackout bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>16</damageAmountBase>
-		  <armorPenetrationSharp>7</armorPenetrationSharp>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -219,7 +219,7 @@
 		<label>.300 AAC Blackout bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>24.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>22</armorPenetrationSharp>
 		  <armorPenetrationBlunt>46.74</armorPenetrationBlunt>
 		  <speed>203</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -177,7 +177,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.66</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -165,7 +165,7 @@
 		<label>.303 British bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.66</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -165,7 +165,7 @@
 		<label>.30 Carbine bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 			<armorPenetrationBlunt>25.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -167,7 +167,7 @@
 		<label>.44-40 Winchester bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>5.33</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -165,7 +165,7 @@
 		<label>.45-70 Government cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -164,7 +164,7 @@
 		<label>4.73mm Caseless bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -165,7 +165,7 @@
 		<label>5.45mm Soviet bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>28.04</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -165,7 +165,7 @@
 		<label>5.56mm NATO bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>34.18</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -165,7 +165,7 @@
 		<label>.56-56 Spencer bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>23</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 			<armorPenetrationBlunt>30.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -177,7 +177,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>35.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -165,7 +165,7 @@
 		<label>6.5x52mm Carcano bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>22</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -165,7 +165,7 @@
 		<label>6.5mmSR Arisaka bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>22</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -165,7 +165,7 @@
 		<label>7.92mm Mauser bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -165,7 +165,7 @@
 		<label>7.5mm French bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>60.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -177,7 +177,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -165,7 +165,7 @@
 		<label>7.62mm NATO bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.66</armorPenetrationSharp>
 			<armorPenetrationBlunt>66.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -165,7 +165,7 @@
 		<label>7.62mmR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>4.66</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -166,7 +166,7 @@
 		<label>7.7x58mm Arisaka bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>60.24</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -165,7 +165,7 @@
 		<label>7.92mm Kurz bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 			<armorPenetrationBlunt>37.54</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -165,7 +165,7 @@
 		<label>8mmR Lebel bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>26</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -164,7 +164,7 @@
 		<label>9mm Soviet bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>2.64</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.48</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- Rebalanced certain pistol cartridges based on 0.66/1/2 sharp armor penetration factors
- Rebalanced HP rifle rounds from 0.5x FMJ armor pen to 0.66x 

## Reasoning

- Based on findings for the .44 magnum steel and gel penetration tests, HP and FMJ rounds don't have a 1 to 2 sharp armor penetration relation but something close to 1 to 1.5, so in order to rebalance pistol cartridges in comparison to rifle cartridges and alleviate the arbitrary similarities in sharp pen between them, pistol cartridges received a rebalace.
- In similar vein to the change above, in order to stop rifle HP rounds from severely underperforming in comparison to FMJ ones, the sharp armor penetration of HP rifle cartridges were increased from 0.5xFMJ to 0.66xFMJ

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
