### PR TITLE
Shooting trait modifier tweaks

### DIFF
--- a/Patches/Core/TraitDefs/Traits_Spectrum.xml
+++ b/Patches/Core/TraitDefs/Traits_Spectrum.xml
@@ -3,28 +3,38 @@
 
 	<Operation Class="PatchOperationSequence">
 		<operations>
+
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracyPawn</xpath>
+				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
+				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
 				<value>
 					<statFactors>
 						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
+						<AimingAccuracy>1.1</AimingAccuracy>
 					</statFactors>
 				</value>
 			</li>
+
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracyPawn</xpath>
+				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
+				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
 				<value>
 					<statFactors>
 						<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
 					</statFactors>
 				</value>
 			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/AimingDelayFactor</xpath>
+				<value>
+					<AimingDelayFactor>-0.25</AimingDelayFactor>
+				</value>
+			</li>
+
 		</operations>
 	</Operation>
 </Patch>

--- a/Patches/Core/TraitDefs/Traits_Spectrum.xml
+++ b/Patches/Core/TraitDefs/Traits_Spectrum.xml
@@ -10,7 +10,7 @@
 				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
 				<value>
 					<statFactors>
-						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
 					</statFactors>
 				</value>
 			</li>
@@ -21,7 +21,7 @@
 				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
 				<value>
 					<statFactors>
-						<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
 					</statFactors>
 				</value>
 			</li>

--- a/Patches/Core/TraitDefs/Traits_Spectrum.xml
+++ b/Patches/Core/TraitDefs/Traits_Spectrum.xml
@@ -11,8 +11,8 @@
 				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
 				<value>
 					<statFactors>
-						<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
-						<AimingAccuracy>1.1</AimingAccuracy>
+						<ShootingAccuracyPawn>1.33</ShootingAccuracyPawn>
+						<AimingAccuracy>1.25</AimingAccuracy>
 					</statFactors>
 				</value>
 			</li>


### PR DESCRIPTION
## Changes

- Replaced the Careful shooter trait weapon handling stat modifier from 1.5 to 1.33 and the Trigger-happy trait from 0.5 to 0.75
- Gave the careful shooter trait a 1.25 aiming accuracy bonus and lowered the trigger-happy trait's aim time bonus from -0.5 to -0.75

## References

- https://discord.com/channels/278818534069501953/322827713335394304/954837956793876621

## Reasoning

- Balance reasons considering the called shots system and the reference above

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
