### PR TITLE
Add Shatterer weapon

### DIFF
--- a/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -586,7 +586,7 @@
               <xpath>Defs/ThingDef[defName="ReviaWarPick"]/equippedStatOffsets</xpath>
               <value>
                 <equippedStatOffsets>
-				  <MeleeHitChance>-8</MeleeHitChance>
+		  <MeleeHitChance>-8</MeleeHitChance>
                   <MeleeCritChance>0.1</MeleeCritChance>
                   <MeleeParryChance>0.63</MeleeParryChance>
                   <MeleeDodgeChance>0.67</MeleeDodgeChance>

--- a/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -533,7 +533,7 @@
                 </equippedStatOffsets>
               </value>
             </li>
-            			<!-- ==========  Shatterer  =========== -->
+            <!-- ==========  Shatterer  =========== -->
             <li Class="PatchOperationReplace">
               <xpath>Defs/ThingDef[defName="ReviaWarPick"]/tools</xpath>
               <value>
@@ -556,7 +556,7 @@
 					</capacities>
 					<power>22</power>
 					<cooldownTime>2.56</cooldownTime>
-					<chanceFactor>0.55</chanceFactor>
+					<chanceFactor>0.3</chanceFactor>
 					<armorPenetrationBlunt>16.76</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
@@ -567,7 +567,7 @@
                     </capacities>
                     <power>20</power>
                     <cooldownTime>2.83</cooldownTime>
-                    <chanceFactor>0.3</chanceFactor>
+                    <chanceFactor>0.55</chanceFactor>
                     <armorPenetrationBlunt>6</armorPenetrationBlunt>
                     <armorPenetrationSharp>4</armorPenetrationSharp>
                     <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>

--- a/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -533,6 +533,66 @@
                 </equippedStatOffsets>
               </value>
             </li>
+            			<!-- ==========  Shatterer  =========== -->
+            <li Class="PatchOperationReplace">
+              <xpath>Defs/ThingDef[defName="ReviaWarPick"]/tools</xpath>
+              <value>
+                <tools>
+                  <li Class="CombatExtended.ToolCE">
+                    <label>handle</label>
+                    <capacities>
+                      <li>Blunt</li>
+                    </capacities>
+                    <power>7</power>
+                    <cooldownTime>2.46</cooldownTime>
+                    <armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+                    <chanceFactor>0.15</chanceFactor>
+                    <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                  </li>
+				  <li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Demolish</li>
+					</capacities>
+					<power>22</power>
+					<cooldownTime>2.56</cooldownTime>
+					<chanceFactor>0.55</chanceFactor>
+					<armorPenetrationBlunt>16.76</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+				</li>
+                  <li Class="CombatExtended.ToolCE">
+                    <label>edge</label>
+                    <capacities>
+                      <li>Gash</li>
+                    </capacities>
+                    <power>20</power>
+                    <cooldownTime>2.83</cooldownTime>
+                    <chanceFactor>0.3</chanceFactor>
+                    <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                    <armorPenetrationSharp>4</armorPenetrationSharp>
+                    <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                  </li>
+                </tools>
+              </value>
+            </li>
+            <li Class="PatchOperationAdd">
+              <xpath>Defs/ThingDef[defName="ReviaWarPick"]/statBases</xpath>
+              <value>
+                <Bulk>8</Bulk>
+                <MeleeCounterParryBonus>0.69</MeleeCounterParryBonus>
+              </value>
+            </li>
+            <li Class="PatchOperationReplace">
+              <xpath>Defs/ThingDef[defName="ReviaWarPick"]/equippedStatOffsets</xpath>
+              <value>
+                <equippedStatOffsets>
+				  <MeleeHitChance>-8</MeleeHitChance>
+                  <MeleeCritChance>0.1</MeleeCritChance>
+                  <MeleeParryChance>0.63</MeleeParryChance>
+                  <MeleeDodgeChance>0.67</MeleeDodgeChance>
+                </equippedStatOffsets>
+              </value>
+            </li>
             <!-- ========== Vermillion Tide  =========== -->
             <li Class="PatchOperationReplace">
               <xpath>Defs/ThingDef[defName="ReviaBlessedSerratedScythe"]/tools</xpath>


### PR DESCRIPTION
## Additions

I am not sure how to balance this one. I used upscaled Harvester stats as it's also a scythe of sorts and added Royalty's Warhammer stats for blunt attack and upscaled it too. Offsets are also from Harvester and -8 MeleeHitChance offset is preserved from vanilla variant of Shatterer. 

In other words, it works for me but can probably use some balancing work.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
