### PR TITLE
Minor Fixes

### DIFF
--- a/Patches/Fantasy Metals Reforged/Fantasy Metals Reforged.xml
+++ b/Patches/Fantasy Metals Reforged/Fantasy Metals Reforged.xml
@@ -82,7 +82,6 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Orichalcum"]/stuffProps/statFactors</xpath>
 				<value>
-					<MeleeWeapon_CooldownMultiplier>1.1</MeleeWeapon_CooldownMultiplier>
 					<Mass>1.4</Mass>
 				</value>
 			</li>

--- a/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+		<li>Vanilla Furniture Expanded - Security</li>
+	</mods>
+	<match Class="PatchOperationSequence">
+	<operations>
+
+	<!-- ========== EMP Ammo ========== -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+			<ThingDef ParentName="BaseBullet">
+				<defName>Bullet_EMPCannon</defName>
+				<label>EMP Blast</label>
+				<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>			
+				<graphicData>
+				  <texPath>Things/Projectile/Bullet_EMPCannon</texPath>
+				  <graphicClass>Graphic_Single</graphicClass>
+				  <shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				  <damageDef>EMP</damageDef>
+				  <damageAmountBase>42</damageAmountBase>
+				  <explosionRadius>4</explosionRadius>
+				  <soundExplode>MortarBomb_Explode</soundExplode>				
+				  <speed>130</speed>
+				  <flyOverhead>false</flyOverhead>
+				  <dropsCasings>false</dropsCasings>
+				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				</projectile>
+			</ThingDef>
+		</value>
+    </li>
+
+	<!-- ========== Raider Artillery (To circumvent the issue with vanilla shells.) ========== -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+			<CombatExtended.AmmoSetDef>
+				<defName>AmmoSet_RaiderArtillery</defName>
+				<label>Raider Artillery</label>
+				<ammoTypes>
+				    <Shell_HighExplosive>Bullet_155mmHowitzerShell_HE</Shell_HighExplosive>
+				    <Shell_Incendiary>Bullet_155mmHowitzerShell_HE</Shell_Incendiary>				
+				</ammoTypes>	
+			</CombatExtended.AmmoSetDef>
+		</value>
+    </li>
+	
+	</operations>
+	</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Changes

Had to return the missing projectile and ammo set due to the file's deletion #1398 
- Returned the EMP Cannon Projectile
- Returned the Raider Heavy Artillery AmmoSet

- Orichalcum already has 1.1 MeleeWeapon_CooldownMultiplier and is causing duplicate XML node errors, removed

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
