### PR TITLE
Change bascinet stuff category from Steeled to Metallic

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -9,7 +9,7 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <stuffCategories>
-            <li>Steeled</li>
+            <li>Metallic</li>
         </stuffCategories>
         <costStuffCount>65</costStuffCount>
         <statBases>


### PR DESCRIPTION
## Reasoning

Someone on discord raised a valid point - why can you use uranium (and silver and gold and modded Metallic stuff like Rimefeller's composite) for plate armour and not for bascinet?

## Alternatives

1. Leave it as is
2. Or add Woody category too - haven't seen any historical bascinet-like helmets made out of wood but I also don't know why rimworlders wouldn't try it anyway. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
