### PR TITLE
VFE-Pirates CP retweaks

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Junkers.xml
@@ -73,49 +73,6 @@
           </value>
         </li>
 
-        <!-- === combatPower Patches === -->
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_Footsoldier"]/combatPower</xpath>
-          <value>
-            <combatPower>275</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_Veteran"]/combatPower</xpath>
-          <value>
-            <combatPower>350</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_HeavyWeaponsPlatform"]/combatPower</xpath>
-          <value>
-            <combatPower>430</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_Hussar"]/combatPower</xpath>
-          <value>
-            <combatPower>400</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_Pyro"]/combatPower</xpath>
-          <value>
-            <combatPower>400</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEP_Artillery"]/combatPower</xpath>
-          <value>
-            <combatPower>450</combatPower>
-          </value>
-        </li>
-
       </operations>
     </match>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/PawnKindDefs/PawnKinds_Mercenaries.xml
@@ -63,14 +63,14 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_Major"]/combatPower</xpath>
           <value>
-            <combatPower>400</combatPower>
+            <combatPower>500</combatPower>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/PawnKindDef[defName="VFEP_General"]/combatPower</xpath>
           <value>
-            <combatPower>450</combatPower>
+            <combatPower>550</combatPower>
           </value>
         </li>
 


### PR DESCRIPTION
## Changes

- Reverted and readjusted combat power of warcasket pawns according to the recent update to the original mod

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
