### PR TITLE
Goliath mech weapon tags tweaks

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
@@ -25,12 +25,13 @@
 					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Goliath"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
-			</li>	
+			</li>
 						
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Goliath"]/statBases</xpath>
@@ -45,6 +46,7 @@
 					<MaxHitPoints>500</MaxHitPoints>
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Goliath"]/race/baseHealthScale</xpath>
 				<value>
@@ -81,7 +83,13 @@
 					</li>
 				</value>
 			</li>
-			
+
+			<!-- Remove the explosive bolt projector -->
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/PawnKindDef[defName="AA_Goliath"]/weaponTags/li[.="MechanoidGunLongRange"]</xpath>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Alpha Animals/VFE_Mechs/AdvGoliath.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvGoliath.xml
@@ -29,21 +29,21 @@
 					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
-			</li>	
+			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath"]/race/baseHealthScale</xpath>
 				<value>
 					<baseHealthScale>3.0</baseHealthScale>
 				</value>
-			</li>		
-			
-			
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Goliath"]/statBases</xpath>
 				<value>
@@ -88,14 +88,10 @@
 				</value>
 			</li>
 
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Advanced_Goliath"]/weaponTags</xpath>
-				<value>
-					<weaponTags>
-						<li>VFE_AdvMechanoidGunHeavy</li>
-						<li>VFE_AdvMechanoidGunLongRange</li>
-					</weaponTags>
-				</value>
+			<!-- Remove the explosive bolt projector -->
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Advanced_Goliath"]/weaponTags/li[.="MechanoidGunLongRange"]</xpath>
 			</li>
 
 			<!-- === combatPower Patch === -->

--- a/Patches/Alpha Animals/VFE_Mechs/VFEGoliath.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFEGoliath.xml
@@ -35,7 +35,7 @@
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
-			</li>			
+			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Goliath"]/statBases</xpath>
@@ -50,6 +50,7 @@
 					<MaxHitPoints>500</MaxHitPoints>
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Goliath"]/race/baseHealthScale</xpath>
 				<value>
@@ -85,6 +86,12 @@
 						<compClass>CombatExtended.CompPawnGizmo</compClass>
 					</li>
 				</value>
+			</li>
+
+			<!-- Remove the explosive bolt projector -->
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/PawnKindDef[defName="VFE_Mech_Goliath"]/weaponTags/li[.="MechanoidGunLongRange"]</xpath>
 			</li>
 
 			<!-- === combatPower Patch === -->


### PR DESCRIPTION
## Changes

- Removed the MechanoidGunLongRange weapon tag from the Goliath mech variants

## Reasoning

- Since the needle gun is changed in CE from its original counterpart and is no longer a long range sniper type weapon, the goliath mechs would be put in a disadvantageous position if they still spawned with explosive bolt projectors. The mech itself is stronger than pikemen which is a good idea but the weapon in their hand is weak in comparison which makes the mech a weak target. It was discussed in the original patch PR for them to not have the weapon tag, so the change was made to make them not spawn with said weapon. 

## References

- Based on the comment here: https://github.com/CombatExtended-Continued/CombatExtended/pull/673#pullrequestreview-676471315

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
