### PR TITLE
Shield tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -39,6 +39,7 @@
       <!--<li>Leathery</li>-->
     </stuffCategories>
     <recipeMaker>
+      <researchPrerequisite>Smithing</researchPrerequisite>
       <recipeUsers>
         <!--<li>CraftingSpot</li>-->
         <li>FueledSmithy</li>
@@ -93,6 +94,12 @@
     <stuffCategories>
       <li>Steeled</li>
     </stuffCategories>
+    <recipeMaker>
+	  <researchPrerequisite>Machining</researchPrerequisite>		
+      <recipeUsers>
+        <li>TableMachining</li>
+      </recipeUsers>
+    </recipeMaker>
     <statBases>
       <WorkToMake>19000</WorkToMake>
       <MaxHitPoints>125</MaxHitPoints>

--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -95,7 +95,7 @@
       <li>Steeled</li>
     </stuffCategories>
     <recipeMaker>
-	  <researchPrerequisite>Machining</researchPrerequisite>		
+        <researchPrerequisite>Machining</researchPrerequisite>		
       <recipeUsers>
         <li>TableMachining</li>
       </recipeUsers>


### PR DESCRIPTION
## Changes

Gate ballistic shield behind Machining. Consistent with how CE Shields handles industrial shields. Also prevents tribals from having it if they have a smithy. It feels very imbalanced to have an 8 RHA steel ballistic shield available when most comparable armour at that level is at ~2mm (Melee Shield is 2.5mm).
Melee shield is no longer made at a crafting spot, so it should be unlocked with Smithing, like medieval CE Shields do

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
