### PR TITLE
Smoke howitzer shell texture fix

### DIFF
--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -120,7 +120,7 @@
 		<defName>Ammo_105mmHowitzerShell_Smoke</defName>
 		<label>105mm Howitzer shell (Smoke)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Howitzer/HE</texPath>
+			<texPath>Things/Ammo/Cannon/Howitzer/SMK</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 			<drawSize>0.90</drawSize>
 		</graphicData>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -101,7 +101,7 @@
 		<defName>Ammo_155mmHowitzerShell_Smoke</defName>
 		<label>155mm Howitzer shell (Smoke)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Cannon/Howitzer/HE</texPath>
+			<texPath>Things/Ammo/Cannon/Howitzer/SMK</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>


### PR DESCRIPTION
## Changes

- Fixed the texPath for the 105mm and 155mm smoke howitzer shells

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
