### PR TITLE
Medieval ammo tech level fix

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -34,7 +34,8 @@
 
   <!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="CannonBallBase" ParentName="HeavyAmmoBase" Abstract="True">		<thingCategories>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="CannonBallBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<thingCategories>
 			<li>CannonBall</li>
 		</thingCategories>
 		<stackLimit>25</stackLimit>
@@ -51,6 +52,7 @@
 			<Mass>6.6</Mass>
 			<Bulk>3.99</Bulk>
 		</statBases>
+		<techLevel>Medieval</techLevel>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="CannonBallBase">

--- a/Defs/Ammo/Medieval/Catapult.xml
+++ b/Defs/Ammo/Medieval/Catapult.xml
@@ -30,14 +30,15 @@
 	<!-- ==================== Ammo ========================== -->
 	<ThingDef Class="CombatExtended.AmmoDef" Name="CatapultShellBase" ParentName="AmmoBase" Abstract="True">
 		<thingCategories>
-		<li>AmmoCatapult</li>
+			<li>AmmoCatapult</li>
 		</thingCategories>
 		<stackLimit>5</stackLimit>
 		<tradeTags>
-		<li>CE_AutoEnableTrade</li>
-		<li>CE_AutoEnableCrafting_TableMachining</li>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
 		</tradeTags>
 		<isMortarAmmo>true</isMortarAmmo>
+		<techLevel>Medieval</techLevel>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="CatapultShellBase">
@@ -45,14 +46,14 @@
 		<label>boulder</label>
 		<description>A heavy stone, cut to an appropriate size and shape to be thrown by a siege engine.</description>	
 		<graphicData>
-		<texPath>Things/Ammo/Neolithic/Catapult/CatapultStone_a</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-		<drawSize>0.80</drawSize>	
-		<color>(105,95,97)</color>	    
+			<texPath>Things/Ammo/Neolithic/Catapult/CatapultStone_a</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.80</drawSize>	
+			<color>(105,95,97)</color>	    
 		</graphicData>
 		<statBases>
-		<Mass>12.5</Mass>
-		<MarketValue>0.5</MarketValue>
+			<Mass>12.5</Mass>
+			<MarketValue>0.5</MarketValue>
 		</statBases>
 		<ammoClass>Catapult_Boulder</ammoClass>
 	</ThingDef>
@@ -61,13 +62,13 @@
 	<ThingDef Name="BaseCatapultBullet" ParentName="BaseBullet" Abstract="true">
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>	
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<speed>0</speed>
-		<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
-		<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
-		<soundAmbient>MortarRound_Ambient</soundAmbient>
-		<soundExplode>MortarBomb_Explode</soundExplode>
-		<flyOverhead>true</flyOverhead>
-		<dropsCasings>false</dropsCasings>
+			<speed>0</speed>
+			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+			<soundAmbient>MortarRound_Ambient</soundAmbient>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>true</flyOverhead>
+			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -38,6 +38,7 @@
 		</thingCategories>
 		<stackLimit>100</stackLimit>
 		<cookOffFlashScale>20</cookOffFlashScale>
+		<techLevel>Medieval</techLevel>
 	</ThingDef>
 	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="HandMortarBombBase">


### PR DESCRIPTION
## Changes

- Added proper medieval tech level nodes to certain medieval ammo types missing them causing issues with tech removing mods.

## References

- Fixes https://discord.com/channels/278818534069501953/324222101550661663/959848538328694785

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
