### PR TITLE
Rimcities patch

### DIFF
--- a/Patches/RimCities/Scenarios/Scenarios.xml
+++ b/Patches/RimCities/Scenarios/Scenarios.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>RimCities</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- Add ammunition to RimCities starting scenarios -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[@Name="Crashlanded_City"]/scenario/parts</xpath>
+				<value>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_303British_FMJ</thingDef>
+						<count>100</count>
+					</li>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_44Magnum_FMJ</thingDef>
+						<count>60</count>
+					</li>
+				</value>
+			</li>
+
+			<!-- Remove apparel from RimCities starting scenarios -->
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[@Name="Crashlanded_City"]/scenario/parts/li[thingDef="Apparel_AdvancedHelmet"]</xpath>
+			</li>
+	
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[@Name="Crashlanded_City"]/scenario/parts/li[thingDef="Apparel_FlakVest"]</xpath>
+			</li>
+	
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[@Name="Crashlanded_City"]/scenario/parts/li[thingDef="Apparel_FlakPants"]</xpath>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Changes

- Patched the starting scenarios of the Rimcities mod in accordance to the vanilla Crashlanded scenario

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
