### PR TITLE
Change to industrial for these research projects

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
@@ -19,7 +19,7 @@
     <label>advanced launchers</label>
     <description>Allows production of more advanced launchers like the incendiary, triple rocket or doomsday launcher.</description>
     <baseCost>1000</baseCost>
-    <techLevel>Spacer</techLevel>
+    <techLevel>Industrial</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
     <requiredResearchFacilities>
       <li>MultiAnalyzer</li>
@@ -37,7 +37,7 @@
     <label>advanced ammunition</label>
     <description>Allows production of advanced ammunition for small arms and light weapons systems like armor-piercing incendiary, sabot, and high-explosive rounds.</description>
     <baseCost>800</baseCost>
-    <techLevel>Spacer</techLevel>
+    <techLevel>Industrial</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>    
     <prerequisites>
       <li>PrecisionRifling</li>


### PR DESCRIPTION
change two of the research projects to industrial level because they sure as hell are not spacer


## Changes

Change the spacer tech to industrial tech

## References

We have advanced launchers and advanced ammo in real life, therefore, it is an industrial tech level thing.

## Reasoning

Obviously advanced ammo and launchers should be industrial because they are, and advanced ammo actually is still industrial ammo but you just can't craft it (it still appears in the game)

## Alternatives

I dunno, not fix this?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (One ingame year) 
