### PR TITLE
Advanced Ammo tech level tweak

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
@@ -36,8 +36,8 @@
     <defName>CE_AdvancedAmmo</defName>
     <label>advanced ammunition</label>
     <description>Allows production of advanced ammunition for small arms and light weapons systems like armor-piercing incendiary, sabot, and high-explosive rounds.</description>
-    <baseCost>800</baseCost>
-    <techLevel>Spacer</techLevel>
+    <baseCost>1200</baseCost>
+    <techLevel>Industrial</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>    
     <prerequisites>
       <li>PrecisionRifling</li>


### PR DESCRIPTION
## Changes

- Changed the Advanced Ammo research from spacer to industrial tech level and compensated the change with a research point increase

## Reasoning

- Prerequisite for the research is Precision Rifling which is industrial and the Advanced Ammo research is not gated behind multianalyzer, so there is no reason for it being spacer level. The spacer tech level even causes problems with tech block mods which limit access to an actually industrial research because of the tag.
- Increased the research point cost to reflect the difficulty of the research a bit more and prevent easy tech rushing with mods like Tech Advancing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
