### PR TITLE
HE round bomb damage tweaks

### DIFF
--- a/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
+++ b/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
@@ -10,7 +10,7 @@ namespace CombatExtended
 {
     public class SecondaryDamage
     {
-        private const float SecExplosionPenPerDmg = 3;
+        private const float SecExplosionPenPerDmg = 2;
 
         public DamageDef def;
         public int amount;


### PR DESCRIPTION
## Changes

- Decreased the HE round bomb secondary damage blunt armor factor

## Reasoning

- The secondary bomb damage of HE rounds was overperforming against armored enemies, made the change to tame it a bit.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
