### PR TITLE
Flak pants feet coverage

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -411,7 +411,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/description</xpath>
 		<value>
-			<description>Padded pants made from bullet-resistant materials. Provides limited protection against shrapnel and gunfire at relatively low weight.</description>
+			<description>Padded pants made from bullet-resistant materials. Provides limited protection against shrapnel and gunfire at relatively low weight. Comes with a pair of boots.</description>
 		</value>
 	</Operation>
 
@@ -480,6 +480,36 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/equippedStatOffsets</xpath>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<!-- Partial armor for boots -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]</xpath>
+		<value>
+		  <li Class="CombatExtended.PartialArmorExt">
+			  <stats>
+				  <li>
+					<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+					<parts>
+						<li>Foot</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+					<parts>
+						<li>Foot</li>
+					</parts>
+				  </li>
+			  </stats>
+		  </li>
+		</value>
+	  </Operation>
 
 	<!-- ========== Power armor ========== -->
 


### PR DESCRIPTION
## Changes

- Added feet coverage to flak pants with an appropriate partial armor stat to simulate boots included with the pants.

## Changes

- This change was made to bring the flak pants in line with apparel from CE Armors that have feet coverage/shoes or boots.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
