### PR TITLE
Remove Go-Juice patches

### DIFF
--- a/Patches/Core/Drugs/Drugs.xml
+++ b/Patches/Core/Drugs/Drugs.xml
@@ -54,22 +54,6 @@
 		</value>
 	</Operation>
 
-	<!-- ========== Patch addictiveness ========== -->
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="GoJuice"]/comps/li[@Class="CompProperties_Drug"]</xpath>
-		<value>
-			<minToleranceToAddict>0.05</minToleranceToAddict>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="GoJuiceHigh"]/comps/li[@Class="HediffCompProperties_SeverityPerDay"]/severityPerDay</xpath>
-		<value>
-			<severityPerDay>-0.8</severityPerDay>
-		</value>
-	</Operation>
-
 	<!-- ========== Patch statOffsets ========== -->
 
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Changes

- In an attempt to continue with removing old and outdated patches, removed the depreciated patches for Go-Juice.

## References

- https://discord.com/channels/278818534069501953/322827713335394304/961502167129288724

## Reasoning

- Vanilla game handles hard drugs like go-juice and wake-up differently since not too long ago, so no tolerance gain, only overdoses and addictions based on a chance. Also severity lose per day for go-juice is at -0.75 for go juice which make the patch pointless as the change is negligible, less patches, better load time.

## Alternatives

- Leave the patches be.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors

