### PR TITLE
Patch Opossum Friends Mod

### DIFF
--- a/Patches/Opossum Friends/OpossumFriend.xml
+++ b/Patches/Opossum Friends/OpossumFriend.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Opossum Friends</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- === Opossum === -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/ThingDef[defName="ERN_Opossum"]</xpath>
+        <value>
+          <li Class="CombatExtended.RacePropertiesExtensionCE">
+            <bodyShape>QuadrupedLow</bodyShape>
+          </li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="ERN_Opossum"]/statBases</xpath>
+        <value>
+          <MeleeDodgeChance>0.15</MeleeDodgeChance>
+          <MeleeCritChance>0.01</MeleeCritChance>
+          <MeleeParryChance>0.01</MeleeParryChance>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="ERN_Opossum"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <capacities>
+                <li>Bite</li>
+              </capacities>
+              <power>4</power>
+              <cooldownTime>0.84</cooldownTime>
+              <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+              <armorPenetrationBlunt>0.144</armorPenetrationBlunt>
+              <armorPenetrationSharp>0.02</armorPenetrationSharp>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>head</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>1</power>
+              <cooldownTime>0.84</cooldownTime>
+              <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+              <chanceFactor>0.2</chanceFactor>
+              <armorPenetrationBlunt>0.144</armorPenetrationBlunt>
+              <armorPenetrationSharp>0</armorPenetrationSharp>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -281,6 +281,7 @@ Nyaron Race |
 Not Only Just a Cannon  |
 ODZ Suits |
 Ogam's Warbanner Mod    |
+Opossum Friends |
 Orassans	|
 Outer Rim - Tatooine    |
 Palm Cats   |


### PR DESCRIPTION
## Additions
- Patches the 'Opossum Friends' mod. Opossums have stats identical to raccoons, minus the claw attacks.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
