### PR TITLE
35x32mmSR HEDP

### DIFF
--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -15,6 +15,7 @@
     <label>35x32mmSR Grenades</label>
     <ammoTypes>
       <Ammo_35x32mmSRGrenade_HE>Bullet_35x32mmSRGrenade_HE</Ammo_35x32mmSRGrenade_HE>
+	  <Ammo_35x32mmSRGrenade_HEDP>Bullet_35x32mmSRGrenade_HEDP</Ammo_35x32mmSRGrenade_HEDP>
       <Ammo_35x32mmSRGrenade_EMP>Bullet_35x32mmSRGrenade_EMP</Ammo_35x32mmSRGrenade_EMP>
 			<Ammo_35x32mmSRGrenade_Smoke>Bullet_35x32mmSRGrenade_Smoke</Ammo_35x32mmSRGrenade_Smoke>	        
     </ammoTypes>
@@ -51,6 +52,20 @@
       <MarketValue>2.27</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
+	<detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="35x32mmSRGrenadeBase">
+    <defName>Ammo_35x32mmSRGrenade_HEDP</defName>
+    <label>35x32mmSR grenade (HEDP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/GrenadeLauncher/DP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>2.68</MarketValue>
+    </statBases>
+    <ammoClass>GrenadeHEDP</ammoClass>
 	<detonateProjectile>Bullet_35x32mmSRGrenade_HE</detonateProjectile>
   </ThingDef>
 
@@ -136,6 +151,31 @@
 		</ThingDef>
 
 	<ThingDef ParentName="Base35x32mmSRGrenadeBullet">
+		<defName>Bullet_35x32mmSRGrenade_HEDP</defName>
+		<thingClass>CombatExtended.BulletCE</thingClass>
+		<label>35x32mmSR grenade (HEDP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageDef>Bullet</damageDef>
+		  <damageAmountBase>18</damageAmountBase>
+		  <armorPenetrationSharp>80</armorPenetrationSharp>
+		  <armorPenetrationBlunt>5.94</armorPenetrationBlunt>
+		</projectile>
+		<comps>
+		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+			<damageAmountBase>12</damageAmountBase>
+			<explosiveDamageType>Bomb</explosiveDamageType>
+			<explosiveRadius>0.5</explosiveRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		  </li>
+		  <li Class="CombatExtended.CompProperties_Fragments">
+			<fragments>
+			  <Fragment_Small>15</Fragment_Small>
+			</fragments>
+		  </li>
+		</comps>
+	 </ThingDef>
+
+	<ThingDef ParentName="Base35x32mmSRGrenadeBullet">
 		<defName>Bullet_35x32mmSRGrenade_EMP</defName>
 		<label>35x32mmSR grenade (EMP)</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
@@ -201,6 +241,50 @@
       <Ammo_35x32mmSRGrenade_HE>100</Ammo_35x32mmSRGrenade_HE>
     </products>
     <workAmount>8600</workAmount>    
+  </RecipeDef>
+
+<RecipeDef ParentName="LauncherAmmoRecipeBase">
+    <defName>MakeAmmo_35x32mmSRGrenade_HEDP</defName>
+    <label>make 35x32mmSR HEDP grenades x100</label>
+    <description>Craft 100 35x32mmSR HEDP grenades.</description>
+    <jobString>Making 35x32mmSR HEDP grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>46</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_35x32mmSRGrenade_HEDP>100</Ammo_35x32mmSRGrenade_HEDP>
+    </products>
+    <workAmount>9000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">


### PR DESCRIPTION

## Additions

- Added HEDP variant for 35x32mmSR Grenades 

## References

- Damage and cost based off of 40mm HEDP variants
- Penetration based off of: https://weaponsystems.net/system/1311-BB01%20-%2035x32mm%20Type%2087

## Reasoning

- Building on repository
- Using mods that could function with it (totally not PLA Steel Torrent with GL trucks)
- It actually exists and has a real life counterpart

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (current colony, 1 hr+, several combat scenarios)
