### PR TITLE
Modded turret patch tweaks and modded mech armor adjustments

### DIFF
--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Melee.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Melee.xml
@@ -689,8 +689,27 @@
 					</tools>
 				</value>
 			</li>
-			
-			
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="AMW_MechaWeapon_PowerClaw"
+				]/tools</xpath>
+				<value>
+					<tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>42</power>
+						<cooldownTime>0.7</cooldownTime>
+						<armorPenetrationSharp>15</armorPenetrationSharp>
+						<armorPenetrationBlunt>30</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				</value>
+			</li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
@@ -172,15 +172,9 @@
 					<MaxHitPoints>500</MaxHitPoints>
 				</value>
 			</li>
-			
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_NovaBlossom" or
-				defName="AMW_Mech_Frosthound" or
-				defName="Mech_Scourge" or
-				defName="Mech_Supressor" or
-				defName="Mech_Flayer" or
 				defName="AMW_Mech_Blacklight"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
@@ -190,27 +184,38 @@
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_NovaBlossom" or
-				defName="AMW_Mech_Frosthound" or
-				defName="Mech_Scourge" or
-				defName="Mech_Supressor" or
-				defName="Mech_Flayer" or
 				defName="AMW_Mech_Blacklight"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_NovaBlossom" or
+				defName="Mech_Headhunter" or
+				defName="Mech_Flayer" or
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+				</value>
+			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
+				defName="Mech_NovaBlossom" or
 				defName="Mech_Headhunter" or
-				defName="Mech_Renegade" or
-				defName="Mech_Vortex" or
-				defName="Mech_Nomad" or
-				defName="Mech_Spectre" or
-				defName="Mech_Stalker" or
-				defName="Mech_Sawblade"
+				defName="Mech_Flayer" or
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="AMW_Mech_Frosthound"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
@@ -219,53 +224,37 @@
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_Headhunter" or
-				defName="Mech_Renegade" or
-				defName="Mech_Vortex" or
-				defName="Mech_Nomad" or
-				defName="Mech_Spectre" or
-				defName="Mech_Stalker" or
-				defName="Mech_Sawblade"
+				defName="AMW_Mech_Frosthound"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
-			
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="AMW_Mech_Supernova" or
-				defName="Mech_Anarchist" or
-				defName="Mech_Purger" or
-				defName="Mech_Spike" or
-				defName="Mech_Impulse" or
-				defName="Mech_AMWSeeker" or
-				defName="Mech_Charger"
+				defName="Mech_Scourge" or
+				defName="Mech_Supressor" or
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="AMW_Mech_Supernova" or
-				defName="Mech_Anarchist" or
-				defName="Mech_Purger" or
-				defName="Mech_Spike" or
-				defName="Mech_Impulse" or
-				defName="Mech_AMWSeeker" or
-				defName="Mech_Charger"
+				defName="Mech_Scourge" or
+				defName="Mech_Supressor" or
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_Reaper"
+				defName="Mech_Impulse" or
+				defName="Mech_Vortex"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
@@ -274,56 +263,108 @@
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_Reaper"
+				defName="Mech_Impulse" or
+				defName="Mech_Vortex"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
-			
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
-				defName="Mech_Derg" or
-				defName="Mech_Thrumbo"
+				defName="AMW_Mech_Supernova" or
+				defName="Mech_Sawblade" or
+				defName="Mech_Renegade" or
+				defName="Mech_Charger"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="AMW_Mech_Supernova" or
+				defName="Mech_Sawblade" or
+				defName="Mech_Renegade" or
+				defName="Mech_Charger"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Anarchist" or
+				defName="Mech_Purger" or
+				defName="Mech_Reaper" or
+				defName="Mech_Spike" or
+				defName="Mech_Nomad" or
+				defName="Mech_Spectre"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>58</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Anarchist" or
+				defName="Mech_Purger" or
+				defName="Mech_Reaper" or
+				defName="Mech_Spike" or
+				defName="Mech_Nomad" or
+				defName="Mech_Spectre"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
+				</value>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 				defName="Mech_Derg" or
-				defName="Mech_Thrumbo"
-				]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
-				</value>
-			</li>
-			
-			
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Wraith"
-				]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>30</ArmorRating_Sharp>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[
-				defName="Mech_Wraith"
+				defName="Mech_Thrumbo" or
+				defName="Mech_AMWSeeker" or
+				defName="Mech_Stalker"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>67.5</ArmorRating_Blunt>
 				</value>
 			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Derg" or
+				defName="Mech_Thrumbo" or
+				defName="Mech_AMWSeeker" or
+				defName="Mech_Stalker"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>30</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Wraith"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>33</ArmorRating_Sharp>
+				</value>
+			</li>
 			
-			
-			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Mech_Wraith"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>74</ArmorRating_Blunt>
+				</value>
+			</li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Races.xml
@@ -195,7 +195,7 @@
 				<xpath>Defs/ThingDef[
 				defName="Mech_NovaBlossom" or
 				defName="Mech_Headhunter" or
-				defName="Mech_Flayer" or
+				defName="Mech_Flayer"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>5</ArmorRating_Blunt>
@@ -206,7 +206,7 @@
 				<xpath>Defs/ThingDef[
 				defName="Mech_NovaBlossom" or
 				defName="Mech_Headhunter" or
-				defName="Mech_Flayer" or
+				defName="Mech_Flayer"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3</ArmorRating_Sharp>
@@ -234,7 +234,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 				defName="Mech_Scourge" or
-				defName="Mech_Supressor" or
+				defName="Mech_Supressor"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>27</ArmorRating_Blunt>
@@ -244,7 +244,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 				defName="Mech_Scourge" or
-				defName="Mech_Supressor" or
+				defName="Mech_Supressor"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>12</ArmorRating_Sharp>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
@@ -758,7 +758,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_NomadShot</defaultProjectile>
 						<warmupTime>1.61</warmupTime>
-						<range>38</range>
+						<range>42</range>
 						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 						<burstShotCount>5</burstShotCount>
 						<soundCast>NomadRifle</soundCast>
@@ -774,8 +774,40 @@
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
 			</li>
-			
-			
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_IonPistol</defName>
+					<statBases>
+						<SightsEfficiency>0.9</SightsEfficiency>
+						<ShotSpread>0.21</ShotSpread>
+						<SwayFactor>0.9</SwayFactor>
+						<Bulk>2.5</Bulk>
+						<Mass>1</Mass>
+						<RangedWeapon_Cooldown>1.97</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.21</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_NomadShot</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>16</range>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<burstShotCount>2</burstShotCount>
+						<soundCast>NomadRifle</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>8</muzzleFlashScale>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<AmmoUser>
+						<magazineSize>12</magazineSize>
+						<reloadTime>3</reloadTime>
+						<ammoSet>AmmoSet_Nomad</ammoSet>
+					</AmmoUser>
+			</li>
+
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>AMW_Gun_SShreder</defName>
 					<statBases>
@@ -808,7 +840,73 @@
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
 			</li>
-			
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_SMG</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>0.76</SwayFactor>
+						<Bulk>5</Bulk>
+						<Mass>3</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.03</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_ShrederShot</defaultProjectile>
+						<warmupTime>0.77</warmupTime>
+						<range>31</range>
+						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+						<burstShotCount>8</burstShotCount>
+						<soundCast>Shreder</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>8</muzzleFlashScale>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<AmmoUser>
+						<magazineSize>40</magazineSize>
+						<reloadTime>3</reloadTime>
+						<ammoSet>AmmoSet_Nomad</ammoSet>
+					</AmmoUser>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_SlugRifle</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.16</ShotSpread>
+						<SwayFactor>1.34</SwayFactor>
+						<Bulk>8</Bulk>
+						<Mass>6</Mass>
+						<RangedWeapon_Cooldown>0.58</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.67</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_ShrederShot</defaultProjectile>
+						<warmupTime>1.57</warmupTime>
+						<range>45</range>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<burstShotCount>5</burstShotCount>
+						<soundCast>Shreder</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>8</muzzleFlashScale>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<AmmoUser>
+						<magazineSize>40</magazineSize>
+						<reloadTime>3</reloadTime>
+						<ammoSet>AmmoSet_Nomad</ammoSet>
+					</AmmoUser>
+			</li>
+
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>AMW_Gun_SStalkerRifle</defName>
 					<statBases>
@@ -842,7 +940,6 @@
 					</AmmoUser>
 			</li>
 			
-			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>AMW_Gun_SChargeCannonAWM</defName>
 					<statBases>
@@ -875,10 +972,103 @@
 						<li>CE_AI_Launcher</li>
 					</weaponTags>
 			</li>
-			
-			
-			
-			
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_GaussCannon</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.03</ShotSpread>
+						<SwayFactor>1.75</SwayFactor>
+						<Bulk>15</Bulk>
+						<Mass>5.5</Mass>
+						<RangedWeapon_Cooldown>3</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_StalkersShot</defaultProjectile>
+						<warmupTime>3.0</warmupTime>
+						<range>75</range>
+						<soundCast>StalkerRail</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>10</muzzleFlashScale>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<AmmoUser>
+						<magazineSize>20</magazineSize>
+						<reloadTime>3</reloadTime>
+						<ammoSet>AmmoSet_Stalker</ammoSet>
+					</AmmoUser>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_HeavyRifle</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>1.45</SwayFactor>
+						<Bulk>12</Bulk>
+						<Mass>5.0</Mass>
+						<RangedWeapon_Cooldown>2.1</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_StalkersShot</defaultProjectile>
+						<warmupTime>1.67</warmupTime>
+						<range>62</range>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<burstShotCount>3</burstShotCount>
+						<soundCast>StalkerRail</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>10</muzzleFlashScale>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>3</reloadTime>
+						<ammoSet>AmmoSet_Stalker</ammoSet>
+					</AmmoUser>
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>AMW_Gun_GrenadeShotgun</defName>
+					<statBases>
+						<SightsEfficiency>1.0</SightsEfficiency>
+						<ShotSpread>0.16</ShotSpread>
+						<SwayFactor>1.17</SwayFactor>
+						<Bulk>8</Bulk>
+						<Mass>10</Mass>
+						<RangedWeapon_Cooldown>6</RangedWeapon_Cooldown>
+					</statBases>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>BreacherGrenade</defaultProjectile>
+						<warmupTime>1.5</warmupTime>
+						<range>18</range>
+						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+						<burstShotCount>3</burstShotCount>
+						<soundCast>HeavyLaunch</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>7</muzzleFlashScale>
+						<targetParams>
+							<canTargetLocations>true</canTargetLocations>
+						</targetParams>
+						<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+					</Properties>
+					<FireModes>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+					<weaponTags>
+						<li>CE_AI_Launcher</li>
+					</weaponTags>
+			</li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Turret.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Turret.xml
@@ -49,11 +49,7 @@
 					
 				</value>
 			</li>
-			
-			
-			
-			
-			
+
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>AMW_Gun_AAComplex</defName>
 				<Properties>
@@ -77,7 +73,6 @@
 				</Properties>
 			</li>
 			
-			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName = "AMW_Gun_AAComplex"]</xpath>
 				<value>
@@ -93,9 +88,273 @@
 				</comps>
 				</value>
 			</li>
-			
-			
-			
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="AMW_Turret_AutoCannon" or
+				defName="AMW_Turret_HeavyTurret" or
+				defName="AMW_Turret_CryoTurret" or
+				defName="AMW_Turret_RocketTurret" or
+				defName="AMW_Turret_LotusTurret"
+				]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+
+			<!-- ========== cannon turret ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_AutoCannon"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_AutoCannon"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>AMW_Gun_AutoCannon</defName>
+			<statBases>
+			  <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.07</ShotSpread>
+			  <SwayFactor>1.62</SwayFactor>
+			</statBases>
+			<Properties>
+			  <recoilAmount>1.43</recoilAmount>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>
+			  <warmupTime>3.3</warmupTime>
+			  <range>75</range>
+			  <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+			  <burstShotCount>5</burstShotCount>
+			  <soundCast>MediumLaser</soundCast>
+			  <soundCastTail>GunTail_Light</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>100</magazineSize>
+			  <reloadTime>7.8</reloadTime>
+			  <ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			  <noSnapshot>true</noSnapshot>
+			  <noSingleShot>true</noSingleShot>
+			</FireModes>
+		  </li>
+
+			<!-- ========== heavy turret ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_HeavyTurret"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_HeavyTurret"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>AMW_Gun_HeavyTurret</defName>
+			<statBases>
+			  <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.02</ShotSpread>
+			  <SwayFactor>1.12</SwayFactor>
+			</statBases>
+			<Properties>
+			  <recoilAmount>1.25</recoilAmount>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+			  <warmupTime>1.3</warmupTime>
+			  <range>55</range>
+			  <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+			  <burstShotCount>14</burstShotCount>
+			  <soundCast>SmallLaser</soundCast>
+			  <soundCastTail>GunTail_Light</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>100</magazineSize>
+			  <reloadTime>7.8</reloadTime>
+			  <ammoSet>AmmoSet_8x50mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			  <noSnapshot>true</noSnapshot>
+			  <noSingleShot>true</noSingleShot>
+			</FireModes>
+		  </li>
+
+			<!-- ========== cryo turret ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_CryoTurret"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_CryoTurret"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>AMW_Gun_CryoTurret</defName>
+			<statBases>
+			  <RangedWeapon_Cooldown>2.6</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.5</ShotSpread>
+			  <SwayFactor>1.12</SwayFactor>
+			</statBases>
+			<Properties>
+			  <recoilAmount>0.67</recoilAmount>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_CryoLiquid</defaultProjectile>
+			  <warmupTime>2.3</warmupTime>
+			  <range>62</range>
+			  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+			  <burstShotCount>9</burstShotCount>
+			  <soundCast>SmallLaser</soundCast>
+			  <soundCastTail>GunTail_Light</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>100</magazineSize>
+			  <reloadTime>7.8</reloadTime>
+			</AmmoUser>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			  <noSnapshot>true</noSnapshot>
+			  <noSingleShot>true</noSingleShot>
+			</FireModes>
+		  </li>
+
+			<!-- ========== rocket turret ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_RocketTurret"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_RocketTurret"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>AMW_Gun_RocketTurret</defName>
+			<statBases>
+			  <RangedWeapon_Cooldown>2.6</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.05</ShotSpread>
+			  <SwayFactor>1.12</SwayFactor>
+			</statBases>
+			<Properties>
+			  <recoilAmount>2.67</recoilAmount>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_762x385mmRCannonShell_HEAT</defaultProjectile>
+			  <warmupTime>4.3</warmupTime>
+			  <range>75</range>
+			  <ticksBetweenBurstShots>14</ticksBetweenBurstShots>
+			  <burstShotCount>5</burstShotCount>
+			  <soundCast>HeavyLaunch</soundCast>
+			  <soundCastTail>GunTail_Light</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>30</magazineSize>
+			  <reloadTime>9.8</reloadTime>
+			  <ammoSet>AmmoSet_762x385mmRCannonShell</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			  <noSnapshot>true</noSnapshot>
+			  <noSingleShot>true</noSingleShot>
+			</FireModes>
+		  </li>
+
+			<!-- ========== lotus turret ========== -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_LotusTurret"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName = "AMW_Turret_LotusTurret"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+					<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>AMW_Gun_LotusTurret</defName>
+			<statBases>
+			  <RangedWeapon_Cooldown>2.6</RangedWeapon_Cooldown>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.05</ShotSpread>
+			  <SwayFactor>0.23</SwayFactor>
+			</statBases>
+			<Properties>
+			  <recoilAmount>2.67</recoilAmount>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+			  <warmupTime>1.3</warmupTime>
+			  <range>86</range>
+			  <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+			  <soundCast>HeavyLaunch</soundCast>
+			  <soundCastTail>GunTail_Light</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>30</magazineSize>
+			  <reloadTime>9.8</reloadTime>
+			  <ammoSet>AmmoSet_12mmRailgun</ammoSet>
+			</AmmoUser>
+			<FireModes>
+			  <aiAimMode>AimedShot</aiAimMode>
+			  <noSnapshot>true</noSnapshot>
+			  <noSingleShot>true</noSingleShot>
+			</FireModes>
+		  </li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Demolisher.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Demolisher.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Demolisher"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>55</ArmorRating_Blunt>
+					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Demolisher.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Demolisher.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Demolisher"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>120</ArmorRating_Blunt>
+					<ArmorRating_Blunt>55</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Phalanx.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Phalanx.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>50</ArmorRating_Blunt>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Phalanx.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Phalanx.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Siegebreaker.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Siegebreaker.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>80</ArmorRating_Blunt>
+					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Siegebreaker.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Siegebreaker.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>60</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -29,7 +29,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>25</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -29,7 +29,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>25</ArmorRating_Blunt>
+					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
@@ -29,7 +29,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
@@ -29,7 +29,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+					<ArmorRating_Blunt>16</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/AdvPhalanx.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvPhalanx.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>55</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/AdvPhalanx.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvPhalanx.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>65</ArmorRating_Blunt>
+					<ArmorRating_Blunt>59</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvSiegebreaker.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>85</ArmorRating_Blunt>
+					<ArmorRating_Blunt>65</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFEPhalanx.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFEPhalanx.xml
@@ -21,13 +21,12 @@
 				</value>
 			</li>
 
-
 		<!-- Assign armor values, change replace and add depending on what exists or not -->
 		
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFEPhalanx.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFEPhalanx.xml
@@ -27,7 +27,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Phalanx"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>50</ArmorRating_Blunt>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>80</ArmorRating_Blunt>
+					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESiegebreaker.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>60</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
@@ -33,7 +33,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>25</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
@@ -33,7 +33,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>50</ArmorRating_Blunt>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/PawnKindDefs/PawnKinds_MechanoidsExtraordinaire.xml
@@ -6,6 +6,7 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Hound"]/combatPower</xpath>
 				<value>
@@ -25,12 +26,12 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/PawnKindDef[defName="Vespa" or defName="Hound" or defName="Chimera" or defName="Goliath" or defName="Kraken"]</xpath>
+				<xpath>Defs/PawnKindDef[defName="Vespa" or defName="Hound" or defName="Chimera" or defName="Kraken"]</xpath>
 				<value>
 					<li Class="CombatExtended.LoadoutPropertiesExtension">
 						<primaryMagazineCount>
-						  <min>100</min>
-						  <max>100</max>
+						  <min>8</min>
+						  <max>14</max>
 					</primaryMagazineCount>
 				  </li>
 				</value>
@@ -38,15 +39,5 @@
 		</operations>
 		</match>
 	</Operation>
-	<!-- <Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Vespa" or defName="Hound" or defName="Chimera" or defName="Goliath" or defName="Kraken"]</xpath>
-		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>
-				  <min>100</min>
-				  <max>100</max>
-			</primaryMagazineCount>
-		  </li>
-		</value>
-	</Operation> -->
+
 </Patch>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -204,8 +204,8 @@
 				<value>
 					<CarryWeight>200</CarryWeight>
 					<CarryBulk>40</CarryBulk>
-					<AimingAccuracy>0.5</AimingAccuracy>
-					<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
+					<AimingAccuracy>0.8</AimingAccuracy>
+					<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.50</MeleeCritChance>
 				</value>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -91,7 +91,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -213,7 +213,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>55</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -280,7 +280,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -6,6 +6,7 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>
+
 			<!-- ========== Vespa ========== -->
 			<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]</xpath>
@@ -35,7 +36,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Vespa"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -90,13 +91,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -151,13 +152,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Chimera"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -201,8 +202,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases</xpath>
 				<value>
-					<CarryWeight>550</CarryWeight>
-					<CarryBulk>140</CarryBulk>
+					<CarryWeight>200</CarryWeight>
+					<CarryBulk>40</CarryBulk>
 					<AimingAccuracy>0.5</AimingAccuracy>
 					<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -212,13 +213,19 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>55</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>2.2</baseHealthScale>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -273,13 +280,19 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>67.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>30</ArmorRating_Sharp>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>3.0</baseHealthScale>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -333,6 +346,7 @@
 					</tools>
 				</value>
 			</li>
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -91,13 +91,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Hound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -269,10 +269,10 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases</xpath>
 				<value>
-					<CarryWeight>750</CarryWeight>
+					<CarryWeight>400</CarryWeight>
 					<CarryBulk>200</CarryBulk>
-					<AimingAccuracy>1.5</AimingAccuracy>
-					<ShootingAccuracyPawn>2.5</ShootingAccuracyPawn>
+					<AimingAccuracy>1.0</AimingAccuracy>
+					<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.40</MeleeCritChance>
 				</value>

--- a/Patches/MoreMechanoids/PawnKinds/PawnKinds.xml
+++ b/Patches/MoreMechanoids/PawnKinds/PawnKinds.xml
@@ -8,17 +8,26 @@
 
         <match Class="PatchOperationSequence">
             <operations>
+
                 <li Class="PatchOperationAddModExtension">
                     <xpath>Defs/PawnKindDef[defName="Mech_Assaulter" or defName="Mech_Flamebot"]</xpath>
                     <value>
                         <li Class="CombatExtended.LoadoutPropertiesExtension">
                             <primaryMagazineCount>
-                                <min>100</min>
-                                <max>100</max>
+                                <min>4</min>
+                                <max>8</max>
                             </primaryMagazineCount>
                         </li>
                     </value>
                 </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/PawnKindDef[defName="Mech_Assaulter"]/combatPower</xpath>
+                    <value>
+                        <combatPower>400</combatPower>
+                    </value>
+                </li>
+
             </operations>
         </match>
     </Operation>

--- a/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -12,47 +12,49 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>Gun_ChargeBlasterInternal</defName>
 					<statBases>
-					  <Mass>22.00</Mass>
+					  <Mass>10.00</Mass>
 					  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					  <SightsEfficiency>1</SightsEfficiency>
-					  <ShotSpread>0.01</ShotSpread>
+					  <ShotSpread>3.0</ShotSpread>
 					  <SwayFactor>1.33</SwayFactor>
 					  <Bulk>13.00</Bulk>
 					</statBases>
 					<Properties>
-					  <recoilAmount>1.28</recoilAmount>
+					  <recoilAmount>1.51</recoilAmount>
 					  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					  <hasStandardCommand>true</hasStandardCommand>
-					  <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+					  <defaultProjectile>Bullet_6x22mmCharged</defaultProjectile>
 					  <warmupTime>1.1</warmupTime>
-					  <range>86</range>
+					  <range>31</range>
 					  <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-					  <burstShotCount>80</burstShotCount>
-					  <soundCast>ChargeLance_Fire</soundCast>
+					  <burstShotCount>20</burstShotCount>
+					  <soundCast>Shot_ChargeBlaster</soundCast>
 					  <soundCastTail>GunTail_Heavy</soundCastTail>
 					  <muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
 					<AmmoUser>
 					  <magazineSize>300</magazineSize>
 					  <reloadTime>9.2</reloadTime>
-					  <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+					  <ammoSet>AmmoSet_6x22mmCharged</ammoSet>
 					</AmmoUser>
 					<FireModes>
-					  <aimedBurstShotCount>20</aimedBurstShotCount>
-					  <aiAimMode>AimedShot</aiAimMode>
+					  <aiUseBurstMode>FALSE</aiUseBurstMode>
+					  <aiAimMode>SuppressFire</aiAimMode>
+					  <noSingleShot>true</noSingleShot>
 					</FireModes>
 					<weaponTags>
 					  <li>CE_AI_Suppressive</li>
 					</weaponTags>
 				</li>
+
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>MechanoidFlameThrower</defName>
 					<statBases>
 					  <Mass>2.00</Mass>
 					  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					  <SightsEfficiency>1</SightsEfficiency>
-					  <ShotSpread>0.2</ShotSpread>
-					  <SwayFactor>1.33</SwayFactor>
+					  <ShotSpread>5.0</ShotSpread>
+					  <SwayFactor>1.00</SwayFactor>
 					  <Bulk>1.00</Bulk>
 					</statBases>
 					<Properties>
@@ -60,21 +62,23 @@
 					  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					  <hasStandardCommand>true</hasStandardCommand>
 					  <defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
-					  <warmupTime>0.3</warmupTime>
-					  <range>9</range>
+					  <warmupTime>0.6</warmupTime>
+					  <range>12</range>
 					  <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
-					  <burstShotCount>20</burstShotCount>
+					  <burstShotCount>6</burstShotCount>
 					  <soundCast>FlameThrower</soundCast>
-					  <muzzleFlashScale>9</muzzleFlashScale>
-						<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					  <muzzleFlashScale>5</muzzleFlashScale>
+					  <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
 					</Properties>
 					<AmmoUser>
-					  <magazineSize>100</magazineSize>
-					  <reloadTime>9.2</reloadTime>
+					  <magazineSize>50</magazineSize>
+					  <reloadTime>5</reloadTime>
 					  <ammoSet>AmmoSet_Flamethrower</ammoSet>
 					</AmmoUser>
 					<FireModes>
-					  <aiAimMode>AimedShot</aiAimMode>
+					  <aiUseBurstMode>FALSE</aiUseBurstMode>
+					  <aiAimMode>SuppressFire</aiAimMode>
+					  <noSingleShot>true</noSingleShot>
 					</FireModes>
 				</li>
 			</operations>

--- a/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -33,7 +33,7 @@
 					  <muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>
 					<AmmoUser>
-					  <magazineSize>300</magazineSize>
+					  <magazineSize>100</magazineSize>
 					  <reloadTime>9.2</reloadTime>
 					  <ammoSet>AmmoSet_6x22mmCharged</ammoSet>
 					</AmmoUser>

--- a/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -15,7 +15,7 @@
 					  <Mass>10.00</Mass>
 					  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
 					  <SightsEfficiency>1</SightsEfficiency>
-					  <ShotSpread>3.0</ShotSpread>
+					  <ShotSpread>2.0</ShotSpread>
 					  <SwayFactor>1.33</SwayFactor>
 					  <Bulk>13.00</Bulk>
 					</statBases>
@@ -24,7 +24,7 @@
 					  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					  <hasStandardCommand>true</hasStandardCommand>
 					  <defaultProjectile>Bullet_6x22mmCharged</defaultProjectile>
-					  <warmupTime>1.1</warmupTime>
+					  <warmupTime>1.3</warmupTime>
 					  <range>31</range>
 					  <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 					  <burstShotCount>20</burstShotCount>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -173,6 +173,8 @@
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases</xpath>
                     <value>
+                        <CarryWeight>50</CarryWeight>
+                        <CarryBulk>40</CarryBulk>
                         <MeleeDodgeChance>0.10</MeleeDodgeChance>
                         <MeleeCritChance>0.04</MeleeCritChance>
                         <MeleeParryChance>0.0</MeleeParryChance>
@@ -328,6 +330,8 @@
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases</xpath>
                     <value>
+                        <CarryWeight>50</CarryWeight>
+                        <CarryBulk>40</CarryBulk>
                         <MeleeDodgeChance>0.12</MeleeDodgeChance>
                         <MeleeCritChance>0.16</MeleeCritChance>
                         <MeleeParryChance>0.12</MeleeParryChance>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -252,6 +252,14 @@
                                 <power>72</power>
                                 <cooldownTime>7</cooldownTime>
                                 <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                                <surpriseAttack>
+                                    <extraMeleeDamages>
+                                        <li>
+                                            <def>Stun</def>
+                                            <amount>25</amount>
+                                        </li>
+                                    </extraMeleeDamages>
+                                </surpriseAttack>
                                 <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
                                 <armorPenetrationBlunt>33.750</armorPenetrationBlunt>
                             </li>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -160,13 +160,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>6</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>3</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>3</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>6</ArmorRating_Blunt>
                     </value>
                 </li>
                 

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -175,6 +175,8 @@
                     <value>
                         <CarryWeight>50</CarryWeight>
                         <CarryBulk>100</CarryBulk>
+                        <AimingAccuracy>1.0</AimingAccuracy>
+                        <ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
                         <MeleeDodgeChance>0.10</MeleeDodgeChance>
                         <MeleeCritChance>0.04</MeleeCritChance>
                         <MeleeParryChance>0.0</MeleeParryChance>
@@ -332,6 +334,8 @@
                     <value>
                         <CarryWeight>50</CarryWeight>
                         <CarryBulk>40</CarryBulk>
+                        <AimingAccuracy>1.0</AimingAccuracy>
+                        <ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
                         <MeleeDodgeChance>0.12</MeleeDodgeChance>
                         <MeleeCritChance>0.16</MeleeCritChance>
                         <MeleeParryChance>0.12</MeleeParryChance>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -26,12 +26,6 @@
                         <ArmorRating_Sharp>2</ArmorRating_Sharp>
                     </value>
                 </li>
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Mech_Crawler"]/statBases/ArmorRating_Blunt</xpath>
-                    <value>
-                        <ArmorRating_Blunt>3</ArmorRating_Blunt>
-                    </value>
-                </li>
                 
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[defName="Mech_Crawler"]/statBases</xpath>
@@ -99,13 +93,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Skullywag"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>8</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>3</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Skullywag"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>12</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>5</ArmorRating_Blunt>
                     </value>
                 </li>
                 
@@ -166,13 +160,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>4</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>6</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>6</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>3</ArmorRating_Blunt>
                     </value>
                 </li>
                 
@@ -229,13 +223,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>30</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>22</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>67.5</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>80</ArmorRating_Blunt>
                     </value>
                 </li>
                 
@@ -313,13 +307,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>15</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>24</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>22.5</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>100</ArmorRating_Blunt>
                     </value>
                 </li>
                 
@@ -345,6 +339,14 @@
                                 <power>19</power>
                                 <cooldownTime>2.95</cooldownTime>
                                 <linkedBodyPartsGroup>CoveredByShield</linkedBodyPartsGroup>
+                                <surpriseAttack>
+                                    <extraMeleeDamages>
+                                        <li>
+                                            <def>Stun</def>
+                                            <amount>14</amount>
+                                        </li>
+                                    </extraMeleeDamages>
+                                </surpriseAttack>
                                 <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
                                 <armorPenetrationBlunt>7.5</armorPenetrationBlunt>
                             </li>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -325,7 +325,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>60</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>54</ArmorRating_Blunt>
                     </value>
                 </li>
                 

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -231,7 +231,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>80</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>50</ArmorRating_Blunt>
                     </value>
                 </li>
                 
@@ -323,7 +323,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>100</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>60</ArmorRating_Blunt>
                     </value>
                 </li>
                 

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -236,7 +236,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/race/baseHealthScale</xpath>
                     <value>
-                        <baseHealthScale>3</baseHealthScale>
+                        <baseHealthScale>5</baseHealthScale>
                     </value>
                 </li>
                 

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -238,7 +238,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/race/baseHealthScale</xpath>
                     <value>
-                        <baseHealthScale>5</baseHealthScale>
+                        <baseHealthScale>4</baseHealthScale>
                     </value>
                 </li>
                 

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -174,7 +174,7 @@
                     <xpath>Defs/ThingDef[defName="Mech_Flamebot"]/statBases</xpath>
                     <value>
                         <CarryWeight>50</CarryWeight>
-                        <CarryBulk>40</CarryBulk>
+                        <CarryBulk>100</CarryBulk>
                         <MeleeDodgeChance>0.10</MeleeDodgeChance>
                         <MeleeCritChance>0.04</MeleeCritChance>
                         <MeleeParryChance>0.0</MeleeParryChance>
@@ -377,6 +377,7 @@
                         </tools>
                     </value>
                 </li>
+
             </operations>
         </match>
     </Operation>

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -319,13 +319,13 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
-                        <ArmorRating_Sharp>24</ArmorRating_Sharp>
+                        <ArmorRating_Sharp>18</ArmorRating_Sharp>
                     </value>
                 </li>
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Assaulter"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
-                        <ArmorRating_Blunt>54</ArmorRating_Blunt>
+                        <ArmorRating_Blunt>42</ArmorRating_Blunt>
                     </value>
                 </li>
                 

--- a/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
@@ -18,29 +18,29 @@
 
 		<!-- Replace vanilla thingClass -->
 		<li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[
+		<xpath>Defs/ThingDef[
 			defName = "VFEA_Turret_AncientSecurityTurret" or		
 			@Name = "AncientPointDefenseTurretBase"	        		
 		]/thingClass</xpath>
-        <value>
-          <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-        </value>
+			<value>
+			  <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+			</value>
 		</li>
 
-    <!-- Make turrets taller -->
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
-      <value>
-        <fillPercent>0.85</fillPercent>
-      </value>
-    </li>
+	    <!-- Make turrets taller -->
+	    <li Class="PatchOperationReplace">
+	      <xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
+	      <value>
+		<fillPercent>0.85</fillPercent>
+	      </value>
+	    </li>
 
-    <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
-      <value>
-        <fillPercent>0.95</fillPercent>
-      </value>
-    </li>
+	    <li Class="PatchOperationAdd">
+	      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
+	      <value>
+		<fillPercent>0.95</fillPercent>
+	      </value>
+	    </li>
 
 	  <li Class="PatchOperationAdd">
 	  	<xpath>Defs/ThingDef[
@@ -62,110 +62,110 @@
 	  	</value>
 	  </li>
 
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[
-			defName = "VFEA_Turret_AncientSecurityTurret" or		
-			defName = "VFEA_Turret_AncientPointDefense"	 
-      ]/building/turretBurstCooldownTime</xpath>
-      <value>
-        <turretBurstCooldownTime>1.1</turretBurstCooldownTime>
-      </value>
-    </li>
+	    <li Class="PatchOperationReplace">
+	      <xpath>Defs/ThingDef[
+				defName = "VFEA_Turret_AncientSecurityTurret" or		
+				defName = "VFEA_Turret_AncientPointDefense"	 
+	      ]/building/turretBurstCooldownTime</xpath>
+	      <value>
+		<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+	      </value>
+	    </li>
 
-    <li Class="PatchOperationRemove">
-      <xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret" or defName="VFEA_Turret_AncientPointDefense"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
-    </li>
+	    <li Class="PatchOperationRemove">
+	      <xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret" or defName="VFEA_Turret_AncientPointDefense"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+	    </li>
 
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
-      <value>
-        <fillPercent>0.85</fillPercent>
-      </value>
-    </li>
+	    <li Class="PatchOperationReplace">
+	      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
+	      <value>
+		<fillPercent>0.85</fillPercent>
+	      </value>
+	    </li>
 
-    <!-- Make turrets taller -->
-    <li Class="PatchOperationReplace">
-      <xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/statBases/MaxHitPoints</xpath>
-      <value>
-        <MaxHitPoints>125</MaxHitPoints>
-      </value>
-    </li>
+	    <!-- Make turrets taller -->
+	    <li Class="PatchOperationReplace">
+	      <xpath>Defs/ThingDef[defName = "VFEA_Turret_AncientSecurityTurret"]/statBases/MaxHitPoints</xpath>
+	      <value>
+		<MaxHitPoints>125</MaxHitPoints>
+	      </value>
+	    </li>
 
-    <!-- Ancient Security Turret -->
-    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-      <defName>VFEA_Gun_AncientSecurityTurret</defName>
-      <statBases>
-        <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-        <SightsEfficiency>1</SightsEfficiency>
-        <ShotSpread>0.05</ShotSpread>
-        <SwayFactor>0.78</SwayFactor>
-        <Bulk>10.00</Bulk>
-      </statBases>
-      <Properties>
-        <recoilAmount>0.71</recoilAmount>
-        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-        <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-        <warmupTime>1.2</warmupTime>
-        <range>54</range>
-        <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-        <burstShotCount>10</burstShotCount>
-        <soundCast>GunShotA</soundCast>
-        <soundCastTail>GunTail_Light</soundCastTail>
-        <muzzleFlashScale>9</muzzleFlashScale>
-        <recoilPattern>Mounted</recoilPattern>
-      </Properties>
-      <AmmoUser>
-        <magazineSize>300</magazineSize>
-        <reloadTime>9.5</reloadTime>
-        <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-      </AmmoUser>
-      <FireModes>
-        <aiAimMode>AimedShot</aiAimMode>
-        <noSnapshot>true</noSnapshot>
-        <noSingleShot>true</noSingleShot>
-      </FireModes>
-    </li>
+	    <!-- Ancient Security Turret -->
+	    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	      <defName>VFEA_Gun_AncientSecurityTurret</defName>
+	      <statBases>
+		<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+		<SightsEfficiency>1</SightsEfficiency>
+		<ShotSpread>0.05</ShotSpread>
+		<SwayFactor>0.78</SwayFactor>
+		<Bulk>10.00</Bulk>
+	      </statBases>
+	      <Properties>
+		<recoilAmount>0.71</recoilAmount>
+		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		<hasStandardCommand>true</hasStandardCommand>
+		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+		<warmupTime>1.2</warmupTime>
+		<range>54</range>
+		<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+		<burstShotCount>10</burstShotCount>
+		<soundCast>GunShotA</soundCast>
+		<soundCastTail>GunTail_Light</soundCastTail>
+		<muzzleFlashScale>9</muzzleFlashScale>
+		<recoilPattern>Mounted</recoilPattern>
+	      </Properties>
+	      <AmmoUser>
+		<magazineSize>300</magazineSize>
+		<reloadTime>9.5</reloadTime>
+		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+	      </AmmoUser>
+	      <FireModes>
+		<aiAimMode>AimedShot</aiAimMode>
+		<noSnapshot>true</noSnapshot>
+		<noSingleShot>true</noSingleShot>
+	      </FireModes>
+	    </li>
 
-    <!-- Ancient Point Defense Gun -->
-    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-      <defName>VFEA_Gun_AncientPointDefenseTurret</defName>
-      <statBases>
-        <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
-        <SightsEfficiency>1</SightsEfficiency>
-        <ShotSpread>0.09</ShotSpread>
-        <SwayFactor>1.32</SwayFactor>
-      </statBases>
-      <Properties>
-        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-        <hasStandardCommand>True</hasStandardCommand>
-        <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-        <warmupTime>2.3</warmupTime>
-        <range>62</range>
-        <burstShotCount>25</burstShotCount>
-        <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
-        <soundCast>Shot_Minigun</soundCast>
-        <soundCastTail>GunTail_Heavy</soundCastTail>
-        <muzzleFlashScale>9</muzzleFlashScale>
-        <recoilPattern>Mounted</recoilPattern>
-        <targetParams>
-          <canTargetLocations>True</canTargetLocations>
-        </targetParams>
-      </Properties>
-      <AmmoUser>
-        <magazineSize>500</magazineSize>
-        <reloadTime>9.2</reloadTime>
-        <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
-      </AmmoUser>
-      <weaponTags Inherit="false">
-        <li>TurretGun</li>
-      </weaponTags>
-      <FireModes>
-        <aiAimMode>SuppressFire</aiAimMode>
-        <noSnapshot>true</noSnapshot>
-        <noSingleShot>true</noSingleShot>
-      </FireModes>      
-    </li>
+	    <!-- Ancient Point Defense Gun -->
+	    <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	      <defName>VFEA_Gun_AncientPointDefenseTurret</defName>
+	      <statBases>
+		<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+		<SightsEfficiency>1</SightsEfficiency>
+		<ShotSpread>0.09</ShotSpread>
+		<SwayFactor>1.32</SwayFactor>
+	      </statBases>
+	      <Properties>
+		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		<hasStandardCommand>True</hasStandardCommand>
+		<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+		<warmupTime>2.3</warmupTime>
+		<range>62</range>
+		<burstShotCount>50</burstShotCount>
+		<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+		<soundCast>Shot_Minigun</soundCast>
+		<soundCastTail>GunTail_Heavy</soundCastTail>
+		<muzzleFlashScale>9</muzzleFlashScale>
+		<recoilPattern>Mounted</recoilPattern>
+		<targetParams>
+		  <canTargetLocations>True</canTargetLocations>
+		</targetParams>
+	      </Properties>
+	      <AmmoUser>
+		<magazineSize>1000</magazineSize>
+		<reloadTime>9.2</reloadTime>
+		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+	      </AmmoUser>
+	      <weaponTags Inherit="false">
+		<li>TurretGun</li>
+	      </weaponTags>
+	      <FireModes>
+		<aiAimMode>SuppressFire</aiAimMode>
+		<noSnapshot>true</noSnapshot>
+		<noSingleShot>true</noSingleShot>
+	      </FireModes>      
+	    </li>
 
 		</operations>
 		</match>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -201,7 +201,7 @@
           <warmupTime>1.3</warmupTime>
           <range>54</range>
           <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-          <burstShotCount>10</burstShotCount>
+          <burstShotCount>20</burstShotCount>
           <soundCast>GunShotA</soundCast>
           <soundCastTail>GunTail_Light</soundCastTail>
           <muzzleFlashScale>9</muzzleFlashScale>
@@ -238,7 +238,7 @@
           <warmupTime>1.3</warmupTime>
           <range>54</range>
           <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-          <burstShotCount>10</burstShotCount>
+          <burstShotCount>20</burstShotCount>
           <soundCast>GunShotA</soundCast>
           <soundCastTail>GunTail_Light</soundCastTail>
           <muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
## Changes

- Tweaked the PD turret added by VFE-Ancients to have a larger burst shot count and ammo capacity
- Tweaked the military turrets from VFE-Security to have appropriate burst shot counts
- Readjusted certain values in some old mechanoid mods' patches to bring them up to par to some newly patched mechs and fix some OP or wonkiness issues. 

## Reasoning

- The Ancient PD turret is a 2x2 building with twin miniguns mounted on top, considering that the VFE-Security sentry gun is a 1x1 building with only one mounted minigun and shoots 50 rounds in each burst with a 500 round capacity, it was only appropriate to tweak the PD turret to resemble its design. Also the vanilla minigun has a 50/100 burst shot count.
- The military turrets have two mini-turrets mounted on top so made the change to differentiate them from normal mini-turrets.
- The old patches done for More Mechanoids, Mechanoid extraordinaire and Advanced Mechanoid Warfare were not consistent with how vanilla mechs and other newly patched mechs are handled and patched, included subjective and arbitrary design choices that clashed with the intended vanilla design of the mods. Made he necessary changes to keep things consistent and less all over the place.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
