### PR TITLE
Tweaks to Bow Ranges

### DIFF
--- a/Patches/A Rimworld of Magic/Patch_Ranged.xml
+++ b/Patches/A Rimworld of Magic/Patch_Ranged.xml
@@ -404,7 +404,7 @@
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
 				  <warmupTime>1.2</warmupTime>
-				  <range>38</range>
+				  <range>34</range>
 				  <soundCast>TM_ThrumBow</soundCast>
 				  <soundCastTail>TM_Woosh</soundCastTail>
 				  <muzzleFlashScale>1</muzzleFlashScale>

--- a/Patches/Anty the war Ant/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Anty the war Ant/ThingDefs_Misc/Weapons.xml
@@ -414,7 +414,7 @@
 				<hasStandardCommand>True</hasStandardCommand>
 				<defaultProjectile>Projectile_CrossbowBolt_AntyAcid</defaultProjectile>
 				<warmupTime>1</warmupTime>
-				<range>34</range>
+				<range>20</range>
 				<soundCast>Bow_Large</soundCast>
 			  </Properties>
 			  <AmmoUser>

--- a/Patches/Arrow Please/ArrowPlease_Ranged.xml
+++ b/Patches/Arrow Please/ArrowPlease_Ranged.xml
@@ -42,7 +42,7 @@
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
             <warmupTime>0.90</warmupTime>
-            <range>25</range>
+            <range>20</range>
             <soundCast>Bow_Small</soundCast>
           </Properties>
           <AmmoUser>
@@ -94,7 +94,7 @@
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
             <warmupTime>1.05</warmupTime>
-            <range>28</range>
+            <range>24</range>
             <soundCast>Bow_Large</soundCast>
           </Properties>
           <AmmoUser>
@@ -146,7 +146,7 @@
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
             <warmupTime>1.15</warmupTime>
-            <range>34</range>
+            <range>20</range>
             <soundCast>Bow_Large</soundCast>
           </Properties>
           <AmmoUser>
@@ -200,7 +200,7 @@
             <burstShotCount>5</burstShotCount>
             <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
             <warmupTime>0.95</warmupTime>
-            <range>20</range>
+            <range>18</range>
             <soundCast>Bow_Small</soundCast>
           </Properties>
           <AmmoUser>

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -29,14 +29,14 @@
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <WoodLog>10</WoodLog>
+      <WoodLog>15</WoodLog>
     </costList>
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_Arrow_Stone</defaultProjectile>
       <warmupTime>1</warmupTime>
-      <range>28</range>
+      <range>14</range>
       <soundCast>Bow_Small</soundCast>
     </Properties>
     <AmmoUser>
@@ -77,14 +77,14 @@
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <WoodLog>15</WoodLog>
+      <WoodLog>25</WoodLog>
     </costList>
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>22</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -108,7 +108,7 @@
           	</capacities>
           	<power>7</power>
           	<cooldownTime>1.6</cooldownTime>
- 	 	<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+ 	 	        <armorPenetrationBlunt>0.65</armorPenetrationBlunt>
         </li>
       </tools>
     </value>
@@ -126,14 +126,14 @@
       <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
     </statBases>
     <costList>
-      <WoodLog>20</WoodLog>
+      <WoodLog>40</WoodLog>
     </costList>
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
       <warmupTime>1.3</warmupTime>
-      <range>33</range>
+      <range>30</range>
       <soundCast>Bow_Large</soundCast>
     </Properties>
     <AmmoUser>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ThingDefs_Weapons.xml
@@ -524,7 +524,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Projectile_ForsakensArrows</defaultProjectile>
 						<warmupTime>1.2</warmupTime>
-						<range>32</range>
+						<range>26</range>
 						<soundCast>Bow_Large</soundCast>
 					</Properties>
 					<AmmoUser>

--- a/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -51,7 +51,7 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
         <warmupTime>1.3</warmupTime>
-        <range>30</range>
+        <range>32</range>
         <soundCast>Bow_Large</soundCast>
       </Properties>
       <AmmoUser>

--- a/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -51,7 +51,7 @@
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
         <warmupTime>1.3</warmupTime>
-        <range>40</range>
+        <range>30</range>
         <soundCast>Bow_Large</soundCast>
       </Properties>
       <AmmoUser>

--- a/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
@@ -98,7 +98,7 @@
                 <hasStandardCommand>True</hasStandardCommand>
                 <defaultProjectile>Projectile_ArbalestBolt_Steel</defaultProjectile>
                 <warmupTime>1</warmupTime>
-                <range>28</range>
+                <range>26</range>
                 <soundCast>Bow_Large</soundCast>
             </Properties>
             <AmmoUser>
@@ -134,7 +134,7 @@
                 <hasStandardCommand>true</hasStandardCommand>
                 <defaultProjectile>Projectile_HuntingArrow_Stone</defaultProjectile>
                 <warmupTime>1.2</warmupTime>
-                <range>32</range>
+                <range>16</range>
                 <soundCast>Bow_Recurve</soundCast>
             </Properties>
             <AmmoUser>
@@ -183,7 +183,7 @@
                 <hasStandardCommand>true</hasStandardCommand>
                 <defaultProjectile>Projectile_WarArrow_Stone</defaultProjectile>
                 <warmupTime>1.5</warmupTime>
-                <range>40</range>
+                <range>32</range>
                 <soundCast>Bow_Large</soundCast>
             </Properties>
             <AmmoUser>

--- a/Patches/MorrowRim - Bloodmoon/Hunter_Weapons.xml
+++ b/Patches/MorrowRim - Bloodmoon/Hunter_Weapons.xml
@@ -76,7 +76,7 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Projectile_HuntardArrow_Stone</defaultProjectile>
 						<warmupTime>1.2</warmupTime>
-						<range>32</range>
+						<range>26</range>
 						<soundCast>Bow_Recurve</soundCast>
 					</Properties>
 					<AmmoUser>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -93,7 +93,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
 			  <warmupTime>1</warmupTime>
-			  <range>26</range>
+			  <range>20</range>
 			  <soundCast>Bow_Small</soundCast>
 			</Properties>
 			<costList>
@@ -134,7 +134,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
 			  <warmupTime>1</warmupTime>
-			  <range>32</range>
+			  <range>28</range>
 			  <soundCast>Bow_Large</soundCast>
 			</Properties>
 			<AmmoUser>
@@ -171,7 +171,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
 			  <warmupTime>1</warmupTime>
-			  <range>24</range>
+			  <range>18</range>
 			  <soundCast>Bow_Large</soundCast>
 			</Properties>
 			<AmmoUser>

--- a/Patches/Nyaron/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Nyaron/ThingDefs_Misc/Weapons.xml
@@ -454,7 +454,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Projectile_GreatArrowNyaron_Stone</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
-			  <range>35</range>
+			  <range>30</range>
 			  <soundCast>Bow_Large</soundCast>
 			</Properties>
 			<AmmoUser>

--- a/Patches/O21 Outland - Eastborn/Eastborn_WeaponsRanged.xml
+++ b/Patches/O21 Outland - Eastborn/Eastborn_WeaponsRanged.xml
@@ -26,7 +26,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
 				<warmupTime>1.2</warmupTime>
-				<range>32</range>
+				<range>20</range>
 				<soundCast>Bow_Recurve</soundCast>
 			</Properties>
 			<AmmoUser>

--- a/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Revia Race/ThingDefs_Misc/Weapons_Guns.xml
@@ -165,7 +165,7 @@
                 <hasStandardCommand>True</hasStandardCommand>
                 <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
                 <warmupTime>1</warmupTime>
-                <range>28</range>
+                <range>22</range>
                 <burstShotCount>6</burstShotCount>
                 <soundCast>Bow_Small</soundCast>              
                 <ai_IsBuildingDestroyer>false</ai_IsBuildingDestroyer>

--- a/Patches/Rimcraft Collection/Weapons/Patch_WOW_Ranged.xml
+++ b/Patches/Rimcraft Collection/Weapons/Patch_WOW_Ranged.xml
@@ -61,7 +61,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
       <warmupTime>1.3</warmupTime>
-      <range>34</range>
+      <range>32</range>
       <soundCast>Bow_Large</soundCast>
     </Properties>
     <AmmoUser>
@@ -88,7 +88,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>26</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -115,7 +115,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>26</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -142,7 +142,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>26</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -169,7 +169,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
       <warmupTime>1.3</warmupTime>
-      <range>34</range>
+      <range>32</range>
       <soundCast>Bow_Large</soundCast>
     </Properties>
     <AmmoUser>
@@ -196,7 +196,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>26</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -223,7 +223,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_StreamlinedArrow_Stone</defaultProjectile>
       <warmupTime>1.2</warmupTime>
-      <range>32</range>
+      <range>26</range>
       <soundCast>Bow_Recurve</soundCast>
     </Properties>
     <AmmoUser>
@@ -250,7 +250,7 @@
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
             <warmupTime>1</warmupTime>
-            <range>32</range>
+            <range>28</range>
             <soundCast>Bow_Large</soundCast>
           </Properties>
           <AmmoUser>
@@ -278,7 +278,7 @@
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
       <warmupTime>1.3</warmupTime>
-      <range>36</range>
+      <range>32</range>
       <soundCast>Bow_Large</soundCast>
     </Properties>
     <AmmoUser>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Ranged_Misc.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_Ranged_Misc.xml
@@ -118,13 +118,13 @@
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Projectile_Arrow_Steel</defaultProjectile>
+					<defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
 					<warmupTime>1.25</warmupTime>
-					<range>27</range>
+					<range>24</range>
 					<soundCast>Bow_Recurve</soundCast>
 				</Properties>
 				<AmmoUser>
-					<ammoSet>AmmoSet_Arrow</ammoSet>
+					<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>
@@ -166,7 +166,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
 					<warmupTime>1</warmupTime>
-					<range>30</range>
+					<range>26</range>
 					<soundCast>RNCrossbow</soundCast>
 				</Properties>
 				<AmmoUser>

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -39,7 +39,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Projectile_CompoundArrow_Broadhead</defaultProjectile>
 					<warmupTime>1</warmupTime>
-					<range>38</range>
+					<range>26</range>
 					<soundCast>Bow_Large</soundCast>
 				</Properties>
 				<AmmoUser>

--- a/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Weapons_Ranged.xml
@@ -188,7 +188,7 @@
               <hasStandardCommand>true</hasStandardCommand>
               <defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
               <warmupTime>1.2</warmupTime>
-              <range>32</range>
+              <range>20</range>
               <soundCast>Bow_Recurve</soundCast>
             </Properties>
             <AmmoUser>

--- a/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
+++ b/Patches/Tribal Warrior Set/TribalWarrior_Apparel.xml
@@ -128,7 +128,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
 				<warmupTime>1.3</warmupTime>
-				<range>33</range>
+				<range>30</range>
 				<soundCast>Bow_Large</soundCast>
 			</Properties>
 			<AmmoUser>

--- a/Patches/VFWE/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/VFWE/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -61,7 +61,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Projectile_CrossbowBolt_Stone</defaultProjectile>
 					<warmupTime>1.1</warmupTime>
-					<range>37</range>
+					<range>20</range>
 					<soundCast>Bow_Large</soundCast>
 				</Properties>
 				<AmmoUser>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Crypto.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Crypto.xml
@@ -224,7 +224,7 @@
         <hasStandardCommand>True</hasStandardCommand>
         <defaultProjectile>Bullet_CryptoHeavyBolt</defaultProjectile>
         <warmupTime>1</warmupTime>
-        <range>55</range>
+        <range>42</range>
         <soundCast>VFEV_CryptoLightCrossbowShot</soundCast>
         <soundCastTail>GunTail_Light</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>
@@ -255,7 +255,7 @@
         <hasStandardCommand>True</hasStandardCommand>
         <defaultProjectile>Bullet_CryptoBolt</defaultProjectile>
         <warmupTime>1</warmupTime>
-        <range>55</range>
+        <range>28</range>
         <soundCast>Bow_Large</soundCast>
       </Properties>
       <AmmoUser>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -167,13 +167,13 @@
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
-						<defaultProjectile>Projectile_Arrow_Steel</defaultProjectile>
+						<defaultProjectile>Projectile_StreamlinedArrow_Steel</defaultProjectile>
 						<warmupTime>1</warmupTime>
-						<range>33</range>
+						<range>24</range>
 						<soundCast>VWE_Bow_Compound</soundCast>
 					</Properties>
 					<AmmoUser>
-						<ammoSet>AmmoSet_Arrow</ammoSet>
+						<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
 					</AmmoUser>
 					<FireModes />
 					<weaponTags Inherit="false">

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -112,7 +112,7 @@
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Projectile_CrossbowBolt_Steel</defaultProjectile>
             <warmupTime>1</warmupTime>
-            <range>26</range>
+            <range>20</range>
             <soundCast>Bow_Large</soundCast>
           </Properties>
           <AmmoUser>

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -27,7 +27,7 @@
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Projectile_GreatArrow_Stone</defaultProjectile>
             <warmupTime>1.5</warmupTime>
-            <range>37</range>
+            <range>30</range>
             <soundCast>Bow_Large</soundCast>
           </Properties>
           <AmmoUser>


### PR DESCRIPTION
## Changes
- Decrease CE's cost reduction of vanilla bows (from almost 70% to around 40 - 50%).
- Decrease the overall range of many bows.

## Reasoning
The current range of bows is, in many cases, more reflective of their _absolute_ maximum range rather than their realistic maximum _effective_ range. Given the low velocity of the arrows they fire, this leads to an issue where they consistently engage well beyond their actual effective range, making them less effective in combat due to long flight times. I recommend the new range brackets be as follows:

Short bow (and other crude, simple bows): 14 tiles = 60 m.
Recurve bow, crossbows (and other more 'advanced' medieval bows): ~20 tiles = ~100 m.
Great bow (and other long bows): 30 tiles = 190 m.

Figure a range of +/- 10% or so on the ranges for a bit of variance as needed.

In real life, precision shooting with a bow isn't practical beyond to 60 - 80m. These ranges represent distances that the bows might realistically be used to engage enemy formations on the battlefield with a reasonable expectation of accuracy (here, meaning the arrow landing close to or hitting the target); remember that bows were historically more area weapons than precision ones, more to harass, wound, and suppress than snipe.

Modern compound bows would probably fall somewhere between 22 - 26 tiles. Unrealistic (high fantasy or sci-fi) bows are to be handled on a case-by-case basis, and will likely continue to be treated more like rifles and SMGs than actual bows. 

## Alternatives
Could leave it as is.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
