### PR TITLE
Patch Vanilla Chemfuel Expanded Bulk

### DIFF
--- a/Patches/Vanilla Chemfuel Expanded/Items_Chemfuel.xml
+++ b/Patches/Vanilla Chemfuel Expanded/Items_Chemfuel.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Chemfuel Expanded</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- Give chemfuel-like product appropriate bulk. -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="VCHE_Deepchem"]/statBases</xpath>
+        <value>
+          <Bulk>0.05</Bulk>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -374,6 +374,7 @@ Vanilla Apparel Expanded — Accessories  |
 Vanilla Armour Expanded	|
 Vanilla Bionics Expansion	|
 Vanilla Brewing Expanded    |
+Vanilla Chemfuel Expanded   |
 Vanilla Factions Expanded - Ancients    |
 Vanilla Factions Expanded - Classical   |
 Vanilla Factions Expanded - Insectoids |


### PR DESCRIPTION
## Additions
- A very simple patch that gives 'deep chemfuel' a bulk of 0.05 per unit (like regular chemfuel) instead of 1.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
