### PR TITLE
Crude projectile speed check

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>23</speed>
+			<speed>24</speed>
 		</projectile>
 	</ThingDef>
 
@@ -143,7 +143,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>23</speed>
+			<speed>22</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
@@ -160,10 +160,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>26</speed>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>30</speed>			
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -177,10 +177,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>28</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
-			<speed>36</speed>				
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
 		</projectile>
@@ -194,11 +194,11 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>26</speed>
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<speed>30</speed>	
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
 		</projectile>

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -143,7 +143,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
+			<speed>18</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
@@ -160,7 +160,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>26</speed>
+			<speed>22</speed>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
@@ -177,7 +177,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>28</speed>
+			<speed>24</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
@@ -194,7 +194,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>26</speed>
+			<speed>22</speed>
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
@@ -213,6 +213,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>22</speed>
 			<explosionRadius>0.2</explosionRadius>
 			<damageDef>ArrowFire</damageDef>
 			<damageAmountBase>3</damageAmountBase>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -141,7 +141,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>18</speed>
+      <speed>16</speed>
     </projectile>
   </ThingDef>
 
@@ -158,7 +158,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>16</speed>
+      <speed>18</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
       <armorPenetrationBlunt>0.88</armorPenetrationBlunt>
@@ -209,7 +209,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
+    <speed>20</speed>
 		<damageDef>Arrow</damageDef>
 		<damageAmountBase>7</damageAmountBase>
 		<secondaryDamage>
@@ -234,7 +234,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <explosionRadius>0.1</explosionRadius>
+    <explosionRadius>0.1</explosionRadius>
 	  <damageDef>ArrowFire</damageDef>
 	  <damageAmountBase>2</damageAmountBase>
 	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
@@ -314,9 +314,9 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+    <speed>24</speed>
 	  <damageDef>Arrow</damageDef>
-      <damageAmountBase>9</damageAmountBase>
+    <damageAmountBase>9</damageAmountBase>
 		<secondaryDamage>
 			<li>
 			<def>ArrowVenom</def>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -141,7 +141,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>24</speed>
+      <speed>18</speed>
     </projectile>
   </ThingDef>
 
@@ -158,7 +158,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
+      <speed>16</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
       <armorPenetrationBlunt>0.88</armorPenetrationBlunt>
@@ -175,7 +175,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>36</speed>
+      <speed>20</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.02</armorPenetrationBlunt>
@@ -192,7 +192,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>36</speed>
+      <speed>22</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -209,7 +209,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>36</speed>
+      <speed>20</speed>
 		<damageDef>Arrow</damageDef>
 		<damageAmountBase>7</damageAmountBase>
 		<secondaryDamage>
@@ -263,7 +263,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>33</speed>
+      <speed>20</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>1.740</armorPenetrationBlunt>
@@ -280,7 +280,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>38</speed>
+      <speed>24</speed>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>5.9</armorPenetrationBlunt>
@@ -297,7 +297,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>38</speed>
+      <speed>26</speed>
       <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
@@ -314,7 +314,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>38</speed>
+      <speed>24</speed>
 	  <damageDef>Arrow</damageDef>
       <damageAmountBase>9</damageAmountBase>
 		<secondaryDamage>

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
+      <speed>16</speed>
 		  <damageDef>ArrowVenom</damageDef>
 		  <damageAmountBase>3</damageAmountBase> 
       <armorPenetrationSharp>0.35</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/BlowDarts.xml
+++ b/Defs/Ammo/Neolithic/BlowDarts.xml
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>20</speed>
 		  <damageDef>ArrowVenom</damageDef>
 		  <damageAmountBase>3</damageAmountBase> 
       <armorPenetrationSharp>0.35</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -127,7 +127,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>22</speed>
+			<speed>20</speed>
 		</projectile>
 	</ThingDef>
 	
@@ -144,7 +144,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>24</speed>
+			<speed>18</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -161,7 +161,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>26</speed>
+			<speed>22</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
@@ -178,7 +178,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>30</speed>
+			<speed>24</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -195,7 +195,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>28</speed>
+			<speed>22</speed>
 			<damageDef>Arrow</damageDef>
 			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -78,7 +78,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Blunt</damageDef>
-			<speed>20</speed>
+			<speed>18</speed>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- Made projectile speed of Arrows and Bolts consistent with IRL data and other low velocity projectiles in the mod while fixing some overtuning done to crude projectile speeds

## References

- Contributes towards https://discord.com/channels/278818534069501953/322827713335394304/963592426721771560

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
