### PR TITLE
Problematic VFE-Pirates grenade removal

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -65,10 +65,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile/speed</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile</xpath>
 		<value>
-			<speed>12</speed>
 			<gravityFactor>2</gravityFactor>
 		</value>
 	</Operation>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -8,6 +8,11 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+        <!-- === Remove the grenade projectile failing CE's grenade patch=== -->
+        <li Class="PatchOperationRemove">
+          <xpath>/Defs/ThingDef[defName="VFEP_Proj_GrenadierGrenade"]</xpath>
+        </li>
+
         <!-- === Remove the added weapon tag from the Charge Lance === -->
         <li Class="PatchOperationRemove">
           <xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"VFEP_Captain")]</xpath>


### PR DESCRIPTION
## Changes

- Removed the problematic grenade from VFE-Pirates that was throwing a red error at startup
- Tweaked the gravity factor patch, vanilla grenades are already set to 12 speed

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
