### PR TITLE
Antigrain shell thingSetMakerTag fix

### DIFF
--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -41,7 +41,7 @@
     <stackLimit>25</stackLimit>
     <cookOffFlashScale>30</cookOffFlashScale>
     <cookOffSound>MortarBomb_Explode</cookOffSound>
-	<isMortarAmmo>true</isMortarAmmo>
+    <isMortarAmmo>true</isMortarAmmo>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBaseCraftableBase" ParentName="81mmMortarShellBase" Abstract="True">
@@ -65,7 +65,7 @@
       <Bulk>8.17</Bulk>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
-	<detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
+    <detonateProjectile>Bullet_81mmMortarShell_HE</detonateProjectile>
     <comps>
 		<!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
@@ -73,8 +73,8 @@
         <explosiveDamageType>Bomb</explosiveDamageType>
     <!--<explosiveExpandPerStackcount>0.4</explosiveExpandPerStackcount>-->
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		<explodeOnKilled>True</explodeOnKilled>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+        <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
       </li>
     </comps>
@@ -93,7 +93,7 @@
       <Bulk>10.01</Bulk>
     </statBases>
     <ammoClass>GrenadeIncendiary</ammoClass>
-	<detonateProjectile>Bullet_81mmMortarShell_Incendiary</detonateProjectile>
+    <detonateProjectile>Bullet_81mmMortarShell_Incendiary</detonateProjectile>
     <comps>
 		<!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
@@ -101,8 +101,8 @@
         <explosiveDamageType>Flame</explosiveDamageType>
     <!--<explosiveExpandPerStackcount>0.4</explosiveExpandPerStackcount>-->
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		<explodeOnKilled>True</explodeOnKilled>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+        <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
       </li>
     </comps>
@@ -134,8 +134,8 @@
         <explosiveDamageType>EMP</explosiveDamageType>
     <!--<explosiveExpandPerStackcount>0.4</explosiveExpandPerStackcount>-->
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		<explodeOnKilled>True</explodeOnKilled>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+        <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
       </li>
     </comps>
@@ -154,7 +154,7 @@
       <Bulk>10.01</Bulk>
     </statBases>
     <ammoClass>FoamFuel</ammoClass>
-	<detonateProjectile>Bullet_81mmMortarShell_Firefoam</detonateProjectile>
+    <detonateProjectile>Bullet_81mmMortarShell_Firefoam</detonateProjectile>
     <comps>
 		<!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
@@ -167,7 +167,7 @@
         <postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
         <explosionEffect>ExtinguisherExplosion</explosionEffect>
-		<explodeOnKilled>True</explodeOnKilled>
+        <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
       </li>
     </comps>
@@ -186,7 +186,7 @@
       <Bulk>10.01</Bulk>
     </statBases>
     <ammoClass>Smoke</ammoClass>
-	<detonateProjectile>Bullet_81mmMortarShell_Smoke</detonateProjectile>
+    <detonateProjectile>Bullet_81mmMortarShell_Smoke</detonateProjectile>
     <comps>
 		<!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
@@ -195,7 +195,7 @@
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
         <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
         <preExplosionSpawnChance>1</preExplosionSpawnChance>
-		    <explodeOnKilled>True</explodeOnKilled>
+        <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
       </li>
     </comps>
@@ -214,7 +214,7 @@
       <Bulk>6</Bulk>
     </statBases>
     <thingSetMakerTags>
-      <li>RewardSpecial</li>
+      <li>RewardStandardHighFreq</li>
     </thingSetMakerTags>
     <tradeTags>
       <li>CE_AutoEnableTrade_Sellable</li>
@@ -225,7 +225,7 @@
 		<damageAmountBase>800</damageAmountBase>
 		<explosiveDamageType>Bomb</explosiveDamageType>
 		<explosiveRadius>20</explosiveRadius>
-        <explosionSound>Explosion_GiantBomb</explosionSound>
+		<explosionSound>Explosion_GiantBomb</explosionSound>
 	  </li>
 		<!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
@@ -238,8 +238,8 @@
         <explosionEffect>GiantExplosion</explosionEffect>
         <explosionSound>Explosion_GiantBomb</explosionSound>
         <wickTicks>60~120</wickTicks>
-		<explodeOnKilled>True</explodeOnKilled>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+        <explodeOnKilled>True</explodeOnKilled>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       </li>
     </comps>
   </ThingDef>
@@ -261,7 +261,7 @@
       <flyOverhead>true</flyOverhead>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_BigShell</casingMoteDefname>
-	  <gravityFactor>5</gravityFactor>
+      <gravityFactor>5</gravityFactor>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- Fixed the thingSetMakerTag of the Antigrain shell which was set to an outdated and obsolete tag and set it to the original vanilla tag.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
