### PR TITLE
FFGermanShepherd patch typo fix

### DIFF
--- a/Patches/FFGermanSheperd/Races_Animal_FFGermanShepherd.xml
+++ b/Patches/FFGermanSheperd/Races_Animal_FFGermanShepherd.xml
@@ -7,6 +7,7 @@
 		</mods>	
 		<match Class="PatchOperationSequence">			
 			<operations>
+
 				<!-- === Quadruped === -->
 				<li Class="PatchOperationAddModExtension">
 					<xpath>/Defs/ThingDef[defName="GermanShepherd"]</xpath>
@@ -18,7 +19,7 @@
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDefdefName="GermanShepherd"]/statBases</xpath>
+					<xpath>/Defs/ThingDef[defName="GermanShepherd"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.23</MeleeDodgeChance>
 						<MeleeCritChance>0.06</MeleeCritChance>
@@ -34,7 +35,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[ defName="GermanShepherd"]/race/baseHealthScale</xpath>
+					<xpath>/Defs/ThingDef[defName="GermanShepherd"]/race/baseHealthScale</xpath>
 					<value>
 						<baseHealthScale>0.65</baseHealthScale>
 					</value>
@@ -97,7 +98,7 @@
 						</tools>
 					</value>
 				</li>
-				
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- What it says on the tin, fixed a typo that caused the patch to fail.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
