### PR TITLE
Gravity factor patch revert

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -73,6 +73,7 @@
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <speed>10</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -148,6 +149,7 @@
       <explosionDelay>90</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <speed>8</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -217,6 +219,7 @@
       <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>12</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 
@@ -291,6 +294,7 @@
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>12</speed>
+      <gravityFactor>2</gravityFactor>
     </projectile>
   </ThingDef>
 

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -1332,6 +1332,7 @@
 							<dropsCasings>false</dropsCasings>
 							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 							<speed>10</speed>
+							<gravityFactor>2</gravityFactor>
 						</projectile>
 					</value>
 				</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -65,13 +65,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile</xpath>
-		<value>
-			<gravityFactor>2</gravityFactor>
-		</value>
-	</Operation>
-
 	<!-- ========== Frag Grenade ========== -->
 
 	<!-- Projectile -->

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -9,13 +9,6 @@
 		<value>BaseWeapon</value>
 	</Operation>
 
-	<!-- <Operation Class="PatchOperationRemove">
-		<xpath>
-			Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]/costList |
-			Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]/recipeMaker	
-		</xpath>
-	</Operation> -->
-
 	<!-- ========== Melee tools ========== -->
 
 	<Operation Class="PatchOperationAdd">
@@ -98,6 +91,7 @@
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>12</speed>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -245,6 +239,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -376,6 +371,7 @@
 				<dropsCasings>true</dropsCasings>
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<speed>12</speed>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</Operation>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -572,6 +572,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
+++ b/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
@@ -78,6 +78,7 @@
 					  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
 					  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 					  <speed>8</speed>
+					  <gravityFactor>2</gravityFactor>
 					</projectile>
 				  </ThingDef>
 				</value>

--- a/Patches/LTS Military/Weapons.xml
+++ b/Patches/LTS Military/Weapons.xml
@@ -615,6 +615,7 @@
               <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
               <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
               <speed>12</speed>
+              <gravityFactor>2</gravityFactor>
             </projectile>
           </value>
         </li>

--- a/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
+++ b/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
@@ -355,6 +355,7 @@
 					<preExplosionSpawnChance>1</preExplosionSpawnChance>
 					<speed>12</speed>
 					<ai_IsIncendiary>true</ai_IsIncendiary>
+					<gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>

--- a/Patches/O21 Outer Rim/Patch_OuterRim_Weapons.xml
+++ b/Patches/O21 Outer Rim/Patch_OuterRim_Weapons.xml
@@ -8,11 +8,6 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-		<!-- Remove Unused grenade -->
-		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="O21_Bullet_Ion_Energy"]</xpath>
-		</li>
-
 		<li Class="PatchOperationAdd">
 			<xpath>Defs</xpath>
 			<value>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -223,6 +223,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -350,6 +351,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -492,6 +494,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -623,6 +626,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -754,6 +758,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -885,6 +890,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Red Army/RedArmy_Weapons.xml
+++ b/Patches/Red Army/RedArmy_Weapons.xml
@@ -6,10 +6,6 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
-        <!-- Remove Unused grenade -->
-        <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Proj_GrenadeRG" or defName="Weapon_RGFortyTwo"]</xpath>
-        </li>
         <!-- START SovietFlag -->
         <li Class="PatchOperationReplace">
           <xpath>Defs/ThingDef[defName="SovietBanner"]/tools</xpath>

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
@@ -106,6 +106,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>
@@ -206,6 +207,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>6</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_Grenades.xml
@@ -70,6 +70,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>6</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_Explosives.xml
@@ -75,6 +75,7 @@
 				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>	
@@ -91,6 +92,7 @@
 				  <speed>10</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>	
@@ -107,6 +109,7 @@
 				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>	
@@ -122,6 +125,7 @@
 				  <speed>12</speed>
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>	

--- a/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
+++ b/Patches/Rimsenal Collection/Marauder/Marauder_Grenades.xml
@@ -57,6 +57,7 @@
 				<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>8</speed>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</li>

--- a/Patches/Save Our Ship 2/Weapons_Grenades.xml
+++ b/Patches/Save Our Ship 2/Weapons_Grenades.xml
@@ -34,6 +34,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</li>

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -276,6 +276,7 @@
 						<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						<gravityFactor>2</gravityFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -8,11 +8,6 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-        <!-- === Remove the grenade projectile failing CE's grenade patch=== -->
-        <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFEP_Proj_GrenadierGrenade"]</xpath>
-        </li>
-
         <!-- === Remove the added weapon tag from the Charge Lance === -->
         <li Class="PatchOperationRemove">
           <xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"VFEP_Captain")]</xpath>

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
@@ -42,6 +42,7 @@
 					<damageDef>Flame</damageDef>
 					<speed>10</speed>
 					<ai_IsIncendiary>true</ai_IsIncendiary>
+					<gravityFactor>2</gravityFactor>
 				</projectile>
 			</value>
 		</li>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -224,6 +224,7 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 				<speed>10</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
+				<gravityFactor>2</gravityFactor>
 			</projectile>
 		</value>
 	</li>


### PR DESCRIPTION
## Changes

- Reverted the gravity factor patch for base grenade projectile that was being very problematic with vanilla "grenade" projectiles that are unpatched for CE
- Added the factor to vanilla and CE thrown grenades only.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
