### PR TITLE
Add night vision to advanced turrets and guns

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -50,6 +50,7 @@
       <ShotSpread>0.08</ShotSpread>
       <SwayFactor>0.72</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -225,6 +226,7 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.14</SwayFactor>
       <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
+      <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Weapons_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Weapons_Spacer.xml
@@ -204,6 +204,7 @@
             <ShotSpread>0.15</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>
             <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+            <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
           </statBases>
 
           <Properties>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -264,6 +264,7 @@
           <ShotSpread>0.08</ShotSpread>
           <SwayFactor>0.72</SwayFactor>
           <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+          <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
         </statBases>
         <Properties>
           <recoilAmount>1.1</recoilAmount>
@@ -423,6 +424,7 @@
           <SightsEfficiency>1</SightsEfficiency>
           <ShotSpread>0.09</ShotSpread>
           <SwayFactor>0.46</SwayFactor>
+          <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
         </statBases>
         <Properties>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -451,6 +453,7 @@
           <SightsEfficiency>1.2</SightsEfficiency>
           <ShotSpread>0.09</ShotSpread>
           <SwayFactor>0.26</SwayFactor>
+          <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
         </statBases>
         <Properties>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -188,6 +188,7 @@
             <ShotSpread>0.01</ShotSpread>
             <SightsEfficiency>2.20</SightsEfficiency>
             <RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+            <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
           </statBases>
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
@@ -383,6 +383,7 @@
           <ShotSpread>0.04</ShotSpread>
           <SightsEfficiency>2.48</SightsEfficiency>
           <RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
+          <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <Properties>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -417,6 +418,7 @@
           <ShotSpread>0.03</ShotSpread>
           <SightsEfficiency>2.36</SightsEfficiency>
           <RangedWeapon_Cooldown>0.65</RangedWeapon_Cooldown>
+          <NightVisionEfficiency_Weapon>0.3</NightVisionEfficiency_Weapon>
         </statBases>
         <Properties>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -247,6 +247,7 @@
             <ShotSpread>0.05</ShotSpread>
             <SightsEfficiency>2.6</SightsEfficiency>
             <RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+            <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
           </statBases>
           <costList>
             <Steel>75</Steel>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -16,6 +16,7 @@
         <ShotSpread>0.08</ShotSpread>
         <SwayFactor>0.72</SwayFactor>
         <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+        <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
       </statBases>
       <verbs>
         <li Class="CombatExtended.VerbPropertiesCE">
@@ -63,6 +64,7 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.33</SwayFactor>
       <Bulk>13.00</Bulk>
+      <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -72,7 +74,7 @@
 		  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
 		  <warmupTime>1.3</warmupTime>
 		  <range>75</range>
-      <minRange>3</minRange>
+		  <minRange>3</minRange>
 		  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 		  <burstShotCount>20</burstShotCount>
 		  <soundCast>Shot_ChargeBlaster</soundCast>
@@ -110,20 +112,21 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>0.82</SwayFactor>
       <Bulk>20.00</Bulk>
+      <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-      <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
-      <warmupTime>4.3</warmupTime>
-      <range>86</range>
-      <burstShotCount>1</burstShotCount>
-      <soundCast>InfernoCannon_Fire</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
-      <muzzleFlashScale>14</muzzleFlashScale>
-      <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-      <minRange>5</minRange>
+		  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+		  <hasStandardCommand>true</hasStandardCommand>
+		  <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+		  <warmupTime>4.3</warmupTime>
+		  <range>86</range>
+		  <burstShotCount>1</burstShotCount>
+		  <soundCast>InfernoCannon_Fire</soundCast>
+		  <soundCastTail>GunTail_Light</soundCastTail>
+		  <muzzleFlashScale>14</muzzleFlashScale>
+		  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+		  <minRange>5</minRange>
       </li>
     </verbs>	
     <comps>


### PR DESCRIPTION
## Changes

- Added NV capability to mech cluster turrets and other advanced buildable turrets

## Reasoning

- It doesn't make sense for mechanoids themselves to have NV but their turrets not having the capability, added an appropriate amount to them to stay consistent to that reasoning
- Added NV to certain buildable turrets to recreate them having advanced scopes.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
