### PR TITLE
Add BuildCompat.py to automate building compat libraries from .sln

### DIFF
--- a/BuildCompat.py
+++ b/BuildCompat.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+import os
+from twisted.python.filepath import FilePath
+from subprocess import Popen
+import re
+
+PROJECT_PATTERN = re.compile(r'''Project.".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}.". = '''
+                             '''"([0-9a-zA-Z]+Compat)", '''
+                             '''"([0-9A-zA-Z\/]+.csproj)", '''
+                             '''".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}."''')
+
+
+def system(*cmd):
+    sp = Popen(cmd)
+    sp.wait()
+    ec = sp.poll()
+    if ec:
+        raise SystemExit(ec)
+
+with open("Source/CombatExtended.sln") as f:
+    for line in f.readlines():
+        line = line.strip()
+        match = PROJECT_PATTERN.match(line)
+        if match:
+            name, csproj = match.groups()
+            csproj = csproj.replace('\\', '/').split('/')
+            csproj = FilePath("Source").descendant(csproj)
+            print(f"Building {name}")
+            output = FilePath("AssembliesCompat").child(name+".dll")
+            system("python3", "Make.py", "--csproj", csproj.path, "--output", output.path, "--download-libs", "--all-libs", "--publicizer", "./AssemblyPublicizer", "--", "-r:Assemblies/CombatExtended.dll")
+

--- a/BuildCompat.py
+++ b/BuildCompat.py
@@ -5,9 +5,9 @@ from subprocess import Popen
 import re
 
 PROJECT_PATTERN = re.compile(r'''Project.".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}.". = '''
-                             '''"([0-9a-zA-Z]+Compat)", '''
-                             '''"([0-9A-zA-Z\/]+.csproj)", '''
-                             '''".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}."''')
+                             r'''"([0-9a-zA-Z]+Compat)", '''
+                             r'''"([0-9A-zA-Z\/]+.csproj)", '''
+                             r'''".[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}."''')
 
 
 def system(*cmd):


### PR DESCRIPTION

## Changes

Automates building compat libraries

## Reasoning

Why did you choose to implement things this way, e.g.
- When new compat libraries are added, they'll be listed in the CombatExtended.sln, 
- We don't want to have to manually keep the CI and the .sln in sync

## Alternatives

Describe alternative implementations you have considered, e.g.
- Statically set the list, either in the workflow or in another file.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
