### PR TITLE
Readjust Rimsenal's partial armor

### DIFF
--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -61,14 +61,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -108,49 +108,61 @@
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>
 						  <li>
-							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<ArmorRating_Sharp>1.25</ArmorRating_Sharp>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>1.25</ArmorRating_Blunt>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>Hand</li>
 							</parts>
@@ -302,7 +314,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/thingDef[defName="Apparel_SecurityArmor"]</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]</xpath>
 				<value>
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>
@@ -1043,14 +1055,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>27</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>	
 			
@@ -1059,6 +1071,18 @@
 				<value>
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>
+						  <li>
+							<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
 						  <li>
 							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 							<parts>
@@ -1072,49 +1096,49 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Foot</li>
 							</parts>

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -1084,13 +1084,13 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
 							</parts>
@@ -1102,7 +1102,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
 							</parts>

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -261,7 +261,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
@@ -269,7 +269,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -279,13 +279,25 @@
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>
 						  <li>
-							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<ArmorRating_Sharp>1.80</ArmorRating_Sharp>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>2.0</ArmorRating_Blunt>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
 							</parts>
@@ -293,59 +305,47 @@
 						  <li>
 							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
-								<li>Shoulder</li>
+								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
-								<li>Shoulder</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.30</ArmorRating_Sharp>
-							<parts>
 								<li>Arm</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.30</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.40</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.40</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
 							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
 							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
 							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Sharp>0.40</ArmorRating_Sharp>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.40</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
 								<li>Foot</li>
 							</parts>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -204,7 +204,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralMail"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationReplace">
@@ -220,13 +220,19 @@
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>
 						  <li>
+							<ArmorRating_Blunt>1.50</ArmorRating_Blunt>
+							<parts>
+								<li>Torso</li>
+							</parts>
+						  </li>
+						  <li>
 							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
 							</parts>
@@ -238,7 +244,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Shoulder</li>
 							</parts>
@@ -250,7 +256,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.40</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
 							</parts>
@@ -262,7 +268,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.40</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Leg</li>
 							</parts>
@@ -274,7 +280,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.375</ArmorRating_Blunt>
 							<parts>
 								<li>Hand</li>
 							</parts>
@@ -286,7 +292,7 @@
 							</parts>
 						  </li>
 						  <li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 							<parts>
 								<li>Foot</li>
 							</parts>
@@ -410,8 +416,6 @@
 				</value>
 			</li>
 
-			
-			
 		</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- Readjusted certain Rimsenal collection armor pieces' partial armor value

## Reasoning

- Certain base armor values were changed without consideration for the partial armor system being optional and toggleable, readjusted the partial armor values and reverted some base armor values to adjust for that

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
