### PR TITLE
Add toughnessMultiplier to modded woody materials

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
@@ -43,21 +43,21 @@
 					<nomatch Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="GU_RedWood"]</xpath>
 						<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+							<equippedStatOffsets>
+								<MeleeCritChance>0.2</MeleeCritChance>
+								<MeleeParryChance>1</MeleeParryChance>
+								<MeleeDodgeChance>0.13</MeleeDodgeChance>
+							</equippedStatOffsets>
 						</value>
 					</nomatch>
 					<match Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
 						<value>
-				<equippedStatOffsets>
-					<MeleeCritChance>0.2</MeleeCritChance>
-					<MeleeParryChance>1</MeleeParryChance>
-					<MeleeDodgeChance>0.13</MeleeDodgeChance>
-				</equippedStatOffsets>
+							<equippedStatOffsets>
+								<MeleeCritChance>0.2</MeleeCritChance>
+								<MeleeParryChance>1</MeleeParryChance>
+								<MeleeDodgeChance>0.13</MeleeDodgeChance>
+							</equippedStatOffsets>
 						</value>
 					</match>
 				</li>
@@ -68,39 +68,39 @@
 					<nomatch Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 						<value>
-		<statBases>
-			<Bulk>0.07</Bulk>
-			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-			<MarketValue>1.2</MarketValue>
-			<MaxHitPoints>150</MaxHitPoints>
-			<Mass>0.4</Mass>
-			<Flammability>0.6</Flammability>
-			<DeteriorationRate>1</DeteriorationRate>
-			<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-			<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-		</statBases>
+							<statBases>
+								<Bulk>0.07</Bulk>
+								<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+								<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+								<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+								<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+								<MarketValue>1.2</MarketValue>
+								<MaxHitPoints>150</MaxHitPoints>
+								<Mass>0.4</Mass>
+								<Flammability>0.6</Flammability>
+								<DeteriorationRate>1</DeteriorationRate>
+								<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+								<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
+							</statBases>
 						</value>
 					</nomatch>
 					<match Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 						<value>
-		<statBases>
-			<Bulk>0.07</Bulk>
-			<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
-			<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
-			<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
-			<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
-			<MarketValue>1.2</MarketValue>
-			<MaxHitPoints>150</MaxHitPoints>
-			<Mass>0.4</Mass>
-			<Flammability>0.6</Flammability>
-			<DeteriorationRate>1</DeteriorationRate>
-			<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
-			<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
-		</statBases>
+							<statBases>
+								<Bulk>0.07</Bulk>
+								<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
+								<StuffPower_Armor_Sharp>0.1</StuffPower_Armor_Sharp>
+								<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
+								<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
+								<MarketValue>1.2</MarketValue>
+								<MaxHitPoints>150</MaxHitPoints>
+								<Mass>0.4</Mass>
+								<Flammability>0.6</Flammability>
+								<DeteriorationRate>1</DeteriorationRate>
+								<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
+								<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
+							</statBases>
 						</value>
 					</match>
 				</li>
@@ -122,6 +122,14 @@
 					</match>
 				</li>
 
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[defName="GU_RedWood"]</xpath>
+					<value>
+						<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
+							<toughnessMultiplier>5</toughnessMultiplier>
+						</li>
+					</value>
+				</li>
 
 		</operations>
 		</match>

--- a/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -62,6 +62,15 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+			<value>
+				<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
+					<toughnessMultiplier>4</toughnessMultiplier>
+				</li>
+			</value>
+		</li>
+
     	<li Class="PatchOperationFindMod">
         <mods>
           <li>Alpha Animals</li>

--- a/Patches/Rimefeller/Items_Resource_Stuff.xml
+++ b/Patches/Rimefeller/Items_Resource_Stuff.xml
@@ -118,6 +118,15 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAddModExtension">
+					<xpath>/Defs/ThingDef[@Name="SynthyleneBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
+							<toughnessMultiplier>4</toughnessMultiplier>
+						</li>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions

- Added toughnessMultiplier to modded woody materials in preparation for the Toughness stat PR to replicate the same toughness as wood to some extent.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors

