### PR TITLE
Patch Fort's Firefighter gadget 

### DIFF
--- a/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
+++ b/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Fort's Firefighter gadget</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Firefighter Helmet === -->		
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_FirefighterHelmetA" or
+				defName="Apparel_FirefighterHelmetB" or
+				defName="Apparel_FirefighterHelmetC" or
+				defName="Apparel_FirefighterHelmetG"
+				]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_FirefighterHelmetA" or
+				defName="Apparel_FirefighterHelmetB" or
+				defName="Apparel_FirefighterHelmetC" or
+				defName="Apparel_FirefighterHelmetG"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_FirefighterHelmetA" or
+				defName="Apparel_FirefighterHelmetB" or
+				defName="Apparel_FirefighterHelmetC" or
+				defName="Apparel_FirefighterHelmetG"
+				]/statBases</xpath>
+				<value>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_FirefighterHelmetA" or
+				defName="Apparel_FirefighterHelmetB" or
+				defName="Apparel_FirefighterHelmetC" or
+				defName="Apparel_FirefighterHelmetG"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.ApparelHediffExtension">
+						<hediff>WearingGasMask</hediff>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Firefighter Jacket === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_Firefighter_A" or
+				defName="Apparel_Firefighter_B" or
+				defName="Apparel_Firefighter_R"
+				]/statBases</xpath>
+				<value>
+					<Bulk>15</Bulk>
+					<WornBulk>7.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_Firefighter_A" or
+				defName="Apparel_Firefighter_B" or
+				defName="Apparel_Firefighter_R"
+				defName="Apparel_FirefighterHelmetG"
+				]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_Firefighter_A" or
+				defName="Apparel_Firefighter_B" or
+				defName="Apparel_Firefighter_R"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_Firefighter_A" or
+				defName="Apparel_Firefighter_B" or
+				defName="Apparel_Firefighter_R"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
+++ b/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
@@ -46,6 +46,18 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[
+				defName="Apparel_FirefighterHelmetA" or
+				defName="Apparel_FirefighterHelmetB" or
+				defName="Apparel_FirefighterHelmetC" or
+				defName="Apparel_FirefighterHelmetG"
+				]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ThingDef[
 				defName="Apparel_FirefighterHelmetA" or
@@ -54,9 +66,46 @@
 				defName="Apparel_FirefighterHelmetG"
 				]</xpath>
 				<value>
-					<li Class="CombatExtended.ApparelHediffExtension">
-						<hediff>WearingGasMask</hediff>
-					</li>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
+								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
+								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
 				</value>
 			</li>
 

--- a/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
+++ b/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
@@ -42,7 +42,7 @@
 				defName="Apparel_FirefighterHelmetG"
 				]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -78,7 +78,6 @@
 				defName="Apparel_Firefighter_A" or
 				defName="Apparel_Firefighter_B" or
 				defName="Apparel_Firefighter_R"
-				defName="Apparel_FirefighterHelmetG"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
@@ -103,7 +102,7 @@
 				defName="Apparel_Firefighter_R"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
+++ b/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
@@ -332,7 +332,7 @@
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/statBases</xpath>
 			<value>
-				<Bulk>7</Bulk>
+				<Bulk>15</Bulk>
 				<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
 			</value>
 		</li>

--- a/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
+++ b/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
@@ -8,343 +8,343 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-				<!-- Bolt Cutters -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>blade</label>
-								<capacities>
-									<li>Cut</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>1.32</cooldownTime>
-								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
-								<armorPenetrationSharp>5</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>13</power>
-								<cooldownTime>2.81</cooldownTime>
-								<armorPenetrationBlunt>5</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>                             
-						</tools>
-					</value>
-				</li>
+		<!-- Bolt Cutters -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>1.32</cooldownTime>
+						<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>13</power>
+						<cooldownTime>2.81</cooldownTime>
+						<armorPenetrationBlunt>5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>                             
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/statBases</xpath>
-					<value>
-						<Bulk>5.25</Bulk>
-						<MeleeCounterParryBonus>0.34</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/statBases</xpath>
+			<value>
+				<Bulk>5.25</Bulk>
+				<MeleeCounterParryBonus>0.34</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/equippedStatOffsets</xpath>
-					<value>
-							<MeleeCritChance>0.40</MeleeCritChance>
-							<MeleeParryChance>0.16</MeleeParryChance>
-							<MeleeDodgeChance>0.21</MeleeDodgeChance>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.40</MeleeCritChance>
+				<MeleeParryChance>0.16</MeleeParryChance>
+				<MeleeDodgeChance>0.21</MeleeDodgeChance>
+			</value>
+		</li>
 
-				<!-- Crowbar -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>point</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>12</power>
-								<cooldownTime>1.32</cooldownTime>
-								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.02</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>15</power>
-								<cooldownTime>0.63</cooldownTime>
-								<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>                
-							<li Class="CombatExtended.ToolCE">
-								<label>prying</label>
-								<capacities>
-									<li>Demolish</li>
-								</capacities>
-								<power>8</power>
-								<cooldownTime>1.63</cooldownTime>
-								<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>                
-						</tools>
-					</value>
-				</li>
+		<!-- Crowbar -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>1.32</cooldownTime>
+						<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.02</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>0.63</cooldownTime>
+						<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>                
+					<li Class="CombatExtended.ToolCE">
+						<label>prying</label>
+						<capacities>
+							<li>Demolish</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.63</cooldownTime>
+						<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>                
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/statBases</xpath>
-					<value>
-						<Bulk>3.5</Bulk>
-						<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/statBases</xpath>
+			<value>
+				<Bulk>3.5</Bulk>
+				<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]</xpath>
-					<value>
-						<equippedStatOffsets>
-							<MeleeCritChance>0.42</MeleeCritChance>
-							<MeleeParryChance>0.24</MeleeParryChance>
-							<MeleeDodgeChance>0.2</MeleeDodgeChance>
-						</equippedStatOffsets>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.42</MeleeCritChance>
+					<MeleeParryChance>0.24</MeleeParryChance>
+					<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
 
-				<!-- Halligan Bar -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>pick</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>9</power>
-								<cooldownTime>1.68</cooldownTime>
-								<armorPenetrationBlunt>2.34</armorPenetrationBlunt>
-								<armorPenetrationSharp>2.34</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>handle</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>7</power>
-								<cooldownTime>0.63</cooldownTime>
-								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>                
-							<li Class="CombatExtended.ToolCE">
-								<label>prying</label>
-								<capacities>
-									<li>Demolish</li>
-								</capacities>
-								<power>8</power>
-								<cooldownTime>1.43</cooldownTime>
-								<armorPenetrationBlunt>2.625</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>                
-						</tools>
-					</value>
-				</li>
+		<!-- Halligan Bar -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>pick</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>9</power>
+						<cooldownTime>1.68</cooldownTime>
+						<armorPenetrationBlunt>2.34</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.34</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>7</power>
+						<cooldownTime>0.63</cooldownTime>
+						<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>                
+					<li Class="CombatExtended.ToolCE">
+						<label>prying</label>
+						<capacities>
+							<li>Demolish</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.43</cooldownTime>
+						<armorPenetrationBlunt>2.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>                
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/statBases</xpath>
-					<value>
-						<Bulk>5</Bulk>
-						<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/equippedStatOffsets</xpath>
-					<value>
-							<MeleeCritChance>0.22</MeleeCritChance>
-							<MeleeParryChance>0.30</MeleeParryChance>
-							<MeleeDodgeChance>0.30</MeleeDodgeChance>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.22</MeleeCritChance>
+				<MeleeParryChance>0.30</MeleeParryChance>
+				<MeleeDodgeChance>0.30</MeleeDodgeChance>
+			</value>
+		</li>
 
-				<!-- Fire Axe -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>handle</label>
-								<capacities>
-									<li>Poke</li>
-								</capacities>
-								<power>9</power>
-								<cooldownTime>1.3</cooldownTime>
-								<armorPenetrationBlunt>3.263</armorPenetrationBlunt>
-								<chanceFactor>0.15</chanceFactor>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>pick</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>10</power>
-								<cooldownTime>1.96</cooldownTime>
-								<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
-								<armorPenetrationSharp>1.31</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>edge</label>
-								<capacities>
-									<li>Cut</li>
-								</capacities>
-								<power>41</power>
-								<cooldownTime>2.41</cooldownTime>
-								<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
-								<armorPenetrationSharp>1.16</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
-							</li>
-						</tools>
-					</value>
-				</li>
+		<!-- Fire Axe -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>9</power>
+						<cooldownTime>1.3</cooldownTime>
+						<armorPenetrationBlunt>3.263</armorPenetrationBlunt>
+						<chanceFactor>0.15</chanceFactor>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>pick</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>1.96</cooldownTime>
+						<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.31</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>41</power>
+						<cooldownTime>2.41</cooldownTime>
+						<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.16</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases</xpath>
-					<value>
-						<Bulk>4</Bulk>
-						<MeleeCounterParryBonus>0.28</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases</xpath>
+			<value>
+				<Bulk>4</Bulk>
+				<MeleeCounterParryBonus>0.28</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases/Mass</xpath>
-					<value>
-						<Mass>2.9</Mass>						
-					</value>
-				</li>
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases/Mass</xpath>
+			<value>
+				<Mass>2.9</Mass>						
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]</xpath>
-					<value>
-            <equippedStatOffsets>          
-							<MeleeCritChance>0.11</MeleeCritChance>
-							<MeleeParryChance>0.28</MeleeParryChance>
-							<MeleeDodgeChance>0.23</MeleeDodgeChance>
-            </equippedStatOffsets>              
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]</xpath>
+			<value>
+				<equippedStatOffsets>          
+					<MeleeCritChance>0.11</MeleeCritChance>
+					<MeleeParryChance>0.28</MeleeParryChance>
+					<MeleeDodgeChance>0.23</MeleeDodgeChance>
+				</equippedStatOffsets>              
+			</value>
+		</li>
 
-				<!-- Sledgehammer -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>handle</label>
-								<capacities>
-									<li>Poke</li>
-								</capacities>
-								<power>4</power>
-								<cooldownTime>1.87</cooldownTime>
-								<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
-								<chanceFactor>0.15</chanceFactor>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Demolish</li>
-								</capacities>
-								<power>22</power>
-								<cooldownTime>2.43</cooldownTime>
-								<armorPenetrationBlunt>10.8</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>
-						</tools>
-					</value>
-				</li>
+		<!-- Sledgehammer -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.87</cooldownTime>
+						<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+						<chanceFactor>0.15</chanceFactor>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Demolish</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>2.43</cooldownTime>
+						<armorPenetrationBlunt>10.8</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/statBases</xpath>
-					<value>
-						<Bulk>7</Bulk>
-						<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/statBases</xpath>
+			<value>
+				<Bulk>7</Bulk>
+				<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]</xpath>
-					<value>
-            <equippedStatOffsets>
-							<MeleeCritChance>1.2</MeleeCritChance>
-							<MeleeParryChance>0.5</MeleeParryChance>
-							<MeleeDodgeChance>0.3</MeleeDodgeChance>
-            </equippedStatOffsets>              
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>1.2</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
+					<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				</equippedStatOffsets>              
+			</value>
+		</li>
 
-				<!-- Hydraulic Rescue Tool -->			
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>body</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>9</power>
-								<cooldownTime>3.33</cooldownTime>
-								<armorPenetrationBlunt>3.2</armorPenetrationBlunt>
-								<chanceFactor>0.15</chanceFactor>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>12</power>
-								<cooldownTime>2.33</cooldownTime>
-								<armorPenetrationBlunt>3.45</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.23</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-							</li>              
-							<li Class="CombatExtended.ToolCE">
-								<label>cut and spread</label>
-								<capacities>
-									<li>Demolish</li>
-								</capacities>
-								<power>50</power>
-								<cooldownTime>3.63</cooldownTime>
-								<armorPenetrationBlunt>8.8</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-							</li>
-						</tools>
-					</value>
-				</li>
+		<!-- Hydraulic Rescue Tool -->			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>body</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>9</power>
+						<cooldownTime>3.33</cooldownTime>
+						<armorPenetrationBlunt>3.2</armorPenetrationBlunt>
+						<chanceFactor>0.15</chanceFactor>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>2.33</cooldownTime>
+						<armorPenetrationBlunt>3.45</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.23</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>              
+					<li Class="CombatExtended.ToolCE">
+						<label>cut and spread</label>
+						<capacities>
+							<li>Demolish</li>
+						</capacities>
+						<power>50</power>
+						<cooldownTime>3.63</cooldownTime>
+						<armorPenetrationBlunt>8.8</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/statBases</xpath>
-					<value>
-						<Bulk>7</Bulk>
-						<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/statBases</xpath>
+			<value>
+				<Bulk>7</Bulk>
+				<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+			</value>
+		</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/equippedStatOffsets</xpath>
-					<value>
-							<MeleeCritChance>1.2</MeleeCritChance>
-							<MeleeParryChance>0.5</MeleeParryChance>
-							<MeleeDodgeChance>0.3</MeleeDodgeChance>
-					</value>
-				</li>
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/equippedStatOffsets</xpath>
+			<value>
+					<MeleeCritChance>1.2</MeleeCritChance>
+					<MeleeParryChance>0.5</MeleeParryChance>
+					<MeleeDodgeChance>0.3</MeleeDodgeChance>
+			</value>
+		</li>
 
       </operations>
     </match>

--- a/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
+++ b/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Fort's Firefighter gadget</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+				<!-- Bolt Cutters -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>blade</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>1.32</cooldownTime>
+								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+								<armorPenetrationSharp>5</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>13</power>
+								<cooldownTime>2.81</cooldownTime>
+								<armorPenetrationBlunt>5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>                             
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/statBases</xpath>
+					<value>
+						<Bulk>5.25</Bulk>
+						<MeleeCounterParryBonus>0.34</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Boltcutter"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>0.40</MeleeCritChance>
+							<MeleeParryChance>0.16</MeleeParryChance>
+							<MeleeDodgeChance>0.21</MeleeDodgeChance>
+					</value>
+				</li>
+
+				<!-- Crowbar -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>1.32</cooldownTime>
+								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.02</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>15</power>
+								<cooldownTime>0.63</cooldownTime>
+								<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>                
+							<li Class="CombatExtended.ToolCE">
+								<label>prying</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.63</cooldownTime>
+								<armorPenetrationBlunt>5.625</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>                
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]/statBases</xpath>
+					<value>
+						<Bulk>3.5</Bulk>
+						<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Crowbar"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>0.42</MeleeCritChance>
+							<MeleeParryChance>0.24</MeleeParryChance>
+							<MeleeDodgeChance>0.2</MeleeDodgeChance>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- Halligan Bar -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>pick</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>1.68</cooldownTime>
+								<armorPenetrationBlunt>2.34</armorPenetrationBlunt>
+								<armorPenetrationSharp>2.34</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>0.63</cooldownTime>
+								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>                
+							<li Class="CombatExtended.ToolCE">
+								<label>prying</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.43</cooldownTime>
+								<armorPenetrationBlunt>2.625</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>                
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/statBases</xpath>
+					<value>
+						<Bulk>5</Bulk>
+						<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Halligan_Bar"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>0.22</MeleeCritChance>
+							<MeleeParryChance>0.30</MeleeParryChance>
+							<MeleeDodgeChance>0.30</MeleeDodgeChance>
+					</value>
+				</li>
+
+				<!-- Fire Axe -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>1.3</cooldownTime>
+								<armorPenetrationBlunt>3.263</armorPenetrationBlunt>
+								<chanceFactor>0.15</chanceFactor>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>pick</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>10</power>
+								<cooldownTime>1.96</cooldownTime>
+								<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.31</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>edge</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>41</power>
+								<cooldownTime>2.41</cooldownTime>
+								<armorPenetrationBlunt>13.05</armorPenetrationBlunt>
+								<armorPenetrationSharp>1.16</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases</xpath>
+					<value>
+						<Bulk>4</Bulk>
+						<MeleeCounterParryBonus>0.28</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]/statBases/Mass</xpath>
+					<value>
+						<Mass>2.9</Mass>						
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_FireAxe"]</xpath>
+					<value>
+            <equippedStatOffsets>          
+							<MeleeCritChance>0.11</MeleeCritChance>
+							<MeleeParryChance>0.28</MeleeParryChance>
+							<MeleeDodgeChance>0.23</MeleeDodgeChance>
+            </equippedStatOffsets>              
+					</value>
+				</li>
+
+				<!-- Sledgehammer -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.87</cooldownTime>
+								<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+								<chanceFactor>0.15</chanceFactor>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.43</cooldownTime>
+								<armorPenetrationBlunt>10.8</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/statBases</xpath>
+					<value>
+						<Bulk>7</Bulk>
+						<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]</xpath>
+					<value>
+            <equippedStatOffsets>
+							<MeleeCritChance>1.2</MeleeCritChance>
+							<MeleeParryChance>0.5</MeleeParryChance>
+							<MeleeDodgeChance>0.3</MeleeDodgeChance>
+            </equippedStatOffsets>              
+					</value>
+				</li>
+
+				<!-- Hydraulic Rescue Tool -->			
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>body</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>3.33</cooldownTime>
+								<armorPenetrationBlunt>3.2</armorPenetrationBlunt>
+								<chanceFactor>0.15</chanceFactor>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>12</power>
+								<cooldownTime>2.33</cooldownTime>
+								<armorPenetrationBlunt>3.45</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.23</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>              
+							<li Class="CombatExtended.ToolCE">
+								<label>cut and spread</label>
+								<capacities>
+									<li>Demolish</li>
+								</capacities>
+								<power>50</power>
+								<cooldownTime>3.63</cooldownTime>
+								<armorPenetrationBlunt>8.8</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/statBases</xpath>
+					<value>
+						<Bulk>7</Bulk>
+						<MeleeCounterParryBonus>0.38</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/equippedStatOffsets</xpath>
+					<value>
+							<MeleeCritChance>1.2</MeleeCritChance>
+							<MeleeParryChance>0.5</MeleeParryChance>
+							<MeleeDodgeChance>0.3</MeleeDodgeChance>
+					</value>
+				</li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
+++ b/Patches/Fort's Firefighter Gadget/Industrial_Melee.xml
@@ -340,9 +340,9 @@
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="MeleeWeapon_HydraulicRescueTool"]/equippedStatOffsets</xpath>
 			<value>
-					<MeleeCritChance>1.2</MeleeCritChance>
-					<MeleeParryChance>0.5</MeleeParryChance>
-					<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<MeleeCritChance>1.2</MeleeCritChance>
+				<MeleeParryChance>0.5</MeleeParryChance>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
 			</value>
 		</li>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -181,6 +181,7 @@ Forgotten Realms - Lizardfolk	|
 Forgotten Realms - Minotaur	|
 Forsakens	|
 Forsakens Fauna |  
+Fort's Firefighter gadget   |
 Fortifications - Industrial |
 Frontline Collection  |
 FROG Suit Set   |


### PR DESCRIPTION
## Additions
Patches apparel and melee "weapons" from Fort's Firefighter gadget mod.

**Apparel:**
A helmet and bunker jacket (with identical copies in different colors) are based on the actual material thickness (which aren't tremendous) of the real-world equivalents (though real helmets aren't made of metal) plus some additional blunt protection for additional padding both incorporate to protect the wearer from falling debris. Their actual sharp/blunt protective value is unimpressive; the heat protection is the key. I got the thickness info from manufacturers online.

The helmets incorporate a SCBA mask and so protect from smoke. After some consideration, I opted not to have them give the gasmask hediff (and their associated debuffs) since, in real life, these SCBAs have broad visors and supply air, making them considerably easier to breath in than a gas mask. Due to the visor, they also offer less protection over the face.  

**Tools/Weapons:**
The patches for the sledgehammer, crowbar, and fireaxe are copy-pasted from the Simply More Melee patch, with the addition of a `demolish` capability for breaking down doors and walls.

The halligan bar, bolt cutters, and hydraulic rescue tool are new. While the halligan bar has a dangerous-looking (if short) spike on it, all three are generally pretty poor weapons, mainly useful for their demolish capability. The spreader, theoretically, has a nasty point on the end, but realistically they weigh around 20 kg and aren't a useful weapon in a fight (unless you dropped it on someone's head, perhaps?)

## References
Closes #1486 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
