### PR TITLE
More toughness and melee combat tweaks.

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -488,7 +488,7 @@ namespace CombatExtended
             else
             {
                 float parryThingArmor;
-                var dmgAmount = dinfo.Amount * Rand.Range(0.2f, 0.3f);
+                var dmgAmount = dinfo.Amount * 0.5f;
                 // For apparel
                 if (parryThing.def.IsApparel)
                     parryThingArmor = parryThing.GetStatValue(dinfo.Def.armorCategory.armorRatingStat);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -282,7 +282,10 @@ namespace CombatExtended
             if (EquipmentSource != null)
             {
                 //melee weapon damage variation
-                damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
+                if (isCrit)
+                    damAmount *= StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn);
+                else
+                    damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
             }
             else if (!CE_StatDefOf.UnarmedDamage.Worker.IsDisabledFor(CasterPawn))  //ancient soldiers can punch even if non-violent, this prevents the disabled stat from being used
             {

--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -19,7 +19,7 @@ namespace CombatExtended.Compatibility
                 if (!def.statBases.Any(x => x.stat == CE_StatDefOf.StuffEffectMultiplierToughness || x.stat == CE_StatDefOf.ToughnessRating))
                 {
                     // Approximate weapon thickness via the bulk of the weapon. Longswords get 2mm, knives get 1mm, spears get about 2.2mm
-                    float weaponThickness = Mathf.Pow(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f, 1f / 3f);
+                    float weaponThickness = Mathf.Sqrt(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f);
 
                     // Tech level improves toughness
                     switch (def.techLevel)


### PR DESCRIPTION
## Additions

- Landing a critical hit forces the damage variation to return the max damage. Does not affect ripostes.

## Changes

- Reintroduced the flat multiplier to parry damage;
- Autopatcher returns thicker weapons.

## Reasoning

- A critical is a critical - a vital, debilitating blow. It would not make sense for the damage to be anything but the max possible on such a hit;
- Melee damage variation exists, so a flat value is I believe better. The value is higher to compensate for weapon toughness;
- Aids in reducing chip damage.

## Testing

- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
