### PR TITLE
Reintroduced flat parry damage multiplier, edited toughness autopatcher results

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -488,7 +488,7 @@ namespace CombatExtended
             else
             {
                 float parryThingArmor;
-                var dmgAmount = dinfo.Amount * Rand.Range(0.2f, 0.3f);
+                var dmgAmount = dinfo.Amount * 0.5f;
                 // For apparel
                 if (parryThing.def.IsApparel)
                     parryThingArmor = parryThing.GetStatValue(dinfo.Def.armorCategory.armorRatingStat);

--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -18,8 +18,8 @@ namespace CombatExtended.Compatibility
             {
                 if (!def.statBases.Any(x => x.stat == CE_StatDefOf.StuffEffectMultiplierToughness || x.stat == CE_StatDefOf.ToughnessRating))
                 {
-                    // Approximate weapon thickness via the bulk of the weapon. Longswords get 2mm, knives get 1mm, spears get about 2.2mm
-                    float weaponThickness = Mathf.Pow(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f, 1f / 3f);
+                    // Approximate weapon thickness via the bulk of the weapon. Longswords get about 2.83mm, knives get 1mm, spears get about 3.162mm
+                    float weaponThickness = Mathf.Sqrt(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f);
 
                     // Tech level improves toughness
                     switch (def.techLevel)
@@ -36,7 +36,7 @@ namespace CombatExtended.Compatibility
                             break;
                     }
 
-                    // Blunt weapons get double thickness because edges are easier to damage. Note that ranged weapons are excluded.
+                    // Blunt weapons get double thickness because edges are easier to damage. Note that ranged weapons are excluded
                     if (!def.IsRangedWeapon && (!def.tools?.Any(tool => tool.capacities?.Any(capacityDef => DefDatabase<DamageDef>.defsList.Any(damageDef => damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp && capacityDef.defName == damageDef.defName)) ?? false) ?? false))
                         weaponThickness *= 2f;
 


### PR DESCRIPTION
## Changes

- Reintroduced the flat multiplier to parry damage;
- Autopatcher calculates bigger base weapon thickness.

## Reasoning

- Melee damage variation exists, so a flat value is I believe better. The value is higher to compensate for weapon toughness;
- Aids in reducing chip damage;
- All in all, it should better reward larger penetrating attacks than chip damage.

## Alternatives

- Keeping the current random values:
  - Attacks that have more AP than the weapon has toughness rarely deal more damage;
  - Melee damage (both armed and unarmed) is already varied based on the attacker's skill.
- Remove the parry damage multiplier:
  - Weapons and shields are quite fragile;
  - There was a flat multiplier of 0.1 before the toughness changes.
- Keeping the current way of getting the base weapon thickness:
  - Extremely likely chip damage;
  - 140 squirrels against a normal steel spear armed level 20 skill pawn were able to reduce the weapon's health to 40%. If it were done with the proposed changes, the final health value would've been at around 60%.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [x] Playtested a colony (specify how long).
