### PR TITLE
Force max damage on a critical hit

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -150,7 +150,7 @@
   <StatDef>
     <defName>MeleeCritChance</defName>
     <label>melee critical chance</label>
-    <description>Base chance to land a critical hit with a melee attack. Critical hits from sharp attacks get double penetration, while critical hits from blunt attacks stun the target.\nThe final chance depends on the opponent's critical skill and equal opponents will always have a 10% chance to crit. The internal formula is:\n\nFinalCritChance = ClampBetweenZeroAndOne(0.1 + AttackerCritChance - DefenderCritChance)*100%</description>
+    <description>Base chance to land a critical hit with a melee attack. Critical hits force max damage from the damage variation. On a critical hit, sharp attacks get double penetration, while blunt attacks stun the target.\nThe final chance depends on the opponent's critical skill and equal opponents will always have a 10% chance to crit. The internal formula is:\n\nFinalCritChance = ClampBetweenZeroAndOne(0.1 + AttackerCritChance - DefenderCritChance)*100%</description>
     <category>PawnCombat</category>
     <displayPriorityInCategory>99</displayPriorityInCategory>
     <defaultBaseValue>1</defaultBaseValue>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -281,8 +281,12 @@ namespace CombatExtended
 
             if (EquipmentSource != null)
             {
+				//crits force a max damage variation roll
+                if (isCrit)
+                    damAmount *= StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn);
                 //melee weapon damage variation
-                damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
+                else
+                    damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
             }
             else if (!CE_StatDefOf.UnarmedDamage.Worker.IsDisabledFor(CasterPawn))  //ancient soldiers can punch even if non-violent, this prevents the disabled stat from being used
             {


### PR DESCRIPTION
## Additions

- Landing a critical hit forces the damage variation to return the max damage. Does not affect ripostes.

## Reasoning

- A critical is a critical - a debilitating, often fatal blow. It would not make sense for the damage to be anything but the max possible on such a hit.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony (specify how long).
