### PR TITLE
Warcasket material costs adjustments

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
@@ -120,6 +120,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Warcasket"]/costList/Steel</xpath>
+			<value>
+				<Steel>160</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Warcasket"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>4</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Basic Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Warcasket"]/statBases</xpath>
@@ -140,6 +155,14 @@
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Warcasket"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>45</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Warcasket"]/costList/Steel</xpath>
+			<value>
+				<Steel>80</Steel>
 			</value>
 		</li>
 
@@ -172,6 +195,21 @@
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>36</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/costList/Steel</xpath>
+			<value>
+				<Steel>80</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>2</ComponentIndustrial>
 			</value>
 		</li>
 
@@ -208,6 +246,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Marine"]/costList/Steel</xpath>
+			<value>
+				<Steel>260</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Marine"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>8</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Marine Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Marine"]/statBases</xpath>
@@ -231,37 +284,60 @@
 			</value>
 		</li>
 
-		  <!-- === Marine Warcasket Helmet === -->
-		  <li Class="PatchOperationAdd">
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Marine"]/costList/Steel</xpath>
+			<value>
+				<Steel>110</Steel>
+			</value>
+		</li>
+
+		<!-- === Marine Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/statBases</xpath>
 			<value>
 			  <Bulk>10</Bulk>
 			  <WornBulk>5</WornBulk>
 			  <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/equippedStatOffsets</xpath>
 			<value>
 			  <SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
-		  </li>
-  
-		  <!-- Armor values scaled by vanilla stat ratios compared to basic warcasket helmet [e.g (1.20/1.06)*16 = ~18 ]. -->
-		  <li Class="PatchOperationReplace">
+		</li>
+
+		<!-- Armor values scaled by vanilla stat ratios compared to basic warcasket helmet [e.g (1.20/1.06)*16 = ~18 ]. -->
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-			  <ArmorRating_Sharp>20</ArmorRating_Sharp>
+				<ArmorRating_Sharp>20</ArmorRating_Sharp>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-			  <ArmorRating_Blunt>45</ArmorRating_Blunt>
+				<ArmorRating_Blunt>45</ArmorRating_Blunt>
 			</value>
-		  </li>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/costList/Steel</xpath>
+			<value>
+				<Steel>130</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>2</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Recon Warcasket ========== -->
 		<li Class="PatchOperationAdd">
@@ -295,6 +371,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Recon"]/costList/Steel</xpath>
+			<value>
+				<Steel>160</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Recon"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Recon Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Recon"]/statBases</xpath>
@@ -318,36 +409,59 @@
 			</value>
 		</li>
 
-		  <!-- === Recon Warcasket Helmet === -->
-		  <li Class="PatchOperationAdd">
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Recon"]/costList/Steel</xpath>
+			<value>
+				<Steel>80</Steel>
+			</value>
+		</li>
+
+		<!-- === Recon Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/statBases</xpath>
 			<value>
-			  <Bulk>8</Bulk>
-			  <WornBulk>4</WornBulk>
-			  <NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
+				<Bulk>8</Bulk>
+				<WornBulk>4</WornBulk>
+				<NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/equippedStatOffsets</xpath>
 			<value>
-			  <SmokeSensitivity>-1</SmokeSensitivity>
+				<SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-			  <ArmorRating_Sharp>16.5</ArmorRating_Sharp>
+				<ArmorRating_Sharp>16.5</ArmorRating_Sharp>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-			  <ArmorRating_Blunt>37</ArmorRating_Blunt>
+				<ArmorRating_Blunt>37</ArmorRating_Blunt>
 			</value>
-		  </li>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/costList/Steel</xpath>
+			<value>
+				<Steel>80</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>2</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Cataphract Warcasket ========== -->
 		<li Class="PatchOperationAdd">
@@ -381,6 +495,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Cataphract"]/costList/Steel</xpath>
+			<value>
+				<Steel>350</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Cataphract"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>10</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Cataphract Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Cataphract"]/statBases</xpath>
@@ -404,36 +533,59 @@
 			</value>
 		</li>
 
-		  <!-- === Cataphract Warcasket Helmet === -->
-		  <li Class="PatchOperationAdd">
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Cataphract"]/costList/Steel</xpath>
+			<value>
+				<Steel>150</Steel>
+			</value>
+		</li>
+
+		<!-- === Cataphract Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/statBases</xpath>
 			<value>
-			  <Bulk>15</Bulk>
-			  <WornBulk>8</WornBulk>
-			  <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+				<Bulk>15</Bulk>
+				<WornBulk>8</WornBulk>
+				<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/equippedStatOffsets</xpath>
 			<value>
-			  <SmokeSensitivity>-1</SmokeSensitivity>
+				<SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-			  <ArmorRating_Sharp>28</ArmorRating_Sharp>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-			  <ArmorRating_Blunt>63</ArmorRating_Blunt>
+				<ArmorRating_Blunt>63</ArmorRating_Blunt>
 			</value>
-		  </li>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/costList/Steel</xpath>
+			<value>
+				<Steel>150</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>4</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Aerial Warcasket ========== -->
 		<li Class="PatchOperationAdd">
@@ -467,6 +619,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Aerial"]/costList/Steel</xpath>
+			<value>
+				<Steel>290</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Aerial"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>16</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Aerial Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Aerial"]/statBases</xpath>
@@ -490,36 +657,59 @@
 			</value>
 		</li>
 
-		  <!-- === Aerial Warcasket Helmet === -->
-		  <li Class="PatchOperationAdd">
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Aerial"]/costList/Steel</xpath>
+			<value>
+				<Steel>40</Steel>
+			</value>
+		</li>
+
+		<!-- === Aerial Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/statBases</xpath>
 			<value>
-			  <Bulk>15</Bulk>
-			  <WornBulk>8</WornBulk>
-			  <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+				<Bulk>15</Bulk>
+				<WornBulk>8</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/equippedStatOffsets</xpath>
 			<value>
-			  <SmokeSensitivity>-1</SmokeSensitivity>
+				<SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-			  <ArmorRating_Sharp>25</ArmorRating_Sharp>
+				<ArmorRating_Sharp>25</ArmorRating_Sharp>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-			  <ArmorRating_Blunt>56</ArmorRating_Blunt>
+				<ArmorRating_Blunt>56</ArmorRating_Blunt>
 			</value>
-		  </li>  
+		</li>  
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/costList/Steel</xpath>
+			<value>
+				<Steel>90</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Barrage Warcasket ========== -->
 		<li Class="PatchOperationAdd">
@@ -550,6 +740,21 @@
 				<CarryWeight>250</CarryWeight>
 				<CarryBulk>225</CarryBulk>
 				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barrage"]/costList/Steel</xpath>
+			<value>
+				<Steel>480</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barrage"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>16</ComponentIndustrial>
 			</value>
 		</li>
 
@@ -625,37 +830,59 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barrage"]/costList/Steel</xpath>
+			<value>
+				<Steel>150</Steel>
+			</value>
+		</li>
+
 		<!-- === Barrage Warcasket Helmet === -->
 		<li Class="PatchOperationAdd">
-		  <xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases</xpath>
-		  <value>
-		    <Bulk>20</Bulk>
-		    <WornBulk>10</WornBulk>
-		    <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
-		  </value>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-		  <xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/equippedStatOffsets</xpath>
-		  <value>
-		    <SmokeSensitivity>-1</SmokeSensitivity>
-		  </value>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		  <xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases/ArmorRating_Sharp</xpath>
-		  <value>
-		    <ArmorRating_Sharp>32</ArmorRating_Sharp>
-		  </value>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		  <xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases/ArmorRating_Blunt</xpath>
-		  <value>
-		    <ArmorRating_Blunt>72</ArmorRating_Blunt>
-		  </value>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>72</ArmorRating_Blunt>
+			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/costList/Steel</xpath>
+			<value>
+				<Steel>90</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Hazard Warcasket ========== -->
 		<li Class="PatchOperationAdd">
@@ -690,7 +917,20 @@
 			</value>
 		</li>
 
-		
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Hazard"]/costList/Steel</xpath>
+			<value>
+				<Steel>270</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Hazard"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>8</ComponentIndustrial>
+			</value>
+		</li>
 
 		<!-- ========== Hazard Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
@@ -713,6 +953,14 @@
 			<value>
 				<ArmorRating_Blunt>50</ArmorRating_Blunt>
 				<ArmorRating_Electric>1</ArmorRating_Electric>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Hazard"]/costList/Steel</xpath>
+			<value>
+				<Steel>110</Steel>
 			</value>
 		</li>
 
@@ -748,6 +996,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Hazard"]/costList/Steel</xpath>
+			<value>
+				<Steel>70</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Hazard"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Shock Warcasket ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Shock"]/statBases</xpath>
@@ -780,6 +1043,21 @@
 			</value>
 		</li>
 
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Shock"]/costList/Steel</xpath>
+			<value>
+				<Steel>240</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Shock"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>20</ComponentIndustrial>
+			</value>
+		</li>
+
 		<!-- ========== Shock Warcasket - Shoulders ========== -->
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Shock"]/statBases</xpath>
@@ -802,37 +1080,60 @@
 				<ArmorRating_Blunt>70</ArmorRating_Blunt>
 			</value>
 		</li>
-		
-		  <!-- === Shock Warcasket Helmet === -->
-		  <li Class="PatchOperationAdd">
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Shock"]/costList/Steel</xpath>
+			<value>
+				<Steel>120</Steel>
+			</value>
+		</li>
+
+		<!-- === Shock Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/statBases</xpath>
 			<value>
-			  <Bulk>15</Bulk>
-			  <WornBulk>8</WornBulk>
-			  <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+				<Bulk>15</Bulk>
+				<WornBulk>8</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/equippedStatOffsets</xpath>
 			<value>
-			  <SmokeSensitivity>-1</SmokeSensitivity>
+				<SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-			  <ArmorRating_Sharp>25</ArmorRating_Sharp>
+				<ArmorRating_Sharp>25</ArmorRating_Sharp>
 			</value>
-		  </li>
+		</li>
   
-		  <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-			  <ArmorRating_Blunt>56</ArmorRating_Blunt>
+				<ArmorRating_Blunt>56</ArmorRating_Blunt>
 			</value>
-		  </li>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/costList/Steel</xpath>
+			<value>
+				<Steel>80</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>8</ComponentIndustrial>
+			</value>
+		</li>
 
 		</operations>
 		</match>


### PR DESCRIPTION
## Changes

- Patched the Warcasket armors' steel and component cost to be 2x of the vanilla value

## Reasoning

- Warcaskets same as vanilla Power Armors are cheap and their material costs have remained untouched making them too accessible and powerful for the cost. The PR aims to balance things out by doubling their steel and component cost to bring them more in line with how Power Armors are patched to be more expensive while not introduce other materials into their recipe because Spacer Warcaskets are coming in the near future which require steel instead of plasteel to craft.

- Also on another note since Warcasket armor pieces lack market value, the material increase will not affect how the armor pieces are spawned on pawns so there will be no need for further PawnKind Apparel budget patching. In-game testing suggests as such too.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
