### PR TITLE
4.6 Finalized Fixes & Adjustments

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -7,7 +7,7 @@
 		<li>1.3</li>
 	</supportedVersions>
 	<packageId>CETeam.CombatExtended</packageId>
-	<description>Version: 1.3.4.5\n\nExtends combat mechanics to make them deeper and more tactical.</description>
+	<description>Version: 1.3.4.6\n\nExtends combat mechanics to make them deeper and more tactical.</description>
 	<modDependencies>
 		<li>
 			<packageId>brrainz.harmony</packageId>

--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
   <identifier>CombatExtended</identifier>
-  <version>1.3.4.5</version>
+  <version>1.3.4.6</version>
   <dependencies>
     <li>2009463077</li> <!-- Harmony -->
   </dependencies>

--- a/About/ModSync.xml
+++ b/About/ModSync.xml
@@ -2,7 +2,7 @@
 <ModSyncNinjaData>
   <ID>32418f60-269c-4a70-ae6e-a51d7a34cb2f</ID>
   <ModName>Combat Extended</ModName>
-  <Version>1.3.4.5</Version>
+  <Version>1.3.4.6</Version>
   <SaveBreaking>False</SaveBreaking>
   <Host name="Github">
     <Owner>CombatExtended-Continued</Owner>

--- a/Patches/Alpha Animals/BodyDefs/AlphaAnimals_CE_Patch_Bodies.xml
+++ b/Patches/Alpha Animals/BodyDefs/AlphaAnimals_CE_Patch_Bodies.xml
@@ -303,24 +303,6 @@
 					</match>
 					</li>
 
-					<li Class="PatchOperationConditional">
-					<xpath>/Defs/BodyDef[defName="AA_Arachnid"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
-					<nomatch Class="PatchOperationAdd">
-							<xpath>/Defs/BodyDef[defName="AA_Arachnid"]/corePart/parts/li[def="InsectLeg"]</xpath>
-							<value>
-								<groups>
-									<li>CoveredByNaturalArmor</li>
-								</groups>
-							</value>
-					</nomatch>
-					<match Class="PatchOperationAdd">
-						<xpath>/Defs/BodyDef[defName="AA_Arachnid"]/corePart/parts/li[def="InsectLeg"]/groups</xpath>
-						<value>
-							<li>CoveredByNaturalArmor</li>
-						</value>
-					</match>
-					</li>
-
 			<!-- ====== AA_ArmouredSlug ====== -->
 
 					<li Class="PatchOperationConditional">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.4</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -34,14 +34,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>2.55</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -118,7 +118,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/MoveSpeed</xpath>
 				<value>
-					<MoveSpeed>4.8</MoveSpeed>
+					<MoveSpeed>4.7</MoveSpeed>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>0.20</MeleeCritChance>
 					<MeleeParryChance>0.28</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
@@ -18,14 +18,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+						<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>1</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Frostling"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -31,7 +31,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/race/baseHealthScale</xpath>
 				<value>
-					<baseHealthScale>30</baseHealthScale>
+					<baseHealthScale>20</baseHealthScale>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
@@ -27,7 +27,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Groundrunner"]/statBases</xpath>
 				<value>
-					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
 					<MeleeParryChance>0.25</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/statBases</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.14</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
 					<MeleeParryChance>0.11</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
@@ -34,7 +34,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/PawnKindDef[defName="AA_MegaLouse"]/combatPower</xpath>
 				<value>
-					<combatPower>75</combatPower>
+					<combatPower>50</combatPower>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
@@ -31,7 +31,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_GallatrossMoribund"]/race/baseHealthScale</xpath>
 				<value>
-					<baseHealthScale>30</baseHealthScale>
+					<baseHealthScale>20</baseHealthScale>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/statBases</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
 					<MeleeParryChance>0.2</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/statBases</xpath>
 				<value>
-					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
 					<MeleeParryChance>0</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularNightling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularNightling.xml
@@ -24,7 +24,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_OcularNightling"]/statBases/MoveSpeed</xpath>
 				<value>
-					<MoveSpeed>6.0</MoveSpeed>
+					<MoveSpeed>6.8</MoveSpeed>
 					<NightVisionEfficiency>0.8</NightVisionEfficiency>
 					<AimingAccuracy>0.8</AimingAccuracy>
 					<MeleeDodgeChance>0.37</MeleeDodgeChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
 					<MeleeCritChance>0.34</MeleeCritChance>
 					<MeleeParryChance>0.4</MeleeParryChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
@@ -20,14 +20,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
@@ -29,14 +29,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.85</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>3.4</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.6</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.3</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>15</ArmorRating_Blunt>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Sharp>9</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
@@ -26,7 +26,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
@@ -19,14 +19,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+						<ArmorRating_Blunt>2.8</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
@@ -35,13 +35,13 @@
 					<li Class="PatchOperationReplace">
 						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Blunt</xpath>
 						<value>
-							<ArmorRating_Blunt>12</ArmorRating_Blunt>
+							<ArmorRating_Blunt>9.85</ArmorRating_Blunt>
 						</value>
 					</li>
 					<li Class="PatchOperationReplace">
 						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Sharp</xpath>
 						<value>
-							<ArmorRating_Sharp>6</ArmorRating_Sharp>
+							<ArmorRating_Sharp>4.25</ArmorRating_Sharp>
 						</value>
 					</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>50</ArmorRating_Blunt>
+					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>25</ArmorRating_Sharp>
+					<ArmorRating_Sharp>23</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
@@ -19,14 +19,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>4</ArmorRating_Blunt>
+						<ArmorRating_Blunt>2.8</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 					</value>
 				</li>
 

--- a/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
@@ -64,7 +64,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>40</DevilstrandCloth>
+						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -79,7 +79,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmor"]/costList</xpath>
 					<value>
-						<DevilstrandCloth>50</DevilstrandCloth>
+						<DevilstrandCloth>40</DevilstrandCloth>
 					</value>
 				</li>
 
@@ -148,7 +148,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>15</DevilstrandCloth>
+						<DevilstrandCloth>10</DevilstrandCloth>
 						<Plasteel>50</Plasteel>
 					</value>
 				</li>
@@ -163,7 +163,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>20</DevilstrandCloth>
+						<DevilstrandCloth>15</DevilstrandCloth>
 						<Plasteel>60</Plasteel>
 					</value>
 				</li>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -474,36 +474,6 @@
 		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/equippedStatOffsets</xpath>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]/apparel/bodyPartGroups</xpath>
-		<value>
-			<li>Feet</li>
-		</value>
-	</Operation>
-
-	<!-- Partial armor for boots -->
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Apparel_FlakPants"]</xpath>
-		<value>
-		  <li Class="CombatExtended.PartialArmorExt">
-			  <stats>
-				  <li>
-					<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-					<parts>
-						<li>Foot</li>
-					</parts>
-				  </li>
-				  <li>
-					<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-					<parts>
-						<li>Foot</li>
-					</parts>
-				  </li>
-			  </stats>
-		  </li>
-		</value>
-	</Operation>
-
 	<!-- ========== Power armor ========== -->
 
 	<Operation Class="PatchOperationAdd">

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Insect.xml
@@ -55,14 +55,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megascarab"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Megascarab"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
@@ -85,7 +85,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Spelopede"]/statBases/MoveSpeed</xpath>
 		<value>
-			<MoveSpeed>4.6</MoveSpeed>
+			<MoveSpeed>4.5</MoveSpeed>
 			<MeleeDodgeChance>0.08</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BasiliskCE.xml
@@ -46,7 +46,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="WMH_Basilisk"]/statBases</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_BearofleetCE.xml
@@ -32,14 +32,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Bearofleet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
@@ -32,21 +32,21 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/MoveSpeed</xpath>
 				<value>
-					<MoveSpeed>4</MoveSpeed>
+					<MoveSpeed>3.65</MoveSpeed>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Cyclops"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.25</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_EkimmaraCE.xml
@@ -32,14 +32,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>3.75</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Ekimmara"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FlederCE.xml
@@ -37,14 +37,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Fleder"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_FoglerCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_FoglerCE.xml
@@ -28,14 +28,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>4</ArmorRating_Blunt>
+					<ArmorRating_Blunt>2.4</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Fogler"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_GolemCE.xml
@@ -32,21 +32,21 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>36</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Golem"]/statBases/MoveSpeed</xpath>
 				<value>
-					<MoveSpeed>3</MoveSpeed>
+					<MoveSpeed>2.85</MoveSpeed>
 				</value>
 			</li>
 

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_WerewolfCE.xml
@@ -36,14 +36,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Werewolf"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>2</ArmorRating_Blunt>
+					<ArmorRating_Blunt>1.45</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="WMH_Werewolf"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Animals Expanded/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Caves_Animals.xml
@@ -52,14 +52,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>2</ArmorRating_Blunt>
+        <ArmorRating_Blunt>1.65</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+        <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
       </value>
     </li>
 
@@ -478,14 +478,14 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Blunt</xpath>
       <value>
-        <ArmorRating_Blunt>20</ArmorRating_Blunt>
+        <ArmorRating_Blunt>14</ArmorRating_Blunt>
       </value>
     </li>
     
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Sharp</xpath>
       <value>
-        <ArmorRating_Sharp>10</ArmorRating_Sharp>
+        <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
@@ -23,14 +23,14 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>15</ArmorRating_Blunt>
+            <ArmorRating_Blunt>22</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>6</ArmorRating_Sharp>
+            <ArmorRating_Sharp>10</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -77,31 +77,31 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
           <value>
-            <MoveSpeed>4.2</MoveSpeed>
+            <MoveSpeed>4.4</MoveSpeed>
             <MeleeDodgeChance>0.06</MeleeDodgeChance>
             <MeleeCritChance>0.33</MeleeCritChance>
-            <MeleeParryChance>0.27</MeleeParryChance>
+            <MeleeParryChance>0.23</MeleeParryChance>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>20</ArmorRating_Blunt>
+            <ArmorRating_Blunt>14</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+            <ArmorRating_Sharp>6</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/race/baseHealthScale</xpath>
           <value>
-            <baseHealthScale>2.4</baseHealthScale>
+            <baseHealthScale>2.5</baseHealthScale>
           </value>
         </li>
 
@@ -148,7 +148,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/MoveSpeed</xpath>
           <value>
-            <MoveSpeed>2.8</MoveSpeed>
+            <MoveSpeed>3.3</MoveSpeed>
             <MeleeDodgeChance>0.03</MeleeDodgeChance>
             <MeleeCritChance>0.36</MeleeCritChance>
             <MeleeParryChance>0.38</MeleeParryChance>
@@ -158,14 +158,14 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>28</ArmorRating_Blunt>
+            <ArmorRating_Blunt>15</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>12</ArmorRating_Sharp>
+            <ArmorRating_Sharp>6</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -251,7 +251,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/MoveSpeed</xpath>
           <value>
-            <MoveSpeed>4.8</MoveSpeed>
+            <MoveSpeed>5.2</MoveSpeed>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
             <MeleeCritChance>0.41</MeleeCritChance>
             <MeleeParryChance>0.19</MeleeParryChance>
@@ -261,7 +261,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>27</ArmorRating_Blunt>
+            <ArmorRating_Blunt>28</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -329,7 +329,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/statBases/MoveSpeed</xpath>
           <value>
-            <MoveSpeed>1.8</MoveSpeed>
+            <MoveSpeed>1.5</MoveSpeed>
             <MeleeDodgeChance>0.06</MeleeDodgeChance>
             <MeleeCritChance>0.02</MeleeCritChance>
             <MeleeParryChance>0.04</MeleeParryChance>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>2</ArmorRating_Blunt>
+            <ArmorRating_Blunt>0.65</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>1</ArmorRating_Sharp>
+            <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
@@ -12,7 +12,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/MoveSpeed</xpath>
 
           <value>
-            <MoveSpeed>4.8</MoveSpeed>
+            <MoveSpeed>5.2</MoveSpeed>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
             <MeleeCritChance>0.68</MeleeCritChance>
             <MeleeParryChance>0.39</MeleeParryChance>
@@ -24,7 +24,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>15</ArmorRating_Blunt>
+            <ArmorRating_Blunt>16</ArmorRating_Blunt>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>8</ArmorRating_Blunt>
+            <ArmorRating_Blunt>4.65</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>4</ArmorRating_Sharp>
+            <ArmorRating_Sharp>2.25</ArmorRating_Sharp>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
@@ -10,7 +10,6 @@
       <operations>
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/MoveSpeed</xpath>
-
           <value>
             <MoveSpeed>1.15</MoveSpeed>
             <MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -21,23 +20,20 @@
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Blunt</xpath>
-
           <value>
-            <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+            <ArmorRating_Blunt>0.3</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Sharp</xpath>
-
           <value>
-            <ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+            <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/tools</xpath>
-
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
@@ -12,7 +12,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/MoveSpeed</xpath>
 
           <value>
-            <MoveSpeed>3.1</MoveSpeed>
+            <MoveSpeed>2.85</MoveSpeed>
             <MeleeDodgeChance>0.04</MeleeDodgeChance>
             <MeleeCritChance>0.37</MeleeCritChance>
             <MeleeParryChance>0.41</MeleeParryChance>
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>16</ArmorRating_Blunt>
+            <ArmorRating_Blunt>26</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>8</ArmorRating_Sharp>
+            <ArmorRating_Sharp>10</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -39,7 +39,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/race/baseHealthScale</xpath>
 
           <value>
-            <baseHealthScale>2.7</baseHealthScale>
+            <baseHealthScale>2.75</baseHealthScale>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
@@ -12,9 +12,9 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/MoveSpeed</xpath>
 
           <value>
-            <MoveSpeed>4.8</MoveSpeed>
+            <MoveSpeed>5.2</MoveSpeed>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
-            <MeleeCritChance>0.39</MeleeCritChance>
+            <MeleeCritChance>0.38</MeleeCritChance>
             <MeleeParryChance>0.19</MeleeParryChance>
           </value>
         </li>
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>24</ArmorRating_Blunt>
+            <ArmorRating_Blunt>22</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>10</ArmorRating_Sharp>
+            <ArmorRating_Sharp>9</ArmorRating_Sharp>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>26</ArmorRating_Blunt>
+            <ArmorRating_Blunt>14</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>11</ArmorRating_Sharp>
+            <ArmorRating_Sharp>4.65</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -47,7 +47,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/race/baseHealthScale</xpath>
 
           <value>
-            <baseHealthScale>3.5</baseHealthScale>
+            <baseHealthScale>3.45</baseHealthScale>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>3</ArmorRating_Blunt>
+            <ArmorRating_Blunt>2.25</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>1</ArmorRating_Sharp>
+            <ArmorRating_Sharp>0.7</ArmorRating_Sharp>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
@@ -12,7 +12,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/MoveSpeed</xpath>
 
           <value>
-            <MoveSpeed>4.6</MoveSpeed>
+            <MoveSpeed>4.5</MoveSpeed>
             <MeleeDodgeChance>0.11</MeleeDodgeChance>
             <MeleeCritChance>0.17</MeleeCritChance>
             <MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
@@ -23,7 +23,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
-            <ArmorRating_Blunt>12</ArmorRating_Blunt>
+            <ArmorRating_Blunt>10.8</ArmorRating_Blunt>
           </value>
         </li>
 
@@ -31,7 +31,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>5</ArmorRating_Sharp>
+            <ArmorRating_Sharp>3.65</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -39,7 +39,7 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/race/baseHealthScale</xpath>
           
           <value>
-            <baseHealthScale>2.5</baseHealthScale>
+            <baseHealthScale>2</baseHealthScale>
           </value>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
@@ -31,7 +31,15 @@
           <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
-            <ArmorRating_Sharp>3</ArmorRating_Sharp>
+            <ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/race/baseHealthScale</xpath>
+          
+          <value>
+            <baseHealthScale>1.3</baseHealthScale>
           </value>
         </li>
 

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -221,7 +221,7 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Apparel_ArmorMarineHelmetPrestige"]/statBases</xpath>
     <value>
-      <NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+      <NightVisionEfficiency_Apparel>0.70</NightVisionEfficiency_Apparel>
     </value>
   </Operation>
 	

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -235,7 +235,7 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]/statBases</xpath>
     <value>
-      <NightVisionEfficiency_Apparel>0.85</NightVisionEfficiency_Apparel>
+      <NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes
- Increment mod version number to 4.6.
- Revert prestige cataphract NV to 0.75. At 0.8, prestige recon helmet trades protection for the best night vision of any base RW helmet. Cataphract offers far more protection and still has superb night vision, but it should be as good/better than recon's.
- Removed flak pant's coverage of feet. The apparel is a rather simple pair of pants with plates sewn into them, as opposed to a more all-encompassing jumpsuit or similar, and it doesn't have this coverage in vanilla.
- Slightly reduced the devilstrand cost for animal power armor for some small sizes of animal power armor.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
