### PR TITLE
Fix observed errors during melee combat

### DIFF
--- a/Patches/Vanilla Animals Expanded/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Caves_Animals.xml
@@ -345,24 +345,6 @@
             <armorPenetrationBlunt>6</armorPenetrationBlunt>
           </li>
           <li Class="CombatExtended.ToolCE">
-            <capacities>
-              <li>VAE_InfectedMandibles</li>
-            </capacities>
-            <power>23</power>
-            <cooldownTime>2.4</cooldownTime>
-            <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-            <surpriseAttack>
-              <extraMeleeDamages>
-                <li>
-                  <def>Stun</def>
-                  <amount>20</amount>
-                </li>
-              </extraMeleeDamages>
-            </surpriseAttack>
-            <armorPenetrationSharp>1.5</armorPenetrationSharp>
-            <armorPenetrationBlunt>6</armorPenetrationBlunt>
-          </li>
-          <li Class="CombatExtended.ToolCE">
             <label>head</label>
             <capacities>
               <li>Blunt</li>

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -120,7 +120,9 @@ namespace CombatExtended
                 }
                 catch (Exception e)
                 {
-                    Log.Error("CombatExtended :: BulletCE impacting thing " + hitThing.LabelCap + " of def " + hitThing.def.LabelCap + " added by mod " + hitThing.def.modContentPack.Name + ". See following stacktrace for information.");
+                    // Log errors from the impact process with additional diagnostic context before rethrowing
+                    // for easier identification of the problematic projectiles in larger firefights
+                    Log.Error($"CombatExtended :: BulletCE impacting thing {hitThing.LabelCap} of def {hitThing.def.LabelCap} added by mod {hitThing.def.modContentPack.Name}.\n{e}");
                     throw e;
                 }
                 finally

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -227,8 +227,17 @@ namespace CombatExtended
                 MoteMakerCE.ThrowText(targetThing.PositionHeld.ToVector3Shifted(), targetThing.MapHeld, moteText);
             }
             soundDef.PlayOneShot(new TargetInfo(targetThing.PositionHeld, targetThing.MapHeld));
-            casterPawn.Drawer.Notify_MeleeAttackOn(targetThing);
-            if (defender != null && !defender.Dead)
+
+            // The caster could be dead at this point due to a successful riposte from the defender,
+            // so check for that as appropriate.
+            if (casterPawn.Spawned)
+            {
+                casterPawn.Drawer.Notify_MeleeAttackOn(targetThing);
+            }
+
+            // The defender may still be alive but not spawned at this point due to a side-effect of the melee attack,
+            // such as the cocoon bite of giant spiders from VAE: Caves
+            if (defender != null && !defender.Dead && defender.Spawned)
             {
                 defender.stances.StaggerFor(95);
                 if (casterPawn.MentalStateDef != MentalStateDefOf.SocialFighting || defender.MentalStateDef != MentalStateDefOf.SocialFighting)
@@ -237,11 +246,10 @@ namespace CombatExtended
                     defender.mindState.lastMeleeThreatHarmTick = Find.TickManager.TicksGame;
                 }
             }
-            casterPawn.rotationTracker.FaceCell(targetThing.Position);
-            if (casterPawn.caller != null)
-            {
-                casterPawn.caller.Notify_DidMeleeAttack();
-            }
+
+            casterPawn.rotationTracker?.FaceCell(targetThing.Position);
+            casterPawn.caller?.Notify_DidMeleeAttack();
+
             return result;
         }
         /// <summary>


### PR DESCRIPTION

## Changes

Resolve various exceptions that plagued melee combat:
* Make Verb_MeleeAttackCE check that the defender and attacker are
  still spawned; a successful riposte may kill the attacker, and
  certain melee attacks such as cocoon bites from VAE: Caves' giant
  spiders may despawn the defender.
* Make the vanilla Verb class correctly handle the situation where
  the attacker missed their melee attack and was killed in the process
  (i.e. got riposted and killed). The vanilla logic was already checking
  the state of the attacker in the case their attack connected, but not
  when it missed.
* Remove mandibles from VAE: Caves' giant spiders - they no longer have them,
  only the ancient giant spider does. This was causing errors every time
  the giant spider attempted to use them for an attack.
* Tweak error logging for projectile impacts - currently the original stack
  trace is lost, which complicated debugging. Let's log it before rethrowing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Tested melee combat vs squirrels (for ripostes) and giant spiders (cocoon bite)
