### PR TITLE
Make VerbProperties.LaunchesProjectile cache vary per property

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_VerbProperties.cs
+++ b/Source/CombatExtended/Harmony/Harmony_VerbProperties.cs
@@ -13,15 +13,16 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch("LaunchesProjectile", MethodType.Getter)]
     internal static class Harmony_VerbProperties
     {
-        private static Dictionary<Type, bool> cache = new Dictionary<Type, bool>();
+        private static Dictionary<VerbProperties, bool> cache = new Dictionary<VerbProperties, bool>();
         internal static void Postfix(VerbProperties __instance, ref bool __result)
         {
             if (!__result)
             {
-		if (!cache.TryGetValue(__instance.GetType(), out __result)) {
-		    __result = typeof(Verb_LaunchProjectileCE).IsAssignableFrom(__instance.verbClass);
-		    cache[__instance.GetType()] = __result;
-		}
+                if (!cache.TryGetValue(__instance, out __result))
+                {
+                    __result = typeof(Verb_LaunchProjectileCE).IsAssignableFrom(__instance.verbClass);
+                    cache[__instance] = __result;
+                }
             }
         }
     }


### PR DESCRIPTION


## Changes

123cc55e898a17c3baedb56868586c3f9eb8fe3f added caching to our Harmony
patch that uses reflection to determine whether a given verb is melee
or not, but the cache only varied on the type of the VerbProperties class,
which is always VerbPropertiesCE. This could result in e.g. melee verbs
getting classified as ranged ones. Let's fix it by varying the cache
per property instance.








## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned tribal breachers to verify they now utilize their stick bombs for breaching
