### PR TITLE
Added different suppression calculation for explosives and explosions

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -881,7 +881,7 @@ namespace CombatExtended
                 {
                     var dPosX = ExactPosition.x - pawn.DrawPos.x;
                     var dPosZ = ExactPosition.z - pawn.DrawPos.z;
-                    // Affected by the ratio of distance from the explosion to the max suppression radius raised to the power of two. Larger suppression amount compared to linear interpolation
+                    // Affected by the ratio of distance from the explosion to the max suppression radius raised to the power of two. Larger suppression amount compared to linear interpolation. Also helps that square root isn't used
                     suppressionAmount *= Mathf.Clamp01(1f - (dPosX * dPosX + dPosZ * dPosZ) / ((explodeRadius + SuppressionRadius) * (explodeRadius + SuppressionRadius))) * explosiveSuppressionMultiplier;
                 }
                 compSuppressable.AddSuppression(suppressionAmount, OriginIV3);
@@ -1103,15 +1103,14 @@ namespace CombatExtended
 
                     // Apply suppression around impact area
                     if (explodePos.y < SuppressionRadius)
-                        suppressThings.AddRange(GenRadial.RadialDistinctThingsAround(explodePos.ToIntVec3(), Map, SuppressionRadius + def.projectile.explosionRadius, true).OfType<Pawn>());
+                        suppressThings.AddRange(explodePos.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius));
                 }
                 else if (explodingComp != null)
                 {
                     explodingComp.Explode(this, explodePos, Map, 1f, dir, ignoredThings);
 
                     if (explodePos.y < SuppressionRadius)
-                        suppressThings.AddRange(GenRadial
-                            .RadialDistinctThingsAround(explodePos.ToIntVec3(), Map, SuppressionRadius + (explodingComp.props as CompProperties_ExplosiveCE).explosiveRadius, true).OfType<Pawn>());
+                        suppressThings.AddRange(explodePos.ToIntVec3().PawnsInRange(Map, SuppressionRadius + (explodingComp.props as CompProperties_ExplosiveCE).explosiveRadius));
                 }
 
                 foreach (var thing in suppressThings)

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -27,6 +27,11 @@ namespace CombatExtended
         /// </summary>
         private const int collisionCheckSize = 5;
 
+        /// <summary>
+        /// Additional suppression multiplier for suppression caused by an explosion.
+        /// </summary>
+        private const float explosionSuppressionFactor = 3f;
+
         #region Origin destination
         public Vector2 origin;
 
@@ -844,7 +849,7 @@ namespace CombatExtended
         }
         #endregion
 
-        private void ApplySuppression(Pawn pawn, float explosiveSuppressionMultiplier = 1f)
+        private void ApplySuppression(Pawn pawn, float suppressionMultiplier = 1f)
         {
             ShieldBelt shield = null;
             if (pawn.RaceProps.Humanlike)
@@ -881,8 +886,9 @@ namespace CombatExtended
                 {
                     var dPosX = ExactPosition.x - pawn.DrawPos.x;
                     var dPosZ = ExactPosition.z - pawn.DrawPos.z;
-                    // Affected by the ratio of distance from the explosion to the max suppression radius raised to the power of two. Larger suppression amount compared to linear interpolation. Also helps that square root isn't used
-                    suppressionAmount *= Mathf.Clamp01(1f - (dPosX * dPosX + dPosZ * dPosZ) / ((explodeRadius + SuppressionRadius) * (explodeRadius + SuppressionRadius))) * explosiveSuppressionMultiplier;
+                    var totalRadius = explodeRadius + SuppressionRadius;
+                    // Affected by the ratio of distance from the explosion to the max suppression radius raised to the power of two. Larger suppression amount at distances compared to linear interpolation
+                    suppressionAmount *= Mathf.Clamp01(1f - (dPosX * dPosX + dPosZ * dPosZ) / (totalRadius * totalRadius)) * suppressionMultiplier;
                 }
                 compSuppressable.AddSuppression(suppressionAmount, OriginIV3);
             }
@@ -1114,7 +1120,7 @@ namespace CombatExtended
                 }
 
                 foreach (var thing in suppressThings)
-                    ApplySuppression(thing, 3f);
+                    ApplySuppression(thing, explosionSuppressionFactor);
             }
 
             Destroy();

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverage.cs
@@ -24,7 +24,7 @@ namespace CombatExtended
                 totalCoverage += coverage;
             }
 
-            return totalCoverage > 0 ? weightedArmor / totalCoverage : 0;
+            return totalCoverage > 0 ? weightedArmor : 0;
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorCoverage.cs
@@ -14,17 +14,15 @@ namespace CombatExtended
         public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
         {
             var weightedArmor = 0f;
-            var totalCoverage = 0f;
 
             var pawn = (Pawn)req.Thing;
             foreach (var apparel in pawn.apparel.WornApparel)
             {
                 var coverage = apparel.def.apparel.HumanBodyCoverage;
                 weightedArmor += apparel.GetStatValue(StatDefOf.ArmorRating_Sharp) * coverage;
-                totalCoverage += coverage;
             }
 
-            return totalCoverage > 0 ? weightedArmor : 0;
+            return weightedArmor;
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)


### PR DESCRIPTION
## Changes

- Explosions and explosive projectiles use a different formula for giving suppression; they also ignore sharp armor;
- Explosions deal more suppression than the explosive projectile itself.

## Reasoning

- Explosion suppression was broken due to the fact that it always checked against average sharp armor with its sharp penetration, which is 0. This should fix the issue of explosives not doing enough suppression, while raising the T in the lerp to the power of two should help reduce suppression the further a pawn is from the projectile or explosion;
- Projectiles can suppress the same pawn multiple times if it is in the suppression radius of the projectile for multiple ticks, therefore to me it didn't make sense how explosive projectiles can suppress more than the explosion itself.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony;
- Did battlefield testing (image taken with the fragment changes included) (10000 point raid, one doomsday rocket);
![image](https://user-images.githubusercontent.com/34545746/165374886-8c3a653e-dd02-44d2-a5eb-0943365081a3.png)
