### PR TITLE
M72 LAW Rebalanced and RPG consistency check

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -12,6 +12,9 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>
+    <weaponClasses>
+      <li>RangedHeavy</li>
+    </weaponClasses>
     <statBases>
       <WorkToMake>9000</WorkToMake>
       <SightsEfficiency>1</SightsEfficiency>
@@ -110,12 +113,15 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>
+    <weaponClasses>
+      <li>RangedHeavy</li>
+    </weaponClasses>
     <thingClass>ThingWithComps</thingClass>
     <tickerType>Normal</tickerType>
     <resourceReadoutPriority>First</resourceReadoutPriority>
     <techLevel>Industrial</techLevel>
     <statBases>
-      <MarketValue>35.72</MarketValue>
+      <MarketValue>113</MarketValue>
       <SightsEfficiency>1.0</SightsEfficiency>
       <ShotSpread>0.2</ShotSpread>
       <SwayFactor>1.24</SwayFactor>
@@ -198,7 +204,7 @@
     <label>make disposable rocket launcher x5</label>
     <description>Craft 5 disposable rocket launchers.</description>
     <jobString>Making disposable rocket launchers.</jobString>
-    <workAmount>6200</workAmount>
+    <workAmount>38500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -206,7 +212,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>150</count>
       </li>
       <li>
         <filter>
@@ -222,7 +228,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -121,7 +121,7 @@
     <resourceReadoutPriority>First</resourceReadoutPriority>
     <techLevel>Industrial</techLevel>
     <statBases>
-      <MarketValue>113</MarketValue>
+      <MarketValue>91</MarketValue>
       <SightsEfficiency>1.0</SightsEfficiency>
       <ShotSpread>0.2</ShotSpread>
       <SwayFactor>1.24</SwayFactor>
@@ -204,7 +204,7 @@
     <label>make disposable rocket launcher x5</label>
     <description>Craft 5 disposable rocket launchers.</description>
     <jobString>Making disposable rocket launchers.</jobString>
-    <workAmount>38500</workAmount>
+    <workAmount>32500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -212,7 +212,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>150</count>
+        <count>100</count>
       </li>
       <li>
         <filter>

--- a/Patches/LF Red Dawn/RD_Launchers.xml
+++ b/Patches/LF Red Dawn/RD_Launchers.xml
@@ -234,7 +234,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 
@@ -286,7 +286,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG16Grenade</ammoSet>
 				</AmmoUser>
 
@@ -338,7 +338,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.9</reloadTime>
+					<reloadTime>5.9</reloadTime>
 					<ammoSet>AmmoSet_RPG29</ammoSet>
 				</AmmoUser>
 

--- a/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
+++ b/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
@@ -147,10 +147,10 @@
 
    <RecipeDef ParentName="GrenadeRecipeBase">
     <defName>MakeGun_RPG18D</defName>
-    <label>make M72 LAW x5</label>
+    <label>make RPG18 LAW launchers x5</label>
     <description>Craft 5 RPG18 launchers.</description>
     <jobString>Making RPG 18 LAW launchers.</jobString>
-    <workAmount>6200</workAmount>
+    <workAmount>38500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -158,7 +158,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>150</count>
       </li>
       <li>
         <filter>
@@ -174,7 +174,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -195,7 +195,7 @@
     <label>make RPG22 x5</label>
     <description>Craft 5 RPG22 launchers.</description>
     <jobString>Making RPG22 launchers.</jobString>
-    <workAmount>6200</workAmount>
+    <workAmount>38500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -203,7 +203,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>150</count>
       </li>
       <li>
         <filter>
@@ -219,7 +219,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -240,7 +240,7 @@
     <label>make RPG26 x5</label>
     <description>Craft 5 RPG26 launchers.</description>
     <jobString>Making RPG26 launchers.</jobString>
-    <workAmount>6200</workAmount>
+    <workAmount>38500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -248,7 +248,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>150</count>
       </li>
       <li>
         <filter>
@@ -264,7 +264,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -286,7 +286,7 @@
     <label>make RPG27 x5</label>
     <description>Craft 5 RPG27 launchers.</description>
     <jobString>Making RPG27 launchers.</jobString>
-    <workAmount>6200</workAmount>
+    <workAmount>38500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -294,7 +294,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>26</count>
+        <count>150</count>
       </li>
       <li>
         <filter>
@@ -310,7 +310,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
+++ b/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
@@ -150,7 +150,7 @@
     <label>make RPG18 LAW launchers x5</label>
     <description>Craft 5 RPG18 launchers.</description>
     <jobString>Making RPG 18 LAW launchers.</jobString>
-    <workAmount>38500</workAmount>
+    <workAmount>32500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -158,7 +158,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>150</count>
+        <count>100</count>
       </li>
       <li>
         <filter>
@@ -195,7 +195,7 @@
     <label>make RPG22 x5</label>
     <description>Craft 5 RPG22 launchers.</description>
     <jobString>Making RPG22 launchers.</jobString>
-    <workAmount>38500</workAmount>
+    <workAmount>32500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -203,7 +203,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>150</count>
+        <count>100</count>
       </li>
       <li>
         <filter>
@@ -240,7 +240,7 @@
     <label>make RPG26 x5</label>
     <description>Craft 5 RPG26 launchers.</description>
     <jobString>Making RPG26 launchers.</jobString>
-    <workAmount>38500</workAmount>
+    <workAmount>32500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -248,7 +248,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>150</count>
+        <count>100</count>
       </li>
       <li>
         <filter>
@@ -286,7 +286,7 @@
     <label>make RPG27 x5</label>
     <description>Craft 5 RPG27 launchers.</description>
     <jobString>Making RPG27 launchers.</jobString>
-    <workAmount>38500</workAmount>
+    <workAmount>32500</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -294,7 +294,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>150</count>
+        <count>100</count>
       </li>
       <li>
         <filter>

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_GER.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_GER.xml
@@ -1092,7 +1092,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_88mmRPzBRocket</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_UK.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_UK.xml
@@ -609,7 +609,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_83mmPIATGrenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_US.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Ranged_US.xml
@@ -1186,7 +1186,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_M6A3Rocket</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Allegiance/RH_Allegiance_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Allegiance/RH_Allegiance_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -61,7 +61,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 
@@ -111,7 +111,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG32Rocket</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Coalition/RH_Coalition_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Coalition/RH_Coalition_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -145,7 +145,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -133,7 +133,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -43,7 +43,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -133,7 +133,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Militaires Sans Frontieres/RH_MSF_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -133,7 +133,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -134,7 +134,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction Umbra Company/RH_Umbra_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction Umbra Company/RH_Umbra_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -146,7 +146,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -61,7 +61,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
@@ -3270,7 +3270,7 @@
 				</Properties>
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 				<FireModes>
@@ -3339,7 +3339,7 @@
 				</Properties>
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_84x246mmR</ammoSet>
 				</AmmoUser>
 				<FireModes>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_BigGuns.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_BigGuns.xml
@@ -87,7 +87,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_84x246mmR</ammoSet>
 				</AmmoUser>
 
@@ -329,7 +329,7 @@
 
 				<AmmoUser>
 					<magazineSize>4</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_M74</ammoSet>
 				</AmmoUser>
 
@@ -574,7 +574,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 
@@ -670,7 +670,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG32Rocket</ammoSet>
 				</AmmoUser>
 
@@ -721,7 +721,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_83mmSMAW</ammoSet>
 				</AmmoUser>
 

--- a/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
+++ b/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
@@ -904,7 +904,7 @@
 
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>8.6</reloadTime>
+					<reloadTime>5.6</reloadTime>
 					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
 				</AmmoUser>
 


### PR DESCRIPTION
## Changes

- Rebalanced the M72 LAWs crafting cost and market value

## Reasoning

- M72 LAWs are currently dirt cheap to buy and craft for 5 whole weapons which is kinda against the output given by the spreadsheet. The Crafting Mats. tab in the spreadsheet seem to state the materials needed for only 1 LAW which is still higher than the in-game costs. If we scale the costs to 5 crafted weapons, it'd result the current values in this PR. The result makes much more sense for a recipe that outputs 5 M72 LAWs. The current market value is very low at 35.72 and the material costs are 26 steel and 2 components which is also unreasonable for 5 rocket launchers.

- Before scaling the values
![image](https://user-images.githubusercontent.com/56392968/165477096-ad65b33e-685c-48e6-a211-aa03d162cfbc.png)
  
- After scaling the values
![image](https://user-images.githubusercontent.com/56392968/165499916-74891895-7b8b-4175-8acc-c06de16b3141.png)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors

