### PR TITLE
Starship Troopers Arachnids' patch updated

### DIFF
--- a/Patches/Starship Troopers Arachnids/Races.xml
+++ b/Patches/Starship Troopers Arachnids/Races.xml
@@ -71,7 +71,7 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>head</label>
 								<capacities>
-									<li>Cut</li>
+									<li>Stab</li>
 								</capacities>
 								<power>36</power>
 								<cooldownTime>1.33</cooldownTime>

--- a/Patches/Starship Troopers Arachnids/Races.xml
+++ b/Patches/Starship Troopers Arachnids/Races.xml
@@ -28,8 +28,8 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Arachnid_WarriorBug" or defName="Arachnid_WarriorBugHive"]/statBases</xpath>
 					<value>
-						<ArmorRating_Blunt>2</ArmorRating_Blunt>
-						<ArmorRating_Sharp>2</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 					</value>
 				</li>
 				
@@ -107,19 +107,12 @@
 				</li>
 			
 				<!-- Plasma Grenadier -->
-					
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>1.8</baseHealthScale>
-					</value>
-				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaGrenadierBug"]/statBases</xpath>
 					<value>
-						<ArmorRating_Blunt>28</ArmorRating_Blunt>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+						<ArmorRating_Blunt>2</ArmorRating_Blunt>
+						<ArmorRating_Sharp>1</ArmorRating_Sharp>
 					</value>
 				</li>
 				
@@ -174,39 +167,35 @@
 				</li>
 			
 				<!-- Large-class -->
+
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug" or defName="Arachnid_PlasmaBug"]/race/baseHealthScale</xpath>
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<baseHealthScale>5.0</baseHealthScale>
+						<ArmorRating_Sharp>22</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+						<ArmorRating_Blunt>33</ArmorRating_Blunt>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>23</ArmorRating_Sharp>
-					</value>
-				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Arachnid_ScorpionBug"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>25</ArmorRating_Sharp>
 					</value>
 				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Arachnid_PlasmaBug"]/statBases</xpath>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Arachnid_ScorpionBug"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Sharp>30</ArmorRating_Sharp>
-						<ArmorRating_Blunt>14</ArmorRating_Blunt>
+						<ArmorRating_Blunt>38</ArmorRating_Blunt>
 					</value>
 				</li>
-				
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Arachnid_TankerBug" or defName="Arachnid_ScorpionBug" or defName="Arachnid_PlasmaBug"]/statBases</xpath>
 					<value>

--- a/Patches/Starship Troopers Arachnids/Resources.xml
+++ b/Patches/Starship Troopers Arachnids/Resources.xml
@@ -6,6 +6,7 @@
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
+
 				<!-- Arachnid Leg -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="ArachnidLeg"]/statBases</xpath>
@@ -13,6 +14,7 @@
 						<Bulk>12</Bulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="ArachnidLeg"]/tools</xpath>
 					<value>
@@ -25,7 +27,7 @@
 								</capacities>
 								<power>20</power>
 								<cooldownTime>2.6</cooldownTime>
-								<armorPenetrationSharp>20</armorPenetrationSharp>
+								<armorPenetrationSharp>5</armorPenetrationSharp>
 								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 							</li>
 						</tools>
@@ -37,52 +39,96 @@
 					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases</xpath>
 					<value>
 						<Bulk>0.05</Bulk>
+						<WornBulk>0.75</WornBulk>
 					</value>
 				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>1.25</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>1.75</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
-						<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/SharpDamageMultiplier</xpath>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/stuffProps</xpath>
 					<value>
-						<MeleePenetrationFactor>3.0</MeleePenetrationFactor>
+						<statOffsets>
+							<Mass>0.5</Mass>
+						</statOffsets>
 					</value>
 				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/SharpDamageMultiplier</xpath>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/statBases/BluntDamageMultiplier</xpath>
+					<value>
+						<BluntDamageMultiplier>1.25</BluntDamageMultiplier>
+					</value>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/stuffProps/categories</xpath>
 					<value>
 						<li>Metallic_Weapon</li>
 					</value>
 				</li>
-				
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="ArachnidCarapace"]/stuffProps/statFactors</xpath>
+					<value>
+						<Mass>2.45</Mass>
+						<MeleePenetrationFactor>1.2</MeleePenetrationFactor>
+					</value>
+				</li>
+
 				<!-- Arachnid Leather, made a bit worse than thrumbofur -->
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases</xpath>
 					<value>
 						<Bulk>0.05</Bulk>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.35</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.55</StuffPower_Armor_Sharp>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.07</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.4</StuffPower_Armor_Blunt>
 					</value>
 				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Leather_Arachnids"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
 						<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
 					</value>
 				</li>
+
 				<li Class="PatchOperationConditional">
 					<xpath>Defs/ThingDef[defName="Leather_Arachnids"]/stuffProps/categories</xpath>
 					<nomatch Class="PatchOperationAdd">
@@ -100,6 +146,7 @@
 						</value>
 					</match>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
+++ b/Patches/Starship Troopers Arachnids/Weapons_Bugs.xml
@@ -13,7 +13,7 @@
 					<statBases>
 						<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.2</ShotSpread>
+						<ShotSpread>3.0</ShotSpread>
 						<SwayFactor>1.52</SwayFactor>
 						<Bulk>36</Bulk>
 					</statBases>
@@ -39,7 +39,7 @@
 					<statBases>
 						<RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
 						<SightsEfficiency>1</SightsEfficiency>
-						<ShotSpread>0.2</ShotSpread>
+						<ShotSpread>3.0</ShotSpread>
 						<SwayFactor>1.52</SwayFactor>
 						<Bulk>36</Bulk>
 					</statBases>
@@ -336,6 +336,7 @@
 						</ThingDef>
 					</value>
 				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- Updated the Starship Troopers Arachnids' patch with appropriate values

## Reasoning

- Some of the bugs needed an armor value adjustments to make them consistent with other insectoids in vanilla and mods. Some of them are supposed to be unarmored which the change reflects that to some extent as best as possible.
- The flamethrower weapons that the bugs use got the same treatment as other flamethrower weapons in regards to spread.
- The leathery and metallic materials added by the mod needed a proper value adjustment to make them consistent with other built-in patches while making the Arachnid Carapace a bit less OP since is abundantly available.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
