### PR TITLE
Implementing the sub-carbine warmup time category

### DIFF
--- a/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
+++ b/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
@@ -220,7 +220,7 @@
       <recoilAmount>1.60</recoilAmount>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-      <warmupTime>0.6</warmupTime>
+      <warmupTime>0.85</warmupTime>
       <range>31</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
+++ b/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
@@ -220,7 +220,7 @@
       <recoilAmount>1.60</recoilAmount>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-      <warmupTime>0.85</warmupTime>
+      <warmupTime>0.9</warmupTime>
       <range>31</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
+++ b/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
@@ -741,7 +741,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -1276,7 +1276,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
+++ b/Patches/High Caliber/HighCaliber_CE_Patch_Weapons.xml
@@ -741,7 +741,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -1276,7 +1276,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Midworld Weaponry Expanded/Industrial_Ranged.xml
+++ b/Patches/Midworld Weaponry Expanded/Industrial_Ranged.xml
@@ -176,7 +176,7 @@
 				<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
 				<burstShotCount>6</burstShotCount>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<warmupTime>0.75</warmupTime>
+				<warmupTime>0.85</warmupTime>
 				<range>35</range>
 				<soundCast>Shot_AssaultRifle</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Midworld Weaponry Expanded/Industrial_Ranged.xml
+++ b/Patches/Midworld Weaponry Expanded/Industrial_Ranged.xml
@@ -176,7 +176,7 @@
 				<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
 				<burstShotCount>6</burstShotCount>
 				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				<warmupTime>1.0</warmupTime>
+				<warmupTime>0.75</warmupTime>
 				<range>35</range>
 				<soundCast>Shot_AssaultRifle</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -154,7 +154,7 @@
             <recoilAmount>1.46</recoilAmount>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-            <warmupTime>0.91</warmupTime>
+            <warmupTime>0.85</warmupTime>
             <range>30</range>
             <soundCast>Shot545x39</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
@@ -196,7 +196,7 @@
             <recoilAmount>1.38</recoilAmount>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-            <warmupTime>0.91</warmupTime>
+            <warmupTime>0.85</warmupTime>
             <range>31</range>
             <soundCast>Shot545x39</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -154,7 +154,7 @@
             <recoilAmount>1.46</recoilAmount>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-            <warmupTime>0.85</warmupTime>
+            <warmupTime>0.9</warmupTime>
             <range>30</range>
             <soundCast>Shot545x39</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
@@ -196,7 +196,7 @@
             <recoilAmount>1.38</recoilAmount>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-            <warmupTime>0.85</warmupTime>
+            <warmupTime>0.9</warmupTime>
             <range>31</range>
             <soundCast>Shot545x39</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
@@ -1288,7 +1288,7 @@
             <recoilAmount>1.43</recoilAmount>
             <burstShotCount>6</burstShotCount>
             <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-            <warmupTime>0.85</warmupTime>
+            <warmupTime>0.9</warmupTime>
             <range>31</range>
             <soundCast>Shot_AssaultRifle</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -1288,7 +1288,7 @@
             <recoilAmount>1.43</recoilAmount>
             <burstShotCount>6</burstShotCount>
             <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-            <warmupTime>1.1</warmupTime>
+            <warmupTime>0.85</warmupTime>
             <range>31</range>
             <soundCast>Shot_AssaultRifle</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Cordis Die/RH_CordisDie_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction Last Man Contingent/RH_LMC_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Red Horse Faction Task Force 141/RH_TF141_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.5</warmupTime>
+					<warmupTime>0.75</warmupTime>
 					<range>40</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.75</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>40</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction The Ghosts/RH_Ghosts_CE_Patch_RangedIndustrial_SMG.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>40</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>

--- a/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Red Horse Faction War Mongrels/RH_WarMongrels_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_HRT_Pack.xml
@@ -30,7 +30,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
@@ -267,7 +267,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -314,7 +314,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>1.25</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_R_Others.xml
@@ -267,7 +267,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -314,7 +314,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
@@ -78,7 +78,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -1574,7 +1574,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -78,7 +78,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -124,7 +124,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -224,7 +224,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.75</warmupTime>
+					<warmupTime>0.8</warmupTime>
 					<range>40</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -1574,7 +1574,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
@@ -224,7 +224,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-					<warmupTime>0.5</warmupTime>
+					<warmupTime>0.75</warmupTime>
 					<range>40</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
+++ b/Patches/Rimmu-Nation - Weapons/RNW_CE_Patch_RangedIndustrial_SMG.xml
@@ -29,7 +29,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -124,7 +124,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>1.1</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Rimsenal Collection/Marauder/Marauder_Guns.xml
+++ b/Patches/Rimsenal Collection/Marauder/Marauder_Guns.xml
@@ -239,7 +239,7 @@
       <defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>7</ticksBetweenBurstShots>	  
-      <warmupTime>0.85</warmupTime>
+      <warmupTime>0.9</warmupTime>
       <range>31</range>
       <soundCast>Shot_AssaultRifle</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Rimsenal Collection/Marauder/Marauder_Guns.xml
+++ b/Patches/Rimsenal Collection/Marauder/Marauder_Guns.xml
@@ -239,7 +239,7 @@
       <defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>7</ticksBetweenBurstShots>	  
-      <warmupTime>1.1</warmupTime>
+      <warmupTime>0.85</warmupTime>
       <range>31</range>
       <soundCast>Shot_AssaultRifle</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
+++ b/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
@@ -294,7 +294,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.85</warmupTime>
+					<warmupTime>0.9</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
+++ b/Patches/Soviet Armory/SovietArmory_CE_Patch_Weapons.xml
@@ -294,7 +294,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
-					<warmupTime>0.6</warmupTime>
+					<warmupTime>0.85</warmupTime>
 					<range>31</range>
 					<burstShotCount>6</burstShotCount>
 					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -145,7 +145,7 @@
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-      <warmupTime>0.85</warmupTime>
+      <warmupTime>0.9</warmupTime>
       <range>55</range>
       <soundCast>Shot_AssaultRifle</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -93,7 +93,7 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
-      <warmupTime>0.4</warmupTime>
+      <warmupTime>0.6</warmupTime>
       <range>25</range>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
@@ -145,7 +145,7 @@
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
       <burstShotCount>6</burstShotCount>
       <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-      <warmupTime>0.4</warmupTime>
+      <warmupTime>0.85</warmupTime>
       <range>55</range>
       <soundCast>Shot_AssaultRifle</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
@@ -242,7 +242,7 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
-      <warmupTime>0.4</warmupTime>
+      <warmupTime>0.5</warmupTime>
       <range>12</range>
       <burstShotCount>3</burstShotCount>
       <ticksBetweenBurstShots>3</ticksBetweenBurstShots>


### PR DESCRIPTION
## Changes

- Changed the patched sub-carbines to have the new warmup time for the sub-carbines category, being 0.85 seconds

## References

- The conversation for the implementation started here but the actual change was never made.
https://discord.com/channels/278818534069501953/322827713335394304/959749582835814460

## Reasoning

- Sub-carbines are guns with lower than 12 inch barrels, categorizing them with SMGs in the warmup aspect of things makes them very good with very few downsides. Giving them a separate warmup time balances things out fairly well, keeping SMGs and pistols as the fast firing cqc weapons and rifles for longer range engagements. Sub-carbines will be somewhere in the middle without stepping on the other categories' toes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
