### PR TITLE
1x Recipe for M72 LAW

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -200,7 +200,7 @@
   </ThingDef>
 
    <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeDisposableRocketLaunche_5x</defName>
+    <defName>MakeDisposableRocketLaunche</defName>
     <label>make disposable rocket launcher x5</label>
     <description>Craft 5 disposable rocket launchers.</description>
     <jobString>Making disposable rocket launchers.</jobString>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -200,7 +200,7 @@
   </ThingDef>
 
    <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeDisposableRocketLauncher</defName>
+    <defName>MakeDisposableRocketLaunche_5x</defName>
     <label>make disposable rocket launcher x5</label>
     <description>Craft 5 disposable rocket launchers.</description>
     <jobString>Making disposable rocket launchers.</jobString>
@@ -244,6 +244,50 @@
     <researchPrerequisite>CE_Launchers</researchPrerequisite>
   </RecipeDef>
 
+   <RecipeDef ParentName="GrenadeRecipeBase">
+    <defName>MakeDisposableRocketLauncher_1x</defName>
+    <label>make disposable rocket launcher x1</label>
+    <description>Craft one disposable rocket launcher.</description>
+    <jobString>Making disposable rocket launcher.</jobString>
+    <workAmount>8125</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>25</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>1</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <CE_DisposableRocketLauncher>1</CE_DisposableRocketLauncher>
+    </products>
+    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+  </RecipeDef>
 
   <!-- ==================== Explosive Bolt Launcher ==================== -->
 

--- a/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
+++ b/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
@@ -143,188 +143,367 @@
 		</comps>
 	</ThingDef>
 
-  <!-- ==================== Recipes ========================== -->
+	  <!-- ==================== Recipes ========================== -->
 
-   <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeGun_RPG18D</defName>
-    <label>make RPG18 LAW launchers x5</label>
-    <description>Craft 5 RPG18 launchers.</description>
-    <jobString>Making RPG 18 LAW launchers.</jobString>
-    <workAmount>32500</workAmount>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>100</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>5</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Gun_RPG18D>5</Gun_RPG18D>
-    </products>
-    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-  </RecipeDef>
+	   <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG18D</defName>
+	    <label>make RPG18 LAW launchers x5</label>
+	    <description>Craft 5 RPG18 launchers.</description>
+	    <jobString>Making RPG 18 LAW launchers.</jobString>
+	    <workAmount>32500</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>100</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>6</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>5</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG18D>5</Gun_RPG18D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeGun_RPG22D</defName>
-    <label>make RPG22 x5</label>
-    <description>Craft 5 RPG22 launchers.</description>
-    <jobString>Making RPG22 launchers.</jobString>
-    <workAmount>32500</workAmount>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>100</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>5</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Gun_RPG22D>5</Gun_RPG22D>
-    </products>
-    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-  </RecipeDef>
+	   <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG18D_1x</defName>
+	    <label>make RPG18 LAW launchers x1</label>
+	    <description>Craft one RPG18 launcher.</description>
+	    <jobString>Making RPG 18 LAW launcher.</jobString>
+	    <workAmount>8125</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>25</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>2</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>1</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG18D>1</Gun_RPG18D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeGun_RPG26D</defName>
-    <label>make RPG26 x5</label>
-    <description>Craft 5 RPG26 launchers.</description>
-    <jobString>Making RPG26 launchers.</jobString>
-    <workAmount>32500</workAmount>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>100</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>5</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Gun_RPG26D>5</Gun_RPG26D>
-    </products>
-    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-  </RecipeDef>
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG22D</defName>
+	    <label>make RPG22 x5</label>
+	    <description>Craft 5 RPG22 launchers.</description>
+	    <jobString>Making RPG22 launchers.</jobString>
+	    <workAmount>32500</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>100</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>6</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>5</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG22D>5</Gun_RPG22D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
 
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG22D_1x</defName>
+	    <label>make RPG22 x1</label>
+	    <description>Craft one RPG22 launcher.</description>
+	    <jobString>Making RPG22 launcher.</jobString>
+	    <workAmount>8125</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>25</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>2</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>1</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG22D>1</Gun_RPG22D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeGun_RPG27D</defName>
-    <label>make RPG27 x5</label>
-    <description>Craft 5 RPG27 launchers.</description>
-    <jobString>Making RPG27 launchers.</jobString>
-    <workAmount>32500</workAmount>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>100</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>5</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Gun_RPG27D>5</Gun_RPG27D>
-    </products>
-    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-  </RecipeDef>
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG26D</defName>
+	    <label>make RPG26 x5</label>
+	    <description>Craft 5 RPG26 launchers.</description>
+	    <jobString>Making RPG26 launchers.</jobString>
+	    <workAmount>32500</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>100</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>6</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>5</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG26D>5</Gun_RPG26D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
+
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG26D_1x</defName>
+	    <label>make RPG26 x1</label>
+	    <description>Craft one RPG26 launcher.</description>
+	    <jobString>Making RPG26 launcher.</jobString>
+	    <workAmount>8125</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>25</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>2</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>1</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG26D>1</Gun_RPG26D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
+
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG27D</defName>
+	    <label>make RPG27 x5</label>
+	    <description>Craft 5 RPG27 launchers.</description>
+	    <jobString>Making RPG27 launchers.</jobString>
+	    <workAmount>32500</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>100</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>6</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>5</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG27D>5</Gun_RPG27D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
+
+	  <RecipeDef ParentName="GrenadeRecipeBase">
+	    <defName>MakeGun_RPG27D_1x</defName>
+	    <label>make RPG27 x1</label>
+	    <description>Craft one RPG27 launcher.</description>
+	    <jobString>Making RPG27 launcher.</jobString>
+	    <workAmount>8125</workAmount>
+	    <ingredients>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>Steel</li>
+		  </thingDefs>
+		</filter>
+		<count>25</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>FSX</li>
+		  </thingDefs>
+		</filter>
+		<count>2</count>
+	      </li>
+	      <li>
+		<filter>
+		  <thingDefs>
+		    <li>ComponentIndustrial</li>
+		  </thingDefs>
+		</filter>
+		<count>1</count>
+	      </li>
+	    </ingredients>
+	    <fixedIngredientFilter>
+	      <thingDefs>
+		<li>Steel</li>
+		<li>FSX</li>
+		<li>ComponentIndustrial</li>
+	      </thingDefs>
+	    </fixedIngredientFilter>
+	    <products>
+	      <Gun_RPG27D>1</Gun_RPG27D>
+	    </products>
+	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+	  </RecipeDef>
 
 			</value>
 		</match>


### PR DESCRIPTION
## Additions

- Added a 1x crafting recipe for the M72 LAW

## Reasoning

- Following the much needed change to LAWs, the crafting work cost for 5x LAWs got a bit too high in comparison to 6200 work (which was still too low and incorrect) which was the previous cost. Added the 1x recipe (with appropriate costs to keep the incentive for batch crafting) with the goal of giving the player a quicker access to the rocket launcher in an emergency situation.

## Alternatives

- Go against the spreadsheet and decrease the work cost for crafting 5 LAWs

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
