### PR TITLE
clear cached CompAmmoUser _ammo when gun is null

### DIFF
--- a/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
@@ -20,6 +20,9 @@ namespace CombatExtended.Compatibility {
 	public CompAmmoUser GetAmmo() {
 	    Thing gun = GetGun();
 	    if (gun == null) {
+		if (_ammo != null && _ammo.turret == this) {
+		    _ammo.turret = null;
+		}
 		_ammo = null;
 		return null;
 	    }

--- a/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
@@ -18,15 +18,18 @@ namespace CombatExtended.Compatibility {
 	private CompAmmoUser _ammo;
 	private CompFireModes compFireModes = null;
 	public CompAmmoUser GetAmmo() {
-	    if (_ammo == null) {
-		_ammo = GetGun()?.TryGetComp<CompAmmoUser>();
+	    Thing gun = GetGun();
+	    if (gun == null) {
+		_ammo = null;
+		return null;
 	    }
-	    if (_ammo!=null) {
+	    if (_ammo == null) {
+		_ammo = gun.TryGetComp<CompAmmoUser>();
 		_ammo.turret = this;
 	    }
-	    
 	    return _ammo;
 	}
+
 
 	public Thing GetGun() {
 	    return gun;

--- a/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
+++ b/Source/BetterTurretsCompat/BetterTurretsCompat/BetterTurrets_CE_TurretWeaponBase.cs
@@ -25,7 +25,9 @@ namespace CombatExtended.Compatibility {
 	    }
 	    if (_ammo == null) {
 		_ammo = gun.TryGetComp<CompAmmoUser>();
-		_ammo.turret = this;
+		if (_ammo != null) {
+		    _ammo.turret = this;
+		}
 	    }
 	    return _ammo;
 	}

--- a/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
@@ -20,6 +20,9 @@ namespace CombatExtended.Compatibility {
 	public CompAmmoUser GetAmmo() {
 	    Thing gun = GetGun();
 	    if (gun == null) {
+		if (_ammo != null && _ammo.turret == this) {
+		    _ammo.turret = null;
+		}
 		_ammo = null;
 		return null;
 	    }

--- a/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
@@ -18,13 +18,15 @@ namespace CombatExtended.Compatibility {
 	private CompAmmoUser _ammo;
 	private CompFireModes compFireModes = null;
 	public CompAmmoUser GetAmmo() {
-	    if (_ammo == null) {
-		_ammo = GetGun()?.TryGetComp<CompAmmoUser>();
+	    Thing gun = GetGun();
+	    if (gun == null) {
+		_ammo = null;
+		return null;
 	    }
-	    if (_ammo!=null) {
+	    if (_ammo == null) {
+		_ammo = gun.TryGetComp<CompAmmoUser>();
 		_ammo.turret = this;
 	    }
-	    
 	    return _ammo;
 	}
 

--- a/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
+++ b/Source/MiscTurretsCompat/MiscTurretsCompat/MiscTurrets_CE_TurretWeaponBase.cs
@@ -25,7 +25,9 @@ namespace CombatExtended.Compatibility {
 	    }
 	    if (_ammo == null) {
 		_ammo = gun.TryGetComp<CompAmmoUser>();
-		_ammo.turret = this;
+		if (_ammo != null) {
+		    _ammo.turret = this;
+		}
 	    }
 	    return _ammo;
 	}


### PR DESCRIPTION
## Changes

When asking for the ammo of a Turret Base with a `null`, clear the cached ammo.

## Alternatives

Invalidate the cache when spawning the turret - does the turret spawn get called when the turret is converted from minimized to installed?  
Invalidate the cache when uninstalling the gun - Requires a harmony patch as the un/install gun methods are not virtual.


## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
