### PR TITLE
Adjust shooting inspiration and Gunlink's bonus

### DIFF
--- a/Ideology/Patches/Misc/Hediffs_Casts.xml
+++ b/Ideology/Patches/Misc/Hediffs_Casts.xml
@@ -71,6 +71,8 @@
 			<statOffsets>
 				<MeleeHitChance>2.0</MeleeHitChance>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<MeleeCritChance>0.25</MeleeCritChance>
+				<MeleeParryChance>0.1</MeleeParryChance>
 				<Suppressability>-10</Suppressability>
 			</statOffsets>
 		</value>

--- a/Ideology/Patches/Misc/Hediffs_Casts.xml
+++ b/Ideology/Patches/Misc/Hediffs_Casts.xml
@@ -24,10 +24,14 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="CombatCommandBuff"]/stages/li/statOffsets</xpath>
 		<value>
-			<Suppressability>-0.25</Suppressability>
+			<statOffsets>
+				<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+				<MeleeHitChance>1.5</MeleeHitChance>
+				<Suppressability>-0.25</Suppressability>
+			</statOffsets>
 		</value>
 	</Operation>
 
@@ -40,8 +44,14 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/HediffDef[defName="MarksmanCommandBuff"]/stages/li/statOffsets/AimingDelayFactor</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="MarksmanCommandBuff"]/stages/li/statOffsets</xpath>
+		<value>
+			<statOffsets>
+				<ShootingAccuracyPawn>2.0</ShootingAccuracyPawn>
+				<AimingAccuracy>0.2</AimingAccuracy>
+			</statOffsets>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -49,16 +59,20 @@
 		<value>
 			<statFactors>
 				<ReloadSpeed>1.20</ReloadSpeed>
-			</statFactors>		
+			</statFactors>
 		</value>
 	</Operation>
 
 	<!-- Beserker Trance -->
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="BerserkTrance"]/stages/li/statOffsets</xpath>
 		<value>
-			<Suppressability>-10</Suppressability>
+			<statOffsets>
+				<MeleeHitChance>2.0</MeleeHitChance>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				<Suppressability>-10</Suppressability>
+			</statOffsets>
 		</value>
 	</Operation>
 

--- a/Ideology/Patches/Misc/Precepts_Role.xml
+++ b/Ideology/Patches/Misc/Precepts_Role.xml
@@ -6,13 +6,17 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_ShootingSpecialist"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
 		<value>
-        	<modifier>3</modifier>
+        	<modifier>2</modifier>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_ShootingSpecialist"]/roleEffects/li[./statDef="AimingDelayFactor"]</xpath>
 		<value>
+			<li Class="RoleEffect_PawnStatOffset">
+				<statDef>AimingAccuracy</statDef>
+				<modifier>0.3</modifier>
+			</li>
 			<li Class="RoleEffect_PawnStatOffset">
 				<statDef>ReloadSpeed</statDef>
 				<modifier>0.15</modifier>
@@ -25,14 +29,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_MeleeSpecialist"]/roleEffects/li[./statDef="MeleeHitChance"]/modifier</xpath>
 		<value>
-        	<modifier>3</modifier>
+        	<modifier>2</modifier>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_MeleeSpecialist"]/roleEffects/li[./statDef="MeleeDodgeChance"]/modifier</xpath>
 		<value>
-        	<modifier>0.08</modifier>
+        	<modifier>0.2</modifier>
 		</value>
 	</Operation>
 

--- a/Ideology/Patches/Misc/Precepts_Role.xml
+++ b/Ideology/Patches/Misc/Precepts_Role.xml
@@ -6,7 +6,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_ShootingSpecialist"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
 		<value>
-        	<modifier>2</modifier>
+			<modifier>2</modifier>
 		</value>
 	</Operation>
 
@@ -29,14 +29,28 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_MeleeSpecialist"]/roleEffects/li[./statDef="MeleeHitChance"]/modifier</xpath>
 		<value>
-        	<modifier>2</modifier>
+			<modifier>2</modifier>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PreceptDef[defName="IdeoRole_MeleeSpecialist"]/roleEffects/li[./statDef="MeleeDodgeChance"]/modifier</xpath>
 		<value>
-        	<modifier>0.2</modifier>
+			<modifier>0.2</modifier>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PreceptDef[defName="IdeoRole_MeleeSpecialist"]/roleEffects</xpath>
+		<value>
+			<li Class="RoleEffect_PawnStatOffset">
+				<statDef>MeleeCritChance</statDef>
+				<modifier>0.1</modifier>
+			</li>
+			<li Class="RoleEffect_PawnStatOffset">
+				<statDef>MeleeParryChance</statDef>
+				<modifier>0.2</modifier>
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/Core/InspirationDefs/Inspirations.xml
+++ b/Patches/Core/InspirationDefs/Inspirations.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/InspirationDef[defName="Frenzy_Shoot"]/statOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<ShootingAccuracyPawn>2</ShootingAccuracyPawn>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Patches/Core/InspirationDefs/Inspirations.xml
+++ b/Patches/Core/InspirationDefs/Inspirations.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/InspirationDef[defName="Frenzy_Shoot"]/statOffsets/ShootingAccuracyPawn</xpath>
 		<value>
+			<AimingAccuracy>0.2</AimingAccuracy>
 			<ShootingAccuracyPawn>2</ShootingAccuracyPawn>
 		</value>
 	</Operation>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -85,9 +85,19 @@
   </Operation>
 
   <Operation Class="PatchOperationAttributeAdd">
-  <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
+    <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
     <attribute>Inherit</attribute>
-    <value>false</value>
+      <value>false</value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
+    <value>
+      <equippedStatOffsets>
+        <AimingAccuracy>0.6</AimingAccuracy>
+        <ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+      </equippedStatOffsets>
+    </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Changes

- Patched the shooting inspiration to give +2 shooting accuracy instead of +8 (the vanilla value) and +0.2 aiming accuracy
- Adjusted the Gunlink's bonus from +3 shooting accuracy to +1.5 shooting accuracy and +0.6 aiming accuracy
- Readjusted the Ideology combat related precepts and abilities with the same logic as the Gunlink and combat inspirations.

## Reasoning

- The shooting inspiration being a flat bonus gives a 0 shooting skill pawn with 100% weapon handling, 368.8 weapon handling. this bonus enables the pawn not only to shoot very well but enables ranged targeting for the duration of the inspiration which is 8 days. Gunlinks give a +3 accuracy bonus, a +2 bonus for the inspiration should be enough. It's not like one day the pawn wakes up and goes, "i can shoot a fly on the moon today"...
- Even pawns with 0 shooting skill can have the inspiration as well, they just need to be capable of shooting. Let alone that the flat bonus is even worse for pawns that have higher shooting skill and the bonus stacks on top of the other bonuses gained by apparel and traits etc.
- +2 bonus equals to giving the 0 skill pawn, 10 shooting skills (100% weapon handling stat to 250% as the raw and final value unaffected by external factors) which reflects the vanilla behavior of +8 shooting accuracy bonus giving 8 shooting skills.
- The aiming accuracy bonus of shooting frenzy is added on top of the skill multiplier, so it acts more like more skills rather than how apparel bonuses behave which give the bonus on top of the base 100% prior to other multipliers. So with that in mind a +0.2 bonus for the inspiration and +0.6 for the gunlink should be balanced enough.
- This chart shows the final values for different situations: 
![image](https://user-images.githubusercontent.com/56392968/166094568-e50b0818-6f5b-4e51-99f2-71b062c26f6a.png)


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
