### PR TITLE
Improve turret reloading behavior for non-player pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -13,8 +13,16 @@ namespace CombatExtended
 {
     public class CompAmmoResupplyOnWakeup : ThingComp
     {
-        public HashSet<Building_TurretGunCE> nearbyTurrets = new HashSet<Building_TurretGunCE>();
-        const int turretsWithinDistanceSqr = 100;
+        /// <summary>
+        /// The radius in which to scan for turrets to resupply with ammo.
+        /// </summary>
+        private const float MaxResupplyRadius = 40;
+
+        /// <summary>
+        /// The radius around a given turret in which to search for corresponding ammo.
+        /// </summary>
+        private const float AmmoSearchRadius = 20;
+
         const int ticksBetweenChecks = 600;    //Divide by 60 for seconds
 
         public CompProperties_AmmoResupplyOnWakeup Props => (CompProperties_AmmoResupplyOnWakeup)props;
@@ -23,7 +31,6 @@ namespace CombatExtended
         //Only do something when ammo system is enabled
         public bool IsActive => Controller.settings.EnableAmmoSystem && (parent.TryGetComp<CompCanBeDormant>()?.Awake ?? true);
 
-        //FieldInfo thingsField = typeof(LordJob_MechanoidDefendBase).GetField("things");
         LordJob_MechanoidDefendBase parentLordJob => ((parent as Building)?.GetLord()?.LordJob as LordJob_MechanoidDefendBase);
         public bool ClusterAlive
         {
@@ -38,31 +45,42 @@ namespace CombatExtended
             }
         }
 
+        /// <summary>
+        /// Determine if the amount of ammo in this turret's magazine and on the ground around it
+        /// is sufficient to not require dropping in further ammo supplies.
+        /// </summary>
+        /// <remarks>
+        /// This checks if the cumulative ammo count is at least half the magazine capacity,
+        /// which is the same threshold that triggers the turret reload job.
+        /// </remarks>
         public bool EnoughAmmoAround(Building_TurretGunCE turret)
         {
-            //Prevent ammo being dropped as a result of the turret being reloaded at the time
-            if (turret.GetReloading() || turret.ShouldReload(1.0f))
+            // Prevent ammo being dropped if the turret is being reloaded at the time
+            // or has enough ammo in its magazine
+            if (turret.GetReloading() || !turret.ShouldReload(JobGiver_DefenderReloadTurret.AmmoReloadThreshold))
                 return true;
 
             var ammoComp = turret.CompAmmo;
-            
-            int num = GenRadial.NumCellsInRadius(20f);
-            int num2 = ammoComp.CurMagCount;
-            int num3 = Mathf.CeilToInt((float)ammoComp.MagSize / 6f);
-            
-            for (int i = 0; i < num; i++)
+
+            int numCells = GenRadial.NumCellsInRadius(AmmoSearchRadius);
+            int availableAmmo = ammoComp.CurMagCount;
+            int minRequiredAmmoCount = Mathf.CeilToInt(ammoComp.MagSize * JobGiver_DefenderReloadTurret.AmmoReloadThreshold);
+
+            var map = parent.Map;
+
+            for (int i = 0; i < numCells; i++)
             {
                 IntVec3 c = parent.Position + GenRadial.RadialPattern[i];
-                if (c.InBounds(parent.Map))
+                if (c.InBounds(map))
                 {
-                    List<Thing> thingList = c.GetThingList(parent.Map);
+                    List<Thing> thingList = map.thingGrid.ThingsListAtFast(c);
                     for (int j = 0; j < thingList.Count; j++)
                     {
-                        if ((ammoComp != null && ammoComp.CurrentAmmo == thingList[j].def))
+                        if (ammoComp.CurrentAmmo == thingList[j].def)
                         {
-                            num2 += thingList[j].stackCount;
+                            availableAmmo += thingList[j].stackCount;
 
-                            if (num2 > num3)
+                            if (availableAmmo > minRequiredAmmoCount)
                                 return true;
                         }
                     }
@@ -84,17 +102,23 @@ namespace CombatExtended
         {
             if (!IsActive)
                 return;
-            
-            foreach (var turret in parent.Map.listerThings.ThingsInGroup(ThingRequestGroup.BuildingArtificial)
-                    .Where(x => (x.def?.building?.IsTurret ?? false) && !x.def.building.IsMortar
-                        //ONLY supply nearby turrets which are Building_TurretGunCE
-                        && ((x as Building_TurretGunCE)?.CompAmmo?.UseAmmo ?? false)
-                        && x.Faction?.def == FactionDefOf.Mechanoid
-                        && x.Position.DistanceToSquared(parent.Position) < turretsWithinDistanceSqr).Select(x => x as Building_TurretGunCE))
+
+            var turretTracker = parent.Map.GetComponent<TurretTracker>();
+            var beaconFaction = parent.Faction;
+            var beaconPos = parent.Position;
+
+            foreach (var building in turretTracker.Turrets)
             {
-                if (EnoughAmmoAround(turret)) continue;
-                if (turret.CompAmmo != null && turret.CompAmmo.CurrentAmmo != null)
-                    DropSupplies(turret.CompAmmo.CurrentAmmo, Mathf.CeilToInt(0.5f * (float)turret.CompAmmo.MagSize), turret.Position);
+                if (building is Building_TurretGunCE turret &&
+                    turret.Faction == beaconFaction &&
+                    !turret.def.building.IsMortar &&
+                    (turret.CompAmmo?.UseAmmo ?? false) &&
+                    turret.Position.InHorDistOf(beaconPos, MaxResupplyRadius))
+                {
+                    if (EnoughAmmoAround(turret)) continue;
+                    if (turret.CompAmmo.CurrentAmmo != null)
+                        DropSupplies(turret.CompAmmo.CurrentAmmo, Mathf.CeilToInt(0.5f * (float)turret.CompAmmo.MagSize), turret.Position);
+                }
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_DefenderReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_DefenderReloadTurret.cs
@@ -18,7 +18,7 @@ namespace CombatExtended
         /// How low can ammo get before we want to reload the turret?
         /// Set arbitrarily, balance if needed.
         /// </summary>
-        private const float ammoReloadThreshold = .5f;
+        public const float AmmoReloadThreshold = .5f;
         public override Job TryGiveJob(Pawn pawn)
         {
             var turret = TryFindTurretWhichNeedsReloading(pawn);
@@ -35,8 +35,10 @@ namespace CombatExtended
             {
                 var turret = t as Building_Turret;
                 if (turret == null) { return false; }
-                if (!JobGiverUtils_Reload.CanReload(pawn, turret, forced: false, emergency: true)) { return false; }
-                return turret.ShouldReload(ammoReloadThreshold);
+
+                // Optimization: Check if the turret should be reloaded given its current magazine fullness first,
+                // as CanReload() may trigger a potentially expensive ammo search.
+                return turret.ShouldReload(AmmoReloadThreshold) && JobGiverUtils_Reload.CanReload(pawn, turret, forced: false, emergency: true);
             };
 
             var hopefullyTurret = pawn.Map.GetComponent<TurretTracker>().ClosestTurret(


### PR DESCRIPTION
## Changes

* Make the reload jobgiver check first if a given turret's magazine fullness
  is below the threshold of 50% before additional checks. This avoids triggering
  a potentially expensive search for ammo for the case where the turret doesn't
  even need reloading.
* Introduce a maximum search radius for ammo for non-player pawns. This avoids
  a situation where sieging raiders or mech cluster defenders run halfway across
  the map to reload using dropped ammunition - they should now prefer ammunition
  supplied to them via siege drop pods or mech ammo beacons and not venture far
  from their designated area.
* Fix mech ammo beacons, as they seem to have been accidentally broken by a change
  back in 2020 - the check on whether a turret needed reloading had inverted polarity.
  As part of this, I also cleaned up the code a bit and converted it to use TurretTracker,
  so that it doesn't have to scan every building on the map when it runs. I also adjusted
  their search range for turrets - the current value was way too conservative for anything
  but the smallest mech clusters. They now scan for turrets in a 40-tile radius which should
  cover even a 10k threat point cluster.
* Make the mech ammo beacon and the reload jobgiver agree on the magazine fullness threshold
  under which a given turret should be reloaded. Previously it was 16% for the ammo beacon and
  50% for the jobgiver; it's now 50% for both.

## Reasoning

- Having sieging pirates run across the map to steal HE shells from the player's stockpile or a dead trader just because their last loaded shell was HE but the next round of supplies was incendiary seems like strange behavior, so it's more reasonable to restrict their shell search radius.
- Same stands for mechs in a cluster - they shouldn't venture away from the cluster to pick up ammo from other places.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned in some mech clusters and checked that ammo beacons now function.
