### PR TITLE
Fixed Medieval Overhaul Patches

### DIFF
--- a/Patches/Medieval Overhaul/MO_Apparel_Helmets.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Helmets.xml
@@ -18,7 +18,7 @@
                 defName="DankPyon_Headgear_ChainCoif" or 
                 defName="DankPyon_Headgear_ChainCoifClosed" or 
                 defName="DankPyon_Headgear_ChainCoifFull" or
-                defName="DankPyon_Headgear_PaddedNasalHelm" or 
+                defName="DankPyon_Headgear_PaddedNasalHelmet" or 
                 defName="DankPyon_Headgear_PaddedKettle" or 
                 defName="DankPyon_Headgear_PaddedFlatTop" or
                 defName="DankPyon_Headgear_ChainNasalHelm" or
@@ -37,7 +37,7 @@
         <li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[
                 defName="DankPyon_Headgear_ChainCoifFull" or
-                defName = "DankPyon_Headgear_PaddedNasalHelm" or 
+                defName = "DankPyon_Headgear_PaddedNasalHelmet" or 
                 defName="DankPyon_Headgear_PaddedFlatTop" or
                 defName="DankPyon_Headgear_ChainNasalHelm" or
                 defName="DankPyon_Headgear_ChainNasalHelmRed" or
@@ -64,36 +64,22 @@
             <xpath>Defs/ThingDef[
                 defName = "DankPyon_Headgear_coif" or 
                 defName="DankPyon_Headgear_ArmingCap" or 
-                defName="DankPyon_Headgear_FullArmingCap"]/statBases</xpath>
+				defname="DankPyon_Headgear_RedBandana" or 
+				defName="DankPyon_Headgear_FullArmingCap"]/statBases</xpath>
             <value>
                 <Bulk>2</Bulk>
                 <WornBulk>0</WornBulk>
             </value>
         </li>
 
-        <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[
                 defName="DankPyon_Headgear_ArmingCap" or 
-                defName="DankPyon_Headgear_FullArmingCap"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>1</ArmorRating_Sharp>
-			</value>
-		</li>	
-        <li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[
-                defName="DankPyon_Headgear_ArmingCap" or 
-                defName="DankPyon_Headgear_FullArmingCap"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>1</ArmorRating_Blunt>
-			</value>
-		</li>	
-
-        <li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName = "DankPyon_Headgear_coif"]/statBases/StuffEffectMultiplierArmor</xpath>
+                defName="DankPyon_Headgear_FullArmingCap"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 			</value>
-		</li>	
+		</li>
 
     <!--Chain Coif, Closed, Full-->
         <li Class="PatchOperationAdd">
@@ -111,15 +97,9 @@
 			<xpath>Defs/ThingDef[
                 defName = "DankPyon_Headgear_ChainCoif" or 
                 defName="DankPyon_Headgear_ChainCoifClosed" or 
-                defName="DankPyon_Headgear_ChainCoifFull"]/statBases/ArmorRating_Sharp</xpath>
+                defName="DankPyon_Headgear_ChainCoifFull"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
-				<ArmorRating_Sharp>1.65</ArmorRating_Sharp>
-			</value>
-		</li>	
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName = "DankPyon_Headgear_ChainCoif" or defName="DankPyon_Headgear_ChainCoifClosed" or defName="DankPyon_Headgear_ChainCoifFull"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>1.75</ArmorRating_Blunt>
+				<StuffEffectMultiplierArmor>1.65</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 
@@ -127,26 +107,28 @@
     <!--Chain Helmet Flat Top, Closed Flat Top, Kettle, Nasal-->
         <li Class="PatchOperationRemove">
             <xpath>Defs/ThingDef[
-                defName = "DankPyon_Headgear_PaddedNasalHelm" or 
-                defName="DankPyon_Headgear_PaddedKettle" or 
-                defName="DankPyon_Headgear_PaddedFlatTop" or
-                defName="DankPyon_Headgear_ChainNasalHelm" or
-                defName="DankPyon_Headgear_ChainNasalHelmRed" or
-                defName="DankPyon_Headgear_ChainKettle" or
-                defName="DankPyon_Headgear_Chain_FlatTop" or
-                defName="DankPyon_Headgear_ChainClosedFlatTop"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+                defName = "DankPyon_Headgear_PaddedNasalHelmet" or 
+                defName="DankPyon_Headgear_PaddedKettleHelmet" or 
+                defName="DankPyon_Headgear_PaddedFlatTopHelmet" or
+                defName="DankPyon_Headgear_ChainNasalHelmet" or
+				defname="DankPyon_Headgear_ChainNasalRedHelmet" or
+                defName="DankPyon_Headgear_ChainKettleHelmet" or
+                defName="DankPyon_Headgear_Chain_FlatTopHelmet" or
+				defname="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or
+                defName="DankPyon_Headgear_ChainClosedFlatTopHelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[
-                defName = "DankPyon_Headgear_PaddedNasalHelm" or 
-                defName="DankPyon_Headgear_PaddedKettle" or 
-                defName="DankPyon_Headgear_PaddedFlatTop" or
-                defName="DankPyon_Headgear_ChainNasalHelm" or
-                defName="DankPyon_Headgear_ChainNasalHelmRed" or
-                defName="DankPyon_Headgear_ChainKettle" or
-                defName="DankPyon_Headgear_Chain_FlatTop" or
-                defName="DankPyon_Headgear_ChainClosedFlatTop"]/statBases</xpath>
+                defName = "DankPyon_Headgear_PaddedNasalHelmet" or 
+                defName="DankPyon_Headgear_PaddedKettleHelmet" or 
+                defName="DankPyon_Headgear_PaddedFlatTopHelmet" or
+                defName="DankPyon_Headgear_ChainNasalHelmet" or
+				defname="DankPyon_Headgear_ChainNasalRedHelmet" or
+                defName="DankPyon_Headgear_ChainKettleHelmet" or
+                defName="DankPyon_Headgear_Chain_FlatTopHelmet" or
+				defname="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or
+                defName="DankPyon_Headgear_ChainClosedFlatTopHelmet"]/statBases</xpath>
             <value>
                 <Bulk>4</Bulk>
                 <WornBulk>0</WornBulk>
@@ -155,43 +137,24 @@
         
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[
-                defName = "DankPyon_Headgear_PaddedNasalHelm" or 
-                defName="DankPyon_Headgear_PaddedKettle" or 
-                defName="DankPyon_Headgear_PaddedFlatTop"]/statBases/ArmorRating_Sharp</xpath>
+                defName = "DankPyon_Headgear_PaddedNasalHelmet" or 
+                defName="DankPyon_Headgear_PaddedKettleHelmet" or 
+                defName="DankPyon_Headgear_PaddedFlatTopHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
-				<ArmorRating_Sharp>2.2</ArmorRating_Sharp>
-			</value>
-		</li>	
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[
-                defName = "DankPyon_Headgear_PaddedNasalHelm" or 
-                defName="DankPyon_Headgear_PaddedKettle" or 
-                defName="DankPyon_Headgear_PaddedFlatTop"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>3.5</ArmorRating_Blunt>
+				<StuffEffectMultiplierArmor>2.2</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[
-                defName="DankPyon_Headgear_ChainNasalHelm" or
-                defName="DankPyon_Headgear_ChainNasalHelmRed" or
-                defName="DankPyon_Headgear_ChainKettle" or
-                defName="DankPyon_Headgear_Chain_FlatTop" or
-                defName="DankPyon_Headgear_ChainClosedFlatTop"]/statBases/ArmorRating_Sharp</xpath>
+                defName="DankPyon_Headgear_ChainNasalHelmet" or
+				defname="DankPyon_Headgear_ChainNasalRedHelmet" or
+                defName="DankPyon_Headgear_ChainKettleHelmet" or
+                defName="DankPyon_Headgear_Chain_FlatTopHelmet" or
+				defname="DankPyon_Headgear_ClosedChain_FlatTopHelmet" or
+                defName="DankPyon_Headgear_ChainClosedFlatTopHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
-				<ArmorRating_Sharp>2.7</ArmorRating_Sharp>
-			</value>
-		</li>	
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[
-                defName="DankPyon_Headgear_ChainNasalHelm" or
-                defName="DankPyon_Headgear_ChainNasalHelmRed" or
-                defName="DankPyon_Headgear_ChainKettle" or
-                defName="DankPyon_Headgear_Chain_FlatTop" or
-                defName="DankPyon_Headgear_ChainClosedFlatTop"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>3.8</ArmorRating_Blunt>
+				<StuffEffectMultiplierArmor>2.7</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 
@@ -201,17 +164,13 @@
 
         <li Class="PatchOperationAdd">
         <xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"]/statBases</xpath>
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"]/statBases</xpath>
             <value>
                 <Bulk>6</Bulk>
                 <WornBulk>0</WornBulk>
@@ -220,17 +179,13 @@
 
         <li Class="PatchOperationReplace">
         <xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"]/apparel/bodyPartGroups</xpath>
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"]/apparel/bodyPartGroups</xpath>
 			<value>
 				<bodyPartGroups>
                     <li>FullHead</li>
@@ -240,32 +195,24 @@
 
         <li Class="PatchOperationRemove">
             <xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"]/equippedStatOffsets</xpath>
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"]/equippedStatOffsets</xpath>
             <value>
                 <AimingAccuracy>-0.4</AimingAccuracy>       <!--CE Bascinet-->
                 <MeleeHitChance>-2</MeleeHitChance>
@@ -275,17 +222,13 @@
         
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"]/statBases/StuffEffectMultiplierArmor</xpath>
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
 			</value>
@@ -302,17 +245,13 @@
 
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[
-            defName="DankPyon_Headgear_VisoredKettleHelmet" or
             defName="DankPyon_Headgear_ClosedBascinetHelmet" or
-            defName="DankPyon_Headgear_HounskullHelmet" or
             defName="DankPyon_Headgear_SalletHelmet" or
             defName="DankPyon_Headgear_Bascinet_KlappvisierHelmetClosed" or
-            defName="DankPoyn_Headgear_KlappvisierHelmetOpen" or
             defName="DankPyon_Headgear_GreatHelm" or
-            defName="DankPyon_Headgear_CrusaderGreatHelm" or
-            defName="DankPyon_Headgear_RoyalGreatHelm" or
-            defName="DankPyon_Headgear_HeraldicGreatHelm" or
-            defName="DankPyon_Headgear_Armet"          
+            defName="DankPyon_Headgear_HeraldicGreatHelm1c" or
+            defName="DankPyon_Headgear_Armet" or
+			defname="DankPyon_Headgear_ArmetGilded"
             ]/stuffCategories</xpath>
             <value>
                 <stuffCategories>

--- a/Patches/Medieval Overhaul/MO_Apparel_Various.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Various.xml
@@ -67,7 +67,22 @@
 
 <!--Boots-->
 
-<!--Body-->        
+<!--Body-->
+	<!--Leather Tunic-->
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Sackcloth"]/statBases</xpath>
+            <value>
+                <Bulk>20</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+    	<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Sackcloth"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+			</value>
+		</li>
     <!--Leather Tunic-->
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Leather_Tunic"]/statBases</xpath>
@@ -82,7 +97,7 @@
 			<value>
 				<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
 			</value>
-		</li>	
+		</li>
 
     <!--Padded Surcoat, Gambeson-->
     <!--Surcoat:skin, Gambeson:middle-->
@@ -95,7 +110,7 @@
                 <WornBulk>0</WornBulk>
             </value>
         </li>
-
+<!--
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="DankPyon_Apparel_Padded_Surcoat"]/label</xpath>
 			<value>
@@ -134,7 +149,7 @@
 				<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 			</value>
 		</li>
-        
+-->
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Padded_Surcoat"]/statBases/Mass</xpath>
             <value>
@@ -167,22 +182,6 @@
                 <li>Arms</li>
             </value>
         </li>
-
-        <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[
-                defName="DankPyon_Apparel_Padded_Surcoat"]/costList/Cloth</xpath>
-            <value>
-                <Cloth>70</Cloth>             <!-- Adjusted price for extra coverage-->
-            </value>
-        </li>               
-
-        <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[defName="Dankpyon_Apparel_Gambeson"]/costList/Cloth</xpath>
-            <value>
-                <Cloth>95</Cloth>           <!-- Adjusted price for extra coverage-->
-            </value>
-        </li>
-
     <!--Padded Leather-->
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Padded_Leather"]/statBases</xpath>
@@ -194,6 +193,22 @@
 
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Padded_Leather"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+	<!--Lamellar-->
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Light_Lamellar"]/statBases</xpath>
+            <value>
+                <Bulk>30</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Light_Lamellar"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>13</StuffEffectMultiplierArmor>
 			</value>
@@ -207,11 +222,18 @@
                 <WornBulk>0</WornBulk>
             </value>
         </li>
-
+<!--
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Hauberk"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+			</value>
+		</li>
+-->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Hauberk"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1.8</StuffEffectMultiplierArmor>
 			</value>
 		</li>
         
@@ -228,21 +250,28 @@
                     <Mass>9</Mass>      
             </value>
         </li>
-
+<!--
    		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="DankPyon_Apparel_Heavy_Hauberk"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>1.7</ArmorRating_Sharp>
 			</value>
+		</li>
+-->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="DankPyon_Apparel_Heavy_Hauberk"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2.2</StuffEffectMultiplierArmor>
+			</value>
 		</li>	
-
+<!--
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Hauberk" or defName="DankPyon_Apparel_Heavy_Hauberk"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>0.3</ArmorRating_Blunt>
 			</value>
 		</li>
-
+-->
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName = "DankPyon_Apparel_Hauberk" or defName="DankPyon_Apparel_Heavy_Hauberk"]/apparel/bodyPartGroups</xpath>
             <value>
@@ -282,7 +311,6 @@
     <!--Coat Of Plates, Brigandine-->
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[
-                defName="DankPyon_Apparel_CoatOfPlates" or
                 defName="DankPyon_Apparel_Brigandine"]/statBases</xpath>
             <value>
                 <Bulk>60</Bulk>
@@ -290,29 +318,15 @@
             </value>
         </li>
 
-        <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_CoatOfPlates"]/statBases/ArmorRating_Sharp</xpath>
-			<value>
-				<ArmorRating_Sharp>2.3</ArmorRating_Sharp>
-			</value>
-		</li>
-        <li Class="PatchOperationReplace">
-            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_CoatOfPlates"]/statBases/ArmorRating_Blunt</xpath>
-			<value>
-				<ArmorRating_Blunt>3</ArmorRating_Blunt>
-			</value>
-		</li>
-        
-        <li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Brigandine"]/statBases/StuffEffectMultiplierArmor</xpath>
             <value>
-                <StuffEffectMultiplierArmor>2.4</StuffEffectMultiplierArmor>
+                <StuffEffectMultiplierArmor>2.8</StuffEffectMultiplierArmor>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[
-                defName="DankPyon_Apparel_CoatOfPlates" or
                 defName="DankPyon_Apparel_Brigandine"]/statBases/Mass</xpath>
             <value>
                 <Mass>14</Mass>
@@ -321,13 +335,11 @@
 
         <li Class="PatchOperationRemove">
             <xpath>Defs/ThingDef[
-                defName="DankPyon_Apparel_CoatOfPlates" or
                 defName="DankPyon_Apparel_Brigandine"]/equippedStatOffsets/MoveSpeed</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[
-                defName="DankPyon_Apparel_CoatOfPlates" or
                 defName="DankPyon_Apparel_Brigandine"]/equippedStatOffsets</xpath>
             <value>
                 <MeleeDodgeChance>-0.20</MeleeDodgeChance>
@@ -354,7 +366,7 @@
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_Breast_Plate"]/statBases/StuffEffectMultiplierArmor</xpath>
             <value>
-                <StuffEffectMultiplierArmor>2.6</StuffEffectMultiplierArmor>
+                <StuffEffectMultiplierArmor>3.1</StuffEffectMultiplierArmor>
             </value>
         </li>
 
@@ -375,7 +387,7 @@
         <li Class="PatchOperationReplace">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlate"]/statBases/StuffEffectMultiplierArmor</xpath>
             <value>
-                <StuffEffectMultiplierArmor>2.6</StuffEffectMultiplierArmor>
+                <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
             </value>
         </li>
 
@@ -392,6 +404,41 @@
 
         <li Class="PatchOperationAdd">
             <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlate"]/equippedStatOffsets</xpath>
+            <value>
+                <MeleeDodgeChance>-0.25</MeleeDodgeChance>
+                <Suppressability>-0.25</Suppressability>
+            </value>
+        </li>
+
+		<!--Full Plate Gilded-->
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateGilded"]/statBases</xpath>
+            <value>
+                <Bulk>100</Bulk>
+                <WornBulk>0</WornBulk>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateGilded"]/statBases/StuffEffectMultiplierArmor</xpath>
+            <value>
+                <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateGilded"]/statBases/Mass</xpath>
+            <value>
+                <Mass>15</Mass>
+            </value>
+        </li>
+
+        <li Class="PatchOperationRemove">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateGilded"]/equippedStatOffsets/MoveSpeed</xpath>
+        </li>
+
+        <li Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateGilded"]/equippedStatOffsets</xpath>
             <value>
                 <MeleeDodgeChance>-0.25</MeleeDodgeChance>
                 <Suppressability>-0.25</Suppressability>


### PR DESCRIPTION
MO_Apparel_Helmets.xml and MO_Apparel_Various.xml had a lot of unused Defs, which led to failed Patch Operations.
Removed extra Defs and added new ones, while also adjusting Armour Values to adhere to the Vanilla Plate Armour's Values.

Also one thing that caused issues, was that Gambesons and Sur Coats had cost changes, which somehow broke the patch. These were removed

## Changes

- Removed old/unused Defs
- Added new Defs that weren't present (all Apparel Defs as of 03.05.2022 are present)
- Removed cost change for Gambesons and Sur Coats
- Removed renaming of sur coats to arming doublets.
- Adjusted Plate Armours' values to be closer to the Vanilla Plate Armour's values.

## Reasoning

- Fixed Patch Operation Failures
- New Apparel is now patched
- Cost change and renaming of gambesons/sur coats was unnecessary from my point of view, especially since they caused issues
- There was little incentive to use the new armours if the Vanilla Plate Armour was still superiour

## Alternatives

- No changes to Gambesons and Sur Coats, instead moving them to the bottom of the .xml file or fixing them properly
  1. moving them to the bottom would be a botch job
  2. I didn't want to figure out why it caused issues since I didn't like the change in the first place
- Group more Apparels together e.g. Fullplate and Gilded Fullplate
  1. I didn't want to bother
  2. Maybe you can make the argument that it is now easier to maintain, since they can easily be changed seperately...?

## Testing

Check tests you have performed:
- [X] Compiles without warnings (Sorta, Medieval Overhaul still has other (already existent) warnings)
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded (Vanilla Plate Armour remains unaffected)
- [X] Playtested a colony (20 mins, but spawned in all sorts of apparel through dev mode)
