### PR TITLE
Add a reinforced barrel to the Flak Cannon's recipe

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -377,10 +377,15 @@
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>
     </statBases>
-    <costList>
-      <Steel>500</Steel>
-      <ComponentIndustrial>5</ComponentIndustrial>
-    </costList>
+    <costListForDifficulty>
+      <difficultyVar>classicMortars</difficultyVar>
+      <invert>true</invert>
+      <costList>
+        <ComponentIndustrial>5</ComponentIndustrial>
+        <ReinforcedBarrel>1</ReinforcedBarrel>
+      </costList>
+      <Steel>350</Steel>
+    </costListForDifficulty>
     <building>
       <turretGunDef>Gun_FlakTurret</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>


### PR DESCRIPTION
## Changes

- What it says on the tin

## Reasoning

- Added the reinforced barrel to the recipe just like how the vanilla mortar is set up for consistency's sake and reducing steel cost bloat.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
