### PR TITLE
Add reinforced barrel to Flak gun.

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -381,6 +381,14 @@
       <Steel>500</Steel>
       <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
+    <costListForDifficulty>
+      <difficultyVar>classicMortars</difficultyVar>
+      <costList>
+        <ComponentIndustrial>5</ComponentIndustrial>
+        <ReinforcedBarrel>1</ReinforcedBarrel>
+        <Steel>350</Steel>
+      </costList>   
+    </costListForDifficulty>       
     <building>
       <turretGunDef>Gun_FlakTurret</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>


### PR DESCRIPTION
## Changes
If the player is not using the 'classic mortars' difficulty option, the steel cost of the Flak Gun is reduced by 150, but it now requires a reinforced barrel to construct.

## References
Same as #1551, but with correct formatting.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
