### PR TITLE
Fix hard armor damage without breaking ZL

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -274,8 +274,11 @@ namespace CombatExtended
                 }
                 else
                 {
-                    // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-		    if (isSharpDmg && (penAmount / armorAmount) < 0.5f)
+                    // Hard armor takes damage depending on the damage amount and damage penetration
+                    // Such armor takes the most damage when the attack has the same amount of armor penetration as the armor has armor amount
+                    // Otherwise it's a non-penetration (was unable to perforate the armor) or an over-penetration (creates a nice hole in the armor)
+                    // It is assumed that elastic deformation (no damage) occurs when the attack is blunt and has less armor penetration than the armor amount divided by 2
+		    if (!isSharpDmg && (penAmount / armorAmount) < 0.5f)
 		    {
                         armorDamage = 0;
 		    }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -310,12 +310,7 @@ namespace CombatExtended
 	    if (armorDamage == 0) {
 		return false;
 	    }
-            // If armor damage is less than 1, have a chance for it to become exactly 1 (mind you, this can be an extremely small chance)
-            if ((armorDamage < 1f) && (Rand.Value <= Mathf.Min(1.0f, penAmount / armorAmount)))
-            {
-                armorDamage = 1f;
-            }
-
+            
             // Any fractional armor damage has a chance to get rounded to the largest nearest whole number
             // Combined with the previous dice roll, values between 0 and 1 have an increased chance to get rounded up
             if (Rand.Value < (armorDamage - Mathf.Floor(armorDamage)))

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -275,8 +275,15 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-		    armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
-
+		    if (isSharpDmg && (penAmount / armorAmount) < 0.5f)
+		    {
+                        armorDamage = 0;
+		    }
+		    else 
+		    {
+		        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount * penAmount / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+		    }
+			
 		    if (armorDamage > maxDamage) {
 			armorDamage = maxDamage;
 			newDmgAmount = maxDamage;

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -275,7 +275,8 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-		    armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount);
+		    armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+
 		    if (armorDamage > maxDamage) {
 			armorDamage = maxDamage;
 			newDmgAmount = maxDamage;

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -275,7 +275,7 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-		    armorDamage = (int)((dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount));
+		    armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount);
 		    if (armorDamage > maxDamage) {
 			armorDamage = maxDamage;
 			newDmgAmount = maxDamage;

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -275,7 +275,7 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-                    armorDamage = newDmgAmount;
+		    armorDamage = (int)((dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount / armorAmount));
 		    if (armorDamage > maxDamage) {
 			armorDamage = maxDamage;
 			newDmgAmount = maxDamage;

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -284,7 +284,7 @@ namespace CombatExtended
 		    }
 		    else 
 		    {
-		        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(0, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+		        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
 		    }
 			
 		    if (armorDamage > maxDamage) {

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -284,7 +284,7 @@ namespace CombatExtended
 		    }
 		    else 
 		    {
-		        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Clamp01(penAmount * penAmount / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+		        armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(0, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
 		    }
 			
 		    if (armorDamage > maxDamage) {

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -177,7 +177,7 @@ namespace CombatExtended
             {
                 var curPart = partsToHit[i];
                 var coveredByArmor = curPart.IsInGroup(CE_BodyPartGroupDefOf.CoveredByNaturalArmor);
-                var armorAmount = coveredByArmor ? /*pawn.GetStatValue(dinfo.Def.armorCategory.armorRatingStat)*/ pawn.PartialStat(dinfo.Def.armorCategory.armorRatingStat, curPart, dmgAmount, penAmount) : 0;
+                var armorAmount = coveredByArmor ? pawn.PartialStat(dinfo.Def.armorCategory.armorRatingStat, curPart, dmgAmount, penAmount) : 0;
 
                 // Only apply damage reduction when penetrating armored body parts
                 if (!TryPenetrateArmor(dinfo.Def, armorAmount, ref penAmount, ref dmgAmount, null, partDensity))


### PR DESCRIPTION
## Changes

Go back to the hard armor damage formula that properly handles near-pen deflected damage properly.

## References

Links to the associated issues or other related pull requests, e.g.
- Partially reverts #1437's revert from #1193.
- Related to #1437 and #1504

## Reasoning

Why did you choose to implement things this way, e.g.
- Hard armor needs to take damage from attacks that *almost* pen.
- Clamping 0/1 should avoid the ZL issue

## Alternatives

Square or sqrt the relative AP values to tweak damage taken.
Don't cap the top end damage - probably break ZL again, but maybe use a higher cap?

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
