### PR TITLE
Remove needless animal bodysize changes and some other things

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -32,13 +32,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Muffalo"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>2</baseBodySize>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Muffalo"]</xpath>
 		<value>
@@ -135,12 +128,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Gazelle"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.5</baseBodySize>
-		</value>
-	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Gazelle"]/race/baseHealthScale</xpath>
@@ -222,13 +209,6 @@
 					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Iguana"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.28</baseBodySize>
 		</value>
 	</Operation>
 
@@ -315,13 +295,6 @@
 					<armorPenetrationBlunt>8.5</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Rhinoceros"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>2.1</baseBodySize>
 		</value>
 	</Operation>
 
@@ -429,13 +402,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.1</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Dromedary"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1</baseHealthScale>
@@ -459,4 +425,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -33,13 +33,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.33</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BaseBear"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1.5</baseHealthScale>
@@ -224,12 +217,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Bear_Polar"]/race</xpath>
-		<value>
-			<baseBodySize>1.75</baseBodySize>
-		</value>
-	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Bear_Polar"]/race</xpath>
@@ -239,4 +226,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_BigCat.xml
@@ -97,13 +97,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.9</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="BigCatThingBase"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.9</baseHealthScale>
@@ -227,4 +220,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Birds.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Birds.xml
@@ -74,13 +74,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Cassowary"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.9</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Cassowary"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.7</baseHealthScale>
@@ -152,13 +145,6 @@
 					<armorPenetrationBlunt>1</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Emu"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1</baseBodySize>
 		</value>
 	</Operation>
 
@@ -237,13 +223,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Ostrich"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.2</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Ostrich"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.95</baseHealthScale>
@@ -317,13 +296,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Turkey"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.6</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turkey"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.5</baseHealthScale>
@@ -338,4 +310,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -53,13 +53,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Chicken"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.25</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Chicken"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.2</baseHealthScale>
@@ -195,13 +188,6 @@
 					<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Cow"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.8</baseBodySize>
 		</value>
 	</Operation>
 
@@ -396,13 +382,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Duck"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.3</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Duck"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.3</baseHealthScale>
@@ -465,13 +444,6 @@
 					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Bison"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>2</baseBodySize>
 		</value>
 	</Operation>
 
@@ -580,13 +552,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Goat"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.8</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Goat"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.8</baseHealthScale>
@@ -648,13 +613,6 @@
 					<armorPenetrationBlunt>0.352</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Goose"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.4</baseBodySize>
 		</value>
 	</Operation>
 
@@ -771,13 +729,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Sheep"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.8</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Sheep"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.8</baseHealthScale>
@@ -881,13 +832,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Horse"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.6</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Horse"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1.6</baseHealthScale>
@@ -950,13 +894,6 @@
 					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Yak"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.65</baseBodySize>
 		</value>
 	</Operation>
 
@@ -1053,13 +990,6 @@
 					<armorPenetrationSharp>0</armorPenetrationSharp>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="GuineaPig"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.18</baseBodySize>
 		</value>
 	</Operation>
 
@@ -1162,13 +1092,6 @@
 					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Donkey"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.3</baseBodySize>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Pet.xml
@@ -148,13 +148,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Husky"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.65</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Husky"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.65</baseHealthScale>
@@ -236,13 +229,6 @@
 					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="LabradorRetriever"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.65</baseBodySize>
 		</value>
 	</Operation>
 
@@ -378,4 +364,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -240,13 +240,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Capybara"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.7</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Capybara"]/combatPower</xpath>
 		<value>
 			<combatPower>35</combatPower>
@@ -322,13 +315,6 @@
 					<armorPenetrationSharp>0</armorPenetrationSharp>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Chinchilla"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.17</baseBodySize>
 		</value>
 	</Operation>
 
@@ -545,13 +531,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Raccoon"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.35</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Raccoon"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.35</baseHealthScale>
@@ -633,13 +612,6 @@
 					<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Rat"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.2</baseBodySize>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -104,13 +104,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Deer"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.15</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Deer"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1.15</baseHealthScale>
@@ -223,13 +216,6 @@
 					<armorPenetrationBlunt>3.630</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Ibex"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.9</baseBodySize>
 		</value>
 	</Operation>
 
@@ -350,13 +336,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Elk"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.9</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Elk"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1.9</baseHealthScale>
@@ -473,13 +452,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Caribou"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.9</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Caribou"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>1.9</baseHealthScale>
@@ -563,13 +535,6 @@
 					<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="WildBoar"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.85</baseBodySize>
 		</value>
 	</Operation>
 
@@ -659,4 +624,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -340,13 +340,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="ThingBaseFox"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>0.35</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ThingBaseFox"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>0.35</baseHealthScale>
@@ -361,4 +354,3 @@
 	</Operation>
 
 </Patch>
-


### PR DESCRIPTION
Since they don't affect hitboxes, there's just no reason for us to overwrite them in most cases.
Pretty much just makes pack animals unnecessarily worse.
There are are some wierd values in move speeds too, will probably include changes to those.

Won't touch changes to mechs and insectoids.