### PR TITLE
Miho Patch

### DIFF
--- a/Patches/Miho Race/Ammo/Ammo_Miho.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho.xml
@@ -91,6 +91,22 @@
 						<ai_IsIncendiary>true</ai_IsIncendiary>
 					</projectile>
 				</ThingDef>
+				<!--<ThingDef ParentName="BaseBullet">
+						<defName>Bullet_47x285mmR_Miho</defName>
+						<label>47x285mmR shell (AP)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Bullet_Big</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>Bullet</damageDef>
+						<speed>164</speed>
+						<dropsCasings>true</dropsCasings>
+					<damageAmountBase>131</damageAmountBase>
+					<armorPenetrationSharp>76</armorPenetrationSharp>
+					<armorPenetrationBlunt>10287.7</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>-->
 				<CombatExtended.AmmoSetDef>
 					<defName>AmmoSet_GreatArrowMiho</defName>
 					<label>great arrows</label>

--- a/Patches/Miho Race/Ammo/Ammo_Miho.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho.xml
@@ -275,7 +275,7 @@
 						</thingDefs>
 					</fixedIngredientFilter>
 					<products>
-						<Ammo_GreatArrow_Plasteel>10</Ammo_GreatArrow_Plasteel>
+						<Ammo_MihoStyxArrow>10</Ammo_MihoStyxArrow>
 					</products>
 				</RecipeDef>
 			</value>

--- a/Patches/Miho Race/Ammo/Ammo_Miho.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	  <Operation Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_MihoPlasma</defName>
+					<label>Rifle Plasma Cell</label>
+					<ammoTypes>
+					  <Ammo_PlasmaCellRifle>Bullet_MihoPlasma</Ammo_PlasmaCellRifle>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_MihoPlasmaSniper</defName>
+					<label>Rifle Plasma Cell</label>
+					<ammoTypes>
+					  <Ammo_PlasmaCellRifle>Bullet_MihoPlasmaSniper</Ammo_PlasmaCellRifle>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				<ThingDef ParentName="Base556x45mmNATOBullet">
+					<defName>Bullet_MihoPlasma</defName>
+					<label>Plasma Bolt</label>
+					<graphicData>
+					  <texPath>Things/Projectile/MihoPlasma</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>100</speed>
+					  <damageAmountBase>10</damageAmountBase>
+					  <damageDef>MihoPlasma</damageDef>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>80</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+				<ThingDef ParentName="Base556x45mmNATOBullet">
+					<defName>Bullet_MihoPlasmaSniper</defName>
+					<label>Plasma Bolt</label>
+					<graphicData>
+					  <texPath>Things/Projectile/MihoPlasma</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <speed>200</speed>
+					  <damageAmountBase>15</damageAmountBase>
+					  <damageDef>MihoPlasma</damageDef>
+					  <armorPenetrationSharp>0</armorPenetrationSharp>
+					  <armorPenetrationBlunt>120</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+				<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletRed">
+				  <defName>Bullet_Laser_MihoMiniGun</defName>
+				  <label>laser beam</label>  
+				  <graphicData>
+					<color>(255,160,46)</color>
+				  </graphicData>  
+				  <projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>Miho_Laser</damageDef>
+					<damageAmountBase>4</damageAmountBase>
+					<armorPenetrationSharp>0</armorPenetrationSharp>
+					<armorPenetrationBlunt>0</armorPenetrationBlunt>
+				  </projectile>         
+				</ThingDef>
+				<ThingDef ParentName="BaseBullet">
+					<defName>Bullet_60x180mmMiho_Thermobaric</defName>
+					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+					<label>60x180mm fuel shell (Thermobaric)</label>
+					<graphicData>
+						<texPath>Things/Projectile/LauncherShot</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+						<shaderType>TransparentPostLight</shaderType>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>Thermobaric</damageDef>
+						<damageAmountBase>160</damageAmountBase>
+						<armorPenetrationSharp>0</armorPenetrationSharp>
+						<armorPenetrationBlunt>0</armorPenetrationBlunt>
+						<speed>60</speed>
+						<flyOverhead>false</flyOverhead>
+						<explosionRadius>3.5</explosionRadius>
+						<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+						<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
+						<soundExplode>MortarIncendiary_Explode</soundExplode>
+						<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+						<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+						<soundAmbient>MortarRound_Ambient</soundAmbient>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						<ai_IsIncendiary>true</ai_IsIncendiary>
+					</projectile>
+				</ThingDef>
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_GreatArrowMiho</defName>
+					<label>great arrows</label>
+					<ammoTypes>
+					  <Ammo_GreatArrow_Stone>Projectile_GreatArrowMiho_Stone</Ammo_GreatArrow_Stone>
+					  <Ammo_GreatArrow_Steel>Projectile_GreatArrowMiho_Steel</Ammo_GreatArrow_Steel>
+					  <Ammo_GreatArrow_Plasteel>Projectile_GreatArrowMiho_Plasteel</Ammo_GreatArrow_Plasteel>
+					  <Ammo_GreatArrow_Venom>Projectile_GreatArrowMiho_Venom</Ammo_GreatArrow_Venom>
+					  <Ammo_GreatArrow_Flame>Projectile_GreatArrowMiho_Flame</Ammo_GreatArrow_Flame>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_GreatArrowMiho_Stone</defName>
+					<label>great arrow (stone)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>22</speed>
+						<damageAmountBase>13</damageAmountBase>
+						<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.5</armorPenetrationSharp>
+						<preExplosionSpawnChance>0.2</preExplosionSpawnChance>	<!-- 12.5 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_GreatArrow_Stone</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_GreatArrowMiho_Steel</defName>
+					<label>great arrow (steel)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>33</speed>
+						<damageAmountBase>15</damageAmountBase>
+						<armorPenetrationBlunt>6.22</armorPenetrationBlunt>
+						<armorPenetrationSharp>3.5</armorPenetrationSharp>
+						<preExplosionSpawnChance>0.4</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_GreatArrowMiho_Plasteel</defName>
+					<label>great arrow (plasteel)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>37</speed>
+						<damageAmountBase>12</damageAmountBase>
+						<armorPenetrationBlunt>17.44</armorPenetrationBlunt>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<preExplosionSpawnChance>0.50</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_GreatArrow_Plasteel</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_GreatArrowMiho_Venom</defName>
+					<label>great arrow (venom)</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>33</speed>
+						<damageDef>Arrow</damageDef>
+						<damageAmountBase>12</damageAmountBase>
+						<secondaryDamage>
+							<li>
+							<def>ArrowVenom</def>
+							<amount>3</amount>
+							</li>
+						</secondaryDamage>			
+						<armorPenetrationBlunt>17.44</armorPenetrationBlunt>
+						<armorPenetrationSharp>3.5</armorPenetrationSharp>
+						<preExplosionSpawnChance>0.4</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_GreatArrowMiho_Flame</defName>
+					<label>great arrow (flame)</label>
+				<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				  <explosionRadius>0.2</explosionRadius>
+				  <speed>33</speed>
+				  <damageDef>ArrowFire</damageDef>
+				  <damageAmountBase>6</damageAmountBase>
+				  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+				  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
+				</projectile>
+				</ThingDef>
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_MihoStyxArrow</defName>
+					<label>styx bow</label>
+					<ammoTypes>
+					  <Ammo_MihoStyxArrow>Projectile_MihoStyxArrow</Ammo_MihoStyxArrow>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+					<defName>Ammo_MihoStyxArrow</defName>
+					<label>styx arrow</label>
+					<graphicData>
+					  <texPath>Things/Ammo/Neolithic/Arrow/Plasteel</texPath>
+					  <graphicClass>Graphic_StackCount</graphicClass>
+					</graphicData>
+					<statBases>
+					  <Mass>0.33</Mass>	
+					  <MarketValue>9.72</MarketValue>
+					  <Bulk>1.14</Bulk>
+					</statBases>
+					<ammoClass>PlasteelArrow</ammoClass>
+					<generateAllowChance>0.2</generateAllowChance>
+				</ThingDef>
+				<ThingDef ParentName="BaseGreatArrowProjectile">
+					<defName>Projectile_MihoStyxArrow</defName>
+					<label>styx arrow</label>
+					<graphicData>
+						<texPath>Things/Projectile/Arrows/Arrow_Plasteel</texPath>
+						<graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<speed>54</speed>
+						<damageAmountBase>30</damageAmountBase>
+						<armorPenetrationBlunt>167.68</armorPenetrationBlunt>
+						<armorPenetrationSharp>18</armorPenetrationSharp>
+						<preExplosionSpawnChance>0.25</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
+						<preExplosionSpawnThingDef>Ammo_MihoStyxArrow</preExplosionSpawnThingDef>
+					</projectile>
+				</ThingDef>
+				<RecipeDef ParentName="AmmoRecipeNeolithicBase">
+					<defName>MakeAmmo_MihoStyxArrow</defName>
+					<label>make miho styx arrows x10</label>
+					<description>Craft 10  miho styx arrows.</description>
+					<jobString>Making  miho styx arrows.</jobString>
+					<workAmount>4300</workAmount>
+					<ingredients>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>WoodLog</li>
+						  </thingDefs>
+						</filter>
+						<count>3</count>
+					  </li>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Plasteel</li>
+						  </thingDefs>
+						</filter>
+						<count>10</count>
+					  </li>
+					</ingredients>
+					<fixedIngredientFilter>
+						<thingDefs>
+							<li>WoodLog</li>
+							<li>Plasteel</li>
+						</thingDefs>
+					</fixedIngredientFilter>
+					<products>
+						<Ammo_GreatArrow_Plasteel>10</Ammo_GreatArrow_Plasteel>
+					</products>
+				</RecipeDef>
+			</value>
+		</match>	
+	  </Operation>
+</Patch>

--- a/Patches/Miho Race/Ammo/Ammo_Miho.xml
+++ b/Patches/Miho Race/Ammo/Ammo_Miho.xml
@@ -2,11 +2,17 @@
 <Patch>
 	  <Operation Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationAdd">
 			<xpath>Defs</xpath>
 			<value>
+			  <CombatExtended.AmmoCategoryDef>
+				<defName>IncendiaryMiho</defName>
+				<label>armor-piercing incendiary (Miholic)</label>
+				<labelShort>AP-IM</labelShort>
+				<description>Filled with an high intensity incendiary compound that ignites on impact, burning the target, increasing armor penetration and comprimising the structure of the target.</description>
+			  </CombatExtended.AmmoCategoryDef>
 				<CombatExtended.AmmoSetDef>
 					<defName>AmmoSet_MihoPlasma</defName>
 					<label>Rifle Plasma Cell</label>
@@ -33,7 +39,7 @@
 					  <damageAmountBase>10</damageAmountBase>
 					  <damageDef>MihoPlasma</damageDef>
 					  <armorPenetrationSharp>0</armorPenetrationSharp>
-					  <armorPenetrationBlunt>80</armorPenetrationBlunt>
+					  <armorPenetrationBlunt>200</armorPenetrationBlunt>
 					</projectile>
 				</ThingDef>
 				<ThingDef ParentName="Base556x45mmNATOBullet">
@@ -44,12 +50,21 @@
 					  <graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					  <speed>200</speed>
-					  <damageAmountBase>15</damageAmountBase>
+					  <speed>100</speed>
+					  <damageAmountBase>30</damageAmountBase>
 					  <damageDef>MihoPlasma</damageDef>
 					  <armorPenetrationSharp>0</armorPenetrationSharp>
-					  <armorPenetrationBlunt>120</armorPenetrationBlunt>
+					  <armorPenetrationBlunt>400</armorPenetrationBlunt>
 					</projectile>
+					<comps>
+					  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+						<damageAmountBase>120</damageAmountBase>
+						<explosiveDamageType>MihoPlasma</explosiveDamageType>
+						<explosiveRadius>1.7</explosiveRadius>
+						<explosionSound>Explosion_Bomb</explosionSound>
+						<applyDamageToExplosionCellsNeighbors>false</applyDamageToExplosionCellsNeighbors>
+					  </li>
+					</comps>
 				</ThingDef>
 				<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletRed">
 				  <defName>Bullet_Laser_MihoMiniGun</defName>
@@ -58,10 +73,10 @@
 					<color>(255,160,46)</color>
 				  </graphicData>  
 				  <projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<damageDef>Miho_Laser</damageDef>
-					<damageAmountBase>4</damageAmountBase>
+					<damageDef>MihoPlasma</damageDef>
+					<damageAmountBase>7</damageAmountBase>
 					<armorPenetrationSharp>0</armorPenetrationSharp>
-					<armorPenetrationBlunt>0</armorPenetrationBlunt>
+					<armorPenetrationBlunt>200</armorPenetrationBlunt>
 				  </projectile>         
 				</ThingDef>
 				<ThingDef ParentName="BaseBullet">
@@ -277,6 +292,224 @@
 					<products>
 						<Ammo_MihoStyxArrow>10</Ammo_MihoStyxArrow>
 					</products>
+				</RecipeDef>
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x22mmNambuBase">
+					<defName>Ammo_8x22mmNambu_Miho</defName>
+					<label>8x22mm Nambu cartridge (AP-IM)</label>
+					<graphicData>
+						<texPath>Things/Ammo/Pistol/AP</texPath>
+						<graphicClass>Graphic_StackCount</graphicClass>
+					</graphicData>
+					<statBases>
+						<MarketValue>0.12</MarketValue>
+					</statBases>
+					<ammoClass>IncendiaryMiho</ammoClass>
+					<cookOffProjectile>Bullet_8x22mmNambu_Miho</cookOffProjectile>
+				</ThingDef>
+				<ThingDef ParentName="Base8x22mmNambuBullet">
+					<defName>Bullet_8x22mmNambu_Miho</defName>
+					<label>8x22mm Nambu bullet (AP-IM)</label>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>MihoGunshot</damageDef>
+						<damageAmountBase>5</damageAmountBase>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.88</armorPenetrationBlunt>
+						<secondaryDamage>
+							<li>
+							<def>Flame_Secondary</def>
+							<amount>3</amount>
+							</li>
+						</secondaryDamage>
+					</projectile>
+				</ThingDef>
+				<RecipeDef ParentName="AmmoRecipeBase">
+					<defName>MakeAmmo_8x22mmNambu_Miho</defName>
+					<label>make 8x22mm Nambu (AP-IM) cartridge x500</label>
+					<description>Craft 500 8x22mm Nambu (AP-IM) cartridges.</description>
+					<jobString>Making 8x22mm Nambu (AP-IM) cartridges.</jobString>
+					<researchPrerequisite>Miho_HeavyWeapon</researchPrerequisite>
+					<ingredients>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Steel</li>
+						  </thingDefs>
+						</filter>
+						<count>14</count>
+					  </li>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Prometheum</li>
+						  </thingDefs>
+						</filter>
+						<count>3</count>
+					  </li>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Miho_HeatCeramics</li>
+						  </thingDefs>
+						</filter>
+						<count>1</count>
+					  </li>
+					</ingredients>
+					<fixedIngredientFilter>
+					  <thingDefs>
+						<li>Steel</li>
+						<li>Prometheum</li>
+						<li>Miho_HeatCeramics</li>
+					  </thingDefs>
+					</fixedIngredientFilter>
+					<products>
+						<Ammo_8x22mmNambu_Miho>500</Ammo_8x22mmNambu_Miho>
+					</products>
+					<workAmount>3000</workAmount>
+				</RecipeDef>
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x22mmNambuBase">
+					<defName>Ammo_65x50mmSRArisaka_Miho</defName>
+					<label>6.5x50mmSR cartridge (AP-IM)</label>
+					<graphicData>
+						<texPath>Things/Ammo/Rifle/Incendiary</texPath>
+						<graphicClass>Graphic_StackCount</graphicClass>
+					</graphicData>
+					<statBases>
+						<MarketValue>0.14</MarketValue>
+					</statBases>
+					<ammoClass>IncendiaryMiho</ammoClass>
+					<cookOffProjectile>Bullet_65x50mmSRArisaka_Miho</cookOffProjectile>
+				</ThingDef>
+				<ThingDef ParentName="Base8x22mmNambuBullet">
+					<defName>Bullet_65x50mmSRArisaka_Miho</defName>
+					<label>6.5x50mmSR bullet (AP-IM)</label>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>MihoGunshot</damageDef>
+						<damageAmountBase>5</damageAmountBase>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.88</armorPenetrationBlunt>
+						<secondaryDamage>
+							<li>
+							<def>Flame_Secondary</def>
+							<amount>3</amount>
+							</li>
+						</secondaryDamage>
+					</projectile>
+				</ThingDef>
+				<RecipeDef ParentName="AmmoRecipeBase">
+					<defName>MakeAmmo_65x50mmSRArisaka_Miho</defName>
+					<label>make 6.5x50mmSR (AP-IM) cartridge x500</label>
+					<description>Craft 500 6.5x50mmSR (AP-IM) cartridges.</description>
+					<jobString>Making 6.5x50mmSR (AP-IM) cartridges.</jobString>
+					<researchPrerequisite>Miho_HeavyWeapon</researchPrerequisite>
+					<ingredients>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Steel</li>
+						  </thingDefs>
+						</filter>
+						<count>24</count>
+					  </li>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Prometheum</li>
+						  </thingDefs>
+						</filter>
+						<count>3</count>
+					  </li>
+					  <li>
+						<filter>
+						  <thingDefs>
+							<li>Miho_HeatCeramics</li>
+						  </thingDefs>
+						</filter>
+						<count>2</count>
+					  </li>
+					</ingredients>
+					<fixedIngredientFilter>
+					  <thingDefs>
+						<li>Steel</li>
+						<li>Prometheum</li>
+						<li>Miho_HeatCeramics</li>
+					  </thingDefs>
+					</fixedIngredientFilter>
+					<products>
+						<Ammo_65x50mmSRArisaka_Miho>500</Ammo_65x50mmSRArisaka_Miho>
+					</products>
+					<workAmount>4600</workAmount>
+				</RecipeDef>
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
+					<defName>Ammo_132x92mmSRTuF_Miho</defName>
+					<label>13.2x92mmSR TuF cartridge (AP-IM)</label>
+					<graphicData>
+					<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+					</graphicData>
+					<statBases>
+					<MarketValue>0.77</MarketValue>   
+					</statBases>
+					<ammoClass>IncendiaryMiho</ammoClass>
+					<cookOffProjectile>Bullet_132x92mmSRTuF_Miho</cookOffProjectile>
+				</ThingDef>
+				<ThingDef ParentName="Base132x92mmSRTuFBullet">
+					<defName>Bullet_132x92mmSRTuF_Miho</defName>
+					<label>13.2x92mmSR TuF bullet (AP-IM)</label>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MihoGunshot</damageDef>
+					<damageAmountBase>25</damageAmountBase>
+					<armorPenetrationSharp>44</armorPenetrationSharp>
+					<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
+					<secondaryDamage>
+						<li>
+						<def>Flame_Secondary</def>
+						<amount>16</amount>
+						</li>
+					</secondaryDamage>
+					</projectile>
+				</ThingDef>
+				<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+					<defName>MakeAmmo_132x92mmSRTuF_Miho</defName>
+					<label>make 13.2x92mmSR TuF (AP-IM) cartridge x200</label>
+					<description>Craft 200 13.2x92mmSR TuF (AP-IM) cartridges.</description>
+					<jobString>Making 13.2x92mmSR TuF (AP-IM) cartridges.</jobString>
+					<ingredients>
+					<li>
+						<filter>
+						<thingDefs>
+							<li>Steel</li>
+						</thingDefs>
+						</filter>
+						<count>58</count>
+					</li>
+					<li>
+						<filter>
+						<thingDefs>
+							<li>Prometheum</li>
+						</thingDefs>
+						</filter>
+						<count>6</count>
+					</li>
+					<li>
+						<filter>
+						  <thingDefs>
+							<li>Miho_HeatCeramics</li>
+						  </thingDefs>
+						</filter>
+						<count>2</count>
+					  </li>
+					</ingredients>
+					<fixedIngredientFilter>
+					  <thingDefs>
+						<li>Steel</li>
+						<li>Prometheum</li>
+						<li>Miho_HeatCeramics</li>
+					  </thingDefs>
+					</fixedIngredientFilter>
+					<products>
+					<Ammo_132x92mmSRTuF_Miho>200</Ammo_132x92mmSRTuF_Miho>
+					</products>
+					<workAmount>9800</workAmount>
 				</RecipeDef>
 			</value>
 		</match>	

--- a/Patches/Miho Race/DamageDefs/AbilityDamage.xml
+++ b/Patches/Miho Race/DamageDefs/AbilityDamage.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+		
+	<mods><li>MihoraceBeta</li></mods>
+		
+	<match Class="PatchOperationSequence">
+	<operations>
+	
+		<!--Tempoaryish fix-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[defName="Miho_MagicBombHawk"]/armorCategory</xpath> 
+			<value>
+				<armorCategory>Electric</armorCategory>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[defName="Miho_MagicBomb"]/armorCategory</xpath> 
+			<value>
+				<armorCategory>Electric</armorCategory>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/DamageDef[defName="Miho_MagicBombEMP"]/armorCategory</xpath> 
+			<value>
+				<armorCategory>Electric</armorCategory>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_Fireball_Small_Proj"]/projectile/damageAmountBase</xpath> 
+			<value>
+				<damageAmountBase>14</damageAmountBase>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_Fireball_Proj"]/projectile/damageAmountBase</xpath> 
+			<value>
+				<damageAmountBase>20</damageAmountBase>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_Fireball_Adept_Proj"]/projectile/damageAmountBase</xpath> 
+			<value>
+				<damageAmountBase>16</damageAmountBase>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_Thunder_Proj"]/projectile/damageAmountBase</xpath> 
+			<value>
+				<damageAmountBase>11</damageAmountBase>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_FanofKnives_Proj"]/projectile/damageAmountBase</xpath> 
+			<value>
+				<damageAmountBase>5</damageAmountBase>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Miho_FanofKnives_Proj"]/projectile/speed</xpath> 
+			<value>
+				<speed>75</speed>
+			</value>
+		</li>
+		
+	</operations>
+	</match>	
+  </Operation>
+	  
+</Patch>

--- a/Patches/Miho Race/DamageDefs/AbilityDamage.xml
+++ b/Patches/Miho Race/DamageDefs/AbilityDamage.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
 		
-	<mods><li>MihoraceBeta</li></mods>
+	<mods><li>Miho, the celestial fox</li></mods>
 		
 	<match Class="PatchOperationSequence">
 	<operations>

--- a/Patches/Miho Race/PawnKindDefs/Miho_PawnKind.xml
+++ b/Patches/Miho Race/PawnKindDefs/Miho_PawnKind.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--Ammo-->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="Miho_Soldier_Adventurer" or
+				defName="Miho_Soldier_Hunter" or
+				defName="Miho_Soldier_Militia"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>2</min>
+						<max>5</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="Miho_Soldier_Marksman" or
+				defName="Miho_Soldier_PMC_Sniper"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>10</min>
+						<max>15</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="Miho_Soldier_Firepower" or
+				defName="Miho_Soldier_PMC_Infantry" or
+				defName="Miho_Soldier_PMC_InfantryShield"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>2</min>
+						<max>6</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="Miho_Soldier_AssassinRanged"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>20</min>
+						<max>30</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<!--Backpack-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_Backpack"]/apparel/tags</xpath>
+				<value>
+					<li>MihoCommonNecessary</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[
+				defName="Miho_Soldier_Militia" or
+				defName="Miho_Soldier_Hunter" or
+				defName="Miho_Soldier_Marksman" or
+				defName="Miho_Soldier_Firepower" or
+				defName="Miho_Soldier_PMC_Infantry" or
+				defName="Miho_Soldier_PMC_InfantryShield" or
+				defName="Miho_Soldier_PMC_Sniper" or
+				defName="Miho_Soldier_AssassinRanged"
+				]/apparelRequired</xpath>
+				<value>
+					<li>Apparel_Backpack</li>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/PawnKindDefs/Miho_PawnKind.xml
+++ b/Patches/Miho Race/PawnKindDefs/Miho_PawnKind.xml
@@ -4,7 +4,7 @@
 	<operations>
 	  <li Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Miho Race/Scenario/Miho_Scenario.xml
+++ b/Patches/Miho Race/Scenario/Miho_Scenario.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[defName="Miho_Start"]/scenario/parts</xpath>
+				<value>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_GreatArrow_Stone</thingDef>
+						<count>20</count>
+					</li>
+				</value>
+			</li>
+			
+			<!--Add material filter to faction for MIB type events
+			
+			<li Class="PatchOperationConditional">
+				   <xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter</xpath>
+				<match Class="PatchOperationConditional">
+					<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs</xpath>
+					<match Class="PatchOperationConditional">
+						<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
+						<match Class="PatchOperationReplace">
+							<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
+							<value>
+								<li>Steel</li>
+							</value>
+						</match>
+						<nomatch Class="PatchOperationAdd">
+							<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs</xpath>
+							<value>
+								<li>Steel</li>
+							</value>
+						</nomatch>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter</xpath>
+						<value>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</value>
+					</nomatch>
+				</match>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]</xpath>
+					<value>
+						<apparelStuffFilter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</apparelStuffFilter>
+					</value>
+				</nomatch>
+			</li>-->
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/Scenario/Miho_Scenario.xml
+++ b/Patches/Miho Race/Scenario/Miho_Scenario.xml
@@ -14,53 +14,11 @@
 				<value>
 					<li Class="ScenPart_StartingThing_Defined">
 						<def>StartingThing_Defined</def>
-						<thingDef>Ammo_GreatArrow_Stone</thingDef>
-						<count>20</count>
+						<thingDef>Ammo_8x22mmNambu_FMJ</thingDef>
+						<count>180</count>
 					</li>
 				</value>
 			</li>
-			
-			<!--Add material filter to faction for MIB type events
-			
-			<li Class="PatchOperationConditional">
-				   <xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter</xpath>
-				<match Class="PatchOperationConditional">
-					<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs</xpath>
-					<match Class="PatchOperationConditional">
-						<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
-						<match Class="PatchOperationReplace">
-							<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
-							<value>
-								<li>Steel</li>
-							</value>
-						</match>
-						<nomatch Class="PatchOperationAdd">
-							<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter/thingDefs</xpath>
-							<value>
-								<li>Steel</li>
-							</value>
-						</nomatch>
-					</match>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]/apparelStuffFilter</xpath>
-						<value>
-							<thingDefs>
-								<li>Steel</li>
-							</thingDefs>
-						</value>
-					</nomatch>
-				</match>
-				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/FactionDef[@Name="Moyo_PlayerBase"]</xpath>
-					<value>
-						<apparelStuffFilter>
-							<thingDefs>
-								<li>Steel</li>
-							</thingDefs>
-						</apparelStuffFilter>
-					</value>
-				</nomatch>
-			</li>-->
 			
 		</operations>
 		</match>	

--- a/Patches/Miho Race/Scenario/Miho_Scenario.xml
+++ b/Patches/Miho Race/Scenario/Miho_Scenario.xml
@@ -4,7 +4,7 @@
 	<operations>
 	  <li Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Miho Race/ThingDefs_Items/Items_Resources.xml
+++ b/Patches/Miho Race/ThingDefs_Items/Items_Resources.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		
+		<operations>
+			<li Class="PatchOperationFindMod">
+			<mods><li>MihoraceBeta</li></mods>
+			<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!-- ==========  Ebony Silk  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Ebony_SilkCloth"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				  <StuffPower_Armor_Sharp>0.50</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Ebony_SilkCloth"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				  <StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Ebony_SilkCloth"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				  <StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
+				  <StuffPower_Armor_Electric>0.10</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Ebony_SilkCloth"]/stuffProps/categories</xpath>
+				<value>
+				  <li>SoftArmor</li>
+				</value>
+			</li>
+			
+			<!-- ==========  Military Ceramics  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_MilitaryGradeBalisticCeramics"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				  <StuffPower_Armor_Sharp>1.75</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_MilitaryGradeBalisticCeramics"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				  <StuffPower_Armor_Blunt>2.5</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_MilitaryGradeBalisticCeramics"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				  <StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				  <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_MilitaryGradeBalisticCeramics"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.8</Mass>
+					<MeleePenetrationFactor>1.1</MeleePenetrationFactor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_MilitaryGradeBalisticCeramics"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+			
+			<!-- ==========  Celestial Scale  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_CelestialScale"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				  <StuffPower_Armor_Sharp>2.25</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_CelestialScale"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				  <StuffPower_Armor_Blunt>5.5</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_CelestialScale"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				  <StuffPower_Armor_Heat>0.10</StuffPower_Armor_Heat>
+				  <StuffPower_Armor_Electric>0.15</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_CelestialScale"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.6</Mass>
+					<MeleePenetrationFactor>1.5</MeleePenetrationFactor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_CelestialScale"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+			
+			<!-- ==========  Ceramics  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Ceramics"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				  <StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- ==========  Heat Ceramics  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_HeatCeramics"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				  <StuffPower_Armor_Heat>0.10</StuffPower_Armor_Heat>
+				</value>
+			</li>
+			
+			<!-- ==========  Bulk  =========== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="Miho_Ceramics" or
+				defName="Miho_HeatCeramics" or
+				defName="Miho_MilitaryGradeBalisticCeramics" or
+				defName="Miho_CelestialScale"
+				]/statBases</xpath>
+				<value>
+				  <Bulk>0.03</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="Miho_Ebony_SilkCloth"
+				]/statBases</xpath>
+				<value>
+				  <Bulk>0.04</Bulk>
+				  <WornBulk>0.4</WornBulk>
+				</value>
+			</li>
+			
+			</operations>
+			</match>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Items/Items_Resources.xml
+++ b/Patches/Miho Race/ThingDefs_Items/Items_Resources.xml
@@ -4,7 +4,7 @@
 		
 		<operations>
 			<li Class="PatchOperationFindMod">
-			<mods><li>MihoraceBeta</li></mods>
+			<mods><li>Miho, the celestial fox</li></mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 			

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+			<!--========= Stuffable =========-->
+			
+			<!--Simple Wear-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Simple" or defName="Miho_Apparel_OnSkin_SimpleShort"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<Bulk>2</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<!--Hunter Wear-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Hunter"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<Bulk>5</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Hunter"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
+					<AimingAccuracy>0.1</AimingAccuracy>
+				</value>
+			</li>
+			
+			<!--Milita Vests-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Militia" or defName="Miho_Apparel_Middle_Militia_Tan"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+					<Bulk>6</Bulk>
+					<WornBulk>2.7</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Militia" or defName="Miho_Apparel_Middle_Militia_Tan"]/statBases/Mass</xpath>
+				<value>
+					<Mass>10.5</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Militia" or defName="Miho_Apparel_Middle_Militia_Tan"]/statBases/ArmorRating_Sharp</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Militia" or defName="Miho_Apparel_Middle_Militia_Tan"]/costList/ComponentIndustrial</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Militia" or defName="Miho_Apparel_Middle_Militia_Tan"]/equippedStatOffsets/AimingDelayFactor</xpath>
+				<value>
+				  <CarryBulk>8</CarryBulk>
+				  <ReloadSpeed>0.1</ReloadSpeed>
+				</value>
+			</li>
+			
+			<!--Light Milita Vest-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_MilitiaVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+					<Bulk>4</Bulk>
+					<WornBulk>2.7</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_MilitiaVest"]/statBases/Mass</xpath>
+				<value>
+					<Mass>2.7</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_MilitiaVest"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_MilitiaVest"]/equippedStatOffsets/AimingDelayFactor</xpath>
+				<value>
+				  <CarryBulk>8</CarryBulk>
+				  <ReloadSpeed>0.1</ReloadSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_MilitiaVest"]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+					  <li>SoftArmor</li>
+					</stuffCategories>
+				</value>
+			</li>
+			
+			<!--Exosuit-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Powered"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>9</StuffEffectMultiplierArmor>
+					<Bulk>25</Bulk>
+					<WornBulk>12</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Powered"]/statBases/Mass</xpath>
+				<value>
+					<Mass>15</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Powered"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_Powered"]/equippedStatOffsets</xpath>
+				<value>
+				  <CarryBulk>20</CarryBulk>
+				  <CarryWeight>35</CarryWeight>
+				</value>
+			</li>
+			
+			<!-- Winter -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_Winter"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_Winter"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!-- PMC Coat -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_PMC"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					<Bulk>10</Bulk>
+					<WornBulk>4</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_PMC"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3.5</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_PMC"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_PMC"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+			<!-- Ornated Coat -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_OrnatedOne"]/statBases</xpath>
+				<value>
+					<Bulk>12</Bulk>
+					<WornBulk>4</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_OrnatedOne"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!-- Tuque -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Winter"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>1</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<!-- Milita Helmet -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_MilitiaAssault" or defName="Miho_Apparel_Hat_Militia"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_MilitiaAssault" or defName="Miho_Apparel_Hat_Militia"]/statBases/Mass</xpath>
+				<value>
+					<Mass>3.5</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_MilitiaAssault" or defName="Miho_Apparel_Hat_Militia"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<!-- Milita Helmet -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_PMC"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_PMC"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<!--Assassin Helmet-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Assassin"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Assassin"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.35</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Assassin"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Assassin"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+					<AimingAccuracy>0.5</AimingAccuracy>
+				</value>
+			</li>
+			
+			<!--Assassin Helmet-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_AssassinMelee"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_AssassinMelee"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.35</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_AssassinMelee"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			
+			<!--========= Fixed Armor Value =========-->
+			
+			<!--Ornated-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedOne"]/statBases</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<!--Eltex Mask-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Mask_Eltex"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<!--Engineering Suit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases/MaxHitPoints</xpath>
+				<value>
+					<MaxHitPoints>175</MaxHitPoints>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.50</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>0.6</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!--PMC-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_PMC"]/statBases</xpath>
+				<value>
+					<Bulk>8</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_PMC"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_PMC"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<!--Assassin Suit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>6</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.60</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>50</Plasteel>
+					<DevilstrandCloth>40</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<!--Melee Assassin Suit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.60</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>72</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>0.6</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -22,6 +22,15 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Regular"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.75</StuffEffectMultiplierArmor>
+					<Bulk>2</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
 			<!--Hunter Wear-->
 			
 			<li Class="PatchOperationReplace">
@@ -150,6 +159,32 @@
 				</value>
 			</li>
 			
+			<!--Worker Exo-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_PoweredWorker"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.5</StuffEffectMultiplierArmor>
+					<Bulk>25</Bulk>
+					<WornBulk>10</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace"> <!-- Not actually required, but kept for consistency-->
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_PoweredWorker"]/statBases/Mass</xpath>
+				<value>
+					<Mass>8</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Middle_PoweredWorker"]/equippedStatOffsets</xpath>
+				<value>
+				  <CarryBulk>10</CarryBulk>
+				  <CarryWeight>35</CarryWeight>
+				</value>
+			</li>
+			
 			<!--Pariah-->
 			
 			<li Class="PatchOperationReplace">
@@ -213,6 +248,12 @@
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
@@ -327,6 +368,38 @@
 				</value>
 			</li>
 			
+			<!-- Worker Helmet -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Worker"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Worker"]/statBases/Mass</xpath>
+				<value>
+					<Mass>1.25</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Worker"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Worker"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				</value>
+			</li>
+			
 			<!-- Milita Helmet -->
 			
 			<li Class="PatchOperationReplace">
@@ -341,7 +414,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_MilitiaAssault" or defName="Miho_Apparel_Hat_Militia"]/statBases/Mass</xpath>
 				<value>
-					<Mass>3.5</Mass>
+					<Mass>1.5</Mass>
 				</value>
 			</li>
 			
@@ -352,7 +425,7 @@
 				</value>
 			</li>
 			
-			<!-- Milita Helmet -->
+			<!-- PMC Helmet -->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_PMC"]/statBases/StuffEffectMultiplierArmor</xpath>
@@ -366,7 +439,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_PMC"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_PMC"]/statBases/Mass</xpath>
+				<value>
+					<Mass>2.5</Mass>
 				</value>
 			</li>
 			

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -167,6 +167,27 @@
 				</value>
 			</li>
 			
+			<!-- Padding -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_Padding"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2.5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_Padding"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Shell_Padding"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
 			<!-- PMC Coat -->
 			
 			<li Class="PatchOperationReplace">
@@ -378,7 +399,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -388,6 +409,13 @@
 					<MeleeDodgeChance>0.6</MeleeDodgeChance>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Neck</li>
+				</value>
+			</li>			
 			
 			<!--PMC-->
 			
@@ -428,7 +456,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					<ArmorRating_Electric>0.60</ArmorRating_Electric>
 				</value>
 			</li>
@@ -436,7 +464,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinRanged"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -477,7 +505,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Under_AssassinMelee"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>72</ArmorRating_Blunt>
+					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 			

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -150,6 +150,88 @@
 				</value>
 			</li>
 			
+			<!--Pariah-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+					<Bulk>40</Bulk>
+					<WornBulk>18</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/statBases/Mass</xpath>
+				<value>
+					<Mass>25</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/equippedStatOffsets</xpath>
+				<value>
+				  <CarryBulk>28</CarryBulk>
+				  <CarryWeight>40</CarryWeight>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_Pariah"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<!--Pariah Helmet-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>4</WornBulk>
+					<NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Pariah"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+					<AimingAccuracy>0.75</AimingAccuracy>
+				</value>
+			</li>
+			
 			<!-- Winter -->
 			
 			<li Class="PatchOperationAdd">
@@ -371,7 +453,7 @@
 				</value>
 			</li>
 			
-			<!--Engineering Suit-->
+			<!--Fighter Suit-->
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_OnSkin_OrnatedFighter"]/statBases</xpath>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -4,7 +4,7 @@
 	<operations>
 	  <li Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+			
+			
+			<!--========= Fixed Armor Value =========-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/verbs</xpath>
+				<value>
+					<verbs>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<label>launch thermobaric blast</label>
+							<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<onlyManualCast>False</onlyManualCast>
+							<warmupTime>4.5</warmupTime>
+							<range>50</range>
+							<minRange>5</minRange>
+							<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+							<soundCast>Shot_IncendiaryLauncher</soundCast>
+							<soundCastTail>GunTail_Medium</soundCastTail>
+							<muzzleFlashScale>14</muzzleFlashScale>
+							<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+							<targetParams>
+								<canTargetLocations>true</canTargetLocations>
+							</targetParams>
+							<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
+							<defaultProjectile>Bullet_60x180mmMiho_Thermobaric</defaultProjectile>
+							<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+						</li>
+					</verbs>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+				<value>
+					<ammoDef>FSX</ammoDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+				<value>
+					<ammoCountPerCharge>15</ammoCountPerCharge>
+				</value>
+			</li>
+			
+			<!--Engineering Suit-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>15</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]</xpath>
+				<value>
+					<thingClass Inherit="false">CombatExtended.Apparel_Shield</thingClass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/apparel/bodyPartGroups</xpath>
+				<value>
+				  <bodyPartGroups>
+					<li>LeftShoulder</li>
+				  </bodyPartGroups>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/equippedStatOffsets/MoveSpeed</xpath>
+				<value>
+				  <ReloadSpeed>-0.3</ReloadSpeed>
+				  <MeleeHitChance>-4</MeleeHitChance>
+				  <ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+				  <AimingAccuracy>-0.2</AimingAccuracy>
+				  <Suppressability>-0.5</Suppressability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+				  <MeleeCritChance>-0.2</MeleeCritChance>
+				  <MeleeParryChance>1.0</MeleeParryChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/equippedStatOffsets/IncomingDamageFactor</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/verbs</xpath>
+				<value>
+					<verbs>
+						<li Class="CombatExtended.VerbPropertiesCE">
+							<label>launch 30x29mm smoke</label>
+							<verbClass>CombatExtended.Verb_LaunchProjectileStaticCE</verbClass>
+							<hasStandardCommand>true</hasStandardCommand>
+							<onlyManualCast>False</onlyManualCast>
+							<warmupTime>1.0</warmupTime>
+							<range>40</range>
+							<minRange>1</minRange>
+							<ai_IsBuildingDestroyer>False</ai_IsBuildingDestroyer>
+							<soundCast>Shot_IncendiaryLauncher</soundCast>
+							<soundCastTail>GunTail_Medium</soundCastTail>
+							<muzzleFlashScale>14</muzzleFlashScale>
+							<drawHighlightWithLineOfSight>true</drawHighlightWithLineOfSight>
+							<targetParams>
+								<canTargetLocations>true</canTargetLocations>
+							</targetParams>
+							<ignorePartialLoSBlocker>false</ignorePartialLoSBlocker>
+							<defaultProjectile>Bullet_30x29mmGrenade_Smoke</defaultProjectile>
+							<rangedFireRulepack>Combat_RangedFire_Thrown</rangedFireRulepack>
+						</li>
+					</verbs>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+				<value>
+					<ammoDef>Ammo_30x29mmGrenade_Smoke</ammoDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+				<value>
+					<ammoCountPerCharge>1</ammoCountPerCharge>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/apparel/layers</xpath>
+				<value>
+				  <layers>
+					<li>Shield</li>
+				  </layers>
+				</value>
+			</li>
+			
+			<!--Magnifier-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Magnifier"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+					<NightVisionEfficiency_Apparel>0.3</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Magnifier"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Magnifier"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+			<!--TacAssist-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_TacticalAssist"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>2</WornBulk>
+					<NightVisionEfficiency_Apparel>0.8</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_TacticalAssist"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_TacticalAssist"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
@@ -55,7 +55,36 @@
 				</value>
 			</li>
 			
-			<!--Engineering Suit-->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/statBases/Mass</xpath>
+				<value>
+					<Mass>8</Mass>
+					<Bulk>7</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/equippedStatOffsets/MeleeHitChance</xpath>
+				<value>
+					<MeleeHitChance>-2.5</MeleeHitChance>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>-0.5</MeleeDodgeChance>
+				    <MeleeCritChance>-0.25</MeleeCritChance>
+				    <MeleeParryChance>-0.25</MeleeParryChance>
+				</value>
+			</li>
+			
+			<!--Shield-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]/statBases/ArmorRating_Sharp</xpath>
@@ -197,6 +226,15 @@
 			
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_TacticalAssist"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+			
+			<!--Glasses-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Glasses"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+				  <MeleeDodgeChance>-0.3</MeleeDodgeChance>
+				</value>
 			</li>
 			
 		</operations>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
@@ -4,7 +4,7 @@
 	<operations>
 	  <li Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationSequence">
 		<operations>
@@ -44,14 +44,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
 				<value>
-					<ammoDef>FSX</ammoDef>
+					<ammoDef>Ammo_PlasmaCellRifle</ammoDef>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Special_MissileLauncher"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
 				<value>
-					<ammoCountPerCharge>15</ammoCountPerCharge>
+					<ammoCountPerCharge>48</ammoCountPerCharge>
 				</value>
 			</li>
 			

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
@@ -109,7 +109,7 @@
 						<cooldownTime>0.94</cooldownTime>
 						<chanceFactor>1</chanceFactor>
 						<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
-						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<armorPenetrationSharp>8</armorPenetrationSharp>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					  </li>
 					  <li Class="CombatExtended.ToolCE">
@@ -121,7 +121,7 @@
 						<cooldownTime>0.83</cooldownTime>
 						<chanceFactor>1</chanceFactor>
 						<armorPenetrationBlunt>2.28</armorPenetrationBlunt>
-						<armorPenetrationSharp>12</armorPenetrationSharp>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 					  </li>
 				  </tools>

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
@@ -1,0 +1,810 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		
+		<operations>
+			<li Class="PatchOperationFindMod">
+			<mods><li>MihoraceBeta</li></mods>
+			<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!-- ========== Miho Light Bow ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_BowLight</defName>
+			<statBases>
+			  <SightsEfficiency>0.6</SightsEfficiency>
+			  <ShotSpread>0.5</ShotSpread>
+			  <SwayFactor>1.5</SwayFactor>
+			  <Bulk>7.00</Bulk>
+			  <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Projectile_GreatArrowMiho_Stone</defaultProjectile>
+			  <warmupTime>1.3</warmupTime>
+			  <range>30</range>
+			  <soundCast>Bow_Recurve</soundCast>
+			</Properties>
+			<AmmoUser>
+			  <ammoSet>AmmoSet_GreatArrowMiho</ammoSet>
+			</AmmoUser>
+			<FireModes />
+			<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_BowLight"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>7</power>
+						<cooldownTime>1.6</cooldownTime>
+					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+					</li>
+				  </tools>
+				</value>
+			</li>
+			
+			<!-- ========== Miho Light Bow ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_SniperStyx</defName>
+			<statBases>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>0.05</ShotSpread>
+			  <SwayFactor>1.75</SwayFactor>
+			  <Bulk>11.00</Bulk>
+			  <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Projectile_MihoStyxArrow</defaultProjectile>
+			  <warmupTime>1.8</warmupTime>
+			  <range>86</range>
+			  <soundCast>Bow_Recurve</soundCast>
+			  <soundCastTail>GunTail_Heavy</soundCastTail>
+			  <muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+			  <ammoSet>AmmoSet_MihoStyxArrow</ammoSet>
+			</AmmoUser>
+			<FireModes />
+			<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_SniperStyx"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>7</power>
+						<cooldownTime>1.6</cooldownTime>
+					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
+					</li>
+				  </tools>
+				</value>
+			</li>
+			
+			<!-- ==========  Power Claw =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_PowerClaw"]/tools</xpath>
+				<value>
+				  <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>0.94</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+						<armorPenetrationSharp>16</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>30</power>
+						<cooldownTime>0.83</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>2.28</armorPenetrationBlunt>
+						<armorPenetrationSharp>12</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					  </li>
+				  </tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_PowerClaw"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>2.00</MeleeCounterParryBonus>
+					<Bulk>6.5</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_PowerClaw"]/equippedStatOffsets</xpath>
+				<value>
+				  <MeleeCritChance>0.25</MeleeCritChance>
+				  <MeleeParryChance>1.50</MeleeParryChance>
+				  <MeleeDodgeChance>0.30</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!-- ==========  Ringed Blade  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_RingedBlade"]/tools</xpath>
+				<value>
+				  <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+						  <li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.57</cooldownTime>
+						<chanceFactor>0.4</chanceFactor>
+						<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>20</power>
+						<cooldownTime>1.12</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
+						<armorPenetrationSharp>3</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>32</power>
+						<cooldownTime>1.28</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>2.59</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.3</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					  </li>
+				  </tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_RingedBlade"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>0.67</MeleeCounterParryBonus>
+					<Bulk>5</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_RingedBlade"]/equippedStatOffsets</xpath>
+				<value>
+				  <MeleeCritChance>1.20</MeleeCritChance>
+				  <MeleeParryChance>0.50</MeleeParryChance>
+				  <MeleeDodgeChance>0.40</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!-- ==========  Tachi  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Tachi"]/tools</xpath>
+				<value>
+				  <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+						  <li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.57</cooldownTime>
+						<chanceFactor>0.4</chanceFactor>
+						<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>1.45</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>1.296</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.16</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>45</power>
+						<cooldownTime>1.22</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.8</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					  </li>
+				  </tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Tachi"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>1.03</MeleeCounterParryBonus>
+					<Bulk>8</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Tachi"]/equippedStatOffsets</xpath>
+				<value>
+				  <MeleeCritChance>0.40</MeleeCritChance>
+				  <MeleeParryChance>0.73</MeleeParryChance>
+				  <MeleeDodgeChance>0.60</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!-- ==========  Breacher  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Sappertool"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.78</cooldownTime>
+						<chanceFactor>0.10</chanceFactor>
+						<armorPenetrationBlunt>1.000</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Demolish</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>2.36</cooldownTime>
+						<chanceFactor>0.30</chanceFactor>
+						<armorPenetrationBlunt>11.76</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+				  </tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Sappertool"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+					<Bulk>8</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_Sappertool"]/equippedStatOffsets</xpath>
+				<value>
+					  <MeleeCritChance>2.30</MeleeCritChance>
+					  <MeleeParryChance>0.18</MeleeParryChance>
+					  <MeleeDodgeChance>0.30</MeleeDodgeChance>
+				</value>
+			</li>
+			
+			<!-- ========== SMG =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleCQB</defName>
+				<statBases>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>0.77</SwayFactor>
+					<Bulk>2.7</Bulk>
+					<Mass>2.5</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Steel>30</Steel>
+				  <WoodLog>5</WoodLog>
+				  <ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.2</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x22mmNambu_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<range>21</range>
+					<soundCast>Miho_Pistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>18</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_8x22mmNambu</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleDefence</defName>
+				<statBases>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.22</SwayFactor>
+					<Bulk>8.15</Bulk>
+					<Mass>4.00</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Steel>40</Steel>
+				  <WoodLog>10</WoodLog>
+				  <ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.87</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<range>48</range>
+					<soundCast>Miho_DefenceRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_65x50mmSRArisaka</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== AM Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleMarksman</defName>
+				<statBases>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>2.65</SwayFactor>
+					<Bulk>16.5</Bulk>
+					<Mass>10.00</Mass>
+					<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Steel>20</Steel>
+				  <WoodLog>85</WoodLog>
+				  <ComponentIndustrial>1</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_132x92mmSRTuF_FMJ</defaultProjectile>
+					<warmupTime>2.6</warmupTime>
+					<range>55</range>
+					<soundCast>Miho_HeavyRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>1.6</magazineSize>
+					<reloadTime>1</reloadTime>
+					<ammoSet>AmmoSet_132x92mmSRTuF</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Heavy 'Pistol' =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_HeavyPistol</defName>
+				<statBases>
+					<SightsEfficiency>0.80</SightsEfficiency>
+					<ShotSpread>0.15</ShotSpread>
+					<SwayFactor>0.75</SwayFactor>
+					<Bulk>4.7</Bulk>
+					<Mass>3</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>2.71</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_50AE_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+					<range>21</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>24</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_50AE</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Plamsa Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RiflePlasma</defName>
+				<statBases>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.34</SwayFactor>
+					<Bulk>8.15</Bulk>
+					<Mass>4.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<recoilAmount>0.27</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MihoPlasma</defaultProjectile>
+					<warmupTime>1.0</warmupTime>
+					<burstShotCount>4</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<range>48</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>32</magazineSize>
+					<reloadTime>3.5</reloadTime>
+					<ammoSet>AmmoSet_MihoPlasma</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Plasma Sniper =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RiflePlasmaSniper</defName>
+				<statBases>
+					<SightsEfficiency>3.00</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>1.52</SwayFactor>
+					<Bulk>16.5</Bulk>
+					<Mass>10.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MihoPlasmaSniper</defaultProjectile>
+					<warmupTime>1.7</warmupTime>
+					<range>86</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>3.5</magazineSize>
+					<reloadTime>32</reloadTime>
+					<ammoSet>AmmoSet_MihoPlasmaSniper</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Plamsa Pistol =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RiflePlasmaPistol</defName>
+				<statBases>
+					<SightsEfficiency>0.80</SightsEfficiency>
+					<ShotSpread>0.18</ShotSpread>
+					<SwayFactor>1.75</SwayFactor>
+					<Bulk>2.95</Bulk>
+					<Mass>3.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_MihoPlasma</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>23</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>32</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_MihoPlasma</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_RiflePlasmaPistol"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+			 
+			<!-- ========== Fabricated Variant =========== -->
+			
+			<!-- ========== SMG =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleCQBGap</defName>
+				<statBases>
+					<SightsEfficiency>0.80</SightsEfficiency>
+					<ShotSpread>0.15</ShotSpread>
+					<SwayFactor>0.82</SwayFactor>
+					<Bulk>3.2</Bulk>
+					<Mass>2.5</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Steel>30</Steel>
+				  <Chemfuel>5</Chemfuel>
+				  <ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.2</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x22mmNambu_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<range>25</range>
+					<soundCast>Miho_SilencedPistol</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>1</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>36</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_8x22mmNambu</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleDefenceGap</defName>
+				<statBases>
+					<SightsEfficiency>1.20</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.22</SwayFactor>
+					<Bulk>8.15</Bulk>
+					<Mass>4.00</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Steel>40</Steel>
+				  <Chemfuel>10</Chemfuel>
+				  <ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.87</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<range>62</range>
+					<soundCast>Miho_DefenceRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_65x50mmSRArisaka</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== AM Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Miho_Weapon_RifleMarksmanGap</defName>
+				<statBases>
+					<SightsEfficiency>2.30</SightsEfficiency>
+					<ShotSpread>0.05</ShotSpread>
+					<SwayFactor>2.73</SwayFactor>
+					<Bulk>16.5</Bulk>
+					<Mass>11.00</Mass>
+					<RangedWeapon_Cooldown>1.19</RangedWeapon_Cooldown>
+				</statBases>
+				<costList>
+				  <Chemfuel>20</Chemfuel>
+				  <Steel>85</Steel>
+				  <ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_132x92mmSRTuF_FMJ</defaultProjectile>
+					<warmupTime>3</warmupTime>
+					<range>86</range>
+					<soundCast>Miho_HeavyRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>12</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>1.6</magazineSize>
+					<reloadTime>1</reloadTime>
+					<ammoSet>AmmoSet_132x92mmSRTuF</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			
+			<!-- ========== Melee Attacks =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Weapon_RifleMarksmanGap" or 
+				defName="Miho_Weapon_RifleDefenceGap" or 
+				defName="Miho_Weapon_RiflePlasmaSniper" or 
+				defName="Miho_Weapon_RiflePlasma" or 
+				defName="Miho_Weapon_RifleMarksman" or 
+				defName="Miho_Weapon_RifleDefence"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>stock</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Miho_Weapon_RifleCQBGap" or
+				defName="Miho_Weapon_RiflePlasmaPistol" or
+				defName="Miho_Weapon_HeavyPistol" or
+				defName="Miho_Weapon_RifleCQB"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li> 
+			
+			</operations>
+			</match>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons.xml
@@ -4,7 +4,7 @@
 		
 		<operations>
 			<li Class="PatchOperationFindMod">
-			<mods><li>MihoraceBeta</li></mods>
+			<mods><li>Miho, the celestial fox</li></mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 			
@@ -538,14 +538,15 @@
 					<defaultProjectile>Bullet_MihoPlasmaSniper</defaultProjectile>
 					<warmupTime>1.7</warmupTime>
 					<range>86</range>
-					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCast>Miho_CannonPlasma</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<muzzleFlashScale>9</muzzleFlashScale>
+					<ammoConsumedPerShotCount>48</ammoConsumedPerShotCount>
 				</Properties>
 				
 				<AmmoUser>
-					<magazineSize>3.5</magazineSize>
-					<reloadTime>32</reloadTime>
+					<magazineSize>96</magazineSize>
+					<reloadTime>3.5</reloadTime>
 					<ammoSet>AmmoSet_MihoPlasmaSniper</ammoSet>
 				</AmmoUser>
 				<FireModes>
@@ -801,6 +802,29 @@
 					</tools>
 				</value>
 			</li> 
+			
+			<!-- ========== Ammoset =========== -->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_8x22mmNambu"]/ammoTypes</xpath>
+				<value>
+				  <Ammo_8x22mmNambu_Miho>Bullet_8x22mmNambu_Miho</Ammo_8x22mmNambu_Miho>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_65x50mmSRArisaka"]/ammoTypes</xpath>
+				<value>
+				  <Ammo_65x50mmSRArisaka_Miho>Bullet_65x50mmSRArisaka_Miho</Ammo_65x50mmSRArisaka_Miho>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_132x92mmSRTuF"]/ammoTypes</xpath>
+				<value>
+				  <Ammo_132x92mmSRTuF_Miho>Bullet_132x92mmSRTuF_Miho</Ammo_132x92mmSRTuF_Miho>
+				</value>
+			</li>
 			
 			</operations>
 			</match>

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -12,31 +12,31 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>MihoVEF_Weapon_Bolter</defName>
 				<statBases>
-					<SightsEfficiency>0.80</SightsEfficiency>
+					<SightsEfficiency>1.56</SightsEfficiency>
 					<ShotSpread>0.07</ShotSpread>
-					<SwayFactor>1.75</SwayFactor>
+					<SwayFactor>0.19</SwayFactor>
 					<Bulk>20.00</Bulk>
 					<Mass>55.00</Mass>
-					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+					<RangedWeapon_Cooldown>2.51</RangedWeapon_Cooldown>
 				</statBases>
 				
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_132x92mmSRTuF_FMJ</defaultProjectile>
-					<warmupTime>1</warmupTime>
-					<range>40</range>
-					<soundCast>Shot_AssaultRifle</soundCast>
-					<soundCastTail>GunTail_Medium</soundCastTail>
-					<muzzleFlashScale>9</muzzleFlashScale>
+					<defaultProjectile>Bullet_Miho47x285mm_AP</defaultProjectile>
+					<warmupTime>4.5</warmupTime>
+					<range>86</range>
+					<soundCast>Miho_KineticCannon</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>10</muzzleFlashScale>
 				</Properties>
 				
 				<AmmoUser>
-					<magazineSize>40</magazineSize>
-					<reloadTime>7.8</reloadTime>
+					<magazineSize>1</magazineSize>
+					<reloadTime>9.8</reloadTime>
 				</AmmoUser>
 				<FireModes>
-					<aiAimMode>Snapshot</aiAimMode>
+					<aiAimMode>AimedShot</aiAimMode>
 				</FireModes>
 			</li>
 			

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods><li>MihoraceBeta</li></mods>
+			<match Class="PatchOperationFindMod">
+			<mods><li>Vanilla Expanded Framework</li></mods>
+			<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!-- ========== Bolter =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>MihoVEF_Weapon_Bolter</defName>
+				<statBases>
+					<SightsEfficiency>0.80</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.75</SwayFactor>
+					<Bulk>20.00</Bulk>
+					<Mass>55.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_132x92mmSRTuF_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>40</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>40</magazineSize>
+					<reloadTime>7.8</reloadTime>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Rocket Launcher : 2kg blast mass thermo round ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MihoVEF_Weapon_Rocket</defName>
+				<statBases>
+				  <Mass>99.50</Mass>
+				  <RangedWeapon_Cooldown>2.50</RangedWeapon_Cooldown>
+				  <SightsEfficiency>1.24</SightsEfficiency>
+				  <ShotSpread>0.07</ShotSpread>
+				  <SwayFactor>0.29</SwayFactor>
+				  <Bulk>20.00</Bulk>
+				</statBases>
+				<Properties>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>true</hasStandardCommand>
+				  <defaultProjectile>Bullet_60x180mmMiho_Thermobaric</defaultProjectile>
+				  <warmupTime>4.4</warmupTime>
+				  <range>75</range>
+				  <burstShotCount>1</burstShotCount>
+				  <soundCast>Shot_AssaultRifle</soundCast>
+				  <soundCastTail>GunTail_Heavy</soundCastTail>
+				  <muzzleFlashScale>14</muzzleFlashScale>
+				  <ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+				  <minRange>5</minRange>
+				  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>1</magazineSize>
+				  <reloadTime>9.8</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+				  <li>CE_AI_Launcher</li>
+				</weaponTags>
+			</li>
+		  
+			<!-- ========== LMG =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>MihoVEF_Weapon_Machinegun</defName>
+				<statBases>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.07</ShotSpread>
+					<SwayFactor>1.58</SwayFactor>
+					<Bulk>20.00</Bulk>
+					<Mass>55.00</Mass>
+					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>0.32</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<burstShotCount>10</burstShotCount>
+					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+					<range>48</range>
+					<soundCast>Shot_AssaultRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>100</magazineSize>
+					<reloadTime>7.8</reloadTime>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Laser Minigun =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MihoVEF_Weapon_Minigun</defName>
+				<statBases>
+				  <Mass>65.00</Mass>
+				  <Bulk>20.00</Bulk>
+				  <SwayFactor>1.71</SwayFactor>
+				  <ShotSpread>0.03</ShotSpread>
+				  <SightsEfficiency>1</SightsEfficiency>
+				  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>True</hasStandardCommand>
+				  <defaultProjectile>Bullet_Laser_MihoMiniGun</defaultProjectile>
+				  <burstShotCount>125</burstShotCount>
+				  <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+				  <warmupTime>2.1</warmupTime>
+				  <range>35</range>
+				  <soundCast>VWE_LaserShot_Light</soundCast>
+				  <soundCastTail>GunTail_Heavy</soundCastTail>
+				  <muzzleFlashScale>14</muzzleFlashScale>
+				  <recoilAmount>0.01</recoilAmount>
+				  <recoilPattern>Regular</recoilPattern>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>500</magazineSize>
+				  <reloadTime>6</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aiAimMode>SuppressFire</aiAimMode>
+				  <aimedBurstShotCount>50</aimedBurstShotCount>
+				  <noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Melee Attacks =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="MihoVEF_Weapon_Bolter" or
+				defName="MihoVEF_Weapon_Rocket" or
+				defName="MihoVEF_Weapon_Machinegun" or
+				defName="MihoVEF_Weapon_Minigun"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						  <label>barrel</label>
+						  <capacities>
+							<li>Blunt</li>
+						  </capacities>
+						  <power>10</power>
+						  <cooldownTime>2.44</cooldownTime>
+						  <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+						  <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li> 
+			
+			</operations>
+			</match>
+			</match>
+	</Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -152,6 +152,43 @@
 				</FireModes>
 			</li>
 			
+			<!-- ========== SMG =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>MihoVEF_Weapon_Security</defName>
+				<statBases>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.18</ShotSpread>
+					<SwayFactor>0.39</SwayFactor>
+					<Bulk>4</Bulk>
+					<Mass>1.50</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.60</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x22mmNambu_FMJ</defaultProjectile>
+					<warmupTime>0.80</warmupTime>
+					<burstShotCount>5</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<range>25</range>
+					<soundCast>Miho_Pistol</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>40</magazineSize>
+					<reloadTime>3</reloadTime>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
 			<!-- ========== Melee Attacks =========== -->
 			
 			<li Class="PatchOperationReplace">
@@ -159,7 +196,8 @@
 				defName="MihoVEF_Weapon_Bolter" or
 				defName="MihoVEF_Weapon_Rocket" or
 				defName="MihoVEF_Weapon_Machinegun" or
-				defName="MihoVEF_Weapon_Minigun"
+				defName="MihoVEF_Weapon_Minigun" or
+				defName="MihoVEF_Weapon_Security"
 				]/tools</xpath>
 				<value>
 					<tools>
@@ -172,6 +210,27 @@
 						  <cooldownTime>2.44</cooldownTime>
 						  <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
 						  <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li> 
+			
+			<!-- ========== Melee Attacks =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="Miho_Weapon_SapperRobot"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						  <label>head</label>
+						  <capacities>
+							<li>Demolish</li>
+						  </capacities>
+						  <power>60</power>
+						  <cooldownTime>3.75</cooldownTime>
+						  <armorPenetrationBlunt>30.5</armorPenetrationBlunt>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			<match Class="PatchOperationFindMod">
 			<mods><li>Vanilla Expanded Framework</li></mods>
 			<match Class="PatchOperationSequence">
@@ -24,7 +24,7 @@
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_Miho47x285mm_AP</defaultProjectile>
-					<warmupTime>4.5</warmupTime>
+					<warmupTime>2.5</warmupTime>
 					<range>86</range>
 					<soundCast>Miho_KineticCannon</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
@@ -33,7 +33,7 @@
 				
 				<AmmoUser>
 					<magazineSize>1</magazineSize>
-					<reloadTime>9.8</reloadTime>
+					<reloadTime>4.5</reloadTime>
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>
@@ -56,7 +56,7 @@
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_60x180mmMiho_Thermobaric</defaultProjectile>
-				  <warmupTime>4.4</warmupTime>
+				  <warmupTime>2.1</warmupTime>
 				  <range>75</range>
 				  <burstShotCount>1</burstShotCount>
 				  <soundCast>Shot_AssaultRifle</soundCast>
@@ -68,7 +68,7 @@
 				</Properties>
 				<AmmoUser>
 				  <magazineSize>1</magazineSize>
-				  <reloadTime>9.8</reloadTime>
+				  <reloadTime>4.1</reloadTime>
 				</AmmoUser>
 				<FireModes>
 				  <aiAimMode>AimedShot</aiAimMode>
@@ -85,13 +85,13 @@
 				<statBases>
 					<SightsEfficiency>1.00</SightsEfficiency>
 					<ShotSpread>0.07</ShotSpread>
-					<SwayFactor>1.58</SwayFactor>
+					<SwayFactor>1.00</SwayFactor>
 					<Bulk>20.00</Bulk>
-					<Mass>55.00</Mass>
+					<Mass>15.00</Mass>
 					<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 				</statBases>
 				<Properties>
-					<recoilAmount>0.32</recoilAmount>
+					<recoilAmount>0.89</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_65x50mmSRArisaka_FMJ</defaultProjectile>
@@ -135,7 +135,7 @@
 				  <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 				  <warmupTime>2.1</warmupTime>
 				  <range>35</range>
-				  <soundCast>VWE_LaserShot_Light</soundCast>
+				  <soundCast>Miho_PlasmaFlamer</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>14</muzzleFlashScale>
 				  <recoilAmount>0.01</recoilAmount>
@@ -168,7 +168,7 @@
 					<recoilAmount>1.60</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_8x22mmNambu_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_8x22mmNambu_AP</defaultProjectile>
 					<warmupTime>0.80</warmupTime>
 					<burstShotCount>5</burstShotCount>
 					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>

--- a/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+		
+	<mods><li>MihoraceBeta</li></mods>
+		
+	<match Class="PatchOperationSequence">
+	<operations>
+	
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/comps</xpath>
+				<value>
+					<li>
+					<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+				<value>
+					<comps>
+						<li>
+						<compClass>CombatExtended.CompPawnGizmo</compClass>
+						</li>
+						<li Class="CombatExtended.CompProperties_Suppressable" />
+					</comps>
+				</value>
+			</nomatch>
+		</li>
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+
+		
+		<li Class="PatchOperationReplace">
+		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/statBases/MeleeDodgeChance</xpath>
+			  <value>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				<Suppressability>1</Suppressability>
+				<SmokeSensitivity>0.5</SmokeSensitivity>
+				<AimingAccuracy>0.75</AimingAccuracy>
+			  </value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/tools</xpath> 
+			<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>2</power>
+					<cooldownTime>4.49</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+				</li>
+			</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+		 <xpath>/Defs/ThingDef[@Name="MihoPawn"]/damageMultipliers</xpath>
+			  <value>
+				<li>
+					<damageDef>PrometheumFlame</damageDef>
+					<multiplier>0.25</multiplier>
+				</li>
+				<li>
+					<damageDef>Flame_Secondary</damageDef>
+					<multiplier>0.25</multiplier>
+				</li>
+			  </value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Alien_Miho"]/alienRace/raceRestriction/whiteApparelList</xpath>
+			<value>
+			<li>Apparel_TacVest</li>
+			<li>Apparel_Backpack</li>
+			<li>Apparel_TribalBackpack</li>
+			<li>Apparel_BallisticShield</li>
+			<li>Apparel_MeleeShield</li>
+			<li>Apparel_GasMask</li>
+			<li>Apparel_ImprovGasMask</li>
+			</value>
+		</li>
+		
+	</operations>
+	</match>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
+++ b/Patches/Miho Race/ThingDefs_Races/AlienRace_Miho.xml
@@ -2,7 +2,7 @@
 <Patch>
   <Operation Class="PatchOperationFindMod">
 		
-	<mods><li>MihoraceBeta</li></mods>
+	<mods><li>Miho, the celestial fox</li></mods>
 		
 	<match Class="PatchOperationSequence">
 	<operations>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -38,8 +38,20 @@
 				  <value>
 					<MeleeDodgeChance>0.05</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
-					<MeleeParryChance>0.40</MeleeParryChance>
+					<MeleeParryChance>0.30</MeleeParryChance>
 					<NightVisionEfficiency>0.60</NightVisionEfficiency>
+					<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
+				  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal_Melee"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.45</MeleeCritChance>
+					<MeleeParryChance>0.50</MeleeParryChance>
+					<NightVisionEfficiency>0.60</NightVisionEfficiency>
+					<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
 				  </value>
 			</li>
 			
@@ -51,6 +63,7 @@
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					<AimingAccuracy>4</AimingAccuracy>
 				</value>
 			</li>
 			
@@ -67,12 +80,30 @@
 			
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal_Melee"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal_Melee"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
 				defName="MihoVFE_Mechanoids_Sapsal" or
 				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
 				defName="MihoVFE_Mechanoids_Sapsal_NP"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -83,7 +114,7 @@
 				defName="MihoVFE_Mechanoids_Sapsal_NP"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+					<ArmorRating_Blunt>15</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -125,6 +156,26 @@
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
 							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal_Melee"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>51</power>
+							<cooldownTime>3.73</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 						</li>
 					</tools>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -25,6 +25,17 @@
 					</li>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Birdlike</bodyShape>
+					</li>
+				</value>
+			</li>
 
 			
 			<li Class="PatchOperationAdd">
@@ -41,6 +52,18 @@
 					<MeleeParryChance>0.30</MeleeParryChance>
 					<NightVisionEfficiency>0.60</NightVisionEfficiency>
 					<ShootingAccuracyPawn>4.5</ShootingAccuracyPawn>
+				  </value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Security"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeParryChance>0.15</MeleeParryChance>
+					<NightVisionEfficiency>0.30</NightVisionEfficiency>
+					<ShootingAccuracyPawn>2.5</ShootingAccuracyPawn>
+					<AimingAccuracy>2</AimingAccuracy>
 				  </value>
 			</li>
 			
@@ -137,6 +160,24 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Security"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Security"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal" or
 				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
 				defName="MihoVFE_Mechanoids_Sapsal" or
@@ -163,6 +204,26 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Security"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>14</power>
+							<cooldownTime>2.07</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal_Melee"]/tools</xpath> 
 				<value>
 					<tools>
@@ -176,7 +237,7 @@
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
 							<armorPenetrationBlunt>30</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods><li>MihoraceBeta</li></mods>
+	  <match Class="PatchOperationFindMod">
+			
+		<mods><li>Vanilla Expanded Framework</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal" or
+				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
+				defName="MihoVFE_Mechanoids_Sapsal" or
+				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
+				defName="MihoVFE_Mechanoids_MyeongIl" or
+				defName="MihoVFE_Mechanoids_Bulgasal_NP" or
+				defName="MihoVFE_Mechanoids_Sapsal_NP"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal" or
+				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
+				defName="MihoVFE_Mechanoids_Sapsal" or
+				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
+				defName="MihoVFE_Mechanoids_MyeongIl" or
+				defName="MihoVFE_Mechanoids_Bulgasal_NP" or
+				defName="MihoVFE_Mechanoids_Sapsal_NP"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeParryChance>0.40</MeleeParryChance>
+					<NightVisionEfficiency>0.60</NightVisionEfficiency>
+				  </value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal" or
+				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
+				defName="MihoVFE_Mechanoids_Bulgasal_NP"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Bulgasal" or
+				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
+				defName="MihoVFE_Mechanoids_Bulgasal_NP"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Sapsal" or
+				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
+				defName="MihoVFE_Mechanoids_Sapsal_NP"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Sapsal" or
+				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
+				defName="MihoVFE_Mechanoids_Sapsal_NP"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_MyeongIl"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_MyeongIl"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Bulgasal" or
+				defName="MihoVFE_Mechanoids_Bulgasal_Bolter" or
+				defName="MihoVFE_Mechanoids_Sapsal" or
+				defName="MihoVFE_Mechanoids_Sapsal_LMG" or
+				defName="MihoVFE_Mechanoids_MyeongIl" or
+				defName="MihoVFE_Mechanoids_Bulgasal_NP" or
+				defName="MihoVFE_Mechanoids_Sapsal_NP"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>35</power>
+							<cooldownTime>3.51</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </match>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoMech.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 	  <match Class="PatchOperationFindMod">
 			
 		<mods><li>Vanilla Expanded Framework</li></mods>
@@ -106,7 +106,7 @@
 				defName="MihoVFE_Mechanoids_Bulgasal_Melee"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -115,7 +115,7 @@
 				defName="MihoVFE_Mechanoids_Bulgasal_Melee"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -146,7 +146,7 @@
 				defName="MihoVFE_Mechanoids_MyeongIl"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -155,7 +155,7 @@
 				defName="MihoVFE_Mechanoids_MyeongIl"
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -174,6 +174,42 @@
 				]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Logi"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Logi"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Cleaner"
+				]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Cleaner"
+				]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.25</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -204,7 +240,9 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="MihoVFE_Mechanoids_Security"]/tools</xpath> 
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Security"
+				]/tools</xpath> 
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -217,6 +255,29 @@
 							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 							<chanceFactor>0.2</chanceFactor>
 							<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[
+				defName="MihoVFE_Mechanoids_Cleaner" or
+				defName="MihoVFE_Mechanoids_Logi"
+				]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>5.04</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 						</li>
 					</tools>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>MihoraceBeta</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/ThingDef[defName="Miho_Fox"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>0.27</MeleeDodgeChance>
+					<MeleeCritChance>0.02</MeleeCritChance>
+					<MeleeParryChance>0.01</MeleeParryChance>
+				  </value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Fox"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>left claw</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>0.91</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationBlunt>0.198</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right claw</label>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>0.91</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationBlunt>0.198</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.04</armorPenetrationSharp>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.49</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>20</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetrationBlunt>1.440</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+			 <xpath>/Defs/ThingDef[defName="Miho_Butterfly"]/statBases</xpath>
+				  <value>
+					<MeleeDodgeChance>2</MeleeDodgeChance>
+					<MeleeCritChance>0.75</MeleeCritChance>
+					<MeleeParryChance>0.05</MeleeParryChance>
+				  </value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Miho_Butterfly"]/tools</xpath> 
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>blades</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>0.89</cooldownTime>
+							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>0.05</armorPenetrationBlunt>
+							<armorPenetrationSharp>5.6</armorPenetrationSharp>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Turret_Flame"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Turret_Flame"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Turret_Flame"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Miho_TurretGun_Flame</defName>
+				<statBases>
+				  <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				  <SightsEfficiency>1</SightsEfficiency>
+				  <ShotSpread>0.07</ShotSpread>
+				  <SwayFactor>0.80</SwayFactor>
+				  <Bulk>10.00</Bulk>
+				</statBases>
+				<Properties>
+				  <recoilAmount>1</recoilAmount>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>true</hasStandardCommand>
+				  <defaultProjectile>Miho_TurretGun_Flame_Proj</defaultProjectile>
+				  <warmupTime>1.3</warmupTime>
+				  <range>40</range>
+				  <ticksBetweenBurstShots>16</ticksBetweenBurstShots>
+				  <burstShotCount>3</burstShotCount>
+				  <soundCast>GunShotA</soundCast>
+				  <soundCastTail>GunTail_Light</soundCastTail>
+				  <muzzleFlashScale>9</muzzleFlashScale>
+				  <recoilPattern>Mounted</recoilPattern>
+				</Properties>
+				<FireModes>
+				  <aiAimMode>AimedShot</aiAimMode>
+				  <noSnapshot>true</noSnapshot>
+				  <noSingleShot>true</noSingleShot>
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_TurretGun_Flame_Proj"]</xpath>
+				<value>
+					<ThingDef ParentName="BaseBullet">
+						<defName>Miho_TurretGun_Flame_Proj</defName>
+						<label>fireball</label>
+						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+						<graphicData>
+							<texPath>Things/Projectile/MihoFireball</texPath>
+							<graphicClass>Graphic_Single</graphicClass>
+							<shaderType>TransparentPostLight</shaderType>
+							<drawSize>2.0</drawSize>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageDef>Miho_MagicBomb</damageDef>
+							<damageAmountBase>7</damageAmountBase>
+							<armorPenetrationSharp>0</armorPenetrationSharp>
+							<armorPenetrationBlunt>0</armorPenetrationBlunt>
+							<stoppingPower>3</stoppingPower>
+							<speed>46</speed>
+							<explosionRadius>2</explosionRadius>
+							<alwaysFreeIntercept>false</alwaysFreeIntercept>
+							<flyOverhead>false</flyOverhead>
+							<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+							<soundAmbient>MortarRound_Ambient</soundAmbient>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
@@ -4,7 +4,7 @@
 	<operations>
 	  <li Class="PatchOperationFindMod">
 			
-		<mods><li>MihoraceBeta</li></mods>
+		<mods><li>Miho, the celestial fox</li></mods>
 			
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
+++ b/Patches/Miho Race/ThingDefs_Races/Race_MihoSummon.xml
@@ -202,7 +202,112 @@
 					</ThingDef>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Miho_Thrumbo"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.09</MeleeDodgeChance>
+					<MeleeCritChance>0.76</MeleeCritChance>
+					<MeleeParryChance>0.45</MeleeParryChance>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Thrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>63</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Thrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>28</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Miho_Thrumbo"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>42</power>
+							<cooldownTime>2.32</cooldownTime>
+							<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>16.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>horn</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>25</power>
+							<cooldownTime>2.64</cooldownTime>
+							<chanceFactor>0.65</chanceFactor>
+							<linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
+							<armorPenetrationSharp>26.5</armorPenetrationSharp>
+							<armorPenetrationBlunt>9.11</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>left foot</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>20</power>
+							<cooldownTime>2.13</cooldownTime>
+							<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>57.8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>right foot</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>20</power>
+							<cooldownTime>2.13</cooldownTime>
+							<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+							<armorPenetrationBlunt>57.8</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>33</power>
+							<cooldownTime>1.62</cooldownTime>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>19</armorPenetrationSharp>
+							<armorPenetrationBlunt>51.76</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>45</power>
+							<cooldownTime>2.52</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Miho_Thrumbo"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Birdlike</bodyShape>
+					</li>
+				</value>
+			</li>
+					
 		</operations>
 		</match>	
 	  </li>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -248,6 +248,7 @@ Medieval Overhaul   |
 Medieval Quest Rewards  |
 Megafauna	|
 Midworld Expanded: Flak Armor  |
+Miho the Celestial Fox  |
 Mincho, The Mint Choco Slime  |
 Mincho, The Mint Choco Slime ~ HAR ver. |
 MiningCo. MiningHelmet	|


### PR DESCRIPTION

## Additions

Patch for Miho the Celestial fox.

## Reasoning

Caliber selections for the conventional guns is based on the descriptions. (8mm for pistol, 6.5 for rifle, 13.2 for the sniper).  Added in the addtional AP-I variant that deals the mod specific ammo for those calibers, including for the pistol. 

Ability damage has been moved to electric since getting it working nicely with heat armor type was not really clear what it was using to determine the penetration. Addtionally, sharp (which is what the base magic damage was initially) suffered even worse from the same problem.

## Alternatives

Could set up a specific ammoset for each of the weapons related, but it is honestly kind of easier to manage/control by just adding the ammo.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (12 Hours)
