### PR TITLE
Make reinforced barrels craftable

### DIFF
--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -43,7 +43,7 @@
 		<description>Use the refinery to synthesize 8 FSX from chemfuel.</description>
 		<jobString>Synthesizing FSX</jobString>
 		<workAmount>800</workAmount>
-    	<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<soundWorking>Recipe_Cremate</soundWorking>
 		<ingredients>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -1,73 +1,73 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-	<RecipeDef ParentName="MakeStoneBlocksBase">
+	<RecipeDef>
 		<defName>Make_FSXDrugLab</defName>
 		<label>Synthesize 7 FSX</label>
 		<description>Synthesize 7 FSX from chemfuel using chemistry equipment.</description>
 		<jobString>Synthesizing FSX</jobString>
+		<workAmount>1000</workAmount>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Drug</soundWorking>
 		<ingredients>
-		<li>
-		<filter>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>100</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Chemfuel</li>
 			</thingDefs>
-		</filter>
-		<count>100</count>
-		</li>
-		</ingredients>
-		<fixedIngredientFilter>
-		<thingDefs>
-			<li>Chemfuel</li>		
-		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>1000</workAmount>
-		<workSkill>Intellectual</workSkill>		
-		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_Drug</soundWorking>	
-		<recipeUsers Inherit="false">
-			<li>DrugLab</li>
-		</recipeUsers>	
-		<skillRequirements>
-			<Intellectual>4</Intellectual>
-		</skillRequirements>	
 		<products>
 			<FSX>7</FSX>
 		</products>
+		<recipeUsers>
+			<li>DrugLab</li>
+		</recipeUsers>
+		<workSkill>Intellectual</workSkill>
+		<skillRequirements>
+			<Intellectual>4</Intellectual>
+		</skillRequirements>	
 	</RecipeDef>
 
-	<RecipeDef ParentName="MakeStoneBlocksBase">
+	<RecipeDef>
 		<defName>Make_FSXRefinery</defName>
 		<label>Synthesize 8 FSX</label>
 		<description>Use the refinery to synthesize 8 FSX from chemfuel.</description>
 		<jobString>Synthesizing FSX</jobString>
+		<workAmount>800</workAmount>
+    	<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Cremate</soundWorking>
 		<ingredients>
-		<li>
-		<filter>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>100</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Chemfuel</li>
 			</thingDefs>
-		</filter>
-		<count>100</count>
-		</li>
-		</ingredients>
-		<fixedIngredientFilter>
-		<thingDefs>
-			<li>Chemfuel</li>		
-		</thingDefs>		
 		</fixedIngredientFilter>
-		<workAmount>800</workAmount>
-		<workSkill>Crafting</workSkill>		
-    	<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_Cremate</soundWorking>	
-		<recipeUsers Inherit="false">
-			<li>BiofuelRefinery</li>
-		</recipeUsers>		
 		<products>
 			<FSX>8</FSX>
 		</products>
+		<recipeUsers>
+			<li>BiofuelRefinery</li>
+		</recipeUsers>
+		<workSkill>Crafting</workSkill>
 	</RecipeDef>
 
 	<RecipeDef>
@@ -83,30 +83,103 @@
 		<ingredients>
 		  <li>
 			<filter>
-			<thingDefs>
-				<li>Ammo_5x35mmCharged</li>
-				<li>Ammo_6x22mmCharged</li>
-				<li>Ammo_12x64mmCharged</li>
-			</thingDefs>
+				<thingDefs>
+					<li>Ammo_5x35mmCharged</li>
+					<li>Ammo_6x22mmCharged</li>
+					<li>Ammo_12x64mmCharged</li>
+				</thingDefs>
 			</filter>
 			<count>200</count>
 		  </li>
 		</ingredients>
 		<fixedIngredientFilter>
-		<thingDefs>
+			<thingDefs>
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
-				<li>Ammo_12x64mmCharged</li>	
-		</thingDefs>		
+				<li>Ammo_12x64mmCharged</li>
+			</thingDefs>		
 		</fixedIngredientFilter>
+		<products>
+			<Plasteel>2</Plasteel>
+			<Steel>2</Steel>
+		</products>
 		<recipeUsers Inherit="false">
 			<li>ElectricSmelter</li>
 		</recipeUsers>	
-		<products>
-		  <Plasteel>2</Plasteel>
-		  <Steel>2</Steel>
-		</products>
 	</RecipeDef>
 
+	<RecipeDef>
+		<defName>Make_ReinforcedBarrel_x1</defName>
+		<label>make reinforced barrel x1</label>
+		<description>Use machining technics to craft a reinforced barrel.</description>
+		<jobString>Make reinforced barrel.</jobString>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Machining</soundWorking>
+		<workAmount>2500</workAmount>
+		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+		<unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+		<ingredients>
+		  <li>
+			<filter>
+				<thingDefs>
+					<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>250</count>
+		  </li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<ReinforcedBarrel>1</ReinforcedBarrel>
+		</products>
+		<recipeUsers>
+			<li>TableMachining</li>
+		</recipeUsers>
+		<skillRequirements>
+			<Crafting>8</Crafting>
+		</skillRequirements>
+		<workSkill>Crafting</workSkill>
+	</RecipeDef>
+
+	<RecipeDef>
+		<defName>Make_ReinforcedBarrel_x5</defName>
+		<label>make reinforced barrel x5</label>
+		<description>Use fabrication technics to craft 5 reinforced barrels.</description>
+		<jobString>Make reinforced barrels.</jobString>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Machining</soundWorking>
+		<workAmount>10000</workAmount>
+		<workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+		<unfinishedThingDef>UnfinishedComponent</unfinishedThingDef>
+		<ingredients>
+		  <li>
+			<filter>
+				<thingDefs>
+					<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>1000</count>
+		  </li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<ReinforcedBarrel>5</ReinforcedBarrel>
+		</products>
+		<recipeUsers>
+			<li>FabricationBench</li>
+		</recipeUsers>
+		<skillRequirements>
+			<Crafting>8</Crafting>
+		</skillRequirements>
+		<workSkill>Crafting</workSkill>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -200,7 +200,7 @@
   </ThingDef>
 
    <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeDisposableRocketLaunche</defName>
+    <defName>MakeDisposableRocketLauncher</defName>
     <label>make disposable rocket launcher x5</label>
     <description>Craft 5 disposable rocket launchers.</description>
     <jobString>Making disposable rocket launchers.</jobString>
@@ -245,7 +245,7 @@
   </RecipeDef>
 
    <RecipeDef ParentName="GrenadeRecipeBase">
-    <defName>MakeDisposableRocketLauncher_1x</defName>
+    <defName>MakeDisposableRocketLauncher_x1</defName>
     <label>make disposable rocket launcher x1</label>
     <description>Craft one disposable rocket launcher.</description>
     <jobString>Making disposable rocket launcher.</jobString>

--- a/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
+++ b/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
@@ -9,501 +9,501 @@
 			<xpath>Defs</xpath>
 			<value>
 
-  <!-- ================== Projectiles ================== -->
+			<!-- ================== Projectiles ================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
-		<defName>Bullet_RPG18_HEAT</defName>
-		<label>RPG18 grenade</label>
-		<graphicData>
-			<texPath>Things/Projectile/RPG</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>29</speed>
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>248</damageAmountBase>
-			<armorPenetrationSharp>300</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>105</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>1</explosiveRadius>
-			<explosionSound>MortarBomb_Explode</explosionSound>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		  </li>
-		  <li Class="CombatExtended.CompProperties_Fragments">
-			<fragments>
-				<Fragment_Large>3</Fragment_Large>
-			  <Fragment_Small>26</Fragment_Small>
-			</fragments>
-		  </li>
-		</comps>
-	</ThingDef>
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
+				<defName>Bullet_RPG18_HEAT</defName>
+				<label>RPG18 grenade</label>
+				<graphicData>
+					<texPath>Things/Projectile/RPG</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>29</speed>
+					<damageDef>Bullet</damageDef>
+					<damageAmountBase>248</damageAmountBase>
+					<armorPenetrationSharp>300</armorPenetrationSharp>
+					<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+				  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+					<damageAmountBase>105</damageAmountBase>
+					<explosiveDamageType>Bomb</explosiveDamageType>
+					<explosiveRadius>1</explosiveRadius>
+					<explosionSound>MortarBomb_Explode</explosionSound>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  </li>
+				  <li Class="CombatExtended.CompProperties_Fragments">
+					<fragments>
+						<Fragment_Large>3</Fragment_Large>
+					  <Fragment_Small>26</Fragment_Small>
+					</fragments>
+				  </li>
+				</comps>
+			</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
-		<defName>Bullet_RPG22_HEAT</defName>
-		<label>RPG22 grenade</label>
-		<graphicData>
-			<texPath>Things/Projectile/RPG</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>29</speed>
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>268</damageAmountBase>
-			<armorPenetrationSharp>400</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>105</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>1</explosiveRadius>
-			<explosionSound>MortarBomb_Explode</explosionSound>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		  </li>
-		  <li Class="CombatExtended.CompProperties_Fragments">
-			<fragments>
-				<Fragment_Large>3</Fragment_Large>
-			  <Fragment_Small>26</Fragment_Small>
-			</fragments>
-		  </li>
-		</comps>
-	</ThingDef>
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
+				<defName>Bullet_RPG22_HEAT</defName>
+				<label>RPG22 grenade</label>
+				<graphicData>
+					<texPath>Things/Projectile/RPG</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>29</speed>
+					<damageDef>Bullet</damageDef>
+					<damageAmountBase>268</damageAmountBase>
+					<armorPenetrationSharp>400</armorPenetrationSharp>
+					<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+				  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+					<damageAmountBase>105</damageAmountBase>
+					<explosiveDamageType>Bomb</explosiveDamageType>
+					<explosiveRadius>1</explosiveRadius>
+					<explosionSound>MortarBomb_Explode</explosionSound>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  </li>
+				  <li Class="CombatExtended.CompProperties_Fragments">
+					<fragments>
+						<Fragment_Large>3</Fragment_Large>
+					  <Fragment_Small>26</Fragment_Small>
+					</fragments>
+				  </li>
+				</comps>
+			</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
-		<defName>Bullet_RPG26_HEAT</defName>
-		<label>RPG26 grenade</label>
-		<graphicData>
-			<texPath>Things/Projectile/RocketS</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>29</speed>
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>268</damageAmountBase>
-			<armorPenetrationSharp>440</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>105</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>1</explosiveRadius>
-			<explosionSound>MortarBomb_Explode</explosionSound>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		  </li>
-		  <li Class="CombatExtended.CompProperties_Fragments">
-			<fragments>
-				<Fragment_Large>3</Fragment_Large>
-			  <Fragment_Small>26</Fragment_Small>
-			</fragments>
-		  </li>
-		</comps>
-	</ThingDef>
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
+				<defName>Bullet_RPG26_HEAT</defName>
+				<label>RPG26 grenade</label>
+				<graphicData>
+					<texPath>Things/Projectile/RocketS</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>29</speed>
+					<damageDef>Bullet</damageDef>
+					<damageAmountBase>268</damageAmountBase>
+					<armorPenetrationSharp>440</armorPenetrationSharp>
+					<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+				  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+					<damageAmountBase>105</damageAmountBase>
+					<explosiveDamageType>Bomb</explosiveDamageType>
+					<explosiveRadius>1</explosiveRadius>
+					<explosionSound>MortarBomb_Explode</explosionSound>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  </li>
+				  <li Class="CombatExtended.CompProperties_Fragments">
+					<fragments>
+						<Fragment_Large>3</Fragment_Large>
+					  <Fragment_Small>26</Fragment_Small>
+					</fragments>
+				  </li>
+				</comps>
+			</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
-		<defName>Bullet_RPG27_HEAT</defName>
-		<label>RPG27 grenade</label>
-		<graphicData>
-			<texPath>Things/Projectile/RocketS</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>36</speed>
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>375</damageAmountBase>
-			<armorPenetrationSharp>750</armorPenetrationSharp>
-			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>150</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>1.5</explosiveRadius>
-			<explosionSound>MortarBomb_Explode</explosionSound>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		  </li>
-		  <li Class="CombatExtended.CompProperties_Fragments">
-			<fragments>
-				<Fragment_Large>4</Fragment_Large>
-			  <Fragment_Small>47</Fragment_Small>
-			</fragments>
-		  </li>
-		</comps>
-	</ThingDef>
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseRPG7Grenade">
+				<defName>Bullet_RPG27_HEAT</defName>
+				<label>RPG27 grenade</label>
+				<graphicData>
+					<texPath>Things/Projectile/RocketS</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>36</speed>
+					<damageDef>Bullet</damageDef>
+					<damageAmountBase>375</damageAmountBase>
+					<armorPenetrationSharp>750</armorPenetrationSharp>
+					<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+				  <li Class="CombatExtended.CompProperties_ExplosiveCE">
+					<damageAmountBase>150</damageAmountBase>
+					<explosiveDamageType>Bomb</explosiveDamageType>
+					<explosiveRadius>1.5</explosiveRadius>
+					<explosionSound>MortarBomb_Explode</explosionSound>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  </li>
+				  <li Class="CombatExtended.CompProperties_Fragments">
+					<fragments>
+						<Fragment_Large>4</Fragment_Large>
+					  <Fragment_Small>47</Fragment_Small>
+					</fragments>
+				  </li>
+				</comps>
+			</ThingDef>
 
-	  <!-- ==================== Recipes ========================== -->
+			  <!-- ==================== Recipes ========================== -->
 
-	   <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG18D</defName>
-	    <label>make RPG18 LAW launchers x5</label>
-	    <description>Craft 5 RPG18 launchers.</description>
-	    <jobString>Making RPG 18 LAW launchers.</jobString>
-	    <workAmount>32500</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>100</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>6</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>5</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG18D>5</Gun_RPG18D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			   <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG18D</defName>
+			    <label>make RPG18 LAW launchers x5</label>
+			    <description>Craft 5 RPG18 launchers.</description>
+			    <jobString>Making RPG 18 LAW launchers.</jobString>
+			    <workAmount>32500</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>100</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>6</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>5</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG18D>5</Gun_RPG18D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	   <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG18D_1x</defName>
-	    <label>make RPG18 LAW launchers x1</label>
-	    <description>Craft one RPG18 launcher.</description>
-	    <jobString>Making RPG 18 LAW launcher.</jobString>
-	    <workAmount>8125</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>25</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>2</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>1</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG18D>1</Gun_RPG18D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			   <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG18D_x1</defName>
+			    <label>make RPG18 LAW launchers x1</label>
+			    <description>Craft one RPG18 launcher.</description>
+			    <jobString>Making RPG 18 LAW launcher.</jobString>
+			    <workAmount>8125</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>25</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>2</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>1</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG18D>1</Gun_RPG18D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG22D</defName>
-	    <label>make RPG22 x5</label>
-	    <description>Craft 5 RPG22 launchers.</description>
-	    <jobString>Making RPG22 launchers.</jobString>
-	    <workAmount>32500</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>100</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>6</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>5</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG22D>5</Gun_RPG22D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG22D</defName>
+			    <label>make RPG22 x5</label>
+			    <description>Craft 5 RPG22 launchers.</description>
+			    <jobString>Making RPG22 launchers.</jobString>
+			    <workAmount>32500</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>100</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>6</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>5</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG22D>5</Gun_RPG22D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG22D_1x</defName>
-	    <label>make RPG22 x1</label>
-	    <description>Craft one RPG22 launcher.</description>
-	    <jobString>Making RPG22 launcher.</jobString>
-	    <workAmount>8125</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>25</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>2</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>1</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG22D>1</Gun_RPG22D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG22D_x1</defName>
+			    <label>make RPG22 x1</label>
+			    <description>Craft one RPG22 launcher.</description>
+			    <jobString>Making RPG22 launcher.</jobString>
+			    <workAmount>8125</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>25</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>2</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>1</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG22D>1</Gun_RPG22D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG26D</defName>
-	    <label>make RPG26 x5</label>
-	    <description>Craft 5 RPG26 launchers.</description>
-	    <jobString>Making RPG26 launchers.</jobString>
-	    <workAmount>32500</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>100</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>6</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>5</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG26D>5</Gun_RPG26D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG26D</defName>
+			    <label>make RPG26 x5</label>
+			    <description>Craft 5 RPG26 launchers.</description>
+			    <jobString>Making RPG26 launchers.</jobString>
+			    <workAmount>32500</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>100</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>6</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>5</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG26D>5</Gun_RPG26D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG26D_1x</defName>
-	    <label>make RPG26 x1</label>
-	    <description>Craft one RPG26 launcher.</description>
-	    <jobString>Making RPG26 launcher.</jobString>
-	    <workAmount>8125</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>25</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>2</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>1</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG26D>1</Gun_RPG26D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG26D_x1</defName>
+			    <label>make RPG26 x1</label>
+			    <description>Craft one RPG26 launcher.</description>
+			    <jobString>Making RPG26 launcher.</jobString>
+			    <workAmount>8125</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>25</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>2</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>1</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG26D>1</Gun_RPG26D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG27D</defName>
-	    <label>make RPG27 x5</label>
-	    <description>Craft 5 RPG27 launchers.</description>
-	    <jobString>Making RPG27 launchers.</jobString>
-	    <workAmount>32500</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>100</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>6</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>5</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG27D>5</Gun_RPG27D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG27D</defName>
+			    <label>make RPG27 x5</label>
+			    <description>Craft 5 RPG27 launchers.</description>
+			    <jobString>Making RPG27 launchers.</jobString>
+			    <workAmount>32500</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>100</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>6</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>5</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG27D>5</Gun_RPG27D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
-	  <RecipeDef ParentName="GrenadeRecipeBase">
-	    <defName>MakeGun_RPG27D_1x</defName>
-	    <label>make RPG27 x1</label>
-	    <description>Craft one RPG27 launcher.</description>
-	    <jobString>Making RPG27 launcher.</jobString>
-	    <workAmount>8125</workAmount>
-	    <ingredients>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>Steel</li>
-		  </thingDefs>
-		</filter>
-		<count>25</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>FSX</li>
-		  </thingDefs>
-		</filter>
-		<count>2</count>
-	      </li>
-	      <li>
-		<filter>
-		  <thingDefs>
-		    <li>ComponentIndustrial</li>
-		  </thingDefs>
-		</filter>
-		<count>1</count>
-	      </li>
-	    </ingredients>
-	    <fixedIngredientFilter>
-	      <thingDefs>
-		<li>Steel</li>
-		<li>FSX</li>
-		<li>ComponentIndustrial</li>
-	      </thingDefs>
-	    </fixedIngredientFilter>
-	    <products>
-	      <Gun_RPG27D>1</Gun_RPG27D>
-	    </products>
-	    <researchPrerequisite>CE_Launchers</researchPrerequisite>
-	  </RecipeDef>
+			  <RecipeDef ParentName="GrenadeRecipeBase">
+			    <defName>MakeGun_RPG27D_x1</defName>
+			    <label>make RPG27 x1</label>
+			    <description>Craft one RPG27 launcher.</description>
+			    <jobString>Making RPG27 launcher.</jobString>
+			    <workAmount>8125</workAmount>
+			    <ingredients>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>Steel</li>
+				  </thingDefs>
+				</filter>
+				<count>25</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>FSX</li>
+				  </thingDefs>
+				</filter>
+				<count>2</count>
+			      </li>
+			      <li>
+				<filter>
+				  <thingDefs>
+				    <li>ComponentIndustrial</li>
+				  </thingDefs>
+				</filter>
+				<count>1</count>
+			      </li>
+			    </ingredients>
+			    <fixedIngredientFilter>
+			      <thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			      </thingDefs>
+			    </fixedIngredientFilter>
+			    <products>
+			      <Gun_RPG27D>1</Gun_RPG27D>
+			    </products>
+			    <researchPrerequisite>CE_Launchers</researchPrerequisite>
+			  </RecipeDef>
 
 			</value>
 		</match>


### PR DESCRIPTION
## Additions

- Added x1 and x5 crafting recipes for reinforced barrels

## Reasoning

- Reinforced barrels are used in mortars, flak cannons and the 105mm howitzer and considering that CE makes doomsday and triple rocket launchers craftable, why not make something combat related such as the reinforced barrels not craftable.
- The cost for crafting the barrels are chosen by comparing the mass of the item and the material required and by taking into consideration that a reinforced barrel replaces 175 steel in the build cost of vanilla mortars. 250 steel and 2500 work for one barrel reflects both the difficulty and the material needed to craft such item quite well, the bulk recipe is scaled appropriately to both make sense and make the investment viable.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
