### PR TITLE
Charged Melee Patch

### DIFF
--- a/Patches/Charged Melee/ChargedMelee_Weapons.xml
+++ b/Patches/Charged Melee/ChargedMelee_Weapons.xml
@@ -167,7 +167,7 @@
 						<power>21</power>
 						<cooldownTime>2.25</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>12.3</armorPenetrationSharp>
+						<armorPenetrationSharp>11.3</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.15</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -179,7 +179,7 @@
 						<power>55</power>
 						<cooldownTime>2.1</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>11.78</armorPenetrationSharp>
+						<armorPenetrationSharp>10.78</armorPenetrationSharp>
 						<armorPenetrationBlunt>8</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -197,6 +197,168 @@
 
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.71</MeleeCritChance>
+				<MeleeParryChance>0.32</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Batton -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.59</cooldownTime>
+							<armorPenetrationBlunt>0.6.25</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>batton head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>0.75</cooldownTime>
+							<armorPenetrationBlunt>42.25</armorPenetrationBlunt>
+						</li>				
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/statBases</xpath>
+			<value>
+				<Bulk>2.5</Bulk>
+				<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.2</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+			
+		<!-- Axe -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.59</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>29</power>
+						<cooldownTime>2.36</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>10.31</armorPenetrationSharp>
+						<armorPenetrationBlunt>39</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]/statBases</xpath>
+			<value>
+				<Bulk>3</Bulk>
+				<MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.50</MeleeCritChance>
+				<MeleeParryChance>0.54</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+		
+		<!-- Maul -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>4</power>
+							<cooldownTime>1.78</cooldownTime>
+							<armorPenetrationBlunt>1</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>batton head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>41</power>
+							<cooldownTime>2.76</cooldownTime>
+							<armorPenetrationBlunt>180</armorPenetrationBlunt>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]/statBases</xpath>
+			<value>
+				<Bulk>18</Bulk>
+				<MeleeCounterParryBonus>0.43</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]</xpath>
 			<value>
 				<equippedStatOffsets>
 				<MeleeCritChance>0.71</MeleeCritChance>

--- a/Patches/Charged Melee/ChargedMelee_Weapons.xml
+++ b/Patches/Charged Melee/ChargedMelee_Weapons.xml
@@ -219,7 +219,7 @@
 							</capacities>
 							<power>2</power>
 							<cooldownTime>1.59</cooldownTime>
-							<armorPenetrationBlunt>0.6.25</armorPenetrationBlunt>
+							<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Charged Melee/ChargedMelee_Weapons.xml
+++ b/Patches/Charged Melee/ChargedMelee_Weapons.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Charged Melee Weaponry</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+		<!-- Knife -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>12</power>
+							<cooldownTime>1.05</cooldownTime>
+							<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
+							<armorPenetrationSharp>7.32</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+							<armorPenetrationSharp>7.50</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/statBases</xpath>
+			<value>
+				<Bulk>1.5</Bulk>
+				<MeleeCounterParryBonus>0.60</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.1</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+			
+		<!-- Katana -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.42</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>13</power>
+						<cooldownTime>1.42</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>10.34</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>0.88</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>10.3</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.936</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]/statBases</xpath>
+			<value>
+				<Bulk>8</Bulk>
+				<MeleeCounterParryBonus>1.27</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.95</MeleeCritChance>
+				<MeleeParryChance>0.54</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Longsword -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>2.31</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>2.8</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>2.25</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>12.3</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.15</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>55</power>
+						<cooldownTime>2.1</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>11.78</armorPenetrationSharp>
+						<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]/statBases</xpath>
+			<value>
+				<Bulk>18</Bulk>
+				<MeleeCounterParryBonus>0.43</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.71</MeleeCritChance>
+				<MeleeParryChance>0.32</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

Adds equipment stats for the Charged Melee weapon equipment.

## Reasoning

Weapons possess an extra 7mm for one handed, 9mm for two handed weapons compared to the conventional stats.
This puts them fairly close to the stats of the powered weapons from CE melee, which they mostly match in cost.
Axe gets 2h bonus and operates like powered blunt weapon to give it a hybrid role.
Heavy hammer and batton are heavier and lighter versions of powered maul/mace respectively.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
