### PR TITLE
Vali's Charge Arsenal Series Patch

### DIFF
--- a/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
@@ -277,6 +277,325 @@
 			</value>
 		</li>
 		
+		<!-- Katana -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaKatana"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>1.4</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>18.52</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.375</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>25</power>
+						<cooldownTime>0.81</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>18.22</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.266</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaKatana"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<MeleeCounterParryBonus>0.53</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaKatana"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>1.33</MeleeCritChance>
+				<MeleeParryChance>0.40</MeleeParryChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- Spearlance -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaSpearLance"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.2</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>21.82</armorPenetrationSharp>
+						<armorPenetrationBlunt>3.91</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>40</power>
+						<cooldownTime>2.88</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>23.62</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.05</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaSpearLance"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>3.92</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaSpearLance"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.38</MeleeParryChance>
+				<MeleeDodgeChance>0.70</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- Gunblade -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaGunBlade"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>19</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.35</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>19.12</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>						
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaGunBlade"]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaGunBlade"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>V_AnimaGunBlade</defName>
+			<statBases>
+				<SightsEfficiency>1.10</SightsEfficiency>
+				<ShotSpread>0.09</ShotSpread>
+				<SwayFactor>1.40</SwayFactor>
+				<Bulk>10</Bulk>
+				<Mass>4.00</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.26</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+				<warmupTime>0.5</warmupTime>
+				<burstShotCount>3</burstShotCount>
+				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+				<range>25</range>
+				<soundCast>GunBladeHeavy</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>18</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>2</aimedBurstShotCount>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- Light Gunblade -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaShortGunBlade"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.01</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>17.92</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.391</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>0.88</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>17.24</armorPenetrationSharp>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>						
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaShortGunBlade"]/statBases</xpath>
+			<value>
+				<Bulk>8</Bulk>
+				<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaShortGunBlade"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>V_AnimaShortGunBlade</defName>
+			<statBases>
+				<SightsEfficiency>1.10</SightsEfficiency>
+				<ShotSpread>0.11</ShotSpread>
+				<SwayFactor>1.15</SwayFactor>
+				<Bulk>8.50</Bulk>
+				<Mass>3.00</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_10x18mmCharged</defaultProjectile>
+				<warmupTime>0.5</warmupTime>
+				<range>20</range>
+				<soundCast>GunBladeLight</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>6</magazineSize>
+				<reloadTime>0.85</reloadTime>
+				<reloadOneAtATime>true</reloadOneAtATime>
+				<ammoSet>AmmoSet_10x18mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Vali's Charged Arsenal - Eltex Series</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+		<!-- Knife -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaDagger"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>17</power>
+							<cooldownTime>1.05</cooldownTime>
+							<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
+							<armorPenetrationSharp>16.56</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>12</power>
+							<cooldownTime>0.84</cooldownTime>
+							<armorPenetrationBlunt>0.565</armorPenetrationBlunt>
+							<armorPenetrationSharp>19.64</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaDagger"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<MeleeCounterParryBonus>0.73</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaDagger"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.23</MeleeParryChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaDagger"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+			
+		<!-- Longsword -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaLongSword"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>25.26</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>29</power>
+						<cooldownTime>1.35</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>19.12</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaLongSword"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<MeleeCounterParryBonus>0.73</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaLongSword"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.55</MeleeParryChance>
+				<MeleeDodgeChance>0.37</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- Staff -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaStaff"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>staff top edge</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>0.80</cooldownTime>
+						<armorPenetrationBlunt>75.62</armorPenetrationBlunt>
+					</li>	
+					<li Class="CombatExtended.ToolCE">
+						<label>staff top edge</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>0.80</cooldownTime>
+						<armorPenetrationBlunt>75.62</armorPenetrationBlunt>
+					</li>							
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaStaff"]/statBases</xpath>
+			<value>
+				<Bulk>1.5</Bulk>
+				<MeleeCounterParryBonus>2.4</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaStaff"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>1.8</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- Maul -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaHammer"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.97</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>43</power>
+							<cooldownTime>4.23</cooldownTime>
+							<armorPenetrationBlunt>283.5</armorPenetrationBlunt>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaHammer"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaHammer"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>2.5</MeleeCritChance>
+				<MeleeParryChance>0.06</MeleeParryChance>
+				<MeleeDodgeChance>0.4</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<!-- Mace -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_AnimaMace"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.97</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>32</power>
+							<cooldownTime>3.16</cooldownTime>
+							<armorPenetrationBlunt>202.5</armorPenetrationBlunt>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaMace"]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<MeleeCounterParryBonus>1.25</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_AnimaMace"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>1.5</MeleeCritChance>
+				<MeleeParryChance>0.27</MeleeParryChance>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+			</value>
+		</li>
+		
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal - Eltex Series/EltexMelee_Weapons.xml
@@ -149,18 +149,18 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>10</power>
-						<cooldownTime>0.80</cooldownTime>
-						<armorPenetrationBlunt>75.62</armorPenetrationBlunt>
+						<power>13</power>
+						<cooldownTime>0.83</cooldownTime>
+						<armorPenetrationBlunt>59.09</armorPenetrationBlunt>
 					</li>	
 					<li Class="CombatExtended.ToolCE">
 						<label>staff top edge</label>
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>10</power>
-						<cooldownTime>0.80</cooldownTime>
-						<armorPenetrationBlunt>75.62</armorPenetrationBlunt>
+						<power>13</power>
+						<cooldownTime>0.83</cooldownTime>
+						<armorPenetrationBlunt>59.09</armorPenetrationBlunt>
 					</li>							
 				</tools>
 			</value>
@@ -206,8 +206,8 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>43</power>
-							<cooldownTime>4.23</cooldownTime>
-							<armorPenetrationBlunt>283.5</armorPenetrationBlunt>
+							<cooldownTime>3.4</cooldownTime>
+							<armorPenetrationBlunt>236.33</armorPenetrationBlunt>
 						</li>					
 				</tools>
 			</value>
@@ -253,8 +253,8 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>32</power>
-							<cooldownTime>3.16</cooldownTime>
-							<armorPenetrationBlunt>202.5</armorPenetrationBlunt>
+							<cooldownTime>2.35</cooldownTime>
+							<armorPenetrationBlunt>168.75</armorPenetrationBlunt>
 						</li>					
 				</tools>
 			</value>

--- a/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
@@ -800,6 +800,204 @@
 			</value>
 		</li>
 		
+		<!-- Gunblade -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeGunBlade"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>1.35</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.56</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>						
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeGunBlade"]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeGunBlade"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>V_ChargeGunBlade</defName>
+			<statBases>
+				<SightsEfficiency>0.80</SightsEfficiency>
+				<ShotSpread>0.09</ShotSpread>
+				<SwayFactor>1.40</SwayFactor>
+				<Bulk>10</Bulk>
+				<Mass>4.00</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>1.26</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<burstShotCount>3</burstShotCount>
+				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+				<range>25</range>
+				<soundCast>GunBladeHeavy</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>18</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>2</aimedBurstShotCount>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- Light Gunblade -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeShortGunBlade"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.01</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>8.96</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.391</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>0.88</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>8.67</armorPenetrationSharp>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>						
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeShortGunBlade"]/statBases</xpath>
+			<value>
+				<Bulk>8</Bulk>
+				<MeleeCounterParryBonus>0.44</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeShortGunBlade"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.33</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>V_ChargeShortGunBlade</defName>
+			<statBases>
+				<SightsEfficiency>0.80</SightsEfficiency>
+				<ShotSpread>0.11</ShotSpread>
+				<SwayFactor>1.15</SwayFactor>
+				<Bulk>8.50</Bulk>
+				<Mass>3.00</Mass>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_10x18mmCharged</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<range>20</range>
+				<soundCast>GunBladeLight</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>6</magazineSize>
+				<reloadTime>0.85</reloadTime>
+				<reloadOneAtATime>true</reloadOneAtATime>
+				<ammoSet>AmmoSet_10x18mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
@@ -430,7 +430,7 @@
 				<equippedStatOffsets>
 				<MeleeCritChance>0.33</MeleeCritChance>
 				<MeleeParryChance>0.4</MeleeParryChance>
-				<MeleeDodgeChance>0.0.27</MeleeDodgeChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
 				</equippedStatOffsets>
 			</value>
 		</li>

--- a/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
@@ -34,7 +34,7 @@
 							<power>17</power>
 							<cooldownTime>1.05</cooldownTime>
 							<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
-							<armorPenetrationSharp>8.28</armorPenetrationSharp>
+							<armorPenetrationSharp>10.35</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -45,7 +45,7 @@
 							<power>12</power>
 							<cooldownTime>0.84</cooldownTime>
 							<armorPenetrationBlunt>0.565</armorPenetrationBlunt>
-							<armorPenetrationSharp>9.82</armorPenetrationSharp>
+							<armorPenetrationSharp>12.75</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>					
 				</tools>
@@ -103,7 +103,7 @@
 						<power>15</power>
 						<cooldownTime>1.4</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.26</armorPenetrationSharp>
+						<armorPenetrationSharp>11.39</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.375</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -115,7 +115,7 @@
 						<power>25</power>
 						<cooldownTime>0.81</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.11</armorPenetrationSharp>
+						<armorPenetrationSharp>11.57</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.266</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -167,7 +167,7 @@
 						<power>24</power>
 						<cooldownTime>1.12</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.93</armorPenetrationSharp>
+						<armorPenetrationSharp>11.88</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.586</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -179,7 +179,7 @@
 						<power>30</power>
 						<cooldownTime>1.05</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationSharp>12.41</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>						
@@ -231,7 +231,7 @@
 						<power>18</power>
 						<cooldownTime>1</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>12.63</armorPenetrationSharp>
+						<armorPenetrationSharp>15.79</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -243,7 +243,7 @@
 						<power>29</power>
 						<cooldownTime>1.35</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.56</armorPenetrationSharp>
+						<armorPenetrationSharp>11.95</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -295,7 +295,7 @@
 						<power>25</power>
 						<cooldownTime>1.43</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>12.21</armorPenetrationSharp>
+						<armorPenetrationSharp>15.14</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.563</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -307,7 +307,7 @@
 						<power>46</power>
 						<cooldownTime>2.48</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>12.11</armorPenetrationSharp>
+						<armorPenetrationSharp>15.26</armorPenetrationSharp>
 						<armorPenetrationBlunt>3.063</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -359,7 +359,7 @@
 						<power>26</power>
 						<cooldownTime>2.89</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>11.22</armorPenetrationSharp>
+						<armorPenetrationSharp>14.03</armorPenetrationSharp>
 						<armorPenetrationBlunt>2.531</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -408,10 +408,10 @@
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
-							<power>11</power>
-							<cooldownTime>1.67</cooldownTime>
-							<armorPenetrationBlunt>39.61</armorPenetrationBlunt>
-						</li>				
+							<power>12</power>
+							<cooldownTime>1.1</cooldownTime>
+							<armorPenetrationBlunt>42.35</armorPenetrationBlunt>
+						</li>
 				</tools>
 			</value>
 		</li>
@@ -465,7 +465,7 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>43</power>
-							<cooldownTime>4.23</cooldownTime>
+							<cooldownTime>4</cooldownTime>
 							<armorPenetrationBlunt>189</armorPenetrationBlunt>
 						</li>					
 				</tools>
@@ -514,7 +514,7 @@
 								<li>Blunt</li>
 							</capacities>
 							<power>32</power>
-							<cooldownTime>3.16</cooldownTime>
+							<cooldownTime>2.76</cooldownTime>
 							<armorPenetrationBlunt>135</armorPenetrationBlunt>
 						</li>					
 				</tools>
@@ -566,7 +566,7 @@
 						<power>14</power>
 						<cooldownTime>1.5</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationSharp>11.88</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -578,7 +578,7 @@
 						<power>35</power>
 						<cooldownTime>2.39</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>12.05</armorPenetrationSharp>
+						<armorPenetrationSharp>15.06</armorPenetrationSharp>
 						<armorPenetrationBlunt>5.05</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -631,7 +631,7 @@
 						<power>18</power>
 						<cooldownTime>1.2</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>10.91</armorPenetrationSharp>
+						<armorPenetrationSharp>13.64</armorPenetrationSharp>
 						<armorPenetrationBlunt>3.91</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -643,7 +643,7 @@
 						<power>40</power>
 						<cooldownTime>2.88</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>11.81</armorPenetrationSharp>
+						<armorPenetrationSharp>14.76</armorPenetrationSharp>
 						<armorPenetrationBlunt>5.05</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -696,7 +696,7 @@
 						<power>17</power>
 						<cooldownTime>1.86</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>13.33</armorPenetrationSharp>
+						<armorPenetrationSharp>16.66</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.89</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -708,7 +708,7 @@
 						<power>18</power>
 						<cooldownTime>0.96</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.82</armorPenetrationSharp>
+						<armorPenetrationSharp>12.28</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.844</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -761,7 +761,7 @@
 						<power>21</power>
 						<cooldownTime>2.38</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>15.34</armorPenetrationSharp>
+						<armorPenetrationSharp>19.18</armorPenetrationSharp>
 						<armorPenetrationBlunt>8.34</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>
@@ -773,7 +773,7 @@
 						<power>25</power>
 						<cooldownTime>2.08</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>8.96</armorPenetrationSharp>
+						<armorPenetrationSharp>11.2</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.977</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>					
@@ -825,7 +825,7 @@
 						<power>21</power>
 						<cooldownTime>1.5</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationSharp>11.88</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -837,7 +837,7 @@
 						<power>28</power>
 						<cooldownTime>1.35</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>9.56</armorPenetrationSharp>
+						<armorPenetrationSharp>11.95</armorPenetrationSharp>
 						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>						
@@ -926,7 +926,7 @@
 						<power>18</power>
 						<cooldownTime>1.01</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>8.96</armorPenetrationSharp>
+						<armorPenetrationSharp>11.2</armorPenetrationSharp>
 						<armorPenetrationBlunt>0.391</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					</li>
@@ -938,7 +938,7 @@
 						<power>22</power>
 						<cooldownTime>0.88</cooldownTime>
 						<chanceFactor>1</chanceFactor>
-						<armorPenetrationSharp>8.67</armorPenetrationSharp>
+						<armorPenetrationSharp>10.84</armorPenetrationSharp>
 						<armorPenetrationBlunt>1</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>						

--- a/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
+++ b/Patches/Vali's Charged Arsenal/ChargedMelee_Weapons.xml
@@ -1,0 +1,806 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Vali's Charged Arsenal</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+		<!-- Knife -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>17</power>
+							<cooldownTime>1.05</cooldownTime>
+							<armorPenetrationBlunt>0.72</armorPenetrationBlunt>
+							<armorPenetrationSharp>8.28</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>12</power>
+							<cooldownTime>0.84</cooldownTime>
+							<armorPenetrationBlunt>0.565</armorPenetrationBlunt>
+							<armorPenetrationSharp>9.82</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<MeleeCounterParryBonus>0.73</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.23</MeleeParryChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeCutter"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+			
+		<!-- Katana -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>1.4</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.26</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.375</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>25</power>
+						<cooldownTime>0.81</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.11</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.266</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<MeleeCounterParryBonus>0.53</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKatana"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>1.33</MeleeCritChance>
+				<MeleeParryChance>0.40</MeleeParryChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Kopesh -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeKhopesh"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>24</power>
+						<cooldownTime>1.12</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.93</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.586</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>30</power>
+						<cooldownTime>1.05</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>						
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKhopesh"]/statBases</xpath>
+			<value>
+				<Bulk>7</Bulk>
+				<MeleeCounterParryBonus>0.90</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeKhopesh"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.50</MeleeCritChance>
+				<MeleeParryChance>0.68</MeleeParryChance>
+				<MeleeDodgeChance>0.45</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Longsword -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>12.63</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.125</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>29</power>
+						<cooldownTime>1.35</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.56</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.531</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<MeleeCounterParryBonus>0.73</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeLongSword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>0.55</MeleeParryChance>
+				<MeleeDodgeChance>0.37</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Heavy Blade -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeBlade"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.78</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>25</power>
+						<cooldownTime>1.43</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>12.21</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.563</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>46</power>
+						<cooldownTime>2.48</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>12.11</armorPenetrationSharp>
+						<armorPenetrationBlunt>3.063</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBlade"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>0.48</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBlade"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.25</MeleeCritChance>
+				<MeleeParryChance>0.25</MeleeParryChance>
+				<MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Axe -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>26</power>
+						<cooldownTime>2.89</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>11.22</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.531</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<MeleeCounterParryBonus>1.42</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeAxe"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.60</MeleeParryChance>
+				<MeleeDodgeChance>0.27</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Batton -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>batton head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.67</cooldownTime>
+							<armorPenetrationBlunt>39.61</armorPenetrationBlunt>
+						</li>				
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/statBases</xpath>
+			<value>
+				<Bulk>2.5</Bulk>
+				<MeleeCounterParryBonus>0.4</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.33</MeleeCritChance>
+				<MeleeParryChance>0.4</MeleeParryChance>
+				<MeleeDodgeChance>0.0.27</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeBaton"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+		
+		<!-- Maul -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.97</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>43</power>
+							<cooldownTime>4.23</cooldownTime>
+							<armorPenetrationBlunt>189</armorPenetrationBlunt>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHammer"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>2.5</MeleeCritChance>
+				<MeleeParryChance>0.06</MeleeParryChance>
+				<MeleeDodgeChance>0.4</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Mace -->	
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeMace"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.97</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>32</power>
+							<cooldownTime>3.16</cooldownTime>
+							<armorPenetrationBlunt>135</armorPenetrationBlunt>
+						</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeMace"]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<MeleeCounterParryBonus>1.25</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeMace"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>1.5</MeleeCritChance>
+				<MeleeParryChance>0.27</MeleeParryChance>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Glaive -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeGlaive"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>14</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>35</power>
+						<cooldownTime>2.39</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>12.05</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.05</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeGlaive"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>2.22</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeGlaive"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.33</MeleeCritChance>
+				<MeleeParryChance>0.15</MeleeParryChance>
+				<MeleeDodgeChance>0.50</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Halberd -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeHalberd"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>1.2</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>10.91</armorPenetrationSharp>
+						<armorPenetrationBlunt>3.91</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>40</power>
+						<cooldownTime>2.88</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>11.81</armorPenetrationSharp>
+						<armorPenetrationBlunt>5.05</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHalberd"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>3.92</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeHalberd"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.38</MeleeParryChance>
+				<MeleeDodgeChance>0.70</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Magari -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeMagariYari"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>17</power>
+						<cooldownTime>1.86</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>13.33</armorPenetrationSharp>
+						<armorPenetrationBlunt>1.89</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>0.96</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>9.82</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.844</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeMagariYari"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeMagariYari"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.5</MeleeCritChance>
+				<MeleeParryChance>0.9</MeleeParryChance>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- Scythe -->	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="V_ChargeScythe"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.15</chanceFactor>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>21</power>
+						<cooldownTime>2.38</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>15.34</armorPenetrationSharp>
+						<armorPenetrationBlunt>8.34</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>25</power>
+						<cooldownTime>2.08</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationSharp>8.96</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.977</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>					
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeScythe"]/statBases</xpath>
+			<value>
+				<Bulk>12</Bulk>
+				<MeleeCounterParryBonus>0.30</MeleeCounterParryBonus>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="V_ChargeScythe"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				<MeleeCritChance>0.67</MeleeCritChance>
+				<MeleeParryChance>0.50</MeleeParryChance>
+				<MeleeDodgeChance>0.33</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -369,6 +369,8 @@ Twi'lek Race    |
 T's Samurai Faction |
 Ultratech: Altered Carbon Remastered |
 Useless Clothes |
+Vali's Charged Arsenal |
+Vali's Charged Arsenal - Eltex Series |
 Vanilla Animals Expanded |
 Vanilla Apparel Expanded	|
 Vanilla Apparel Expanded — Accessories  |


### PR DESCRIPTION
## Additions

Patch for what is currently released of the charged/eltex melee stuff

Rather than using existing stuff and just buffing it, this time we have a calc sheet.
Eltex, being ultratech gets a addtional 2x multiplier on sharp, and 1.5x multiplier on blunt.

## Reasoning

Charged equipment now has +7mm on top of the calcualted stat for the equipment. This is universal across sharp again rather than treating the axe differently for the moment.

Blunt as before gets at 10x multiplier on its blunt instead.

## Alternatives

We could just use a static value across them, though that limits what we have. Sharp could also instead use some form of multiplier but would require a lot more tweaking and woudl result in far more significant variation between weapons, that kind of gets flattened out by just giving them a flat bonus

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
