### PR TITLE
Ratkin back pack carrying capacity patch

### DIFF
--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -130,6 +130,7 @@
 				<value>
 					<equippedStatOffsets>
 						<CarryBulk>20</CarryBulk>
+						<CarryingCapacity>15</CarryingCapacity>
 					</equippedStatOffsets>					
 				</value>
 			</li>
@@ -146,6 +147,7 @@
 				<value>
 					<equippedStatOffsets>
 						<CarryBulk>30</CarryBulk>
+						<CarryingCapacity>23</CarryingCapacity>
 					</equippedStatOffsets>					
 				</value>
 			</li>
@@ -163,6 +165,7 @@
 				<value>
 					<equippedStatOffsets>
 						<CarryBulk>40</CarryBulk>
+						<CarryingCapacity>35</CarryingCapacity>
 					</equippedStatOffsets>					
 				</value>
 			</li>
@@ -179,6 +182,7 @@
 				<value>
 					<equippedStatOffsets>
 						<CarryBulk>50</CarryBulk>
+						<CarryingCapacity>45</CarryingCapacity>
 					</equippedStatOffsets>					
 				</value>
 			</li>
@@ -195,7 +199,8 @@
 				<xpath>Defs/ThingDef[defName="RK_SantaSack"]/equippedStatOffsets</xpath>
 				<value>
 					<equippedStatOffsets>
-						<CarryBulk>60</CarryBulk>
+						<CarryBulk>55</CarryBulk>
+						<CarryingCapacity>55</CarryingCapacity>
 					</equippedStatOffsets>					
 				</value>
 			</li>


### PR DESCRIPTION
Ratkin back pack carrying capacity patch

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
