### PR TITLE
Fix for #1456

### DIFF
--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -70,7 +70,7 @@
 		<li>CraftingSpot</li>
 	</recipeUsers>
 	<effectWorking>Smelt</effectWorking>
-	<unfinishedThingDef>UnfinishedWeapon</unfinishedThingDef>
+	<unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
     <workAmount>2500</workAmount>	
     <jobString>Making pila.</jobString>
     <ingredients>


### PR DESCRIPTION
## Changes

- Changed the `unfinishedThingDef` of javelins from `UnfinishedWeapon` to `UnfinishedAmmo` to fix the stuffed unfinished item.

## References

- Closes #1456 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
