### PR TITLE
Human and bionic melee attack tools adjustments

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -31,7 +31,7 @@
 					<power>1</power>
 					<cooldownTime>1.26</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right fist</label>
@@ -41,7 +41,7 @@
 					<power>1</power>
 					<cooldownTime>1.26</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>teeth</label>
@@ -55,7 +55,7 @@
 					<soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
 					<soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
 					<armorPenetrationSharp>0.15</armorPenetrationSharp>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -44,6 +44,20 @@
 					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+					  <li>Bite</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>2</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+					<chanceFactor>0.07</chanceFactor>
+					<soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+					<soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+					<armorPenetrationSharp>0.15</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				</li>
+				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>

--- a/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/Patches/EPOE Forked/Bionics_Patch.xml
@@ -268,6 +268,45 @@
 					</tools>
 				</value>
 			</li>
+
+			<!-- Jaws -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="AdvancedBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.25</cooldownTime>
+						<armorPenetrationSharp>0.3</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/HediffDef[defName="BionicJaw" or defName="SilentJaw" or defName="HydraulicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>1.25</cooldownTime>
+						<armorPenetrationSharp>0.2</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
+
 		</operations>
 	</match>
 	</Operation>

--- a/Patches/RBSE/Bionics.xml
+++ b/Patches/RBSE/Bionics.xml
@@ -3,6 +3,7 @@
   <Operation Class="PatchOperationFindMod">
     <mods>
       <li>Rah's Bionics and Surgery Expansion</li>
+      <li>RBSE Hardcore Edition</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -106,7 +106,11 @@
 				</tools>
 			</value>
 		</li>
-	
+
+		</operations>
+	</match>
+	</Operation>
+
 	<Operation Class="PatchOperationFindMod">
     <mods>
         <li>[FSF] Advanced Bionics Expansion</li>
@@ -165,10 +169,6 @@
 				</tools>
 			</value>
 		</li>
-
-		</operations>
-	</match>
-	</Operation>
 
 		<!--Implants-->
 		

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -165,7 +165,11 @@
 				</tools>
 			</value>
 		</li>
-		
+
+		</operations>
+	</match>
+	</Operation>
+
 		<!--Implants-->
 		
 		<!--Tone down Speed torso implant dodge chance to be more inline with CE stats (also so it doesn't instantly max out dodge)-->

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -89,13 +89,23 @@
 			</value>
 		</li>
 		
-		<!-- CE disables human bite attacks-->
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/HediffDef[defName="FSFAdvBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]</xpath>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FSFAdvBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>1.25</cooldownTime>
+					<armorPenetrationSharp>0.3</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
 		</li>
-		</operations>
-	</match>
-	</Operation>
 	
 	<Operation Class="PatchOperationFindMod">
     <mods>
@@ -249,7 +259,7 @@
 					<capacities>
 						<li>FSFEffectTaser</li>
 					</capacities>
-					<power>2</power>
+					<power>5</power>
 					<cooldownTime>1.84</cooldownTime>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 					<extraMeleeDamages>

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
@@ -85,6 +85,10 @@
 			</value>
 		</li>
 
+		</operations>
+	</match>
+	</Operation>
+
 	<Operation Class="PatchOperationFindMod">
     <mods>
 		<li>[FSF] Vanilla Bionics Expansion</li>

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
@@ -10,6 +10,7 @@
     </mods>
 	<match Class="PatchOperationSequence">
 		<operations>
+
 		<!--Power Arm-->
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/HediffDef[defName="FSFBionicPowerArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
@@ -29,6 +30,7 @@
 				</tools>
 			</value>
 		</li>
+
 		<!--Prosthetics -->
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/HediffDef[defName="FSFProstheticHand"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
@@ -46,14 +48,43 @@
 				</tools>
 			</value>
 		</li>
-		<!-- CE disables human bite attacks-->
-		<li Class="PatchOperationRemove">
-			<xpath>Defs/HediffDef[defName="FSFArchotechJaw" or defName="FSFBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]</xpath>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FSFBionicJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.5</cooldownTime>
+					<armorPenetrationSharp>0.2</armorPenetrationSharp>
+					<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
 		</li>
-		</operations>
-	</match>
-	</Operation>
-	
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FSFArchotechJaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>teeth</label>
+					<capacities>
+						<li>Bite</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1.0</cooldownTime>
+					<armorPenetrationSharp>0.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.0</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
 	<Operation Class="PatchOperationFindMod">
     <mods>
 		<li>[FSF] Vanilla Bionics Expansion</li>


### PR DESCRIPTION
## Additions

- Added the human bite attack tool back tot he melee attack pool of humans.
- Patched modded jaw bionics that have bite attack tools.

## Changes

- Increased human punches' blunt armor penetration from 0.25 to 0.5

## Reasoning

- Human bite attack tools were left out because of an arbitrary reason (they were thought as stupid). Added the base bite tool and patched modded bionic jaw bite tools because it only made sense. A human bite has the force of 150 PSI which translates to 1MPa, hence the AP of the bite attack.
- Punches IRL can range from 150 PSI for average unskilled humans to 800 PSI for skilled boxers which translates to 1MPa to 5.5MPa, hence the increase in AP of punches.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
