### PR TITLE
Siegebreaker energy shield buff

### DIFF
--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -430,6 +430,42 @@
 					</value>
 				</li>
 
+				<!-- === Energy shields === -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldRechargeRate</xpath>
+					<value>
+						<EnergyShieldRechargeRate>0.03</EnergyShieldRechargeRate>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldEnergyMax</xpath>
+					<value>
+						<EnergyShieldEnergyMax>0.6</EnergyShieldEnergyMax>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+					<value>
+						<EnergyShieldRechargeRate>0.15</EnergyShieldRechargeRate>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+					<value>
+						<EnergyShieldRechargeRate>0.3</EnergyShieldRechargeRate>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+					<value>
+						<EnergyShieldEnergyMax>150</EnergyShieldEnergyMax>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- Buffed Siegebreaker armor's energy shield similar to shield belts by a factor of x1.5.

## Reasoning

- Vanilla and modded shield belts have x1.5 the capacity of their vanilla version in CE, patched the siegebreaker armor variants to make them consistent to that design.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded