### PR TITLE
Support for WarCasket Gundam Addon

### DIFF
--- a/Patches/WarCasket Gundam Addon/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Apparel_Warcaskets.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>WarCasket Gundam Addon</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- ========== Remove Vanilla Carry Capacity ========== -->
+		<li Class="PatchOperationRemove">
+			<xpath>/Defs/VFEPirates.WarcasketDef[
+			defName="VFEP_Warcasket_Barbatos"															
+			]/modExtensions/li/carryingCapacity</xpath>
+		</li>
+
+	
+		<!-- ========== Barbatos (Aerial Warcasket) ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/statBases</xpath>
+			<value>
+				<Bulk>250</Bulk>
+				<WornBulk>25</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>70</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>200</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/costList/Steel</xpath>
+			<value>
+				<Steel>290</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Barbatos"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>16</ComponentIndustrial>
+			</value>
+		</li>
+
+		<!-- ========== Barbatos - Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barbatos"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barbatos"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barbatos"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>70</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Barbatos"]/costList/Steel</xpath>
+			<value>
+				<Steel>40</Steel>
+			</value>
+		</li>
+
+		<!-- === Barbatos Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>8</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+  
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+  
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>25</ArmorRating_Sharp>
+			</value>
+		</li>
+  
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>56</ArmorRating_Blunt>
+			</value>
+		</li>  
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/costList/Steel</xpath>
+			<value>
+				<Steel>90</Steel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/costList/ComponentIndustrial</xpath>
+			<value>
+				<ComponentIndustrial>6</ComponentIndustrial>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
@@ -10,7 +10,7 @@
 
 			<!-- Barbatos Katana (Warcasket Broadsword) -->	
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/tools</xpath>
+				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -42,7 +42,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]</xpath>
+				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]</xpath>
 				<value>
 					<equippedStatOffsets>
 						<MeleeCritChance>0.02</MeleeCritChance>
@@ -53,7 +53,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/statBases</xpath>
+				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/statBases</xpath>
 				<value>
 					<Bulk>14</Bulk>
 					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
@@ -63,7 +63,7 @@
 			
 			<!-- Barbatos' mace -->	
 			<Operation Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/tools</xpath>
+				<xpath>Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GMace"]/tools</xpath>
 					<value>
 						<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -90,7 +90,7 @@
 			</Operation>
 
 			<Operation Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/statBases</xpath>
+				<xpath>Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GMace"]/statBases</xpath>
 				<value>
 					<Bulk>20</Bulk>
 					<MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
@@ -99,7 +99,7 @@
 			</Operation>
 
 			<Operation Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]</xpath>
+				<xpath>Defs/ThiVFEP_BaseMeleeWeapon_WarcasketngDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]</xpath>
 				<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>1.5</MeleeCritChance>

--- a/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
@@ -10,7 +10,7 @@
 
 			<!-- Barbatos Katana (Warcasket Broadsword) -->	
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/tools</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -42,7 +42,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]</xpath>
 				<value>
 					<equippedStatOffsets>
 						<MeleeCritChance>0.02</MeleeCritChance>
@@ -53,7 +53,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/statBases</xpath>
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/statBases</xpath>
 				<value>
 					<Bulk>14</Bulk>
 					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
@@ -63,7 +63,7 @@
 			
 			<!-- Barbatos' mace -->	
 			<Operation Class="PatchOperationReplace">
-				<xpath>Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GMace"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/tools</xpath>
 					<value>
 						<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -90,7 +90,7 @@
 			</Operation>
 
 			<Operation Class="PatchOperationAdd">
-				<xpath>Defs/VFEP_BaseMeleeWeapon_Warcasket[defName="VFEP_WarcasketMeleeWeapon_GMace"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/statBases</xpath>
 				<value>
 					<Bulk>20</Bulk>
 					<MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
@@ -99,7 +99,7 @@
 			</Operation>
 
 			<Operation Class="PatchOperationAdd">
-				<xpath>Defs/ThiVFEP_BaseMeleeWeapon_WarcasketngDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]</xpath>
 				<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>1.5</MeleeCritChance>

--- a/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Melee_Warcaskets.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+    	<li>WarCasket Gundam Addon</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>			
+
+			<!-- Barbatos Katana (Warcasket Broadsword) -->	
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>56</power>
+							<cooldownTime>2.4</cooldownTime>
+							<chanceFactor>0.60</chanceFactor>
+							<armorPenetrationBlunt>9</armorPenetrationBlunt>
+							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>68</power>
+							<cooldownTime>3.35</cooldownTime>
+							<chanceFactor>0.30</chanceFactor>
+							<armorPenetrationBlunt>17</armorPenetrationBlunt>
+							<armorPenetrationSharp>4.8</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.02</MeleeCritChance>
+						<MeleeParryChance>0.47</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GKatana"]/statBases</xpath>
+				<value>
+					<Bulk>14</Bulk>
+					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+					<ToughnessRating>10</ToughnessRating>
+				</value>
+			</li>
+			
+			<!-- Barbatos' mace -->	
+			<Operation Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/tools</xpath>
+					<value>
+						<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>spikerod</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+						<power>15</power>
+						<cooldownTime>2.8</cooldownTime>
+						<armorPenetrationBlunt>16</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+						<power>35</power>
+						<cooldownTime>4</cooldownTime>
+						<armorPenetrationBlunt>105</armorPenetrationBlunt>
+						</li>					
+					</tools>
+				</value>
+			</Operation>
+
+			<Operation Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]/statBases</xpath>
+				<value>
+					<Bulk>20</Bulk>
+					<MeleeCounterParryBonus>1.28</MeleeCounterParryBonus>
+					<ToughnessRating>10</ToughnessRating>
+				</value>
+			</Operation>
+
+			<Operation Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GMace"]</xpath>
+				<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>1.5</MeleeCritChance>
+					<MeleeParryChance>0.06</MeleeParryChance>
+					<MeleeDodgeChance>0.2</MeleeDodgeChance>
+				</equippedStatOffsets>
+				</value>
+			</Operation>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Tools === -->
+        <li Class="PatchOperationReplace">
+          <xpath>
+            /Defs/ThingDef[
+              defName = "VFEP_WarcasketGun_GSmoothboreGun"
+            ]/tools
+          </xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>35</power>
+                <cooldownTime>2.44</cooldownTime>
+                <armorPenetrationBlunt>16</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <!-- ========== warcasket "300mm" smoothbore gun (RPG-7) ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>Gun_RPG7v</defName>
+				<statBases>
+					<Mass>40</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.16</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>1.68</SwayFactor>
+					<Bulk>30.50</Bulk>
+					<WorkToMake>25500</WorkToMake>
+				</statBases>
+				<costList>
+					<WoodLog>5</WoodLog>
+					<Steel>70</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_RPG7Grenade_HEAT</defaultProjectile>
+					<warmupTime>2.035</warmupTime>
+					<range>40</range>
+        					<minRange>3</minRange>
+					<soundCast>RPGFire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>5.6</reloadTime>
+					<ammoSet>AmmoSet_RPG7Grenade</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
@@ -56,7 +56,7 @@
 					<warmupTime>2.035</warmupTime>
 					<range>40</range>
         					<minRange>3</minRange>
-					<soundCast>RPGFire</soundCast>
+					<soundCast>InfernoCannon_Fire</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<onlyManualCast>true</onlyManualCast>
 					<stopBurstWithoutLos>false</stopBurstWithoutLos>

--- a/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
@@ -34,7 +34,7 @@
         <!-- ========== warcasket "300mm" smoothbore gun (RPG-7) ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-				<defName>Gun_RPG7v</defName>
+				<defName>VFEP_WarcasketGun_GSmoothboreGun</defName>
 				<statBases>
 					<Mass>40</Mass>
 					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>

--- a/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
@@ -11,7 +11,7 @@
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            /Defs/VFEP_BaseMeleeWeapon_Warcasket[
               defName = "VFEP_WarcasketGun_GSmoothboreGun"
             ]/tools
           </xpath>

--- a/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Ranged_Warcaskets.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>Vanilla Factions Expanded - Pirates</li>
+      <li>WarCasket Gundam Addon</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>


### PR DESCRIPTION
## Additions

Add support for WarCasket Gundam Addon,

## Changes

Gundam suit Barbatos has the same stats as the Aerial Warcasket,the katana has the same stats as the warcasket boardsword the hemmer has the stats of some hammer and a handle with half the power of warcasket range weapon barrel(the weapon has a 2nd attack tool instead of a handle poke attack in vanilla).And the gun is just a rpg.

## References

- Closes #[#1560]

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
