### PR TITLE
Update Vanilla Factions Expanded - Pirates

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Laser.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Laser.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Laser</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs</xpath>
+          <value>
+
+            <!-- === Ammo Sets === -->
+
+            <CombatExtended.AmmoSetDef>
+              <defName>AmmoSet_SalvagedLaserEradicatorCE</defName>
+              <label>laser charge</label>
+              <ammoTypes>
+                <Ammo_LaserChargePack>Bullet_Laser_SalvagedLaserEradicatorCE</Ammo_LaserChargePack>
+              </ammoTypes>
+            </CombatExtended.AmmoSetDef>
+
+            <!-- === Projectiles === -->
+
+            <!--
+              Unstable shots do slightly higher damage, but have slightly less penetration, due to the beams being less focused, delivering the energy over a wider area.
+              Vice versa for stable shots, due to better made weaponry.
+            -->
+
+            <ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletRed">
+              <defName>Bullet_Laser_SalvagedLaserEradicatorCE</defName>
+              <label>eradicator laser beam</label>            
+              <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                <damageDef>Bullet</damageDef>
+                <damageAmountBase>20</damageAmountBase>
+                <armorPenetrationSharp>15.5</armorPenetrationSharp>
+                <armorPenetrationBlunt>0.001</armorPenetrationBlunt>
+                <!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->
+              </projectile>
+              <comps>
+                <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                  <damageAmountBase>40</damageAmountBase>
+                  <explosiveDamageType>Bomb</explosiveDamageType>
+                  <explosiveRadius>3.5</explosiveRadius>
+                  <explosionSound>MortarBomb_Explode</explosionSound>
+                  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                </li>
+              </comps>		  
+            </ThingDef>
+
+          </value>
+        </li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Vikings.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/Ammo_Vikings.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Vikings</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+			<li Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
+
+				<!-- ==================== Ammo Categories ========================== -->
+				<!-- ==================== Thing Categories ========================== -->
+				<ThingCategoryDef>
+					<defName>AmmoCryptoCannon</defName>
+					<label>Crypto Fuel</label>
+					<parent>AmmoAdvanced</parent>
+					<iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+				</ThingCategoryDef>
+				<!-- ==================== AmmoSet ========================== -->
+
+				<CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_CryptoCannon</defName>
+					<label>Crypto Cannon</label>
+					<ammoTypes>
+					<Ammo_CryptoCannon>Bullet_Flamethrower_CryptoCannon</Ammo_CryptoCannon>
+					</ammoTypes>
+				</CombatExtended.AmmoSetDef>
+				<!-- ==================== Ammo ========================== -->
+
+				<ThingDef Class="CombatExtended.AmmoDef" ParentName="CryptoAmmoBase">
+					<defName>Ammo_CryptoCannon</defName>
+					<label>Crypto Cannon Fuel</label>
+					<graphicData>
+					<drawSize>0.75</drawSize>
+					</graphicData>   		
+					<statBases>
+						<MarketValue>0.7</MarketValue>
+						<Mass>0.01</Mass>
+						<Bulk>0.01</Bulk>
+					</statBases>		
+					<thingCategories>
+						<li>AmmoCryptoCannon</li>
+					</thingCategories>
+					<detonateProjectile>Bullet_Flamethrower_CryptoCannon</detonateProjectile>		
+				</ThingDef>
+
+				<!-- ================== Damage ================== -->
+
+				<DamageDef ParentName="Bullet">
+					<defName>CE_Cryptofuel</defName>
+					<label>Crypto Burn</label>
+					<hediff>Frostbite</hediff>
+					<workerClass>DamageWorker_AddInjury</workerClass>
+					<hasForcefulImpact>true</hasForcefulImpact>
+					<makesBlood>false</makesBlood>
+					<canInterruptJobs>true</canInterruptJobs>
+					<externalViolence>true</externalViolence>
+					<deathMessage>{0} has been frozen to death.</deathMessage>
+					<armorCategory>Heat</armorCategory>
+					<minDamageToFragment>15</minDamageToFragment>
+					<defaultArmorPenetration>0</defaultArmorPenetration>
+					<explosionHeatEnergyPerCell>-20</explosionHeatEnergyPerCell>
+					<soundExplosion>Explosion_Stun</soundExplosion>
+					<combatLogRules>Damage_Flame</combatLogRules>
+					<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
+					<explosionColorCenter>(0,1,1,1)</explosionColorCenter>
+					<explosionColorEdge>(0,0.70,1,1)</explosionColorEdge>
+				</DamageDef>
+
+				<!-- ================== Projectiles ================== -->
+
+				<ThingDef ParentName="Base6x24mmChargedBullet">
+				<defName>Bullet_Flamethrower_CryptoCannon</defName>
+				<graphicData>
+					<texPath>Things/Projectile/CryptoBullet</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+					<drawSize>1.50</drawSize>
+				</graphicData>
+				<label>Crygenic stream</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>CE_Cryptofuel</damageDef>
+				<damageAmountBase>1</damageAmountBase>
+				<soundExplode>CE_FlamethrowerExplosion</soundExplode>
+				</projectile>
+				<comps>
+					<li Class="CombatExtended.CompProperties_ExplosiveCE">
+						<damageAmountBase>4</damageAmountBase>
+						<explosiveDamageType>CE_Cryptofuel</explosiveDamageType>
+						<explosiveRadius>1.5</explosiveRadius>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					</li>
+				</comps>
+			</ThingDef>
+
+			<!-- ==================== Recipes ========================== -->
+
+			<RecipeDef ParentName="ChargeAmmoRecipeBase">
+				<defName>MakeAmmo_CryptoCannon</defName>
+				<label>make crypto cannon fuel x200</label>
+				<description>Craft 200 crypto cannon fuel.</description>
+				<jobString>Making crypto cannon fuel.</jobString>
+				<ingredients>
+				<li>
+					<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+					</filter>
+					<count>15</count>
+				</li>
+				<li>
+					<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+					</filter>
+					<count>8</count>
+				</li>
+				</ingredients>
+				<fixedIngredientFilter>
+				<thingDefs>
+					<li>Chemfuel</li>
+					<li>ComponentIndustrial</li>
+				</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+				<Ammo_CryptoCannon>200</Ammo_CryptoCannon>
+				</products>
+				<workAmount>8600</workAmount>		
+			</RecipeDef>
+
+          </value>
+        </li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
@@ -7,7 +7,7 @@
     </mods>
     <match Class="PatchOperationFindMod">
     <mods>
-      <li>Vanilla Factions Expanded - Insectioids</li>
+      <li>Vanilla Factions Expanded - Insectoids</li>
     </mods>
       <match Class="PatchOperationSequence">
         <operations>
@@ -17,8 +17,18 @@
 			<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]/statBases</xpath>
 			<value>
 				<Bulk>35</Bulk>
-				<MeleeCounterParryBonus>0.23</MeleeCounterParryBonus>
-				<!-- <ToughnessRating>8</ToughnessRating> -->
+				<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.02</MeleeCritChance>
+					<MeleeParryChance>0.47</MeleeParryChance>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+				</equippedStatOffsets>
 			</value>
 		</li>
 
@@ -34,7 +44,7 @@
 						<power>46</power>
 						<cooldownTime>2</cooldownTime>
 						<armorPenetrationBlunt>9</armorPenetrationBlunt>
-						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<armorPenetrationSharp>64</armorPenetrationSharp>
 						<extraMeleeDamages>
 						<li>
 							<def>Flame</def>
@@ -51,7 +61,7 @@
 						<power>58</power>
 						<cooldownTime>2.6</cooldownTime>
 						<armorPenetrationBlunt>17</armorPenetrationBlunt>
-						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<armorPenetrationSharp>48</armorPenetrationSharp>
 						<extraMeleeDamages>
 						<li>
 							<def>Flame</def>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Insectioids</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+		<!-- === Plasma Sword === -->
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]/statBases</xpath>
+			<value>
+				<Bulk>35</Bulk>
+				<MeleeCounterParryBonus>0.23</MeleeCounterParryBonus>
+				<!-- <ToughnessRating>8</ToughnessRating> -->
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>46</power>
+						<cooldownTime>2</cooldownTime>
+						<armorPenetrationBlunt>9</armorPenetrationBlunt>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>10</amount>
+							<chance>0.15</chance>
+						</li>
+						</extraMeleeDamages>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+						<li>Cut</li>
+						</capacities>
+						<power>58</power>
+						<cooldownTime>2.6</cooldownTime>
+						<armorPenetrationBlunt>17</armorPenetrationBlunt>
+						<armorPenetrationSharp>5</armorPenetrationSharp>
+						<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>10</amount>
+							<chance>0.5</chance>
+						</li>
+						</extraMeleeDamages>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
@@ -18,6 +18,7 @@
 			<value>
 				<Bulk>35</Bulk>
 				<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+				<ToughnessRating>24</ToughnessRating>
 			</value>
 		</li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Vikings</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName = "VFEP_WarcasketGun_CryptoCannon"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>35</power>
+                <cooldownTime>2.44</cooldownTime>
+                <armorPenetrationBlunt>16</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+      
+      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>VFEP_WarcasketGun_CryptoCannon</defName>
+        <statBases>
+          <Mass>35</Mass>
+          <Bulk>20</Bulk>
+          <SwayFactor>2.10</SwayFactor>
+          <ShotSpread>3.00</ShotSpread>
+          <SightsEfficiency>0.85</SightsEfficiency>
+          <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+        </statBases>
+        <Properties>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+          <recoilAmount>0.55</recoilAmount>
+          <hasStandardCommand>true</hasStandardCommand>
+          <defaultProjectile>Bullet_Flamethrower_CryptoCannon</defaultProjectile>
+          <burstShotCount>15</burstShotCount>
+          <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+          <warmupTime>1.3</warmupTime>
+          <range>30</range>
+          <minRange>3</minRange>
+          <soundCast>HissFlamethrower</soundCast>
+          <soundCastTail>GunTail_Light</soundCastTail>
+          <muzzleFlashScale>12</muzzleFlashScale>
+          <targetParams>
+            <canTargetLocations>true</canTargetLocations>
+          </targetParams>
+          <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+        </Properties>
+        <AmmoUser>
+          <magazineSize>200</magazineSize>
+          <reloadTime>5.6</reloadTime>
+          <ammoSet>AmmoSet_CryptoCannon</ammoSet>
+        </AmmoUser>
+        <FireModes>
+          <aiAimMode>SuppressFire</aiAimMode>
+          <aimedBurstShotCount>5</aimedBurstShotCount>
+          <noSingleShot>True</noSingleShot>
+        </FireModes>
+      </li>
+
+      </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>
+	

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Coilguns</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName = "VFEP_WarcasketGun_Railgun"]/tools
+          </xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>35</power>
+                <cooldownTime>2.44</cooldownTime>
+                <armorPenetrationBlunt>16</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_Railgun</defName>
+          <statBases>
+            <Mass>45.0</Mass>
+            <Bulk>55.0</Bulk>
+            <SwayFactor>2.40</SwayFactor>
+            <ShotSpread>0.66</ShotSpread>
+            <SightsEfficiency>1.25</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.86</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_CoilGun_Lance</defaultProjectile>
+            <burstShotCount>3</burstShotCount>
+            <ticksBetweenBurstShots>6</ticksBetweenBurstShots>     
+            <warmupTime>2.4</warmupTime>
+            <range>85</range>
+            <soundCast>VWE_Shot_GaussLance</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+            <recoilPattern>Regular</recoilPattern>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>15</magazineSize>
+            <reloadTime>5.2</reloadTime>
+            <ammoSet>AmmoSet_8mmRailgun_GaussLance</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aimedBurstShotCount>3</aimedBurstShotCount>
+            <aiUseBurstMode>true</aiUseBurstMode>
+            <aiAimMode>AimedShot</aiAimMode>
+            <noSingleShot>true</noSingleShot>
+          </FireModes>
+          <weaponTags>
+            <li>SpacerGun</li>
+          </weaponTags>
+        </li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
@@ -60,10 +60,9 @@
             <ammoSet>AmmoSet_8mmRailgun_GaussLance</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>3</aimedBurstShotCount>
+            <aimedBurstShotCount>1</aimedBurstShotCount>
             <aiUseBurstMode>true</aiUseBurstMode>
             <aiAimMode>AimedShot</aiAimMode>
-            <noSingleShot>true</noSingleShot>
           </FireModes>
           <weaponTags>
             <li>SpacerGun</li>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
@@ -60,7 +60,6 @@
             <ammoSet>AmmoSet_8mmRailgun_GaussLance</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>1</aimedBurstShotCount>
             <aiUseBurstMode>true</aiUseBurstMode>
             <aiAimMode>AimedShot</aiAimMode>
           </FireModes>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWELRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWELRangedWarcasket.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Laser</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName = "VFEP_WarcasketGun_SalvagedLaserEradicator" or defName = "VFEP_WarcasketGun_LaserBlaster"]/tools
+          </xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>35</power>
+                <cooldownTime>2.44</cooldownTime>
+                <armorPenetrationBlunt>16</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationRemove">
+          <xpath>/Defs/ThingDef[defName = "VFEP_WarcasketGun_SalvagedLaserEradicator" or defName = "VFEP_WarcasketGun_LaserBlaster"]/comps/li[@Class="VanillaWeaponsExpandedLaser.CompProperties_LaserCapacitor"]</xpath>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_SalvagedLaserEradicator</defName>
+          <statBases>
+            <Mass>30</Mass>
+            <Bulk>25</Bulk>
+            <SwayFactor>2.85</SwayFactor>
+            <ShotSpread>0.08</ShotSpread>
+            <SightsEfficiency>2.20</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.60</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_Laser_SalvagedLaserEradicatorCE</defaultProjectile>
+            <ammoConsumedPerShotCount>15</ammoConsumedPerShotCount>
+            <warmupTime>4.6</warmupTime>
+            <range>68</range>
+            <minRange>3</minRange>
+            <soundCast>Shot_TurretSniper</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>16</muzzleFlashScale>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>300</magazineSize>
+            <reloadTime>7.6</reloadTime>
+            <ammoSet>AmmoSet_SalvagedLaserEradicatorCE</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+          </FireModes>
+        </li>
+        
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_LaserBlaster</defName>
+          <statBases>
+            <Mass>30</Mass>
+            <Bulk>40</Bulk>
+            <SwayFactor>2.64</SwayFactor>
+            <ShotSpread>0.06</ShotSpread>
+            <SightsEfficiency>1</SightsEfficiency>
+            <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_Laser_LaserSniperRifle</defaultProjectile>
+            <burstShotCount>25</burstShotCount>
+            <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+            <warmupTime>2</warmupTime>
+            <range>75</range>
+            <soundCast>VWE_LaserShot_Rifle</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+            <recoilAmount>0.01</recoilAmount>
+            <recoilPattern>Regular</recoilPattern>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>200</magazineSize>
+            <reloadTime>6</reloadTime>
+            <ammoSet>AmmoSet_LaserSniperRifle</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>SuppressFire</aiAimMode>
+            <aimedBurstShotCount>10</aimedBurstShotCount>
+            <noSingleShot>true</noSingleShot>
+          </FireModes>
+        </li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Non-Lethal</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName = "VFEP_WarcasketGun_TearGasGrenadeLauncher"]/tools </xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>35</power>
+					<cooldownTime>2.44</cooldownTime>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+	
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>VFEP_WarcasketGun_TearGasGrenadeLauncher</defName>
+			<statBases>
+				<Mass>25</Mass>
+				<Bulk>25</Bulk>
+				<SwayFactor>1.31</SwayFactor>
+				<ShotSpread>0.18</ShotSpread>
+				<SightsEfficiency>0.65</SightsEfficiency>
+				<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_40x46mmGrenade_CN</defaultProjectile>
+				<warmupTime>1</warmupTime>
+				<range>50</range>
+				<burstShotCount>2</burstShotCount>
+				<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+				<soundCast>VWENL_Shot_GrenadeLauncher</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>			
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<ai_IsBuildingDestroyer>True</ai_IsBuildingDestroyer>
+				<ignorePartialLoSBlocker>True</ignorePartialLoSBlocker>
+				<targetParams>
+					<canTargetLocations>True</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>6</magazineSize>
+				<reloadTime>2.2</reloadTime>
+				<ammoSet>AmmoSet_40x46mmGrenadeNL</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+				<aiUseBurstMode>False</aiUseBurstMode>
+			</FireModes>
+			<weaponTags>
+				<li>NonLethal</li>
+			</weaponTags>
+		</li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Weapons Expanded - Quickdraw</li>
+    </mods>
+      <match Class="PatchOperationSequence">
+        <operations>
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName = "VFEP_WarcasketGun_FoldingGun"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>barrel</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>35</power>
+                <cooldownTime>2.44</cooldownTime>
+                <armorPenetrationBlunt>16</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_FoldingGun</defName>
+          <statBases>
+            <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
+            <SightsEfficiency>0.85</SightsEfficiency>
+            <ShotSpread>0.10</ShotSpread>
+            <SwayFactor>2.32</SwayFactor>
+            <Bulk>25</Bulk>
+            <Mass>25</Mass>
+          </statBases>
+          <Properties>
+            <recoilAmount>0.6</recoilAmount>
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
+            <warmupTime>0.5</warmupTime>
+            <range>57</range>
+            <burstShotCount>20</burstShotCount>
+            <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+            <soundCast>VFEP_Shot_Minigun</soundCast>
+            <soundCastTail>GunTail_Medium</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+            <targetParams>
+              <canTargetLocations>true</canTargetLocations>
+            </targetParams>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>100</magazineSize>
+            <reloadTime>9.2</reloadTime>
+            <ammoSet>AmmoSet_338Norma</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aimedBurstShotCount>5</aimedBurstShotCount>
+            <aiUseBurstMode>FALSE</aiUseBurstMode>
+            <aiAimMode>SuppressFire</aiAimMode>
+          </FireModes>
+        </li>
+
+        </operations>
+      </match>
+    </match>    
+  </Operation>    
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
@@ -8,20 +8,6 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
-		<!-- ========== Remove Vanilla Carry Capacity ========== -->
-		<li Class="PatchOperationRemove">
-			<xpath>/Defs/VFEPirates.WarcasketDef[
-			defName="VFEP_Warcasket_Warcasket" or
-			defName="VFEP_Warcasket_Marine" or
-			defName="VFEP_Warcasket_Recon" or
-			defName="VFEP_Warcasket_Cataphract" or
-			defName="VFEP_Warcasket_Aerial" or
-			defName="VFEP_Warcasket_Hazard" or
-			defName="VFEP_Warcasket_Barrage" or
-			defName="VFEP_Warcasket_Shock"																
-			]/modExtensions/li/carryingCapacity</xpath>
-		</li>
-
 		<!-- ========== Remove Warcasket Flammability ========== -->
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[@Name="VFEP_WarcasketPartBase"]/statBases/Flammability</xpath>
@@ -58,18 +44,6 @@
 			<value>
 			  <li Class="CombatExtended.PartialArmorExt">
 				<stats>
-					<li>
-						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-						<parts>
-							<li>Arm</li>
-						</parts>
-					</li>
-					<li>
-						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-						<parts>
-							<li>Arm</li>
-						</parts>
-					</li>
 					<li>
 						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 						<parts>
@@ -182,7 +156,7 @@
 			</value>
 		</li>
 
-			<!--proportionally a bit better armor because assumed better neck suport allows for heavier-->
+		<!-- Proportionally a bit better armor because assumed better neck suport allows for heavier-->
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/statBases/ArmorRating_Sharp</xpath>
 			<value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
@@ -1,0 +1,669 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Pirates</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- ========== Siegebreaker Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>225</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>225</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>8</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- === Energy Shields === -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>350</EnergyShieldEnergyMax>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>15</EnergyShieldRechargeRate>
+			</value>
+		</li>
+
+		<!-- ========== Siegebreaker Warcasket - Shoulders ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Siegebreaker"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Siegebreaker"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Siegebreaker"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<!-- === Siegebreaker Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>72</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>75</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>4</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Guardian Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>110</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>225</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>300</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>8</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Guardian Warcasket - Shoulders ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>110</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Guardian"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>120</Plasteel>
+			</value>
+		</li>
+
+		<!-- === Guardian Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>86</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>105</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>4</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Controller Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>225</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>225</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>14</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Controller Warcasket - Shoulders ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Controller"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Controller"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Controller"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Controller"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Controller"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>1</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- === Siegebreaker Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>72</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>6</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Sarcophagus Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>225</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>225</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>8</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Sarcophagus Warcasket - Shoulders ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sarcophagus"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sarcophagus"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sarcophagus"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>90</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sarcophagus"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<!-- === Sarcophagus Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>72</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>4</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Brute Warcasket ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/statBases</xpath>
+			<value>
+				<Bulk>275</Bulk>
+				<WornBulk>35</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>110</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>225</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>240</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>6</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- ========== Brute Warcasket - Shoulders ========== -->
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Brute"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Brute"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>36</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Brute"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>110</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Brute"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Brute"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>6</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- === Brute Warcasket Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>32</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>86</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- Increase Cost -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/costList/Plasteel</xpath>
+			<value>
+				<Plasteel>90</Plasteel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/costList/ComponentSpacer</xpath>
+			<value>
+				<ComponentSpacer>6</ComponentSpacer>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
@@ -114,6 +114,57 @@
 				</value>
 			</li>
 
+			<!-- Warcasket Gravity Hammer -->	
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GravityHammer"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>VFEP_GravityHammerAttack</li>
+							</capacities>
+							<power>92</power>
+							<cooldownTime>5.73</cooldownTime>
+							<chanceFactor>0.60</chanceFactor>
+							<armorPenetrationBlunt>580</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>50</power>
+							<cooldownTime>2.11</cooldownTime>
+							<chanceFactor>0.30</chanceFactor>
+							<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GravityHammer"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.8</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_GravityHammer"]/statBases</xpath>
+				<value>
+					<Bulk>18</Bulk>
+					<MeleeCounterParryBonus>2</MeleeCounterParryBonus>
+					<ToughnessRating>10</ToughnessRating>
+				</value>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
@@ -161,7 +161,7 @@
 				<value>
 					<Bulk>18</Bulk>
 					<MeleeCounterParryBonus>2</MeleeCounterParryBonus>
-					<ToughnessRating>10</ToughnessRating>
+					<ToughnessRating>25</ToughnessRating>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -259,7 +259,6 @@
           <FireModes>
             <aiAimMode>SuppressFire</aiAimMode>
             <aimedBurstShotCount>10</aimedBurstShotCount>
-            <noSingleShot>True</noSingleShot>
           </FireModes>
         </li>
 
@@ -292,7 +291,7 @@
             <ammoSet>AmmoSet_12x72mmCharged</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>3</aimedBurstShotCount>
+            <aimedBurstShotCount>1</aimedBurstShotCount>
             <aiUseBurstMode>true</aiUseBurstMode>
             <aiAimMode>AimedShot</aiAimMode>
             <noSingleShot>true</noSingleShot>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -291,10 +291,8 @@
             <ammoSet>AmmoSet_12x72mmCharged</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>1</aimedBurstShotCount>
             <aiUseBurstMode>true</aiUseBurstMode>
             <aiAimMode>AimedShot</aiAimMode>
-            <noSingleShot>true</noSingleShot>
           </FireModes>
         </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -30,7 +30,10 @@
               defName = "VFEP_WarcasketGun_Slugthrower" or
               defName = "VFEP_WarcasketGun_Minigun" or
               defName = "VFEP_WarcasketGun_GrenadeLauncher" or
-              defName = "VFEP_WarcasketGun_HeavyFlamer"
+              defName = "VFEP_WarcasketGun_HeavyFlamer" or
+              defName = "VFEP_WarcasketGun_ChargeLance" or
+			        defName = "VFEP_WarcasketGun_HandheldCannon" or
+			        defName = "VFEP_WarcasketGun_ChargeBlaster"              
             ]/tools
           </xpath>
           <value>
@@ -258,6 +261,124 @@
             <aimedBurstShotCount>10</aimedBurstShotCount>
             <noSingleShot>True</noSingleShot>
           </FireModes>
+        </li>
+
+        <!-- === Warcasket Charge Lance === -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_ChargeLance</defName>
+          <statBases>
+            <SightsEfficiency>2.0</SightsEfficiency>
+            <ShotSpread>0.01</ShotSpread>
+            <SwayFactor>2.08</SwayFactor>
+            <Bulk>45.00</Bulk>
+            <Mass>45.00</Mass>
+            <RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>				
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>
+            <warmupTime>2.8</warmupTime>
+            <range>80</range>
+            <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+            <burstShotCount>3</burstShotCount>
+            <soundCast>ChargeLance_Fire</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>9</muzzleFlashScale>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>18</magazineSize>
+            <reloadTime>4</reloadTime>
+            <ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aimedBurstShotCount>3</aimedBurstShotCount>
+            <aiUseBurstMode>true</aiUseBurstMode>
+            <aiAimMode>AimedShot</aiAimMode>
+            <noSingleShot>true</noSingleShot>
+          </FireModes>
+        </li>
+
+        <!-- === Warcasket Handheld Cannon === -->	
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_HandheldCannon</defName>
+          <statBases>
+            <Mass>42</Mass>
+            <Bulk>20</Bulk>
+            <SwayFactor>1.24</SwayFactor>
+            <ShotSpread>0.10</ShotSpread>
+            <SightsEfficiency>0.5</SightsEfficiency>
+            <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+            <hasStandardCommand>True</hasStandardCommand>
+            <defaultProjectile>Bullet_CannonBall_Bursting</defaultProjectile>
+            <warmupTime>3.5</warmupTime>
+            <range>126</range>
+            <minRange>16</minRange>
+            <soundCast>VFEP_Shot_Cannon</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>16</muzzleFlashScale>
+            <circularError>1.1</circularError>
+            <indirectFirePenalty>0.3</indirectFirePenalty>
+            <targetParams>
+              <canTargetLocations>true</canTargetLocations>
+            </targetParams>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>1</magazineSize>
+            <reloadTime>5.2</reloadTime>
+            <ammoSet>AmmoSet_CannonBall</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aiAimMode>AimedShot</aiAimMode>
+          </FireModes>
+          <AllowWithRunAndGun>false</AllowWithRunAndGun>
+        </li>
+	
+        <!-- === Warcasket Charge Blaster === -->
+        <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+          <defName>VFEP_WarcasketGun_ChargeBlaster</defName>
+          <statBases>
+            <SightsEfficiency>1.1</SightsEfficiency>
+            <ShotSpread>0.06</ShotSpread>
+            <SwayFactor>1.18</SwayFactor>
+            <Bulk>31.00</Bulk>
+            <Mass>55</Mass>
+            <RangedWeapon_Cooldown>1.56</RangedWeapon_Cooldown>
+          </statBases>
+          <Properties>
+            <recoilAmount>1.18</recoilAmount>					
+            <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+            <hasStandardCommand>true</hasStandardCommand>
+            <defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
+            <warmupTime>1</warmupTime>
+            <range>75</range>
+            <burstShotCount>50</burstShotCount>
+            <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+            <soundCast>ChargeLance_Fire</soundCast>
+            <soundCastTail>GunTail_Heavy</soundCastTail>
+            <muzzleFlashScale>15</muzzleFlashScale>
+            <targetParams>
+            <canTargetLocations>true</canTargetLocations>
+            </targetParams>
+            <recoilPattern>Mounted</recoilPattern>
+          </Properties>
+          <AmmoUser>
+            <magazineSize>500</magazineSize>
+            <reloadTime>7.9</reloadTime>
+            <ammoSet>AmmoSet_8x50mmCharged</ammoSet>
+          </AmmoUser>
+          <FireModes>
+            <aimedBurstShotCount>25</aimedBurstShotCount>
+            <aiAimMode>AimedShot</aiAimMode>
+          </FireModes>
+          <weaponTags>
+            <li>CE_MachineGun</li>
+            <li>CE_AI_Suppressive</li>
+            <li>AdvancedGun</li>
+          </weaponTags>
         </li>
 
       </operations>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Weapons_Mech.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Pirates</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== VFE Handheld Mini Turret ========== -->
+      <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>VFEPGun_MiniBlaster</defName>
+        <statBases>
+          <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+          <SightsEfficiency>1</SightsEfficiency>
+          <ShotSpread>0.07</ShotSpread>
+          <SwayFactor>0.82</SwayFactor>
+          <Bulk>10.00</Bulk>
+        </statBases>
+        <Properties>
+          <recoilAmount>0.76</recoilAmount>
+          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+          <hasStandardCommand>true</hasStandardCommand>
+          <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+          <warmupTime>1.3</warmupTime>
+          <range>42</range>
+          <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+          <burstShotCount>6</burstShotCount>
+          <soundCast>GunShotA</soundCast>
+          <soundCastTail>GunTail_Light</soundCastTail>
+          <muzzleFlashScale>9</muzzleFlashScale>
+          <recoilPattern>Mounted</recoilPattern>
+        </Properties>
+        <AmmoUser>
+          <magazineSize>50</magazineSize>
+          <reloadTime>7.8</reloadTime>
+        </AmmoUser>      
+        <FireModes>
+          <aiAimMode>AimedShot</aiAimMode>
+          <aimedBurstShotCount>5</aimedBurstShotCount>
+        </FireModes>
+      </li>
+
+      <!-- === Tools === -->
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="VFEPGun_MiniBlaster"]/tools</xpath>
+        <value>
+          <tools>
+          <li Class="CombatExtended.ToolCE">
+            <label>barrel</label>
+            <capacities>
+            <li>Blunt</li>
+            </capacities>
+            <power>5</power>
+            <cooldownTime>2.02</cooldownTime>
+            <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          </li>
+          </tools>
+        </value>
+      </li>
+  
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Weapons_Mech.xml
@@ -17,7 +17,7 @@
           <SightsEfficiency>1</SightsEfficiency>
           <ShotSpread>0.07</ShotSpread>
           <SwayFactor>0.82</SwayFactor>
-          <Bulk>10.00</Bulk>
+          <Bulk>5.00</Bulk>
         </statBases>
         <Properties>
           <recoilAmount>0.76</recoilAmount>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Races/Races_Mechanoid.xml
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Pirates</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone" or defName="VFEP_Mech_Spidermine"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Vehicle</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone" or defName="VFEP_Mech_Spidermine"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.26</MeleeDodgeChance>
+					<MeleeCritChance>0.12</MeleeCritChance>
+					<MeleeParryChance>0.01</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>1.0</AimingAccuracy>
+					<ShootingAccuracyPawn>2.0</ShootingAccuracyPawn>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone" or defName="VFEP_Mech_Spidermine"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone" or defName="VFEP_Mech_Spidermine"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Wardrone"]/tools</xpath>
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>turret</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					</li>					
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFEP_Mech_Spidermine"]/tools</xpath>
+				<value>
+					<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>frame</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					</li>					
+					</tools>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

- Patches for new spacer Warcaskets.
  - Plasteel cost increased by 50%.
  - Increased spacer component count by 2 - 4.
  - Patches mech drones for "controller' armor. They work, but the turret drone may have a seemingly harmless error associated with it.

TO DO:
- Patched-in weapons.

## Changes

- Removed patched-out CarryCapacity changes.

## References
Closes #1586 

## Reasoning


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
