### PR TITLE
Moyo apparel updates

### DIFF
--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -35,14 +35,14 @@
 				<xpath>Defs/ThingDef[defName="Moyo_Parka"]/statBases</xpath>
 				<value>
 					<Bulk>10</Bulk>
-					<WornBulk>5</WornBulk>
+					<WornBulk>3</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_Parka"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -215,6 +215,33 @@
 				</value>
 			</li>
 			
+			<!--Suppressive Mask-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_PShelmet" or defName="Moyo_SShelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.4</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_PShelmet" or defName="Moyo_SShelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.25</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_PShelmet" or defName="Moyo_SShelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			
 			<!--Evasuit-->
 			
 			<li Class="PatchOperationAdd">
@@ -309,6 +336,64 @@
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[@Name="Moyo_PowerArmorBase"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
 				</value>
 			</li>
 			
@@ -437,6 +522,64 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
+				</value>
+			</li>
+			
 			<!--Diving Helmet-->
 			
 			<li Class="PatchOperationAdd">
@@ -492,6 +635,34 @@
 				<value>
 					<Moyo_Abyssteel>50</Moyo_Abyssteel>
 					<DevilstrandCloth>15</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+						</li>
+					  </stats>
+				  </li>
 				</value>
 			</li>
 			

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -16,7 +16,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_Tribal"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -25,7 +25,16 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_SnB"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>2.75</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			
+			<!--Straps-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_BodyStrap"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			
@@ -340,7 +349,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[@Name="Moyo_PowerArmorBase"]</xpath>
+				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]</xpath>
 				<value>
 				  <li Class="CombatExtended.PartialArmorExt">
 					  <stats>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Dragonian_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Dragonian_Apparel.xml
@@ -38,6 +38,35 @@
 					</value>
 				</li>
 				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_Exoframeproto"]/statBases</xpath>
+					<value>
+						<Bulk>7.5</Bulk>
+						<WornBulk>5</WornBulk>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Moyo_Exoframeproto"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Moyo_Exoframeproto"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>1</ArmorRating_Blunt>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_Exoframeproto"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryWeight>7.5</CarryWeight>
+					</value>
+				</li>
+				
 			</operations>
 			</match>
 		</match>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -42,6 +42,38 @@
 				</value>
 			</li>
 			
+			<!--Celeberty-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Holosuit"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>0</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_Holosuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_Holosuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Holosuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Feet</li>
+				</value>
+			</li>
+			
 			<!--Royal Robe-->
 			
 			<li Class="PatchOperationAdd">
@@ -146,6 +178,64 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GDsuit"]/costList/Moyo_Abyssteel</xpath>
 				<value>
 					<Moyo_Abyssteel>260</Moyo_Abyssteel>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_GDsuit"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
 				</value>
 			</li>
 			
@@ -266,6 +356,64 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GSsuit"]/costList/Moyo_Abyssteel</xpath>
 				<value>
 					<Moyo_Abyssteel>150</Moyo_Abyssteel>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_GSsuit"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
 				</value>
 			</li>
 			


### PR DESCRIPTION
## Additions

New royal apparel.
Fixed one we've missed for a while.
New suppession/soothe helmet.

## Changes

Add partials onto the power armor. Most of the moyo helmets aren't significantly thinner looking for the faceplate outside of the light diving helmet, so they all retain 100%. Helmet is glass, but probalby still pressure resistant, just not actually good at stopping penetrating things like bullets, so only reduces the sharp armor, though it is more significant that most other helmets.

## Reasoning

Suppression/Soothe helmets don't have a modification to the suppression in terms of getting shot at helmets since conceptually it'd be the soothe that would have that if nothing else, but I'm not really against adding a suppression offset if it seems reasonable to someone else.

## Alternatives

Could give either the suppression or soothe (or both) neuro-helmet things some form of suppression reduction since they're ultimately dulling senses in some way. Maybe apply a aiming accuracy penalty, or bonus conversely.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
