### PR TITLE
Update mechanite plague

### DIFF
--- a/Patches/Mechanite Plague/Patch_AddAmmo.xml
+++ b/Patches/Mechanite Plague/Patch_AddAmmo.xml
@@ -6,635 +6,632 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+
 		<li Class="PatchOperationAdd">
 			<xpath>Defs</xpath>
 			<value>
 
-	<!-- Ammo Categories -->
-		
-	<CombatExtended.AmmoCategoryDef>
-		<defName>MP_MechDart</defName>
-		<label>mechanite dart</label>
-		<labelShort>M-Dart</labelShort>
-		<description>A dart designed to apply the Mechanite Plague. While dart weapons are normally non-lethal, the lack of concern for target preservation gives these darts the lethality of the average FMJ round.</description>
-	</CombatExtended.AmmoCategoryDef>
-	
-	<CombatExtended.AmmoCategoryDef>
-		<defName>MP_MechShell</defName>
-		<label>plague</label>
-		<description>A mortar shell designed to apply the Mechanite Plague. Combines high explosive power with the power of the plague, resulting in a lethal combination.</description>
-	</CombatExtended.AmmoCategoryDef>
-
-	<!-- ===== Heavy Mechanite Darts ===== -->
-	
-	<!-- AmmoSet -->
-	<CombatExtended.AmmoSetDef>
-		<defName>MP_AmmoSet_MechDart_Heavy</defName>
-		<label>16mm mechanite dart</label>
-		<ammoTypes>
-			<MP_Ammo_MechDart_Heavy>MP_Bullet_MechDart_Heavy</MP_Ammo_MechDart_Heavy>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
-		<defName>MP_Ammo_MechDart_Heavy</defName>
-		<description>Hefty darts used to apply the Mechanite Plague from a distance. Used in heavier dart-based weaponry.</description>
-		<label>16mm mechanite dart cartridge</label>
-		<graphicData>
-			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<Mass>0.03</Mass>
-			<Bulk>0.04</Bulk>
-			<MarketValue>0.514</MarketValue>
-		</statBases>
-		<ammoClass>MP_MechDart</ammoClass>
-	</ThingDef>
-
-	<!-- Projectiles -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>MP_Bullet_MechDart_Heavy</defName>
-		<label>16mm mechanite dart</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_BulletInfect</damageDef>
-			<damageAmountBase>26</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
-			<armorPenetrationBlunt>108</armorPenetrationBlunt>
-			<speed>120</speed>
-		</projectile>
-		<modExtensions>
-            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
-                <addHediffChance>1.00</addHediffChance>
-				<hediffLowerValue>0.23</hediffLowerValue>
-				<hediffUpperValue>0.26</hediffUpperValue>
-            </li>
-        </modExtensions>
-	</ThingDef>
-
-	<!-- Recipes -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Ammo_MechDart_Heavy</defName> <!-- has to be named like this. deal with it. -->
-		<label>make 16mm mechanite dart cartridge x200</label>
-		<description>Craft 200 16mm mechanite dart cartridges.</description>
-		<jobString>Making 16mm mechanite dart cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>12</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>8</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Ammo_MechDart_Heavy>200</MP_Ammo_MechDart_Heavy>
-		</products>
-		<workAmount>6000</workAmount>
-	</RecipeDef>
-	
-	<!-- ===== Light Mechanite Darts ===== -->
-
-	<!-- AmmoSet -->
-	<CombatExtended.AmmoSetDef>
-		<defName>MP_AmmoSet_MechDart_Light</defName>
-		<label>11mm mechanite dart</label>
-		<ammoTypes>
-			<MP_Ammo_MechDart_Light>MP_Bullet_MechDart_Light</MP_Ammo_MechDart_Light>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
-		<defName>MP_Ammo_MechDart_Light</defName>
-		<description>Small darts used to apply the Mechanite Plague from a distance. Used in lighter dart-based weaponry.</description>
-		<label>11mm mechanite dart cartridge</label>
-		<graphicData>
-			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<Mass>0.015</Mass>
-			<Bulk>0.02</Bulk>
-			<MarketValue>0.31</MarketValue>
-		</statBases>
-		<ammoClass>MP_MechDart</ammoClass>
-	</ThingDef>
-
-	<!-- Projectiles -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>MP_Bullet_MechDart_Light</defName>
-		<label>11mm mechanite dart</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_BulletInfect</damageDef>
-			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>6</armorPenetrationBlunt>
-			<speed>36</speed>
-		</projectile>
-		<modExtensions>
-            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
-                <addHediffChance>1.00</addHediffChance>
-                <hediffLowerValue>0.13</hediffLowerValue>
-                <hediffUpperValue>0.15</hediffUpperValue>
-            </li>
-        </modExtensions>
-	</ThingDef>
-
-	<!-- Recipes -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Ammo_MechDart_Light</defName> <!-- has to be named like this. deal with it. -->
-		<label>make 11mm mechanite dart cartridge x200</label>
-		<description>Craft 200 11mm mechanite dart cartridges.</description>
-		<jobString>Making 11mm mechanite dart cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>6</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Ammo_MechDart_Light>200</MP_Ammo_MechDart_Light>
-		</products>
-		<workAmount>3600</workAmount>
-	</RecipeDef>
-	
-	<!-- ===== Plague Mortar Shells ===== -->
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
-		<defName>MP_Plague_Shell_81mm</defName>
-		<label>81mm mortar shell (Plague)</label>
-		<graphicData>
-			<texPath>Things/CE/PlagueShellCE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>67.80</MarketValue>
-			<Mass>5.00</Mass>
-			<Bulk>8.51</Bulk>
-		</statBases>
-		<ammoClass>MP_MechShell</ammoClass>
-		<detonateProjectile>MP_Bullet_81mmMortarShell_Plague</detonateProjectile>
-		<comps>
-			<li Class="CompProperties_Explosive">
-				<explosiveRadius>2.5</explosiveRadius>
-				<explosiveDamageType>MP_BlastInfectMortar</explosiveDamageType>
-				<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-				<explodeOnKilled>True</explodeOnKilled>
-				<wickTicks>30~60</wickTicks>
-			</li>
-		</comps>
-	</ThingDef>
-	
-	<!-- Projectiles -->	
-	<ThingDef ParentName="Base81mmMortarShell">
-		<defName>MP_Bullet_81mmMortarShell_Plague</defName>
-		<label>81mm mortar shell (plague)</label>
-		<graphicData>
-			<texPath>Things/Projectile/Mortar/HE</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_BlastInfectMortar</damageDef>
-			<damageAmountBase>132</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>2.5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<ai_IsIncendiary>true</ai_IsIncendiary>
-		</projectile>
-		<comps>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>15</Fragment_Large>
-					<Fragment_Small>80</Fragment_Small>
-				</fragments>
-			</li>
-		</comps>
-	</ThingDef>
-	
-	<!-- Recipe -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Plague_Shell_81mm</defName>
-		<label>make 81mm plague mortar shells x5</label>
-		<description>Craft 5 81mm plague mortar shells.</description>
-		<jobString>Making 81mm plague mortar shells.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-				  <thingDefs>
-					<li>Steel</li>
-				  </thingDefs>
-				</filter>
-				<count>50</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>FSX</li>
-					</thingDefs>
-				</filter>
-				<count>8</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>ComponentIndustrial</li>
-					</thingDefs>
-				</filter>
-				<count>2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>FSX</li>
-				<li>ComponentIndustrial</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Plague_Shell_81mm>5</MP_Plague_Shell_81mm>
-		</products>
-		<workAmount>12000</workAmount>
-		<researchPrerequisite>MP_MechaniteMortar</researchPrerequisite>
-	</RecipeDef>
-	
-	<!-- ===== Mechanite Shrapnel ===== -->
-
-	<!-- AmmoSet -->
-	<CombatExtended.AmmoSetDef>
-		<defName>MP_AmmoSet_MechShrapnel</defName>
-		<label>mechanite shrapnel</label>
-		<ammoTypes>
-			<MP_Ammo_MechShrapnel>MP_Bullet_MechShrapnel</MP_Ammo_MechShrapnel>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
-		<defName>MP_Ammo_MechShrapnel</defName>
-		<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition.</description>
-		<label>mechanite shrapnel cartridge</label>
-		<graphicData>
-			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<Mass>0.02</Mass>
-			<Bulk>0.01</Bulk>
-			<MarketValue>0.196</MarketValue>
-		</statBases>
-		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>MP_Bullet_MechShrapnel</cookOffProjectile>
-	</ThingDef>
-
-	<!-- Projectiles -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
-		<defName>MP_Bullet_MechShrapnel</defName>
-		<label>mechanite shrapnel</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_BulletInfect</damageDef>
-			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
-			<armorPenetrationBlunt>20</armorPenetrationBlunt>
-			<speed>36</speed>
-		</projectile>
-		<modExtensions>
-            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
-                <addHediffChance>0.75</addHediffChance>
-				<hediffLowerValue>0.06</hediffLowerValue>
-				<hediffUpperValue>0.08</hediffUpperValue>
-            </li>
-        </modExtensions>
-	</ThingDef>
-
-	<!-- Recipes -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Ammo_MechShrapnel</defName> <!-- has to be named like this. deal with it. -->
-		<label>make mechanite shrapnel cartridge x500</label>
-		<description>Craft 500 mechanite shrapnel cartridges.</description>
-		<jobString>Making mechanite shrapnel cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>20</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>6</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Ammo_MechShrapnel>500</MP_Ammo_MechShrapnel>
-		</products>
-		<workAmount>4400</workAmount>
-	</RecipeDef>
-
-	<!-- ===== Neolithic Mechanite Darts ===== -->
-	
-	<!-- AmmoSet -->
-	<CombatExtended.AmmoSetDef>
-		<defName>MP_AmmoSet_MechDart_Neolithic</defName>
-		<label>neolithic mechanite dart</label>
-		<ammoTypes>
-			<MP_Ammo_MechDart_Neolithic>MP_Bullet_MechDart_Neolithic</MP_Ammo_MechDart_Neolithic>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
-		<defName>MP_Ammo_MechDart_Neolithic</defName>
-		<description>Neolithic darts used to apply the Mechanite Plague from a distance. Due to the lack of a sophisticated injection mechanism, these darts may fail to apply the plague.</description>
-		<label>neolithic mechanite dart</label>
-		<graphicData>
-			<texPath>Things/Ammo/Neolithic/Dart</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<Mass>0.01</Mass>
-			<Bulk>0.012</Bulk>
-			<Flammability>1</Flammability>
-			<MarketValue>0.524</MarketValue>
-		</statBases>
-		<ammoClass>MP_MechDart</ammoClass>
-	</ThingDef>
-
-	<!-- Projectiles -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
-		<defName>MP_Bullet_MechDart_Neolithic</defName>
-		<label>Neolithic mechanite dart</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_ArrowInfect</damageDef>
-			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>0.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>1.72</armorPenetrationBlunt>
-			<speed>24</speed>
-		</projectile>
-		<modExtensions>
-            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
-                <addHediffChance>0.80</addHediffChance>
-                <hediffLowerValue>0.14</hediffLowerValue>
-                <hediffUpperValue>0.17</hediffUpperValue>
-            </li>
-        </modExtensions>
-	</ThingDef>
-
-	<!-- Recipes -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Ammo_MechDart_Neolithic</defName> <!-- has to be named like this. deal with it. -->
-		<label>make neolithic mechanite dart x25</label>
-		<description>Craft 25 neolithic mechanite darts.</description>
-		<jobString>Making 25 neolithic mechanite darts.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>1</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>WoodLog</li>
-					</thingDefs>
-				</filter>
-				<count>1</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>1</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Ammo_MechDart_Neolithic>25</MP_Ammo_MechDart_Neolithic>
-		</products>
-		<workAmount>800</workAmount>
-	</RecipeDef>
-
-		
-	
-	
-	<!-- ====== Mechanite Shrapnel Buckshot ====== -->
-	
-	<!-- Ammo Set -->
-	<CombatExtended.AmmoSetDef>
-		<defName>MP_AmmoSet_MechShrapnelBuckshot</defName>
-		<label>mechanite shrapnel buckshot</label>
-		<ammoTypes>
-			<MP_Ammo_MechShrapnelBuckshot>MP_Bullet_MechShrapnelBuckshot</MP_Ammo_MechShrapnelBuckshot>
-		</ammoTypes>
-	</CombatExtended.AmmoSetDef>
-
-	<!-- Ammo -->	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeBase">
-		<defName>MP_Ammo_MechShrapnelBuckshot</defName>
-		<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition. This variant is designed to scatter over a short distance.</description>
-		<label>mechanite shrapnel buckshot shell</label>
-		<graphicData>
-			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<Mass>0.023</Mass>
-			<Bulk>0.07</Bulk>
-			<MarketValue>0.395</MarketValue>
-		</statBases>
-		<ammoClass>BuckShot</ammoClass>
-		<cookOffProjectile>MP_Bullet_MechShrapnelBuckshot</cookOffProjectile>
-	</ThingDef>
-
-	<!-- Projectiles -->
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
-		<defName>MP_Bullet_MechShrapnelBuckshot</defName>
-		<label>mechanite shrapnel buckshot pellet</label>
-		<graphicData>
-			<texPath>Things/Projectile/Shotgun_Pellet</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>MP_BulletInfect</damageDef>
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.78</armorPenetrationBlunt>
-			<speed>76</speed>
-			<spreadMult>17.8</spreadMult>
-			<pelletCount>8</pelletCount>
-		</projectile>
-		<modExtensions>
-            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
-                <addHediffChance>1.00</addHediffChance>
-				<hediffLowerValue>0.03</hediffLowerValue>
-				<hediffUpperValue>0.04</hediffUpperValue>
-				<extraSpawns>1</extraSpawns>
-            </li>
-        </modExtensions>
-	</ThingDef>
-
-	<!-- Recipes -->
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeMP_Ammo_MechShrapnelBuckshot</defName> <!-- has to be named like this. deal with it. -->
-		<label>make mechanite shrapnel buckshot shells x200</label>
-		<description>Craft 200 mechanite shrapnel buckshot shells.</description>
-		<jobString>Making mechanite shrapnel buckshot shells.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>MP_MechaniteCanister</li>
-					</thingDefs>
-				</filter>
-				<count>6</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-				<li>MP_MechaniteCanister</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<MP_Ammo_MechShrapnelBuckshot>200</MP_Ammo_MechShrapnelBuckshot>
-		</products>
-		<workAmount>300</workAmount>
-	</RecipeDef>
-	
-	<!-- ====== Chaos Rocket (uncraftable) ====== -->
-	
-	<!-- Projectile -->
-	<ThingDef ParentName="BaseRPG7Grenade">
-		<defName>MP_Bullet_ChaosLauncher</defName>
-		<label>chaos rocket</label>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<graphicData>
-			<texPath>Things/Projectile/PlaguePod</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>25</speed>
-			<damageDef>Smoke</damageDef>
-			<explosionRadius>5.8</explosionRadius>
-			<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>1</preExplosionSpawnChance>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-			<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
-				<amountSpawned>8</amountSpawned>
-				<doStunPulse>true</doStunPulse>
-				<stunPulseRadius>5.8</stunPulseRadius>
-			</li>
-		</comps>
-	</ThingDef>
-	
-	<!-- ===== Incubator Egg Pod (uncraftable) ===== -->
-	<ThingDef ParentName="BaseRPG7Grenade">
-		<defName>MP_Bullet_EggPod</defName>
-		<label>egg pod</label>
-		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-		<graphicData>
-			<texPath>Things/Projectile/PlaguePod</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-			<shaderType>TransparentPostLight</shaderType>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>25</speed>
-			<damageDef>Smoke</damageDef>
-			<explosionRadius>1.8</explosionRadius>
-			<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>1</preExplosionSpawnChance>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-		</projectile>
-		<comps>
-			<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
-				<amountSpawned>1</amountSpawned>
-				<doStunPulse>false</doStunPulse>
-			</li>
-		</comps>
-	</ThingDef>
-	
+			<!-- Ammo Categories -->
+				
+			<CombatExtended.AmmoCategoryDef>
+				<defName>MP_MechDart</defName>
+				<label>mechanite dart</label>
+				<labelShort>M-Dart</labelShort>
+				<description>A dart designed to apply the Mechanite Plague. While dart weapons are normally non-lethal, the lack of concern for target preservation gives these darts the lethality of the average FMJ round.</description>
+			</CombatExtended.AmmoCategoryDef>
 			
+			<CombatExtended.AmmoCategoryDef>
+				<defName>MP_MechShell</defName>
+				<label>plague</label>
+				<description>A mortar shell designed to apply the Mechanite Plague. Combines high explosive power with the power of the plague, resulting in a lethal combination.</description>
+			</CombatExtended.AmmoCategoryDef>
+
+			<!-- ===== Heavy Mechanite Darts ===== -->
+			
+			<!-- AmmoSet -->
+			<CombatExtended.AmmoSetDef>
+				<defName>MP_AmmoSet_MechDart_Heavy</defName>
+				<label>16mm mechanite dart</label>
+				<ammoTypes>
+					<MP_Ammo_MechDart_Heavy>MP_Bullet_MechDart_Heavy</MP_Ammo_MechDart_Heavy>
+				</ammoTypes>
+			</CombatExtended.AmmoSetDef>
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+				<defName>MP_Ammo_MechDart_Heavy</defName>
+				<description>Hefty darts used to apply the Mechanite Plague from a distance. Used in heavier dart-based weaponry.</description>
+				<label>16mm mechanite dart cartridge</label>
+				<graphicData>
+					<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+				</graphicData>
+				<statBases>
+					<Mass>0.03</Mass>
+					<Bulk>0.04</Bulk>
+					<MarketValue>0.514</MarketValue>
+				</statBases>
+				<ammoClass>MP_MechDart</ammoClass>
+			</ThingDef>
+
+			<!-- Projectiles -->
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+				<defName>MP_Bullet_MechDart_Heavy</defName>
+				<label>16mm mechanite dart</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_BulletInfect</damageDef>
+					<damageAmountBase>26</damageAmountBase>
+					<armorPenetrationSharp>14</armorPenetrationSharp>
+					<armorPenetrationBlunt>108</armorPenetrationBlunt>
+					<speed>120</speed>
+				</projectile>
+				<modExtensions>
+					<li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+						<addHediffChance>1.00</addHediffChance>
+						<hediffLowerValue>0.23</hediffLowerValue>
+						<hediffUpperValue>0.26</hediffUpperValue>
+					</li>
+				</modExtensions>
+			</ThingDef>
+
+			<!-- Recipes -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Ammo_MechDart_Heavy</defName> <!-- has to be named like this. deal with it. -->
+				<label>make 16mm mechanite dart cartridge x200</label>
+				<description>Craft 200 16mm mechanite dart cartridges.</description>
+				<jobString>Making 16mm mechanite dart cartridges.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</filter>
+						<count>12</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>8</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Ammo_MechDart_Heavy>200</MP_Ammo_MechDart_Heavy>
+				</products>
+				<workAmount>6000</workAmount>
+			</RecipeDef>
+			
+			<!-- ===== Light Mechanite Darts ===== -->
+
+			<!-- AmmoSet -->
+			<CombatExtended.AmmoSetDef>
+				<defName>MP_AmmoSet_MechDart_Light</defName>
+				<label>11mm mechanite dart</label>
+				<ammoTypes>
+					<MP_Ammo_MechDart_Light>MP_Bullet_MechDart_Light</MP_Ammo_MechDart_Light>
+				</ammoTypes>
+			</CombatExtended.AmmoSetDef>
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+				<defName>MP_Ammo_MechDart_Light</defName>
+				<description>Small darts used to apply the Mechanite Plague from a distance. Used in lighter dart-based weaponry.</description>
+				<label>11mm mechanite dart cartridge</label>
+				<graphicData>
+					<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+				</graphicData>
+				<statBases>
+					<Mass>0.015</Mass>
+					<Bulk>0.02</Bulk>
+					<MarketValue>0.31</MarketValue>
+				</statBases>
+				<ammoClass>MP_MechDart</ammoClass>
+			</ThingDef>
+
+			<!-- Projectiles -->
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+				<defName>MP_Bullet_MechDart_Light</defName>
+				<label>11mm mechanite dart</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_BulletInfect</damageDef>
+					<damageAmountBase>11</damageAmountBase>
+					<armorPenetrationSharp>5</armorPenetrationSharp>
+					<armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<speed>36</speed>
+				</projectile>
+				<modExtensions>
+					<li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+						<addHediffChance>1.00</addHediffChance>
+						<hediffLowerValue>0.13</hediffLowerValue>
+						<hediffUpperValue>0.15</hediffUpperValue>
+					</li>
+				</modExtensions>
+			</ThingDef>
+
+			<!-- Recipes -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Ammo_MechDart_Light</defName> <!-- has to be named like this. deal with it. -->
+				<label>make 11mm mechanite dart cartridge x200</label>
+				<description>Craft 200 11mm mechanite dart cartridges.</description>
+				<jobString>Making 11mm mechanite dart cartridges.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</filter>
+						<count>6</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>5</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Ammo_MechDart_Light>200</MP_Ammo_MechDart_Light>
+				</products>
+				<workAmount>3600</workAmount>
+			</RecipeDef>
+			
+			<!-- ===== Plague Mortar Shells ===== -->
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
+				<defName>MP_Plague_Shell_81mm</defName>
+				<label>81mm mortar shell (Plague)</label>
+				<graphicData>
+					<texPath>Things/CE/PlagueShellCE</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<statBases>
+					<MarketValue>67.80</MarketValue>
+					<Mass>5.00</Mass>
+					<Bulk>8.51</Bulk>
+				</statBases>
+				<ammoClass>MP_MechShell</ammoClass>
+				<detonateProjectile>MP_Bullet_81mmMortarShell_Plague</detonateProjectile>
+				<comps>
+					<li Class="CompProperties_Explosive">
+						<explosiveRadius>2.5</explosiveRadius>
+						<explosiveDamageType>MP_BlastInfectMortar</explosiveDamageType>
+						<startWickHitPointsPercent>0.7</startWickHitPointsPercent>
+						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						<explodeOnKilled>True</explodeOnKilled>
+						<wickTicks>30~60</wickTicks>
+					</li>
+				</comps>
+			</ThingDef>
+			
+			<!-- Projectiles -->	
+			<ThingDef ParentName="Base81mmMortarShell">
+				<defName>MP_Bullet_81mmMortarShell_Plague</defName>
+				<label>81mm mortar shell (plague)</label>
+				<graphicData>
+					<texPath>Things/Projectile/Mortar/HE</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_BlastInfectMortar</damageDef>
+					<damageAmountBase>132</damageAmountBase>
+					<armorPenetrationSharp>0</armorPenetrationSharp>
+					<armorPenetrationBlunt>0</armorPenetrationBlunt>
+					<explosionRadius>2.5</explosionRadius>
+					<flyOverhead>true</flyOverhead>
+					<soundExplode>MortarBomb_Explode</soundExplode>
+					<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+					<ai_IsIncendiary>true</ai_IsIncendiary>
+				</projectile>
+				<comps>
+					<li Class="CombatExtended.CompProperties_Fragments">
+						<fragments>
+							<Fragment_Large>15</Fragment_Large>
+							<Fragment_Small>80</Fragment_Small>
+						</fragments>
+					</li>
+				</comps>
+			</ThingDef>
+			
+			<!-- Recipe -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Plague_Shell_81mm</defName>
+				<label>make 81mm plague mortar shells x5</label>
+				<description>Craft 5 81mm plague mortar shells.</description>
+				<jobString>Making 81mm plague mortar shells.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+						<thingDefs>
+							<li>Steel</li>
+						</thingDefs>
+						</filter>
+						<count>50</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>FSX</li>
+							</thingDefs>
+						</filter>
+						<count>8</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>10</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>ComponentIndustrial</li>
+							</thingDefs>
+						</filter>
+						<count>2</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>FSX</li>
+						<li>ComponentIndustrial</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Plague_Shell_81mm>5</MP_Plague_Shell_81mm>
+				</products>
+				<workAmount>12000</workAmount>
+				<researchPrerequisite>MP_MechaniteMortar</researchPrerequisite>
+			</RecipeDef>
+			
+			<!-- ===== Mechanite Shrapnel ===== -->
+
+			<!-- AmmoSet -->
+			<CombatExtended.AmmoSetDef>
+				<defName>MP_AmmoSet_MechShrapnel</defName>
+				<label>mechanite shrapnel</label>
+				<ammoTypes>
+					<MP_Ammo_MechShrapnel>MP_Bullet_MechShrapnel</MP_Ammo_MechShrapnel>
+				</ammoTypes>
+			</CombatExtended.AmmoSetDef>
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
+				<defName>MP_Ammo_MechShrapnel</defName>
+				<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition.</description>
+				<label>mechanite shrapnel cartridge</label>
+				<graphicData>
+					<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+				</graphicData>
+				<statBases>
+					<Mass>0.02</Mass>
+					<Bulk>0.01</Bulk>
+					<MarketValue>0.196</MarketValue>
+				</statBases>
+				<ammoClass>FullMetalJacket</ammoClass>
+				<cookOffProjectile>MP_Bullet_MechShrapnel</cookOffProjectile>
+			</ThingDef>
+
+			<!-- Projectiles -->
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
+				<defName>MP_Bullet_MechShrapnel</defName>
+				<label>mechanite shrapnel</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_BulletInfect</damageDef>
+					<damageAmountBase>16</damageAmountBase>
+					<armorPenetrationSharp>7</armorPenetrationSharp>
+					<armorPenetrationBlunt>20</armorPenetrationBlunt>
+					<speed>36</speed>
+				</projectile>
+				<modExtensions>
+					<li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+						<addHediffChance>0.75</addHediffChance>
+						<hediffLowerValue>0.06</hediffLowerValue>
+						<hediffUpperValue>0.08</hediffUpperValue>
+					</li>
+				</modExtensions>
+			</ThingDef>
+
+			<!-- Recipes -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Ammo_MechShrapnel</defName> <!-- has to be named like this. deal with it. -->
+				<label>make mechanite shrapnel cartridge x500</label>
+				<description>Craft 500 mechanite shrapnel cartridges.</description>
+				<jobString>Making mechanite shrapnel cartridges.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</filter>
+						<count>20</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>6</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Ammo_MechShrapnel>500</MP_Ammo_MechShrapnel>
+				</products>
+				<workAmount>4400</workAmount>
+			</RecipeDef>
+
+			<!-- ===== Neolithic Mechanite Darts ===== -->
+			
+			<!-- AmmoSet -->
+			<CombatExtended.AmmoSetDef>
+				<defName>MP_AmmoSet_MechDart_Neolithic</defName>
+				<label>neolithic mechanite dart</label>
+				<ammoTypes>
+					<MP_Ammo_MechDart_Neolithic>MP_Bullet_MechDart_Neolithic</MP_Ammo_MechDart_Neolithic>
+				</ammoTypes>
+			</CombatExtended.AmmoSetDef>
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+				<defName>MP_Ammo_MechDart_Neolithic</defName>
+				<description>Neolithic darts used to apply the Mechanite Plague from a distance. Due to the lack of a sophisticated injection mechanism, these darts may fail to apply the plague.</description>
+				<label>neolithic mechanite dart</label>
+				<graphicData>
+					<texPath>Things/Ammo/Neolithic/Dart</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+				</graphicData>
+				<statBases>
+					<Mass>0.01</Mass>
+					<Bulk>0.012</Bulk>
+					<Flammability>1</Flammability>
+					<MarketValue>0.524</MarketValue>
+				</statBases>
+				<ammoClass>MP_MechDart</ammoClass>
+			</ThingDef>
+
+			<!-- Projectiles -->
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
+				<defName>MP_Bullet_MechDart_Neolithic</defName>
+				<label>Neolithic mechanite dart</label>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_ArrowInfect</damageDef>
+					<damageAmountBase>5</damageAmountBase>
+					<armorPenetrationSharp>0.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>1.72</armorPenetrationBlunt>
+					<speed>24</speed>
+				</projectile>
+				<modExtensions>
+					<li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+						<addHediffChance>0.80</addHediffChance>
+						<hediffLowerValue>0.14</hediffLowerValue>
+						<hediffUpperValue>0.17</hediffUpperValue>
+					</li>
+				</modExtensions>
+			</ThingDef>
+
+			<!-- Recipes -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Ammo_MechDart_Neolithic</defName> <!-- has to be named like this. deal with it. -->
+				<label>make neolithic mechanite dart x25</label>
+				<description>Craft 25 neolithic mechanite darts.</description>
+				<jobString>Making 25 neolithic mechanite darts.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</filter>
+						<count>1</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>WoodLog</li>
+							</thingDefs>
+						</filter>
+						<count>1</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>1</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Ammo_MechDart_Neolithic>25</MP_Ammo_MechDart_Neolithic>
+				</products>
+				<workAmount>800</workAmount>
+			</RecipeDef>
+
+			<!-- ====== Mechanite Shrapnel Buckshot ====== -->
+			
+			<!-- Ammo Set -->
+			<CombatExtended.AmmoSetDef>
+				<defName>MP_AmmoSet_MechShrapnelBuckshot</defName>
+				<label>mechanite shrapnel buckshot</label>
+				<ammoTypes>
+					<MP_Ammo_MechShrapnelBuckshot>MP_Bullet_MechShrapnelBuckshot</MP_Ammo_MechShrapnelBuckshot>
+				</ammoTypes>
+			</CombatExtended.AmmoSetDef>
+
+			<!-- Ammo -->	
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeBase">
+				<defName>MP_Ammo_MechShrapnelBuckshot</defName>
+				<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition. This variant is designed to scatter over a short distance.</description>
+				<label>mechanite shrapnel buckshot shell</label>
+				<graphicData>
+					<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+					<graphicClass>Graphic_StackCount</graphicClass>
+				</graphicData>
+				<statBases>
+					<Mass>0.023</Mass>
+					<Bulk>0.07</Bulk>
+					<MarketValue>0.395</MarketValue>
+				</statBases>
+				<ammoClass>BuckShot</ammoClass>
+				<cookOffProjectile>MP_Bullet_MechShrapnelBuckshot</cookOffProjectile>
+			</ThingDef>
+
+			<!-- Projectiles -->
+			<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+				<defName>MP_Bullet_MechShrapnelBuckshot</defName>
+				<label>mechanite shrapnel buckshot pellet</label>
+				<graphicData>
+					<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<damageDef>MP_BulletInfect</damageDef>
+					<damageAmountBase>12</damageAmountBase>
+					<armorPenetrationSharp>4.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>5.78</armorPenetrationBlunt>
+					<speed>76</speed>
+					<spreadMult>17.8</spreadMult>
+					<pelletCount>8</pelletCount>
+				</projectile>
+				<modExtensions>
+					<li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+						<addHediffChance>1.00</addHediffChance>
+						<hediffLowerValue>0.03</hediffLowerValue>
+						<hediffUpperValue>0.04</hediffUpperValue>
+						<extraSpawns>1</extraSpawns>
+					</li>
+				</modExtensions>
+			</ThingDef>
+
+			<!-- Recipes -->
+			<RecipeDef ParentName="AmmoRecipeBase">
+				<defName>MakeMP_Ammo_MechShrapnelBuckshot</defName> <!-- has to be named like this. deal with it. -->
+				<label>make mechanite shrapnel buckshot shells x200</label>
+				<description>Craft 200 mechanite shrapnel buckshot shells.</description>
+				<jobString>Making mechanite shrapnel buckshot shells.</jobString>
+				<ingredients>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>Steel</li>
+							</thingDefs>
+						</filter>
+						<count>10</count>
+					</li>
+					<li>
+						<filter>
+							<thingDefs>
+								<li>MP_MechaniteCanister</li>
+							</thingDefs>
+						</filter>
+						<count>6</count>
+					</li>
+				</ingredients>
+				<fixedIngredientFilter>
+					<thingDefs>
+						<li>Steel</li>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</fixedIngredientFilter>
+				<products>
+					<MP_Ammo_MechShrapnelBuckshot>200</MP_Ammo_MechShrapnelBuckshot>
+				</products>
+				<workAmount>300</workAmount>
+			</RecipeDef>
+			
+			<!-- ====== Chaos Rocket (uncraftable) ====== -->
+			
+			<!-- Projectile -->
+			<ThingDef ParentName="BaseRPG7Grenade">
+				<defName>MP_Bullet_ChaosLauncher</defName>
+				<label>chaos rocket</label>
+				<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				<graphicData>
+					<texPath>Things/Projectile/PlaguePod</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>25</speed>
+					<damageDef>Smoke</damageDef>
+					<explosionRadius>5.8</explosionRadius>
+					<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+					<preExplosionSpawnChance>1</preExplosionSpawnChance>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+					<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
+						<amountSpawned>8</amountSpawned>
+						<doStunPulse>true</doStunPulse>
+						<stunPulseRadius>5.8</stunPulseRadius>
+					</li>
+				</comps>
+			</ThingDef>
+			
+			<!-- ===== Incubator Egg Pod (uncraftable) ===== -->
+			<ThingDef ParentName="BaseRPG7Grenade">
+				<defName>MP_Bullet_EggPod</defName>
+				<label>egg pod</label>
+				<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+				<graphicData>
+					<texPath>Things/Projectile/PlaguePod</texPath>
+					<graphicClass>Graphic_Single</graphicClass>
+					<shaderType>TransparentPostLight</shaderType>
+				</graphicData>
+				<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					<speed>25</speed>
+					<damageDef>Smoke</damageDef>
+					<explosionRadius>1.8</explosionRadius>
+					<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+					<preExplosionSpawnChance>1</preExplosionSpawnChance>
+					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+				</projectile>
+				<comps>
+					<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
+						<amountSpawned>1</amountSpawned>
+						<doStunPulse>false</doStunPulse>
+					</li>
+				</comps>
+			</ThingDef>
+	
 			</value>
 		</li>
       </operations>

--- a/Patches/Mechanite Plague/Patch_AddAmmo.xml
+++ b/Patches/Mechanite Plague/Patch_AddAmmo.xml
@@ -6,11 +6,12 @@
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs</xpath>
+			<value>
 
-	<li Class="PatchOperationAdd">
-		<xpath>Defs</xpath>
-		<value>
-
+	<!-- Ammo Categories -->
+		
 	<CombatExtended.AmmoCategoryDef>
 		<defName>MP_MechDart</defName>
 		<label>mechanite dart</label>
@@ -24,7 +25,9 @@
 		<description>A mortar shell designed to apply the Mechanite Plague. Combines high explosive power with the power of the plague, resulting in a lethal combination.</description>
 	</CombatExtended.AmmoCategoryDef>
 
-	<!-- ====== AmmoSet ====== -->
+	<!-- ===== Heavy Mechanite Darts ===== -->
+	
+	<!-- AmmoSet -->
 	<CombatExtended.AmmoSetDef>
 		<defName>MP_AmmoSet_MechDart_Heavy</defName>
 		<label>16mm mechanite dart</label>
@@ -33,7 +36,7 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
-	<!-- ====== Ammo ====== -->	
+	<!-- Ammo -->	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>MP_Ammo_MechDart_Heavy</defName>
 		<description>Hefty darts used to apply the Mechanite Plague from a distance. Used in heavier dart-based weaponry.</description>
@@ -50,7 +53,7 @@
 		<ammoClass>MP_MechDart</ammoClass>
 	</ThingDef>
 
-	<!-- ====== Projectiles ====== -->
+	<!-- Projectiles -->
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
 		<defName>MP_Bullet_MechDart_Heavy</defName>
 		<label>16mm mechanite dart</label>
@@ -70,7 +73,7 @@
         </modExtensions>
 	</ThingDef>
 
-	<!-- ====== Recipes ====== -->
+	<!-- Recipes -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeMP_Ammo_MechDart_Heavy</defName> <!-- has to be named like this. deal with it. -->
 		<label>make 16mm mechanite dart cartridge x200</label>
@@ -105,8 +108,10 @@
 		</products>
 		<workAmount>6000</workAmount>
 	</RecipeDef>
+	
+	<!-- ===== Light Mechanite Darts ===== -->
 
-	<!-- ====== AmmoSet ====== -->
+	<!-- AmmoSet -->
 	<CombatExtended.AmmoSetDef>
 		<defName>MP_AmmoSet_MechDart_Light</defName>
 		<label>11mm mechanite dart</label>
@@ -115,7 +120,7 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
-	<!-- ====== Ammo ====== -->	
+	<!-- Ammo -->	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>MP_Ammo_MechDart_Light</defName>
 		<description>Small darts used to apply the Mechanite Plague from a distance. Used in lighter dart-based weaponry.</description>
@@ -132,7 +137,7 @@
 		<ammoClass>MP_MechDart</ammoClass>
 	</ThingDef>
 
-	<!-- ====== Projectiles ====== -->
+	<!-- Projectiles -->
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
 		<defName>MP_Bullet_MechDart_Light</defName>
 		<label>11mm mechanite dart</label>
@@ -152,7 +157,7 @@
         </modExtensions>
 	</ThingDef>
 
-	<!-- ====== Recipes ====== -->
+	<!-- Recipes -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeMP_Ammo_MechDart_Light</defName> <!-- has to be named like this. deal with it. -->
 		<label>make 11mm mechanite dart cartridge x200</label>
@@ -187,8 +192,10 @@
 		</products>
 		<workAmount>3600</workAmount>
 	</RecipeDef>
+	
+	<!-- ===== Plague Mortar Shells ===== -->
 
-	<!-- ====== Ammo ====== -->	
+	<!-- Ammo -->	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
 		<defName>MP_Plague_Shell_81mm</defName>
 		<label>81mm mortar shell (Plague)</label>
@@ -215,7 +222,7 @@
 		</comps>
 	</ThingDef>
 	
-	<!-- ====== Bullet ====== -->	
+	<!-- Projectiles -->	
 	<ThingDef ParentName="Base81mmMortarShell">
 		<defName>MP_Bullet_81mmMortarShell_Plague</defName>
 		<label>81mm mortar shell (plague)</label>
@@ -244,7 +251,7 @@
 		</comps>
 	</ThingDef>
 	
-	<!-- ====== Recipe ====== -->
+	<!-- Recipe -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeMP_Plague_Shell_81mm</defName>
 		<label>make 81mm plague mortar shells x5</label>
@@ -298,8 +305,10 @@
 		<workAmount>12000</workAmount>
 		<researchPrerequisite>MP_MechaniteMortar</researchPrerequisite>
 	</RecipeDef>
+	
+	<!-- ===== Mechanite Shrapnel ===== -->
 
-	<!-- ====== AmmoSet ====== -->
+	<!-- AmmoSet -->
 	<CombatExtended.AmmoSetDef>
 		<defName>MP_AmmoSet_MechShrapnel</defName>
 		<label>mechanite shrapnel</label>
@@ -308,7 +317,7 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
-	<!-- ====== Ammo ====== -->	
+	<!-- Ammo -->	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>MP_Ammo_MechShrapnel</defName>
 		<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition.</description>
@@ -326,7 +335,7 @@
 		<cookOffProjectile>MP_Bullet_MechShrapnel</cookOffProjectile>
 	</ThingDef>
 
-	<!-- ====== Projectiles ====== -->
+	<!-- Projectiles -->
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
 		<defName>MP_Bullet_MechShrapnel</defName>
 		<label>mechanite shrapnel</label>
@@ -346,7 +355,7 @@
         </modExtensions>
 	</ThingDef>
 
-	<!-- ====== Recipes ====== -->
+	<!-- Recipes -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeMP_Ammo_MechShrapnel</defName> <!-- has to be named like this. deal with it. -->
 		<label>make mechanite shrapnel cartridge x500</label>
@@ -382,7 +391,9 @@
 		<workAmount>4400</workAmount>
 	</RecipeDef>
 
-	<!-- ====== AmmoSet ====== -->
+	<!-- ===== Neolithic Mechanite Darts ===== -->
+	
+	<!-- AmmoSet -->
 	<CombatExtended.AmmoSetDef>
 		<defName>MP_AmmoSet_MechDart_Neolithic</defName>
 		<label>neolithic mechanite dart</label>
@@ -391,7 +402,7 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
-	<!-- ====== Ammo ====== -->	
+	<!-- Ammo -->	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
 		<defName>MP_Ammo_MechDart_Neolithic</defName>
 		<description>Neolithic darts used to apply the Mechanite Plague from a distance. Due to the lack of a sophisticated injection mechanism, these darts may fail to apply the plague.</description>
@@ -409,7 +420,7 @@
 		<ammoClass>MP_MechDart</ammoClass>
 	</ThingDef>
 
-	<!-- ====== Projectiles ====== -->
+	<!-- Projectiles -->
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
 		<defName>MP_Bullet_MechDart_Neolithic</defName>
 		<label>Neolithic mechanite dart</label>
@@ -429,7 +440,7 @@
         </modExtensions>
 	</ThingDef>
 
-	<!-- ====== Recipes ====== -->
+	<!-- Recipes -->
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeMP_Ammo_MechDart_Neolithic</defName> <!-- has to be named like this. deal with it. -->
 		<label>make neolithic mechanite dart x25</label>
@@ -473,9 +484,159 @@
 		<workAmount>800</workAmount>
 	</RecipeDef>
 
-		</value>
-	</li>
+		
+	
+	
+	<!-- ====== Mechanite Shrapnel Buckshot ====== -->
+	
+	<!-- Ammo Set -->
+	<CombatExtended.AmmoSetDef>
+		<defName>MP_AmmoSet_MechShrapnelBuckshot</defName>
+		<label>mechanite shrapnel buckshot</label>
+		<ammoTypes>
+			<MP_Ammo_MechShrapnelBuckshot>MP_Bullet_MechShrapnelBuckshot</MP_Ammo_MechShrapnelBuckshot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
+	<!-- Ammo -->	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeBase">
+		<defName>MP_Ammo_MechShrapnelBuckshot</defName>
+		<description>Razor-sharp fragments that can apply the Mechanite Plague from a distance. It is unclear as to how these remain stable during flight, but they're about as effective as normal ammunition. This variant is designed to scatter over a short distance.</description>
+		<label>mechanite shrapnel buckshot shell</label>
+		<graphicData>
+			<texPath>ThirdParty/CP Metal Gear Solid/Rifle/NL</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.023</Mass>
+			<Bulk>0.07</Bulk>
+			<MarketValue>0.395</MarketValue>
+		</statBases>
+		<ammoClass>BuckShot</ammoClass>
+		<cookOffProjectile>MP_Bullet_MechShrapnelBuckshot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- Projectiles -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeBullet">
+		<defName>MP_Bullet_MechShrapnelBuckshot</defName>
+		<label>mechanite shrapnel buckshot pellet</label>
+		<graphicData>
+			<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>MP_BulletInfect</damageDef>
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.78</armorPenetrationBlunt>
+			<speed>76</speed>
+			<spreadMult>17.8</spreadMult>
+			<pelletCount>8</pelletCount>
+		</projectile>
+		<modExtensions>
+            <li Class="MP_MechanitePlague.ModExtension_MechPlagueOdds">
+                <addHediffChance>1.00</addHediffChance>
+				<hediffLowerValue>0.03</hediffLowerValue>
+				<hediffUpperValue>0.04</hediffUpperValue>
+				<extraSpawns>1</extraSpawns>
+            </li>
+        </modExtensions>
+	</ThingDef>
+
+	<!-- Recipes -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeMP_Ammo_MechShrapnelBuckshot</defName> <!-- has to be named like this. deal with it. -->
+		<label>make mechanite shrapnel buckshot shells x200</label>
+		<description>Craft 200 mechanite shrapnel buckshot shells.</description>
+		<jobString>Making mechanite shrapnel buckshot shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>MP_MechaniteCanister</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>MP_MechaniteCanister</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<MP_Ammo_MechShrapnelBuckshot>200</MP_Ammo_MechShrapnelBuckshot>
+		</products>
+		<workAmount>300</workAmount>
+	</RecipeDef>
+	
+	<!-- ====== Chaos Rocket (uncraftable) ====== -->
+	
+	<!-- Projectile -->
+	<ThingDef ParentName="BaseRPG7Grenade">
+		<defName>MP_Bullet_ChaosLauncher</defName>
+		<label>chaos rocket</label>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/PlaguePod</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>25</speed>
+			<damageDef>Smoke</damageDef>
+			<explosionRadius>5.8</explosionRadius>
+			<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+			<preExplosionSpawnChance>1</preExplosionSpawnChance>
+			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+		</projectile>
+		<comps>
+			<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
+				<amountSpawned>8</amountSpawned>
+				<doStunPulse>true</doStunPulse>
+				<stunPulseRadius>5.8</stunPulseRadius>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<!-- ===== Incubator Egg Pod (uncraftable) ===== -->
+	<ThingDef ParentName="BaseRPG7Grenade">
+		<defName>MP_Bullet_EggPod</defName>
+		<label>egg pod</label>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/PlaguePod</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>TransparentPostLight</shaderType>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>25</speed>
+			<damageDef>Smoke</damageDef>
+			<explosionRadius>1.8</explosionRadius>
+			<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+			<preExplosionSpawnChance>1</preExplosionSpawnChance>
+			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+		</projectile>
+		<comps>
+			<li Class="MP_MechanitePlague.CompProperties_ProjectileSpawnBursters">
+				<amountSpawned>1</amountSpawned>
+				<doStunPulse>false</doStunPulse>
+			</li>
+		</comps>
+	</ThingDef>
+	
+			
+			</value>
+		</li>
       </operations>
     </match>
   </Operation>

--- a/Patches/Mechanite Plague/PawnKinds_MechanitePlague.xml
+++ b/Patches/Mechanite Plague/PawnKinds_MechanitePlague.xml
@@ -7,40 +7,40 @@
     <match Class="PatchOperationSequence">
       <operations>
 				
-	<!-- Tribal Blowdarter -->
-	<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/PawnKindDef[defName="MP_Tribal_Blowdarter"]</xpath>
-		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>
-					<min>18</min>
-					<max>32</max>
-				</primaryMagazineCount>
-			</li>
-		</value>
-	</li>
-	
-	<!-- Mercenary Plaguebringer -->
-	<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
-		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>
-					<min>3</min>
-					<max>5</max>
-				</primaryMagazineCount>
-			</li>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationAdd">
-		<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
-		<value>
-			<apparelRequired>
-				<li>Apparel_Backpack</li>
-			</apparelRequired>
-		</value>
-	</li>
+		<!-- Tribal Blowdarter -->
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/PawnKindDef[defName="MP_Tribal_Blowdarter"]</xpath>
+			<value>
+				<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>18</min>
+						<max>32</max>
+					</primaryMagazineCount>
+				</li>
+			</value>
+		</li>
+		
+		<!-- Mercenary Plaguebringer -->
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
+			<value>
+				<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>3</min>
+						<max>5</max>
+					</primaryMagazineCount>
+				</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/PawnKindDef[defName="MP_Mercenary_Plaguebringer"]</xpath>
+			<value>
+				<apparelRequired>
+					<li>Apparel_Backpack</li>
+				</apparelRequired>
+			</value>
+		</li>
 
       </operations>
     </match>

--- a/Patches/Mechanite Plague/ThingDef_Misc.xml
+++ b/Patches/Mechanite Plague/ThingDef_Misc.xml
@@ -7,44 +7,44 @@
     <match Class="PatchOperationSequence">
       <operations>
 			
-	<!-- =========== Apparel =========== -->
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]/statBases</xpath>
-		<value>
-			<Bulk>3</Bulk>
-			<WornBulk>2</WornBulk>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]</xpath>
-		<value>
-			<equippedStatOffsets>
-				<CarryBulk>10</CarryBulk>
-			</equippedStatOffsets>
-		</value>
-	</li>
-	
-	<!-- =========== Mortars & IED =========== -->
-	<li Class="PatchOperationAdd">
-		<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
-		<value>
-			<MP_Plague_Shell_81mm>MP_Bullet_81mmMortarShell_Plague</MP_Plague_Shell_81mm>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationRemove"> <!-- -->
-		<xpath>Defs/ThingDef[defName="MP_Shell_Plague"]</xpath>
-	</li>
-	
-	<li Class="PatchOperationReplace">
-	<xpath>Defs/ThingDef[defName="MP_TrapIED_PlagueSharpnel"]/costList</xpath>
-		<value>
-			<costList>
-				<MP_Plague_Shell_81mm>2</MP_Plague_Shell_81mm>
-			</costList>
-		</value>
-	</li>
+		<!-- =========== Apparel =========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]/statBases</xpath>
+			<value>
+				<Bulk>3</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="MP_Apparel_PlagueBandolier"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<CarryBulk>10</CarryBulk>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- =========== Mortars & IED =========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
+			<value>
+				<MP_Plague_Shell_81mm>MP_Bullet_81mmMortarShell_Plague</MP_Plague_Shell_81mm>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationRemove"> <!-- -->
+			<xpath>Defs/ThingDef[defName="MP_Shell_Plague"]</xpath>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MP_TrapIED_PlagueSharpnel"]/costList</xpath>
+			<value>
+				<costList>
+					<MP_Plague_Shell_81mm>2</MP_Plague_Shell_81mm>
+				</costList>
+			</value>
+		</li>
 
       </operations>
     </match>

--- a/Patches/Mechanite Plague/ThingDef_Races.xml
+++ b/Patches/Mechanite Plague/ThingDef_Races.xml
@@ -17,17 +17,27 @@
 	</value>
 	</li>
 
-	<!-- Armor values for the creature. -->
-	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]</xpath>
+	<!-- Armor / melee values for the creature. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<statBases>
-				<ArmorRating_Blunt>3</ArmorRating_Blunt>
-				<ArmorRating_Sharp>2</ArmorRating_Sharp>
-				<MeleeDodgeChance>0.22</MeleeDodgeChance>
-				<MeleeCritChance>0.05</MeleeCritChance>
-				<MeleeParryChance>0.04</MeleeParryChance>
-			</statBases>
+			<ArmorRating_Blunt>5</ArmorRating_Blunt>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.22</MeleeDodgeChance>
+			<MeleeCritChance>0.05</MeleeCritChance>
+			<MeleeParryChance>0.04</MeleeParryChance>
 		</value>
 	</li>
 	
@@ -61,7 +71,178 @@
 				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
 				</li>
 		</tools>
+		</value>
+	</li>
+	
+	<!-- =========== Drider =========== -->
+	<li Class="PatchOperationAddModExtension">
+	<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]</xpath>
+	<value>
+		<li Class="CombatExtended.RacePropertiesExtensionCE">
+			<bodyShape>Humanoid</bodyShape>
+		</li>
 	</value>
+	</li>
+
+	<!-- Armor / melee values for the creature. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>5</ArmorRating_Blunt>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>3</ArmorRating_Sharp>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.15</MeleeDodgeChance>
+			<MeleeCritChance>0.14</MeleeCritChance>
+			<MeleeParryChance>0.08</MeleeParryChance>
+		</value>
+	</li>
+	
+	<!-- Define attacks. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>28</power>
+					<cooldownTime>2.24</cooldownTime>
+					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.5</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>28</power>
+					<cooldownTime>2.24</cooldownTime>
+					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>2.5</armorPenetrationSharp>
+				</li>  
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>5.58</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
+	</li>
+	
+	<!-- Buff Abdomen HP. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/BodyPartDef[defName="MP_MechanicalAbdomen"]/hitPoints</xpath>
+		<value>
+			<hitPoints>40</hitPoints>
+		</value>
+	</li>
+	
+	<!-- =========== Incubator =========== -->
+	<li Class="PatchOperationAddModExtension">
+	<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]</xpath>
+	<value>
+		<li Class="CombatExtended.RacePropertiesExtensionCE">
+			<bodyShape>Quadruped</bodyShape>
+		</li>
+	</value>
+	</li>
+
+	<!-- Armor / melee values for the creature. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>38</ArmorRating_Blunt>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.24</MeleeCritChance>
+			<MeleeParryChance>0.47</MeleeParryChance>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<MaxHitPoints>550</MaxHitPoints>
+			<CarryWeight>400</CarryWeight>
+			<CarryBulk>80</CarryBulk>
+		</value>
+	</li>
+	
+	<!-- Define attacks. -->
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left palp</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>30</power>
+					<cooldownTime>2.11</cooldownTime>
+					<linkedBodyPartsGroup>LeftPalp</linkedBodyPartsGroup>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>22.5</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right palp</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>30</power>
+					<cooldownTime>2.11</cooldownTime>
+					<linkedBodyPartsGroup>RightPalp</linkedBodyPartsGroup>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>22.5</armorPenetrationSharp>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>37</power>
+					<cooldownTime>4.99</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationBlunt>16</armorPenetrationBlunt>
+				</li>
+			</tools>
+		</value>
 	</li>
 
       </operations>

--- a/Patches/Mechanite Plague/ThingDef_Races.xml
+++ b/Patches/Mechanite Plague/ThingDef_Races.xml
@@ -7,243 +7,243 @@
     <match Class="PatchOperationSequence">
       <operations>
 
-	<!-- =========== Burster =========== -->
-	<li Class="PatchOperationAddModExtension">
-	<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]</xpath>
-	<value>
-		<li Class="CombatExtended.RacePropertiesExtensionCE">
-			<bodyShape>QuadrupedLow</bodyShape>
+		<!-- =========== Burster =========== -->
+		<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>QuadrupedLow</bodyShape>
+			</li>
+		</value>
 		</li>
-	</value>
-	</li>
 
-	<!-- Armor / melee values for the creature. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>5</ArmorRating_Blunt>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>3</ArmorRating_Sharp>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>0.22</MeleeDodgeChance>
-			<MeleeCritChance>0.05</MeleeCritChance>
-			<MeleeParryChance>0.04</MeleeParryChance>
-		</value>
-	</li>
-	
-	<!-- Define attacks. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/tools</xpath>
-		<value>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>fangs</label>
-				<capacities>
-					<li>MP_BiteInfect</li>
-				</capacities>
-				<power>9</power>
-				<cooldownTime>0.83</cooldownTime>
-				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-				<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				<armorPenetrationBlunt>0.768</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.77</armorPenetrationSharp>
-			</li>  
-			<li Class="CombatExtended.ToolCE">
-				<label>head</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>1</power>
-				<cooldownTime>3.57</cooldownTime>
-				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
-				</li>
-		</tools>
-		</value>
-	</li>
-	
-	<!-- =========== Drider =========== -->
-	<li Class="PatchOperationAddModExtension">
-	<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]</xpath>
-	<value>
-		<li Class="CombatExtended.RacePropertiesExtensionCE">
-			<bodyShape>Humanoid</bodyShape>
+		<!-- Armor / melee values for the creature. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>5</ArmorRating_Blunt>
+			</value>
 		</li>
-	</value>
-	</li>
-
-	<!-- Armor / melee values for the creature. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>5</ArmorRating_Blunt>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>3</ArmorRating_Sharp>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>0.15</MeleeDodgeChance>
-			<MeleeCritChance>0.14</MeleeCritChance>
-			<MeleeParryChance>0.08</MeleeParryChance>
-		</value>
-	</li>
-	
-	<!-- Define attacks. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/tools</xpath>
-		<value>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>0.22</MeleeDodgeChance>
+				<MeleeCritChance>0.05</MeleeCritChance>
+				<MeleeParryChance>0.04</MeleeParryChance>
+			</value>
+		</li>
+		
+		<!-- Define attacks. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Burster"]/tools</xpath>
+			<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<label>left blade</label>
+					<label>fangs</label>
 					<capacities>
-						<li>Cut</li>
+						<li>MP_BiteInfect</li>
 					</capacities>
-					<power>28</power>
-					<cooldownTime>2.24</cooldownTime>
-					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+					<power>9</power>
+					<cooldownTime>0.83</cooldownTime>
+					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
-					<armorPenetrationSharp>2.5</armorPenetrationSharp>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>28</power>
-					<cooldownTime>2.24</cooldownTime>
-					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
-					<armorPenetrationSharp>2.5</armorPenetrationSharp>
+					<armorPenetrationBlunt>0.768</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.77</armorPenetrationSharp>
 				</li>  
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>5</power>
-					<cooldownTime>5.58</cooldownTime>
+					<power>1</power>
+					<cooldownTime>3.57</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-				</li>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					</li>
 			</tools>
-		</value>
-	</li>
-	
-	<!-- Buff Abdomen HP. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/BodyPartDef[defName="MP_MechanicalAbdomen"]/hitPoints</xpath>
-		<value>
-			<hitPoints>40</hitPoints>
-		</value>
-	</li>
-	
-	<!-- =========== Incubator =========== -->
-	<li Class="PatchOperationAddModExtension">
-	<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]</xpath>
-	<value>
-		<li Class="CombatExtended.RacePropertiesExtensionCE">
-			<bodyShape>Quadruped</bodyShape>
+			</value>
 		</li>
-	</value>
-	</li>
+		
+		<!-- =========== Drider =========== -->
+		<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+		</li>
 
-	<!-- Armor / melee values for the creature. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Blunt</xpath>
+		<!-- Armor / melee values for the creature. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>5</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>0.15</MeleeDodgeChance>
+				<MeleeCritChance>0.14</MeleeCritChance>
+				<MeleeParryChance>0.08</MeleeParryChance>
+			</value>
+		</li>
+		
+		<!-- Define attacks. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Drider"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>2.24</cooldownTime>
+						<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.5</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>28</power>
+						<cooldownTime>2.24</cooldownTime>
+						<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+						<armorPenetrationSharp>2.5</armorPenetrationSharp>
+					</li>  
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>5.58</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<!-- Buff Abdomen HP. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/BodyPartDef[defName="MP_MechanicalAbdomen"]/hitPoints</xpath>
+			<value>
+				<hitPoints>40</hitPoints>
+			</value>
+		</li>
+		
+		<!-- =========== Incubator =========== -->
+		<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]</xpath>
 		<value>
-			<ArmorRating_Blunt>38</ArmorRating_Blunt>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
 		</value>
-	</li>
-	
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>16</ArmorRating_Sharp>
-		</value>
-	</li>
-	
-	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>0.02</MeleeDodgeChance>
-			<MeleeCritChance>0.24</MeleeCritChance>
-			<MeleeParryChance>0.47</MeleeParryChance>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-			<MaxHitPoints>550</MaxHitPoints>
-			<CarryWeight>400</CarryWeight>
-			<CarryBulk>80</CarryBulk>
-		</value>
-	</li>
-	
-	<!-- Define attacks. -->
-	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left palp</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>30</power>
-					<cooldownTime>2.11</cooldownTime>
-					<linkedBodyPartsGroup>LeftPalp</linkedBodyPartsGroup>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
-					<armorPenetrationSharp>22.5</armorPenetrationSharp>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right palp</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>30</power>
-					<cooldownTime>2.11</cooldownTime>
-					<linkedBodyPartsGroup>RightPalp</linkedBodyPartsGroup>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
-					<armorPenetrationSharp>22.5</armorPenetrationSharp>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>37</power>
-					<cooldownTime>4.99</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>16</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</li>
+		</li>
+
+		<!-- Armor / melee values for the creature. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>38</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>0.02</MeleeDodgeChance>
+				<MeleeCritChance>0.24</MeleeCritChance>
+				<MeleeParryChance>0.47</MeleeParryChance>
+				<AimingAccuracy>1.0</AimingAccuracy>
+				<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+				<MaxHitPoints>550</MaxHitPoints>
+				<CarryWeight>400</CarryWeight>
+				<CarryBulk>80</CarryBulk>
+			</value>
+		</li>
+		
+		<!-- Define attacks. -->
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="MP_Mech_Incubator"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left palp</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>30</power>
+						<cooldownTime>2.11</cooldownTime>
+						<linkedBodyPartsGroup>LeftPalp</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+						<armorPenetrationSharp>22.5</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right palp</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>30</power>
+						<cooldownTime>2.11</cooldownTime>
+						<linkedBodyPartsGroup>RightPalp</linkedBodyPartsGroup>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+						<armorPenetrationSharp>22.5</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>37</power>
+						<cooldownTime>4.99</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>16</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
 
       </operations>
     </match>

--- a/Patches/Mechanite Plague/ThingDefs_Melee.xml
+++ b/Patches/Mechanite Plague/ThingDefs_Melee.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Mechanite Plague</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>			
+
+			<!-- =========== Melee Weaponry =========== -->
+			
+			<!-- Plague Needle -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.45</MeleeCritChance>
+						<MeleeParryChance>0.14</MeleeParryChance>
+						<MeleeDodgeChance>0.05</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.29</cooldownTime>
+							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>MP_CutInfect</li>
+							</capacities>
+							<power>10</power>
+							<cooldownTime>1.21</cooldownTime>
+							<armorPenetrationBlunt>0.396</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.36</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.29</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.46</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Plague Claw -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<MeleeCounterParryBonus>0.46</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.28</MeleeCritChance>
+						<MeleeParryChance>0.46</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>25</power>
+							<cooldownTime>1.32</cooldownTime>
+							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.38</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>MP_CutInfect</li>
+							</capacities>
+							<power>17</power>
+							<cooldownTime>1.2</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.34</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<!-- Plague Fang -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/statBases</xpath>
+				<value>
+					<Bulk>16</Bulk>
+					<MeleeCounterParryBonus>0.83</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.09</MeleeCritChance>
+						<MeleeParryChance>0.82</MeleeParryChance>
+						<MeleeDodgeChance>0.67</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.47</cooldownTime>
+							<chanceFactor>0.15</chanceFactor>
+							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>shaft</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>1.94</cooldownTime>
+							<chanceFactor>0.05</chanceFactor>
+							<armorPenetrationBlunt>1.4</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>MP_StabInfect</li>
+							</capacities>
+							<power>30</power> <!-- owie -->
+							<cooldownTime>1.29</cooldownTime>
+							<chanceFactor>1.00</chanceFactor>
+							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
+							<armorPenetrationSharp>1.58</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+	
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Mechanite Plague/ThingDefs_Ranged.xml
+++ b/Patches/Mechanite Plague/ThingDefs_Ranged.xml
@@ -127,7 +127,7 @@
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				</statBases>
 				<costList>
-					<WoodLog>5</WoodLog>
+					<WoodLog>15</WoodLog>
 				</costList>
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -290,9 +290,9 @@
 					<WorkToMake>52500</WorkToMake>
 				</statBases>
 				<costList>
-					<Plasteel>25</Plasteel>
-					<Steel>60</Steel>
-					<ComponentIndustrial>13</ComponentIndustrial>
+					<Plasteel>45</Plasteel>
+					<Steel>35</Steel>
+					<ComponentSpacer>2</ComponentSpacer>
 				</costList>
 				<Properties>
 					<recoilAmount>2.64</recoilAmount>
@@ -336,9 +336,10 @@
 					<WorkToMake>49000</WorkToMake>
 				</statBases>
 				<costList>
-					<Steel>60</Steel>
-					<Plasteel>60</Plasteel>
-					<ComponentIndustrial>8</ComponentIndustrial>
+					<Steel>80</Steel>
+					<ComponentSpacer>1</ComponentSpacer>
+					<Chemfuel>50</Chemfuel>
+					<MP_MechaniteCanister>20</MP_MechaniteCanister>
 					<FSX>5</FSX>
 				</costList>
 				<Properties>
@@ -538,193 +539,7 @@
 					<description>A portable, automatic turret that fires a barrage of Mechanite Plague inducing shrapnel. While incredibly powerful, it has a short range and is rather ammo hungry. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
 				</value>
 			</li>
-		
-			<!-- =========== Melee Weaponry =========== -->
-			
-			<!-- Plague Needle -->
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/statBases</xpath>
-				<value>
-					<Bulk>1</Bulk>
-					<MeleeCounterParryBonus>0.14</MeleeCounterParryBonus>
-				</value>
-			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeCritChance>0.45</MeleeCritChance>
-						<MeleeParryChance>0.14</MeleeParryChance>
-						<MeleeDodgeChance>0.05</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueNeedle"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>handle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>1</power>
-							<cooldownTime>1.29</cooldownTime>
-							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>blade</label>
-							<capacities>
-								<li>MP_CutInfect</li>
-							</capacities>
-							<power>10</power>
-							<cooldownTime>1.21</cooldownTime>
-							<armorPenetrationBlunt>0.396</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.36</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>point</label>
-							<capacities>
-								<li>MP_StabInfect</li>
-							</capacities>
-							<power>11</power>
-							<cooldownTime>1.29</cooldownTime>
-							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.275</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.46</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-			
-			<!-- Plague Claw -->
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/statBases</xpath>
-				<value>
-					<Bulk>3</Bulk>
-					<MeleeCounterParryBonus>0.46</MeleeCounterParryBonus>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeCritChance>0.28</MeleeCritChance>
-						<MeleeParryChance>0.46</MeleeParryChance>
-						<MeleeDodgeChance>0.18</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueClaw"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>handle</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>2</power>
-							<cooldownTime>1.32</cooldownTime>
-							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>point</label>
-							<capacities>
-								<li>MP_StabInfect</li>
-							</capacities>
-							<power>25</power>
-							<cooldownTime>1.32</cooldownTime>
-							<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.38</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>edge</label>
-							<capacities>
-								<li>MP_CutInfect</li>
-							</capacities>
-							<power>17</power>
-							<cooldownTime>1.2</cooldownTime>
-							<chanceFactor>1.33</chanceFactor>
-							<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
-							<armorPenetrationSharp>0.34</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-			
-			<!-- Plague Fang -->
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/statBases</xpath>
-				<value>
-					<Bulk>16</Bulk>
-					<MeleeCounterParryBonus>0.83</MeleeCounterParryBonus>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]</xpath>
-				<value>
-					<equippedStatOffsets>
-						<MeleeCritChance>0.09</MeleeCritChance>
-						<MeleeParryChance>0.82</MeleeParryChance>
-						<MeleeDodgeChance>0.67</MeleeDodgeChance>
-					</equippedStatOffsets>
-				</value>
-			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="MP_MeleeWeapon_PlagueFang"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>shaft</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>9</power>
-							<cooldownTime>1.47</cooldownTime>
-							<chanceFactor>0.15</chanceFactor>
-							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>shaft</label>
-							<capacities>
-								<li>Poke</li>
-							</capacities>
-							<power>5</power>
-							<cooldownTime>1.94</cooldownTime>
-							<chanceFactor>0.05</chanceFactor>
-							<armorPenetrationBlunt>1.4</armorPenetrationBlunt>
-							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>MP_StabInfect</li>
-							</capacities>
-							<power>30</power> <!-- owie -->
-							<cooldownTime>1.29</cooldownTime>
-							<chanceFactor>1.00</chanceFactor>
-							<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
-							<armorPenetrationSharp>1.58</armorPenetrationSharp>
-							<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-						</li>
-					</tools>
-				</value>
-			</li>
-	
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Mechanite Plague/ThingDefs_Weapons.xml
+++ b/Patches/Mechanite Plague/ThingDefs_Weapons.xml
@@ -58,7 +58,7 @@
 
 			<li Class="PatchOperationReplace">
 				<xpath>
-					Defs/ThingDef[defName="MP_Gun_MechaniteStinger" or defName="MP_Gun_MechaniteTempest"]/tools
+					Defs/ThingDef[defName="MP_Gun_MechaniteStinger" or defName="MP_Gun_MechaniteTempest" or defName="MP_Gun_MechaniteSlugger"]/tools
 				</xpath>
 				<value>
 					<tools>
@@ -94,6 +94,24 @@
 						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 					</li>
 					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="MP_Gun_ChaosRocket" or defName="MP_Gun_IncubatorSpawner"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>barrel</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>2.44</cooldownTime>
+						<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+				  </tools>
 				</value>
 			</li>
 			
@@ -257,6 +275,129 @@
 					<li>CE_AI_AR</li>
 				</weaponTags>
 				<researchPrerequisite>MP_MechaniteWeaponsIndustrial</researchPrerequisite>
+			</li>
+			
+			<!-- Mechanite Slugger -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_MechaniteSlugger</defName>
+				<statBases>
+					<Mass>9.30</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>1.38</SwayFactor>
+					<Bulk>4.5</Bulk>
+					<WorkToMake>52500</WorkToMake>
+				</statBases>
+				<costList>
+					<Plasteel>25</Plasteel>
+					<Steel>60</Steel>
+					<ComponentIndustrial>13</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>2.64</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_MechShrapnelBuckshot</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>16</range>
+					<burstShotCount>3</burstShotCount>
+					<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+					<soundCast>Shot_Shotgun</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>MP_AmmoSet_MechShrapnelBuckshot</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_BROOM</li>
+				</weaponTags>
+				<researchPrerequisite>MP_MechaniteWeaponsSpacer</researchPrerequisite>
+			</li>
+			
+			<!-- Chaos Launcher -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_ChaosRocket</defName>
+				<statBases>
+					<Mass>18.00</Mass>
+					<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>3.04</SwayFactor>
+					<Bulk>13.0</Bulk>
+					<WorkToMake>49000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>60</Steel>
+					<Plasteel>60</Plasteel>
+					<ComponentIndustrial>8</ComponentIndustrial>
+					<FSX>5</FSX>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_ChaosLauncher</defaultProjectile>
+					<warmupTime>2.1</warmupTime>
+					<range>48</range>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>InfernoCannon_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>14</muzzleFlashScale>
+				</Properties>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_AI_AOE</li>
+				</weaponTags>
+				<researchPrerequisite>MP_MechaniteWeaponsSpacer</researchPrerequisite>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+			
+			<!-- Incubator Cannon -->
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>MP_Gun_IncubatorSpawner</defName>
+				<statBases>
+					<Mass>100.00</Mass>
+					<RangedWeapon_Cooldown>25.00</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>0.28</SwayFactor>
+					<Bulk>20.00</Bulk>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>MP_Bullet_EggPod</defaultProjectile>
+					<warmupTime>10.00</warmupTime>
+					<range>86</range>
+					<burstShotCount>2</burstShotCount>
+					<ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+					<soundCast>InfernoCannon_Fire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+					<muzzleFlashScale>14</muzzleFlashScale>
+				</Properties>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSingleShot>true</noSingleShot>
+				</FireModes>
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 			
 			<!-- =========== Turrets =========== -->


### PR DESCRIPTION
From the author of Mechanite Plague, who lacks a GH account.

- Added support for two new mechanoids, the Drider and the Incubator.
- Added support for three new weapons, the Mechanite Slugger, the Chaos Launcher, and the Incubator Cannon.
- Added ammo / projectiles for each new weapon. (Only the Mechanite Slugger's is craftable.)


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
