### PR TITLE
Fix SOS2 Hologram Sword

### DIFF
--- a/Patches/Save Our Ship 2/HologramRace_SOS2.xml
+++ b/Patches/Save Our Ship 2/HologramRace_SOS2.xml
@@ -114,6 +114,75 @@
 			</weaponTags>
 		</li>
 
+
+		<!-- === Hologram Sword === -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="HologramSword"]/tools</xpath>
+			<value>
+			  <tools>
+
+				<li Class="CombatExtended.ToolCE">
+				  <label>point</label>
+				  <capacities>
+					<li>Stab</li>
+				  </capacities>
+				  <power>13</power>
+				  <cooldownTime>1.1</cooldownTime>
+				  <chanceFactor>1.5</chanceFactor>
+				  <armorPenetrationSharp>0.5</armorPenetrationSharp>
+				  <armorPenetrationBlunt>8</armorPenetrationBlunt>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>6</amount>
+							<chance>0.4</chance>
+						</li>
+					</extraMeleeDamages>		
+				</li>
+
+				<li Class="CombatExtended.ToolCE">
+				  <label>edge</label>
+				  <capacities>
+					<li>Cut</li>
+				  </capacities>
+				  <power>24</power>
+				  <cooldownTime>1.1</cooldownTime>
+				  <chanceFactor>1.5</chanceFactor>
+				  <armorPenetrationSharp>1</armorPenetrationSharp>
+				  <armorPenetrationBlunt>6</armorPenetrationBlunt>
+					<extraMeleeDamages>
+						<li>
+							<def>Flame</def>
+							<amount>10</amount>
+							<chance>0.6</chance>
+						</li>
+					</extraMeleeDamages>
+				</li>
+			  </tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="HologramSword"]/statBases</xpath>
+			<value>
+				<MeleeCounterParryBonus>0.8</MeleeCounterParryBonus>
+				<Bulk>0.01</Bulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="HologramSword"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>1.00</MeleeCritChance>
+					<MeleeParryChance>0.60</MeleeParryChance>
+					<MeleeDodgeChance>0.40</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+			
+
 		<!-- === Archo Hologram Blast === -->
 		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>HologramLaserArchotech</defName>


### PR DESCRIPTION
## Additions

None

## Changes

Enables SOS2 holograms to fight in melee mode without breaking the game in interesting ways.

## References

None

## Reasoning

The weapon's properties are set such that the CE Hologram Sword is to the CE Plasmasword what the SOS2 Hologram Sword is to the vanilla Plasmasword.

## Alternatives

Never set SOS2 holograms to melee mode, never hunt animals with said holograms, and mod out social fights.

## Testing

Check tests you have performed:
- [✓] Compiles without warnings
- [✓] Game runs without errors
- [✓] With and without patched mod loaded
- [✓] Playtested a colony (30 in-game days with the hologram pawn in play)
