### PR TITLE
State Better Loading as CE-Incompatible

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -21,6 +21,7 @@
 		<li>hobtook.mortaraccuracy</li>
 		<li>XeoNovaDan.ProperShotguns</li>
 		<li>swedishmask.ProperShotgunsPatch</li>
+		<li>me.samboycoding.betterloading</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- Due to the negligence of the BL author and the myriad of issues that the mod is causing for CE, it's best that the mod is added to the "incompatible mods list" in an attempt to save the players' games and avoid more future troubles.

## Alternatives

- No Alternatives. RIP and TEAR, until it is done.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
