### PR TITLE
Nullcheck in GetDeflectDamageInfo

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -424,7 +424,7 @@ namespace CombatExtended
             {
                 localPenAmount = projectile.armorPenetrationBlunt * penMulti;
             }
-            else if (dinfo.Instigator.def.thingClass == typeof(Building_TrapDamager))
+            else if (dinfo.Instigator?.def.thingClass == typeof(Building_TrapDamager))
             {
                 //Temporarily deriving spike trap blunt AP based on their vanilla stats, just so they're not entirely broken
                 //TODO proper integration


### PR DESCRIPTION
## Additions
No new additions, just a null check

## Changes
A null check in GetDeflectDamageInfo to make this code executes in case if the game deals damage without instigator.

## References

## Reasoning
Mods were broken due to a Null Reference Exception so I decided to PR a fix it directly instead of patching CE manually

## Alternatives
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
