### PR TITLE
Fix #1609: relabel to "weapon handling" in description.

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -176,7 +176,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/description</xpath>
 		<value>
-			<description>How well a shooter can hold a gun steady when aiming and compensate for recoil.\n\nThe total sway is calculated as:\n(4.5 - shooting accuracy) * weapon sway factor\n\nThe recoil per shot is determined by multiplying this value against the weapon's inherent recoil amount and increases after every shot in a burst.</description>
+			<description>How well a shooter can hold a gun steady when aiming and compensate for recoil.\n\nThe total sway is calculated as:\n(4.5 - weapon handling) * weapon sway factor\n\nThe recoil per shot is determined by multiplying this value against the weapon's inherent recoil amount and increases after every shot in a burst.</description>
 		</value>
 	</Operation>
 


### PR DESCRIPTION

## References

- Closes #1609 

## Reasoning

We rename the ShootingAccuracy stat to WeaponHandling, but in its description it still uses "shooting accuracy" in the description of the formula.  This changes that to "weapon handling". 