### PR TITLE
Add translation keys for bipod gizmos.

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -24,6 +24,12 @@
   <CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
   <CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
   <CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
+  
+  <!-- Bipod system -->
+  <CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
+  <CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
+  <CE_Deploy_Bipod>Deploy bipod</CE_Deploy_Bipod>
+  <CE_Close_Bipod>Close bipod</CE_Close_Bipod>
 
   <!-- Aiming system -->
   <CE_MarkedForArtillery>Marked for artillery, expires in</CE_MarkedForArtillery>

--- a/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/BipodComp.cs
@@ -77,7 +77,7 @@ namespace CombatExtended
 								yield return new Command_Action
 								{
 									action = delegate {},
-									defaultLabel = "Bipod IS set up",
+									defaultLabel = "CE_Bipod_Set_Up".Translate(),
 									icon = ContentFinder<Texture2D>.Get("UI/Buttons/open_bipod")
 								};
 							}
@@ -86,7 +86,7 @@ namespace CombatExtended
 								yield return new Command_Action
 								{
 									action = delegate { },
-									defaultLabel = "Bipod IS NOT set up",
+									defaultLabel = "CE_Bipod_Not_Set_Up".Translate(),
 									icon = ContentFinder<Texture2D>.Get("UI/Buttons/closed_bipod")
 								};
 							}
@@ -105,7 +105,7 @@ namespace CombatExtended
 								yield return new Command_Action
 								{
 									action = DeployUpBipod,
-									defaultLabel = "Deploy bipod",
+									defaultLabel = "CE_Deploy_Bipod".Translate(),
 									icon = ContentFinder<Texture2D>.Get("UI/Buttons/open_bipod")
 								};
 							}
@@ -114,7 +114,7 @@ namespace CombatExtended
 								yield return new Command_Action
 								{
 									action = CloseBipod,
-									defaultLabel = "Close bipod",
+									defaultLabel = "CE_Close_Bipod".Translate(),
 									icon = ContentFinder<Texture2D>.Get("UI/Buttons/closed_bipod")
 								};
 


### PR DESCRIPTION


## References

Links to the associated issues or other related pull requests, e.g.
- Closes #1549 

## Reasoning

Embedding English strings for gizmo descriptions prevents translating CE to other languages.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
