### PR TITLE
Add blacklist to Autopatcher

### DIFF
--- a/Defs/ApparelModBlacklist.xml
+++ b/Defs/ApparelModBlacklist.xml
@@ -7,5 +7,7 @@
 	<li>Ludeon.RimWorld</li>
 	<li>Ludeon.RimWorld.Royalty</li>
       </modIDs>
+      <defNames>
+      </defNames>
     </CombatExtended.ApparelModBlacklist>
 </Defs>

--- a/Defs/ApparelModBlacklist.xml
+++ b/Defs/ApparelModBlacklist.xml
@@ -6,6 +6,7 @@
 	<li>CETeam.CombatExtended</li>
 	<li>Ludeon.RimWorld</li>
 	<li>Ludeon.RimWorld.Royalty</li>
+	<li>Ludeon.Rimworld.Ideology</li>
 	<li>dismarzero.vgp.vgpgardendyes</li>
 	<li>unlimitedhugs.remotetech</li>
 	<li>kentington.saveourship2</li>

--- a/Defs/ApparelModBlacklist.xml
+++ b/Defs/ApparelModBlacklist.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <!-- Example def -->
+    <CombatExtended.ApparelModBlacklist>
+      <modIDs>
+	<li>CETeam.CombatExtended</li>
+	<li>Ludeon.RimWorld</li>
+	<li>Ludeon.RimWorld.Royalty</li>
+      </modIDs>
+    </CombatExtended.ApparelModBlacklist>
+</Defs>

--- a/Defs/ApparelModBlacklist.xml
+++ b/Defs/ApparelModBlacklist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
-    <!-- Example def -->
     <CombatExtended.ApparelModBlacklist>
+      <defName>CEIntegratedAutopatcherBlacklist</defName>
       <modIDs>
 	<li>CETeam.CombatExtended</li>
 	<li>Ludeon.RimWorld</li>

--- a/Defs/ApparelModBlacklist.xml
+++ b/Defs/ApparelModBlacklist.xml
@@ -6,6 +6,10 @@
 	<li>CETeam.CombatExtended</li>
 	<li>Ludeon.RimWorld</li>
 	<li>Ludeon.RimWorld.Royalty</li>
+	<li>dismarzero.vgp.vgpgardendyes</li>
+	<li>unlimitedhugs.remotetech</li>
+	<li>kentington.saveourship2</li>
+	<li>dninemfive.advancedshieldbelts</li>
       </modIDs>
       <defNames>
       </defNames>

--- a/Source/CombatExtended/CombatExtended/Defs/ApparelModBlacklist.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ApparelModBlacklist.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace CombatExtended
+{
+    public class ApparelModBlacklist : Def
+    {
+	public List<string> modIDs;
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Defs/ApparelModBlacklist.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/ApparelModBlacklist.cs
@@ -10,5 +10,6 @@ namespace CombatExtended
     public class ApparelModBlacklist : Def
     {
 	public List<string> modIDs;
+	public List<string> defNames;
     }
 }

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -87,6 +87,8 @@ namespace CombatExtended
         private bool debugShowSuppressionBuildup = false;
         private bool debugDrawInterceptChecks = false;
 
+	private bool debugAutopatcherLogger = false;
+
         public bool DebuggingMode => debuggingMode;
         public bool DebugVerbose => debugVerbose;
         public bool DebugDrawInterceptChecks => debugDrawInterceptChecks && debuggingMode;
@@ -97,6 +99,9 @@ namespace CombatExtended
         public bool DebugShowTreeCollisionChance => debugShowTreeCollisionChance && debuggingMode;
         public bool DebugShowSuppressionBuildup => debugShowSuppressionBuildup && debuggingMode;
         public bool DebugGenClosetPawn => debugGenClosetPawn && debuggingMode;
+
+	public bool DebugAutopatcherLogger => debugAutopatcherLogger;
+	
         #endregion
 
         private bool lastAmmoSystemStatus;
@@ -132,6 +137,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref debugShowTreeCollisionChance, "debugShowTreeCollisionChance", false);
             Scribe_Values.Look(ref debugShowSuppressionBuildup, "debugShowSuppressionBuildup", false);
 #endif
+	    Scribe_Values.Look(ref debugAutopatcherLogger, "debugAutopatcherLogger", false);
 
             // Ammo settings
             Scribe_Values.Look(ref enableAmmoSystem, "enableAmmoSystem", true);
@@ -196,6 +202,9 @@ namespace CombatExtended
                 list.Label("CE_Settings_ShowWebbing_Title".Translate(), tooltip: "CE_Settings_ShowWebbing_Desc".Translate());
                 list.Gap();
             }
+
+	    list.GapLine();
+            list.CheckboxLabeled("Enable autopatcher verbose logging", ref debugAutopatcherLogger, "This will enable verbose logging of the autopatcher.");	    
 
 #if DEBUG
             // Do Debug settings

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -13,7 +13,21 @@ namespace CombatExtended
     {
         static ApparelAutoPatcher()
         {
-            var Apparels = new List<ThingDef>(); // DefDatabase<ThingDef>.AllDefs.Where(x => x.IsApparel && !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) && !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
+	    var blacklist = new HashSet<string>
+		(from a in DefDatabase<ApparelModBlacklist>.AllDefs.First().modIDs
+		 select a.ToLower());
+	    
+
+	    HashSet<ModContentPack> mods = new HashSet<ModContentPack>
+		(LoadedModManager.RunningMods.Where
+		 (x => !blacklist.Contains(x.PackageId)));
+	    
+	    
+            var Apparels = DefDatabase<ThingDef>.AllDefs.Where
+		(x => x.IsApparel &&
+		 mods.Contains(x.modContentPack) &&
+		 !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) &&
+		 !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 
             foreach (var preset in DefDatabase<ApparelPatcherPresetDef>.AllDefs)
             {

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -38,9 +38,12 @@ namespace CombatExtended
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) &&
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 
-	    foreach (var apparel in Apparels)
+	    if (Settings.DebugAutopatcherLogger)
 	    {
-		Log.Message($"Seeking patches for {apparel} from {apparel.modContentPack.PackageId}");
+		foreach (var apparel in Apparels)
+		{
+		    Log.Message($"Seeking patches for {apparel} from {apparel.modContentPack.PackageId}");
+		}
 	    }
 
             foreach (var preset in DefDatabase<ApparelPatcherPresetDef>.AllDefs)
@@ -50,7 +53,10 @@ namespace CombatExtended
                 foreach (var apparel in toPatch)
                 {
 		    patched.Add(apparel);
-                    Log.Message($"Autopatching {apparel.label} from {apparel.modContentPack.PackageId}");
+		    if (Settings.DebugAutopatcherLogger)
+		    {
+			Log.Message($"Autopatching {apparel.label} from {apparel.modContentPack.PackageId}");
+		    }
 
                     if (apparel.statBases == null)
                     {

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -13,7 +13,7 @@ namespace CombatExtended
     {
         static ApparelAutoPatcher()
         {
-            var Apparels = DefDatabase<ThingDef>.AllDefs.Where(x => x.IsApparel && !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) && !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
+            var Apparels = new List<ThingDef>(); // DefDatabase<ThingDef>.AllDefs.Where(x => x.IsApparel && !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) && !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 
             foreach (var preset in DefDatabase<ApparelPatcherPresetDef>.AllDefs)
             {

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -17,8 +17,13 @@ namespace CombatExtended
 	    HashSet<ThingDef> patched = new HashSet<ThingDef>();
 	    var blacklist = new HashSet<string>
 		(from a in DefDatabase<ApparelModBlacklist>.AllDefs
-		 from b in a.modIds
+		 from b in a.modIDs
 		 select b.ToLower());
+
+	    var blacklistDefNames = new HashSet<string>
+		(from a in DefDatabase<ApparelModBlacklist>.AllDefs
+		 from b in a.defNames
+		 select b);
 	    
 
 	    HashSet<ModContentPack> mods = new HashSet<ModContentPack>
@@ -29,6 +34,7 @@ namespace CombatExtended
             var Apparels = DefDatabase<ThingDef>.AllDefs.Where
 		(x => x.IsApparel &&
 		 mods.Contains(x.modContentPack) &&
+		 !blacklistDefNames.Contains(x.defName) &&
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) &&
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -38,7 +38,7 @@ namespace CombatExtended
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) &&
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 
-	    if (Settings.DebugAutopatcherLogger)
+	    if (Controller.settings.DebugAutopatcherLogger)
 	    {
 		foreach (var apparel in Apparels)
 		{
@@ -53,7 +53,7 @@ namespace CombatExtended
                 foreach (var apparel in toPatch)
                 {
 		    patched.Add(apparel);
-		    if (Settings.DebugAutopatcherLogger)
+		    if (Controller.settings.DebugAutopatcherLogger)
 		    {
 			Log.Message($"Autopatching {apparel.label} from {apparel.modContentPack.PackageId}");
 		    }

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -16,8 +16,9 @@ namespace CombatExtended
 
 	    HashSet<ThingDef> patched = new HashSet<ThingDef>();
 	    var blacklist = new HashSet<string>
-		(from a in DefDatabase<ApparelModBlacklist>.AllDefs.First().modIDs
-		 select a.ToLower());
+		(from a in DefDatabase<ApparelModBlacklist>.AllDefs
+		 from b in a.modIds
+		 select b.ToLower());
 	    
 
 	    HashSet<ModContentPack> mods = new HashSet<ModContentPack>

--- a/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/ApparelAutoPatcher.cs
@@ -13,6 +13,8 @@ namespace CombatExtended
     {
         static ApparelAutoPatcher()
         {
+
+	    HashSet<ThingDef> patched = new HashSet<ThingDef>();
 	    var blacklist = new HashSet<string>
 		(from a in DefDatabase<ApparelModBlacklist>.AllDefs.First().modIDs
 		 select a.ToLower());
@@ -29,13 +31,19 @@ namespace CombatExtended
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.Bulk) &&
 		 !x.statBases.Any(x => x.stat == CE_StatDefOf.WornBulk));
 
+	    foreach (var apparel in Apparels)
+	    {
+		Log.Message($"Seeking patches for {apparel} from {apparel.modContentPack.PackageId}");
+	    }
+
             foreach (var preset in DefDatabase<ApparelPatcherPresetDef>.AllDefs)
             {
-                var toPatch = Apparels.Where(x => x.Matches(preset));
+                var toPatch = Apparels.Where(x => x.Matches(preset) && !patched.Contains(x));
 
                 foreach (var apparel in toPatch)
                 {
-                    Log.Message("Autopatching " + apparel.label);
+		    patched.Add(apparel);
+                    Log.Message($"Autopatching {apparel.label} from {apparel.modContentPack.PackageId}");
 
                     if (apparel.statBases == null)
                     {


### PR DESCRIPTION

## Reasoning

The autopatcher hits nearly *everything*, limited only by what templates match.
This means the patched values of anything that falls in the range of a template get replaced again.  
There are two problems with the first approach.  

First is that things like hats do not have a bulk added, they get a default assigned, but since it isn't in their statBases, they get targeted, despite already being patched.

Second is anything inheriting values from patched defs get targeted.  This is what happens with the corset, the parent def is patched to 2.0 for the value, which matches the armor vest range and gets changed to 16.

## Alternatives

Push back the release till a solution is found.

Add a `<patched>` tag to things manually patched which should be skipped. -- significant work, including in downstream mods which may not update regularly.

Use some sort of whitelist that can be updated quickly and easily.

Use the mod settings system to let the player select what defs to autopatch.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
