### PR TITLE
Fixing them dragons descending

### DIFF
--- a/Patches/Dragon's Descent/BodyDefs/Bodies_Animal_Dragon.xml
+++ b/Patches/Dragon's Descent/BodyDefs/Bodies_Animal_Dragon.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/Patches/Dragon's Descent/DamageDefs/Damage_Dragons.xml
+++ b/Patches/Dragon's Descent/DamageDefs/Damage_Dragons.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
+++ b/Patches/Dragon's Descent/Drugs/Draconic_Ambrosia.xml
@@ -3,7 +3,7 @@
 	<!-- Hooray, more updating -->
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
+++ b/Patches/Dragon's Descent/Drugs/Dragon_Blood_Potion.xml
@@ -3,7 +3,7 @@
 	<!-- Hooray, more updating -->
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Dragon's Descent/HediffDefs/Hediffs.xml
+++ b/Patches/Dragon's Descent/HediffDefs/Hediffs.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<!-- === Filthy_Wound === -->

--- a/Patches/Dragon's Descent/Projectiles/Projectile_Animal.xml
+++ b/Patches/Dragon's Descent/Projectiles/Projectile_Animal.xml
@@ -2,19 +2,20 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>
 			<!-- Fire Breath -->
+			<!--
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Projectile_DragonBreath"]/thingClass</xpath>
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonSpitBlunt"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Projectile_DragonBreath"]/projectile</xpath>
+				<xpath>/Defs/ThingDef[defName="Projectile_DragonSpitBlunt"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<speed>26</speed>
@@ -22,11 +23,15 @@
 						<damageDef>Flame</damageDef>
 						<damageAmountBase>5</damageAmountBase>
 						<soundExplode>DragonBreathFire</soundExplode>
-						<explosionRadius>1.5</explosionRadius>
+					    <preExplosionSpawnThingDef>Filth_Dirt</preExplosionSpawnThingDef>
+					    <preExplosionSpawnChance>0.3</preExplosionSpawnChance>
+						<explosionRadius>2</explosionRadius>
 						<ai_IsIncendiary>true</ai_IsIncendiary>
+						<shadowSize>1</shadowSize>
 					</projectile>
 				</value>
-			</li>
+			</li> 
+			-->
 			<!-- Fire Spit -->
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Projectile_DragonSpit"]/thingClass</xpath>

--- a/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
+++ b/Patches/Dragon's Descent/Scenarios/Scenarios_DragonsDescent.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/Patches/Dragon's Descent/ThingDefs_Items/Items_Exotic.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Items/Items_Exotic.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/Patches/Dragon's Descent/ThingDefs_Items/Items_Resource_Leather.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Items/Items_Resource_Leather.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">
@@ -43,9 +43,9 @@
 					</value>
 				</li>
 
-				<!-- === Rich_Dragon_Leather === -->
+				<!-- === Rare_Dragon_Leather === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>/Defs/ThingDef[defName="Rare_Dragon_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
 
 					<value>
 						<StuffPower_Armor_Sharp>1.079</StuffPower_Armor_Sharp>
@@ -53,7 +53,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>/Defs/ThingDef[defName="Rare_Dragon_Leather"]/statBases/StuffPower_Armor_Blunt</xpath>
 
 					<value>
 						<StuffPower_Armor_Blunt>0.279</StuffPower_Armor_Blunt>
@@ -61,7 +61,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
+					<xpath>/Defs/ThingDef[defName="Rare_Dragon_Leather"]/statBases/StuffPower_Armor_Heat</xpath>
 
 					<value>
 						<StuffPower_Armor_Heat>0.2</StuffPower_Armor_Heat>
@@ -69,7 +69,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Rich_Dragon_Leather"]/stuffProps</xpath>
+					<xpath>/Defs/ThingDef[defName="Rare_Dragon_Leather"]/stuffProps</xpath>
 
 					<value>
 						<categories>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Common_Dragon.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Dragon_Base.xml
@@ -3,7 +3,7 @@
 	<!-- I took 3 months off of RimWorld and I've forgotten how to do patches. Great. -->
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
+++ b/Patches/Dragon's Descent/ThingDefs_Races/Races_Animal_Rare_Dragon.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Dragon's Descent</li>
+			<li>Dragons Descent</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
OHH why did you change mod name... Also, this one is just "fixing pre-existing patch" rather than making one from scratch. However, this one will still make your dragons not fall from very angry sheep kicking sand in the eyes and will instead properly bite their heads clean off.

## Additions

nothing

## Changes

Changed mod name in all patch targets (OHH why), leather name and i think that's it.

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards #452 i guess?

## Reasoning

It dun work
I wanted to make it work
I made it work

## Alternatives

I've just fixed what was broken without implementing anything new.

## Testing

Check tests you have performed:
- [yes] Compiles without warnings
- [yes] Game runs without errors
- [maybe] (For compatibility patches) ...with and without patched mod loaded - "Draftable animals" or any way to make dragons draftable removes all their UI buttons. It's an issue with DD itself and not CE.
- [yes] Playtested a colony (specify how long) - a colony with several colorful dragons, including true one. They spit and bite all fine and dandy. For several in-game years, till death by "ran out of ram" fell my colony.
