### PR TITLE
Replace BiteBlunt with Bite in patches

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Devil_Sheep.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Devil_Sheep.xml
@@ -54,7 +54,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>4</power>
 							<cooldownTime>1.85</cooldownTime>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
@@ -39,7 +39,7 @@
 					<tools>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>28</power>
 							<cooldownTime>2.4</cooldownTime>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
@@ -42,7 +42,7 @@
 						<tools>
 							<li Class="CombatExtended.ToolCE">
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>28</power>
 								<cooldownTime>2.4</cooldownTime>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Radyak.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Radyak.xml
@@ -54,7 +54,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>7</power>
 							<cooldownTime>2</cooldownTime>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShockGoat.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShockGoat.xml
@@ -54,7 +54,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>5</power>
 							<cooldownTime>1.85</cooldownTime>

--- a/Patches/Anima Animals/ThingDefs_AnimaCreatures.xml
+++ b/Patches/Anima Animals/ThingDefs_AnimaCreatures.xml
@@ -408,7 +408,7 @@
 			<tools>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>4</power>
 					<cooldownTime>1.66</cooldownTime>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Giraffe.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Giraffe.xml
@@ -62,7 +62,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>6</power>
 							<cooldownTime>1.66</cooldownTime>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Horse.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Horse.xml
@@ -78,7 +78,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>5</power>
 							<cooldownTime>1.97</cooldownTime>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Llama.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Llama.xml
@@ -62,7 +62,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>1</power>
 							<cooldownTime>0.84</cooldownTime>

--- a/Patches/Bastyon/CE_Patch_BastRace_All.xml
+++ b/Patches/Bastyon/CE_Patch_BastRace_All.xml
@@ -461,7 +461,7 @@
 							<armorPenetrationBlunt>21</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/Bastyon/CE_Patch_BastRace_All2.xml
+++ b/Patches/Bastyon/CE_Patch_BastRace_All2.xml
@@ -342,7 +342,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>

--- a/Patches/Bastyon/CE_Patch_BastRace_All3.xml
+++ b/Patches/Bastyon/CE_Patch_BastRace_All3.xml
@@ -55,7 +55,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -106,7 +106,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>1</power>
 					<cooldownTime>0.84</cooldownTime>
@@ -380,7 +380,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>1</power>
 					<cooldownTime>0.84</cooldownTime>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -293,7 +293,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>1</power>
 					<cooldownTime>1.26</cooldownTime>
@@ -705,7 +705,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>2</power>
 					<cooldownTime>1.5</cooldownTime>
@@ -808,7 +808,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>5</power>
 					<cooldownTime>1.97</cooldownTime>
@@ -862,7 +862,7 @@
 			<tools>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>
@@ -1072,7 +1072,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.6</cooldownTime>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -68,7 +68,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>
@@ -300,7 +300,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>
@@ -416,7 +416,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>

--- a/Patches/Devilstrand Animals/Devilstrand_Animals.xml
+++ b/Patches/Devilstrand Animals/Devilstrand_Animals.xml
@@ -151,7 +151,7 @@
 			<tools>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>3</power>
 					<cooldownTime>1.66</cooldownTime>

--- a/Patches/Forsakens - Fauna/Races_ShadowChargerCE.xml
+++ b/Patches/Forsakens - Fauna/Races_ShadowChargerCE.xml
@@ -63,7 +63,7 @@
 							</li>
 							<li Class="CombatExtended.ToolCE">
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>7</power>
 								<cooldownTime>2</cooldownTime>

--- a/Patches/Forsakens - Fauna/Races_ThunderoxCE.xml
+++ b/Patches/Forsakens - Fauna/Races_ThunderoxCE.xml
@@ -79,7 +79,7 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>Chewy</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>10</power>
 								<cooldownTime>2</cooldownTime>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/GeneticRim_Mega_CE_Races_Animal.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/GeneticRim_Mega_CE_Races_Animal.xml
@@ -477,7 +477,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>15</power>
 							<cooldownTime>3.0</cooldownTime>
@@ -646,7 +646,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>3</power>
 							<cooldownTime>3.0</cooldownTime>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Alpha_HybridCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_Alpha_HybridCE.xml
@@ -448,7 +448,7 @@
 							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>4</power>
 							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ParagonCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ParagonCE.xml
@@ -478,7 +478,7 @@
 							<armorPenetrationBlunt>20</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -610,7 +610,7 @@
 							<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>3</power>
 							<cooldownTime>1</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ThrumbohybridsCE.xml
+++ b/Patches/Genetic Rim/GeneticRim_Races_CE/Races_Animal_ThrumbohybridsCE.xml
@@ -80,7 +80,7 @@
 							<armorPenetrationBlunt>45</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>24</power>
 							<cooldownTime>2.6</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/HLX ReGrowth - Extinct Animals Pack/Extinct_Mammals.xml
+++ b/Patches/HLX ReGrowth - Extinct Animals Pack/Extinct_Mammals.xml
@@ -66,7 +66,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>4</power>
 							<cooldownTime>2</cooldownTime>
@@ -132,7 +132,7 @@
 							<armorPenetrationBlunt>21</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/HLX ReGrowth - Mutated Animals Pack/Mutant_Deer.xml
+++ b/Patches/HLX ReGrowth - Mutated Animals Pack/Mutant_Deer.xml
@@ -76,7 +76,7 @@
 					  </li>
 						<li Class="CombatExtended.ToolCE">
 						<capacities>
-						  <li>BiteBlunt</li>
+						  <li>Bite</li>
 						</capacities>
 						<power>3</power>
 						<cooldownTime>2</cooldownTime>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -1431,7 +1431,7 @@
 							</li>
 							<li Class="CombatExtended.ToolCE">
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>5</power>
 								<cooldownTime>1.97</cooldownTime>
@@ -1822,7 +1822,7 @@
 							</li>
 							<li Class="CombatExtended.ToolCE">
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>5</power>
 								<cooldownTime>1.97</cooldownTime>

--- a/Patches/Megafauna/Races_Animal_Megafauna.xml
+++ b/Patches/Megafauna/Races_Animal_Megafauna.xml
@@ -513,7 +513,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>88</power>
 								<cooldownTime>2.5</cooldownTime>
@@ -829,7 +829,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>13</power>
 								<cooldownTime>2.6</cooldownTime>
@@ -941,7 +941,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>4</power>
 								<cooldownTime>1.9</cooldownTime>
@@ -1338,7 +1338,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>10</power>
 								<cooldownTime>2.45</cooldownTime>
@@ -1542,7 +1542,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>11</power>
 								<cooldownTime>2.55</cooldownTime>
@@ -1951,7 +1951,7 @@ https://docs.google.com/spreadsheets/d/1pnhJUo3bkEPxhpmPrHj4spPdvjifLhOsnfFrZmOo
 							<li Class="CombatExtended.ToolCE">
 								<label>teeth</label>
 								<capacities>
-									<li>BiteBlunt</li>
+									<li>Bite</li>
 								</capacities>
 								<power>38</power>
 								<cooldownTime>1.95</cooldownTime>

--- a/Patches/MorrowRim - Bloodmoon/Bloodmoon_Deer.xml
+++ b/Patches/MorrowRim - Bloodmoon/Bloodmoon_Deer.xml
@@ -65,7 +65,7 @@
 					  </li>
 						<li Class="CombatExtended.ToolCE">
 						<capacities>
-						  <li>BiteBlunt</li>
+						  <li>Bite</li>
 						</capacities>
 						<power>3</power>
 						<cooldownTime>2</cooldownTime>

--- a/Patches/ReGrowth - Extinct Animals Pack/Extinct_Mammals.xml
+++ b/Patches/ReGrowth - Extinct Animals Pack/Extinct_Mammals.xml
@@ -66,7 +66,7 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>4</power>
 							<cooldownTime>2</cooldownTime>
@@ -132,7 +132,7 @@
 							<armorPenetrationBlunt>21</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/ReGrowth - Mutated Animals Pack/Mutant_Deer.xml
+++ b/Patches/ReGrowth - Mutated Animals Pack/Mutant_Deer.xml
@@ -76,7 +76,7 @@
 					  </li>
 						<li Class="CombatExtended.ToolCE">
 						<capacities>
-						  <li>BiteBlunt</li>
+						  <li>Bite</li>
 						</capacities>
 						<power>3</power>
 						<cooldownTime>2</cooldownTime>

--- a/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
+++ b/Patches/RimWorld - Witcher Monster Hunt/Races_CyclopsCE.xml
@@ -77,7 +77,7 @@
 						<li Class="CombatExtended.ToolCE">
 							<label>teeth</label>
 							<capacities>
-								<li>BiteBlunt</li>
+								<li>Bite</li>
 							</capacities>
 							<power>30</power>
 							<cooldownTime>2</cooldownTime>

--- a/Patches/Rimcraft Collection/Animals/CE_Gargantuan.xml
+++ b/Patches/Rimcraft Collection/Animals/CE_Gargantuan.xml
@@ -26,7 +26,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<capacities><li>BiteBlunt</li></capacities>
+							<capacities><li>Bite</li></capacities>
 							<power>10</power>
 							<cooldownTime>2</cooldownTime>
 							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Patches/Rimcraft Collection/Animals/CE_Horses.xml
+++ b/Patches/Rimcraft Collection/Animals/CE_Horses.xml
@@ -90,7 +90,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>5</power>
 					<cooldownTime>1.97</cooldownTime>
@@ -158,7 +158,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>6</power>
 					<cooldownTime>1.97</cooldownTime>
@@ -237,7 +237,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>5</power>
 					<cooldownTime>1.97</cooldownTime>
@@ -294,7 +294,7 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
-						<li>BiteBlunt</li>
+						<li>Bite</li>
 					</capacities>
 					<power>6</power>
 					<cooldownTime>1.97</cooldownTime>

--- a/Patches/Vanilla Animals Expanded/Tundra_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Tundra_Animals.xml
@@ -113,7 +113,7 @@
               <li Class="CombatExtended.ToolCE">
                 <label>bite</label>
                 <capacities>
-                  <li>BiteBlunt</li>
+                  <li>Bite</li>
                 </capacities>
                 <power>1</power>
                 <cooldownTime>1</cooldownTime>

--- a/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Races_Animal_Giant.xml
@@ -286,7 +286,7 @@
 		<tools>
 			<li Class="CombatExtended.ToolCE">
 				<capacities>
-					<li>BiteBlunt</li>
+					<li>Bite</li>
 				</capacities>
 				<power>4</power>
 				<cooldownTime>1.8</cooldownTime>


### PR DESCRIPTION
## Changes
- Remove all uses of `BiteBlunt` with `Bite`, but leave the `BiteBlunt` capacity in place.

## References
Closes #1618 

## Reasoning

The regular `Bite` attack functions like a normal blunt attack if it does not have a sharp AP value assigned to it, which was the role that `BiteBlunt` originally filled, meaning there is no need for it. Additionally, `BiteBlunt` appears to have some adverse effects on the way the DPS is calculated, creating inaccuracies that can be confusing to the player.

For now, the `BiteBlunt` tool capacity def has been left in place to avoid creating issues for external patches that may use it, but it  and the related translation stuff will eventually go away.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
