### PR TITLE
Gun autopatcher fixes

### DIFF
--- a/Defs/GunPatcherDefs/SniperRifle.xml
+++ b/Defs/GunPatcherDefs/SniperRifle.xml
@@ -87,9 +87,7 @@
 
         <!-- ==== Special gun specifications ==== -->
         <specialGuns>
-            <li>
 
-            </li>
         </specialGuns>
 
         <!-- ==== Caliber determination ==== -->

--- a/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
@@ -42,7 +42,7 @@ namespace CombatExtended
                             return false;
                         }
                     }
-                    var t = verb.GetType();
+                    var t = verb.verbClass;
                     if (t != typeof(Verb_ShootOneUse)  && t != typeof(Verb_Shoot) && t != typeof(Verb_LaunchProjectile) && t != typeof(Verb_LaunchProjectileStatic))
                     {
                         return false;

--- a/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
@@ -72,7 +72,16 @@ namespace CombatExtended
 
             foreach (var preset in patcherDefs)
             {
-                unpatchedGuns.PatchGunsFromPreset(preset);
+		try
+		{
+		    unpatchedGuns.PatchGunsFromPreset(preset);
+		}
+		catch (Exception e)
+		{
+		    Log.messageQueue.Enqueue(new LogMessage(LogMessageType.Error, ""+e, StackTraceUtility.ExtractStringFromException(e)));
+		    Log.Error($"Unhandled exception handling {preset}");
+
+		}
             }
 
             if (unpatchedGuns.Count() > 0)

--- a/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
@@ -15,7 +15,7 @@ namespace CombatExtended
     {
         private static bool shouldPatch(ThingDef thingDef)
         {
-            if (thingDef.weaponTags?.Contains("Patched") ?? true)
+            if (thingDef.weaponTags?.Contains("Patched") ?? false)
             {
                 return false;
             }

--- a/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/GunAutoPatcher.cs
@@ -42,6 +42,10 @@ namespace CombatExtended
                             return false;
                         }
                     }
+		    else
+		    {
+			return false;
+		    }
                     var t = verb.verbClass;
                     if (t != typeof(Verb_ShootOneUse)  && t != typeof(Verb_Shoot) && t != typeof(Verb_LaunchProjectile) && t != typeof(Verb_LaunchProjectileStatic))
                     {


### PR DESCRIPTION


## Changes

* consider autopatching guns with null weaponTags
* Use verbClass instead of typeof verb to get the verb class
* don't try to patch guns with null `defaultProjectile`

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
