### PR TITLE
Warcasket energy shield readjustments

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
@@ -55,19 +55,19 @@
 			</value>
 		</li>
 
-		<!-- === Energy Shields === -->
+		<!-- === Energy Shield === -->
 
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
 			<value>
-				<EnergyShieldEnergyMax>350</EnergyShieldEnergyMax>
+				<EnergyShieldEnergyMax>375</EnergyShieldEnergyMax>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Siegebreaker"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
 			<value>
-				<EnergyShieldRechargeRate>15</EnergyShieldRechargeRate>
+				<EnergyShieldRechargeRate>1.5</EnergyShieldRechargeRate>
 			</value>
 		</li>
 
@@ -196,6 +196,22 @@
 			</value>
 		</li>
 
+		<!-- === Energy Shield === -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>225</EnergyShieldEnergyMax>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Guardian"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>1.5</EnergyShieldRechargeRate>
+			</value>
+		</li>
+
 		<!-- ========== Guardian Warcasket - Shoulders ========== -->
 
 		<li Class="PatchOperationAdd">
@@ -318,6 +334,22 @@
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/costList/ComponentSpacer</xpath>
 			<value>
 				<ComponentSpacer>14</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- === Energy Shield === -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>225</EnergyShieldEnergyMax>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Controller"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>1.5</EnergyShieldRechargeRate>
 			</value>
 		</li>
 
@@ -453,6 +485,22 @@
 			</value>
 		</li>
 
+		<!-- === Energy Shield === -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>225</EnergyShieldEnergyMax>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Sarcophagus"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>1.5</EnergyShieldRechargeRate>
+			</value>
+		</li>
+
 		<!-- ========== Sarcophagus Warcasket - Shoulders ========== -->
 
 		<li Class="PatchOperationAdd">
@@ -575,6 +623,22 @@
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/costList/ComponentSpacer</xpath>
 			<value>
 				<ComponentSpacer>6</ComponentSpacer>
+			</value>
+		</li>
+
+		<!-- === Energy Shield === -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+			<value>
+				<EnergyShieldEnergyMax>750</EnergyShieldEnergyMax>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_Warcasket_Brute"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+			<value>
+				<EnergyShieldRechargeRate>0.75</EnergyShieldRechargeRate>
 			</value>
 		</li>
 


### PR DESCRIPTION
## Additions

- Patched the remaining warcasket variants' energy shields

## References

- https://github.com/AndroidQuazar/VanillaFactionsExpanded-Pirates/commit/7cbc8a5748c78cf26be528ee01b5f5d077a18921

## Reasoning

- The energy shield recharge rates were set to 10 by mistake which is fixed in the original mod. Other warcasket variants besides the Siegebreaker one did not have their energy shield characteristics patched for CE which is done in this PR

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
