### PR TITLE
Only display armor ranges when partial armor enabled

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorPartial.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_ArmorPartial.cs
@@ -148,8 +148,8 @@ namespace CombatExtended
 
 	public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq, bool finalized = true)
         {
-	    if (this.stat == global::RimWorld.StatDefOf.ArmorRating_Blunt ||
-		    this.stat == global::RimWorld.StatDefOf.ArmorRating_Sharp) {
+	    if (Controller.settings.PartialStat && (this.stat == global::RimWorld.StatDefOf.ArmorRating_Blunt ||
+		 this.stat == global::RimWorld.StatDefOf.ArmorRating_Sharp)) {
 
 		if(optionalReq != null) {
 		    if (optionalReq.Thing is Apparel apparel) {


### PR DESCRIPTION

## Changes

The description of apparel now only shows a range if partial armor is enabled.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
