### PR TITLE
Add trigger for explosionEffect tag of projectiles

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1091,7 +1091,13 @@ namespace CombatExtended
                 Destroy();
                 return;
             }
-
+	    
+            if (def.projectile.explosionEffect != null)
+            {
+                Effecter effecter = def.projectile.explosionEffect.Spawn();
+                effecter.Trigger(new TargetInfo(explodePos.ToIntVec3(), Map, false), new TargetInfo(explodePos.ToIntVec3(), Map, false));
+                effecter.Cleanup();
+            }
             var explodingComp = this.TryGetComp<CompExplosiveCE>();
 
             if (explodingComp == null)


### PR DESCRIPTION
[As illustrated here](https://github.com/CombatExtended-Continued/CombatExtended/issues/1575), projectiles converted to CE didn't use effecters when spawning explosions, unlike vanilla does.

## Additions

Describe new functionality added by your code, e.g.
- Added a check to trigger explosionEffect for ProjectileCE comp if there is an effecter set in XML
- I took [these lines of vanilla code](https://github.com/josh-m/RW-Decompile/blob/d5bbfd741a46452bbfbec3a38b11a122f766f057/Verse/Projectile_Explosive.cs#L44) and added them to the CE comp.

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changed the variable names from vanilla code to fit the ones existing in CE method.

## References

Links to the associated issues or other related pull requests, e.g.

- Contributes towards #1575
- [In this screenshot you can see ](https://cdn.discordapp.com/attachments/278818534069501953/987746955625136178/unknown.png) how antimatter shells explode with effects working in this PR
- Please note, that this **only fixes the normal projectile comp**. **Lasers still don't display their impact effects.**

## Reasoning

Why did you choose to implement things this way, e.g.
- Antimatter and firefoam shells, some modded projectiles use effecters, but they weren't displayed.
- I copied from decompiled vanilla code to not reinvent the wheel


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded (tested VE lasers, they don't display effects)
- [x] Playtested a colony (shot antimatter shells from mortar, works as intended; damaged antimatter shells on ground, works as intended)
