### PR TITLE
Ideology ancient junk heights adjusted

### DIFF
--- a/Ideology/Patches/ThingDefs_Buildings/Buildings_Ancient_Outdoors.xml
+++ b/Ideology/Patches/ThingDefs_Buildings/Buildings_Ancient_Outdoors.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>  
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AncientRustedCar" or defName="AncientWarwalkerLeg" or defName="AncientWarwalkerShell" or defName="AncientPodCar"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.65</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AncientRustedTruck" or defName="AncientJetEngine" or defName="AncientDropshipEngine"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.7</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AncientRustedJeep" or defName="AncientMiniWarwalkerRemains" or defName="AncientTank" or defName="AncientAPC"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.75</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AncientRustedCarFrame"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.25</fillPercent>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="AncientWarwalkerTorso" or defName="AncientRustedDropship" or defName="AncientWarspiderRemains"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Changes

- Patched the untouched outdoor ancient junk buildings from ideology, they can serve as semi-decent cover now.

## Reasoning

- Said buildings had the vanilla fillPercent value of 0.5 which is too short for their texture in CE standards, the change aims to make them consistent to their appearance. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
