### PR TITLE
Moyo Cartel Patch

### DIFF
--- a/Patches/Moyo Cartel/Ammo/Ammo_Moyo.xml
+++ b/Patches/Moyo Cartel/Ammo/Ammo_Moyo.xml
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Moyo-The cartel arrives</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!-- ==================== Cartel Specific Ammosets ========================== -->
+			
+			<!--6x18 Moyo-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_6x18mmCMoyo</defName>
+						<label>6x18mm Charged Bullet</label>
+						<ammoTypes>
+						  <Ammo_6x18mmCharged>Bullet_6x18mmCMoyo</Ammo_6x18mmCharged>
+						  <Ammo_6x18mmCharged_AP>Bullet_6x18mmCMoyo_AP</Ammo_6x18mmCharged_AP>
+						  <Ammo_6x18mmCharged_Ion>Bullet_6x18mmCMoyo_Ion</Ammo_6x18mmCharged_Ion>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				
+					<ThingDef ParentName="Base6x18mmChargedBullet">
+						<defName>Bullet_6x18mmCMoyo</defName>
+						<label>6x18mm Charged bullet</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>10</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Bomb_Secondary</def>
+							  <amount>3</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>12</armorPenetrationSharp>
+						  <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+						</projectile>
+					</ThingDef>
+					
+					<ThingDef ParentName="Base6x18mmChargedBullet">
+						<defName>Bullet_6x18mmCMoyo_AP</defName>
+						<label>6x18mm Charged bullet (Conc.)</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>8</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Bomb_Secondary</def>
+							  <amount>1</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>24</armorPenetrationSharp>
+						  <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+						</projectile>		
+					</ThingDef>
+					
+					<ThingDef ParentName="Base6x18mmChargedBullet">
+						<defName>Bullet_6x18mmCMoyo_Ion</defName>
+						<label>6x18mm Charged bullet (Ion)</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>8</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>EMP</def>
+							  <amount>5</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>18</armorPenetrationSharp>
+						  <armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+						  <empShieldBreakChance>1</empShieldBreakChance>
+						</projectile>
+					</ThingDef>
+					
+				</value>
+			</li>
+			
+			<!--6x24 Moyo-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_6x24mmCMoyo</defName>
+						<label>6x24mm Charged Bullet</label>
+						<ammoTypes>
+						  <Ammo_6x24mmCharged>Bullet_6x24mmCMoyo</Ammo_6x24mmCharged>
+						  <Ammo_6x24mmCharged_AP>Bullet_6x24mmCMoyo_AP</Ammo_6x24mmCharged_AP>
+						  <Ammo_6x24mmCharged_Ion>Bullet_6x24mmCMoyo_Ion</Ammo_6x24mmCharged_Ion>
+						</ammoTypes>
+					</CombatExtended.AmmoSetDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				
+					<ThingDef ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_6x24mmCMoyo</defName>
+						<label>6x24mm Charged bullet</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>13</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Bomb_Secondary</def>
+							  <amount>4</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>15</armorPenetrationSharp>
+						  <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+						</projectile>
+					</ThingDef>
+					
+					<ThingDef ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_6x24mmCMoyo_AP</defName>
+						<label>6x24mm Charged bullet (Conc.)</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>10</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>Bomb_Secondary</def>
+							  <amount>2</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>30</armorPenetrationSharp>
+						  <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+						</projectile>
+					</ThingDef>
+					
+					<ThingDef ParentName="Base6x24mmChargedBullet">
+						<defName>Bullet_6x24mmCMoyo_Ion</defName>
+						<label>6x24mm Charged bullet (Ion)</label>
+						<graphicData>
+						  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+						  <graphicClass>Graphic_Single</graphicClass>
+						</graphicData>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						  <damageAmountBase>10</damageAmountBase>
+						  <secondaryDamage>
+							<li>
+							  <def>EMP</def>
+							  <amount>6</amount>
+							</li>
+						  </secondaryDamage>
+						  <armorPenetrationSharp>22.5</armorPenetrationSharp>
+						  <armorPenetrationBlunt>25.6</armorPenetrationBlunt>
+						  <empShieldBreakChance>0.2</empShieldBreakChance>
+						</projectile>
+					</ThingDef>
+					
+				</value>
+			</li>
+			<!--8x35 Moyo-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				  <CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_10x18mmCMoyo</defName>
+					<label>10x18mm Charged Bullet</label>
+					<ammoTypes>
+					  <Ammo_10x18mmCharged>Bullet_10x18mmCMoyo</Ammo_10x18mmCharged>
+					  <Ammo_10x18mmCharged_AP>Bullet_10x18mmCMoyo_AP</Ammo_10x18mmCharged_AP>
+					  <Ammo_10x18mmCharged_Ion>Bullet_10x18mmCMoyo_Ion</Ammo_10x18mmCharged_Ion>
+					</ammoTypes>
+				  </CombatExtended.AmmoSetDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				
+				<ThingDef ParentName="Base10x18mmChargedBullet">
+					<defName>Bullet_10x18mmCMoyo</defName>
+					<label>10x18mm Charged bullet</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>15</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>Bomb_Secondary</def>
+						  <amount>4</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>13</armorPenetrationSharp>
+					  <armorPenetrationBlunt>22.56</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+
+				<ThingDef ParentName="Base10x18mmChargedBullet">
+					<defName>Bullet_10x18mmCMoyo_AP</defName>
+					<label>10x18mm Charged bullet (Conc.)</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>11</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>Bomb_Secondary</def>
+						  <amount>2</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>26</armorPenetrationSharp>
+					  <armorPenetrationBlunt>22.56</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+
+				<ThingDef ParentName="Base10x18mmChargedBullet">
+					<defName>Bullet_10x18mmCMoyo_Ion</defName>
+					<label>10x18mm Charged bullet (Ion)</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>11</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>EMP</def>
+						  <amount>7</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>19.5</armorPenetrationSharp>
+					  <armorPenetrationBlunt>22.5</armorPenetrationBlunt>
+					  <empShieldBreakChance>0.4</empShieldBreakChance>
+					</projectile>
+				</ThingDef>
+				  
+				</value>
+			</li>
+			
+			<!--8x50 Moyo-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				  <CombatExtended.AmmoSetDef>
+					<defName>AmmoSet_8x50mmCMoyo</defName>
+					<label>8x50mm Charged Bullet</label>
+					<ammoTypes>
+					  <Ammo_8x50mmCharged>Bullet_8x50mmCMoyo</Ammo_8x50mmCharged>
+					  <Ammo_8x50mmCharged_AP>Bullet_8x50mmCMoyo_AP</Ammo_8x50mmCharged_AP>
+					  <Ammo_8x50mmCharged_Ion>Bullet_8x50mmCMoyo_Ion</Ammo_8x50mmCharged_Ion>
+					</ammoTypes>
+				  </CombatExtended.AmmoSetDef>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+				
+				<ThingDef ParentName="Base8x50mmChargedBullet">
+					<defName>Bullet_8x50mmCMoyo</defName>
+					<label>8x50mm Charged bullet</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>24</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>Bomb_Secondary</def>
+						  <amount>7</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>18</armorPenetrationSharp>
+					  <armorPenetrationBlunt>120</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+
+				<ThingDef ParentName="Base8x50mmChargedBullet">
+					<defName>Bullet_8x50mmCMoyo_AP</defName>
+					<label>8x50mm Charged bullet (Conc.)</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>19</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>Bomb_Secondary</def>
+						  <amount>3</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>36</armorPenetrationSharp>
+					  <armorPenetrationBlunt>120</armorPenetrationBlunt>
+					</projectile>
+				</ThingDef>
+
+				<ThingDef ParentName="Base8x50mmChargedBullet">
+					<defName>Bullet_8x50mmCMoyo_Ion</defName>
+					<label>8x50mm Charged bullet (Ion)</label>
+					<graphicData>
+					  <texPath>Things/Weapons/MoyoCNeedleshot</texPath>
+					  <graphicClass>Graphic_Single</graphicClass>
+					</graphicData>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+					  <damageAmountBase>19</damageAmountBase>
+					  <secondaryDamage>
+						<li>
+						  <def>EMP</def>
+						  <amount>11</amount>
+						</li>
+					  </secondaryDamage>
+					  <armorPenetrationSharp>27</armorPenetrationSharp>
+					  <armorPenetrationBlunt>120</armorPenetrationBlunt>
+					  <empShieldBreakChance>1</empShieldBreakChance>
+					</projectile>
+				</ThingDef>
+				  
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Moyo Cartel/PawnKindDefs/Moyo_PawnKind.xml
+++ b/Patches/Moyo Cartel/PawnKindDefs/Moyo_PawnKind.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Moyo-The cartel arrives</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--Ammo-->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="Moyo_CartelTech" or
+				defName="Moyo_CartelSmuggler" or
+				defName="Moyo_CartelLabourer" or
+				defName="Moyo_CartelTrooper"
+				]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>2</min>
+						<max>6</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="CartelSoldierLight"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>3</min>
+						<max>5</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="CartelSoldierLight"]</xpath>
+				<value>
+					<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>3</min>
+						<max>5</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="CartelSniper"]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>5</min>
+						<max>6</max>
+					</primaryMagazineCount>
+					<forcedSidearm>
+					  <sidearmMoney>
+						<min>500</min>
+						<max>1200</max>
+					  </sidearmMoney>
+					  <weaponTags>
+						<li>MoyoBasicGun</li>
+						<li>MoyoCartelBasicGun</li>
+					  </weaponTags>
+					  <magazineCount>
+						<min>1</min>
+						<max>2</max>
+					  </magazineCount>
+					</forcedSidearm>
+					</li>
+				</value>
+			</li>
+			
+			<!--Backpack-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[
+				@Name="CartelSoldierLight" or
+				@Name="CartelSniper" or
+				defName="Moyo_CartelTrooper" or
+				defName="Moyo_CartelSmuggler"
+				]/apparelRequired</xpath>
+				<value>
+					<li>Apparel_Backpack</li>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Moyo-The cartel arrives</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+			
+			
+			<!--========= Fixed Armor Value =========-->
+			
+			
+			<!--Ballistic Suit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]/statBases</xpath>
+				<value>
+					<Bulk>25</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]/statBases/Mass</xpath>
+				<value>
+					<Mass>12</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]/statBases/MaxHitPoints</xpath>
+				<value>
+					<MaxHitPoints>175</MaxHitPoints>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>11.25</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.15</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>16.875</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_CBsuit"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
+				</value>
+			</li>
+			
+			<!--Ballistic Helmet-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CBhelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBhelmet"]/statBases/MaxHitPoints</xpath>
+				<value>
+					<MaxHitPoints>100</MaxHitPoints>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBhelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.15</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CBhelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			
+			<!--Evasuit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Cartelsuit"]/statBases</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_Cartelsuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.15</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_Cartelsuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Cartelsuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<!--Evasuit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelStrikerHood"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelStrikerHood"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelStrikerHood"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!--Strike Armor-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/statBases</xpath>
+				<value>
+					<Bulk>80</Bulk>
+					<WornBulk>8</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/statBases/Mass</xpath>
+				<value>
+					<Mass>30</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/statBases/Flammability</xpath>
+				<value>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]</xpath>
+				<value>
+				<equippedStatOffsets>
+					<CarryWeight>40</CarryWeight>
+					<CarryBulk>20</CarryBulk>
+					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
+					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<MoveSpeed>0.3</MoveSpeed>
+				</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>115</Moyo_Abyssteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_CSgear"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
+				</value>
+			</li>
+			
+			<!--Strike Helmet-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>1</WornBulk>
+					<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/statBases/Mass</xpath>
+				<value>
+					<Mass>2</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/statBases/Flammability</xpath>
+				<value>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+					<ToxicSensitivity>-0.50</ToxicSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<AimingAccuracy>0.15</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>55</Moyo_Abyssteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Moyo-The cartel arrives</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<!--Royal suit-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelRoyalsuit"]/statBases</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelRoyalsuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.40</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelRoyalsuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>5.25</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelRoyalsuit"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Hands</li>
+					<li>Feet</li>
+				</value>
+			</li>
+			
+			<!--Royal Robe-->
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="Moyo_CartelRobeBase"]/statBases</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="Moyo_CartelRobeBase"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>5</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.60</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name="Moyo_CartelRobeBase"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!--Cartel Executioner Helmet-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases/MarketValue</xpath>
+				<value>
+					<MarketValue>1745</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases</xpath>
+				<value>
+					<Bulk>6</Bulk>
+					<WornBulk>4</WornBulk>
+					<NightVisionEfficiency_Apparel>0.8</NightVisionEfficiency_Apparel> 
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases/Mass</xpath>
+				<value>
+					<Mass>7</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.55</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>64</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/statBases/Flammability</xpath>
+				<value>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+					<ToxicSensitivity>-0.50</ToxicSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+				<value>
+					<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
+					<AimingAccuracy>0.50</AimingAccuracy>
+				</value>
+			</li>
+			
+			<!--Cartel Executioner Armor-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases/MarketValue</xpath>
+				<value>
+					<MarketValue>4435</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases</xpath>
+				<value>
+					<Bulk>80</Bulk>
+					<WornBulk>15</WornBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases/Mass</xpath>
+				<value>
+					<Mass>30</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/statBases/Flammability</xpath>
+				<value>
+					<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryWeight>80</CarryWeight>
+					<CarryBulk>30</CarryBulk>
+					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
+					<ToxicSensitivity>-0.50</ToxicSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="Moyo_CEsuit"]</xpath>
+				<value>
+				  <li Class="CombatExtended.PartialArmorExt">
+					  <stats>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+					  </stats>
+				  </li>
+				</value>
+			</li>
+			
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Weapons.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		
+		<operations>
+			<li Class="PatchOperationFindMod">
+			<mods><li>Moyo-The cartel arrives</li></mods>
+			<match Class="PatchOperationSequence">
+			<operations>
+			
+			<!-- ==========  Moyo Knife  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CombatKnife"]/tools</xpath>
+				<value>
+				  <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+						  <li>Poke</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.01</cooldownTime>
+						<chanceFactor>0.4</chanceFactor>
+						<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+						  <li>Stab</li>
+						</capacities>
+						<power>14</power>
+						<cooldownTime>1.36</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>0.30</armorPenetrationBlunt>
+						<armorPenetrationSharp>2</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					  </li>
+					  <li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+						  <li>Cut</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>1.23</cooldownTime>
+						<chanceFactor>1</chanceFactor>
+						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.2</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					  </li>
+				  </tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CombatKnife"]/statBases</xpath>
+				<value>
+					<MeleeCounterParryBonus>0.39</MeleeCounterParryBonus>
+					<Bulk>1.5</Bulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_CombatKnife"]</xpath>
+				<value>
+					<equippedStatOffsets>
+					  <MeleeCritChance>0.16</MeleeCritChance>
+					  <MeleeParryChance>0.24</MeleeParryChance>
+					  <MeleeDodgeChance>1.07</MeleeDodgeChance>
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			
+			<!-- ==========  Moyo Vibrokatana  =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Moyo_Katana"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>handle</label>
+							<capacities>
+								<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.5</cooldownTime>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>1.03</cooldownTime>
+							<chanceFactor>1.33</chanceFactor>
+							<armorPenetrationBlunt>3.75</armorPenetrationBlunt>
+							<armorPenetrationSharp>23.44</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+							<li>Stab</li>
+							</capacities>
+							<power>28</power>					
+							<cooldownTime>0.98</cooldownTime>
+							<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+							<armorPenetrationSharp>25</armorPenetrationSharp>
+						</li>					
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Katana"]/statBases</xpath>
+				<value>
+					<Bulk>8.5</Bulk>
+					<MeleeCounterParryBonus>0.80</MeleeCounterParryBonus>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Katana"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>1.00</MeleeCritChance>
+						<MeleeParryChance>0.60</MeleeParryChance>
+						<MeleeDodgeChance>0.40</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+			
+			<!-- ========== Charge Pistol =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Moyo_CartelPistol</defName>
+				<statBases>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>1.08</SwayFactor>
+					<Bulk>2.45</Bulk>
+					<Mass>0.8</Mass>
+					<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<recoilAmount>2.47</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x18mmCMoyo</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<burstShotCount>2</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<range>15</range>
+					<soundCast>Shot_ChargeRifle</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>12</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_6x18mmCMoyo</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Pistol"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+			
+			<!-- ========== Charge Revolver =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Moyo_CartelRevolver</defName>
+				<statBases>
+					<SightsEfficiency>0.70</SightsEfficiency>
+					<ShotSpread>0.13</ShotSpread>
+					<SwayFactor>1.75</SwayFactor>
+					<Bulk>3.25</Bulk>
+					<Mass>2.00</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_10x18mmCMoyo</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>21</range>
+					<soundCast>Shot_ChargeRifle</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>5.1</reloadTime>
+					<ammoSet>AmmoSet_10x18mmCMoyo</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Moyo_Pistol"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li>
+				</value>
+			</li>
+			
+			<!-- ========== Charge SMG =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Moyo_CartelSMG</defName>
+				<statBases>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.17</ShotSpread>
+					<SwayFactor>0.94</SwayFactor>
+					<Bulk>6.25</Bulk>
+					<Mass>3.10</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<recoilAmount>1.24</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x18mmCMoyo</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<burstShotCount>5</burstShotCount>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<range>31</range>
+					<soundCast>Shot_ChargeRifle</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>42</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_6x18mmCMoyo</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Charge Carbine =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Moyo_CarteCarbine</defName>
+				<statBases>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.11</ShotSpread>
+					<SwayFactor>1.19</SwayFactor>
+					<Bulk>8.80</Bulk>
+					<Mass>3.10</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<recoilAmount>0.14</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_6x24mmCMoyo</defaultProjectile>
+					<warmupTime>1.0</warmupTime>
+					<burstShotCount>3</burstShotCount>
+					<ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+					<range>61</range>
+					<soundCast>Shot_ChargeRifle</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>32</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_6x24mmCMoyo</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Charge Precision Rifle =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Moyo_CartelLongRifle</defName>
+				<statBases>
+					<SightsEfficiency>5.00</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>2.04</SwayFactor>
+					<Bulk>11.00</Bulk>
+					<Mass>8.1</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+				</statBases>
+				
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_8x50mmCMoyo</defaultProjectile>
+					<warmupTime>2.7</warmupTime>
+					<range>86</range>
+					<soundCast>Shot_ChargeRifle</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				
+				<AmmoUser>
+					<magazineSize>6</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_8x50mmCMoyo</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+			<!-- ========== Melee Attacks =========== -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelLongRifle" or 
+				defName="Moyo_CarteCarbine" or 
+				defName="Moyo_CartelSMG"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>stock</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_CartelPistol" or 
+				defName="Moyo_CartelRevolver"
+				]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li> 
+			
+			<!--Persona : Royalty Only-->
+			
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="Moyo_PersonaKatana"]</xpath>
+				<match Class="PatchOperationSequence">
+				<operations>
+					<li Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="Moyo_PersonaKatana"]/tools</xpath>
+						<value>
+							<tools>
+								<li Class="CombatExtended.ToolCE">
+									<label>handle</label>
+									<capacities>
+										<li>Poke</li>
+									</capacities>
+									<power>2</power>
+									<cooldownTime>1.5</cooldownTime>
+									<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+									<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+								</li>
+								<li Class="CombatExtended.ToolCE">
+									<label>edge</label>
+									<capacities>
+										<li>Cut</li>
+									</capacities>
+									<power>50</power>
+									<cooldownTime>1.03</cooldownTime>
+									<chanceFactor>1.33</chanceFactor>
+									<armorPenetrationBlunt>3.75</armorPenetrationBlunt>
+									<armorPenetrationSharp>28</armorPenetrationSharp>
+									<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+								</li>
+								<li Class="CombatExtended.ToolCE">
+									<label>point</label>
+									<capacities>
+									<li>Stab</li>
+									</capacities>
+									<power>28</power>					
+									<cooldownTime>0.98</cooldownTime>
+									<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
+									<armorPenetrationSharp>36.29</armorPenetrationSharp>
+								</li>					
+							</tools>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Moyo_PersonaKatana"]/statBases</xpath>
+						<value>
+							<Bulk>8.5</Bulk>
+							<MeleeCounterParryBonus>0.90</MeleeCounterParryBonus>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Moyo_PersonaKatana"]</xpath>
+						<value>
+							<equippedStatOffsets>
+								<MeleeCritChance>1.10</MeleeCritChance>
+								<MeleeParryChance>0.70</MeleeParryChance>
+								<MeleeDodgeChance>0.50</MeleeDodgeChance>	
+							</equippedStatOffsets>
+						</value>
+					</li>
+					
+				</operations>
+				</match>
+			</li>
+			
+			</operations>
+			</match>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Weapons.xml
@@ -223,7 +223,7 @@
 			<!-- ========== Charge SMG =========== -->
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-			<defName>Moyo_CartelSMG</defName>
+			<defName>Moyo_CartelSMGa</defName>
 				<statBases>
 					<SightsEfficiency>1.10</SightsEfficiency>
 					<ShotSpread>0.17</ShotSpread>
@@ -337,7 +337,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_CartelLongRifle" or 
 				defName="Moyo_CarteCarbine" or 
-				defName="Moyo_CartelSMG"
+				defName="Moyo_CartelSMGa"
 				]/tools</xpath>
 				<value>
 					<tools>


### PR DESCRIPTION
## Additions

Moyo Cartel PR
Note that there is a lot of content looking stuff in the mod that is not implemented yet, so realistically we ought to expect updates

## Reasoning

Mostly simmialr to the existing Moyo equipment, the executioner armor is high spec but unbuildable for a skin/middle apparel.

## Alternatives

Not really an alternative, but unless there's a intent to change how they function might be worth taking the dive and converting over all the moyo charge weapons to be more unified with CE charge gun costs.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
