### PR TITLE
Readjusted 20mm rounds' armor penetration values

### DIFF
--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -116,7 +116,7 @@
 		<label>20x102mm NATO bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>34</armorPenetrationSharp>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -126,7 +126,7 @@
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>34</armorPenetrationSharp>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>20x102mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>17</armorPenetrationSharp>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>60</armorPenetrationSharp>
+			<armorPenetrationSharp>56</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -116,7 +116,7 @@
 		<label>20x102mm NATO bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationSharp>30</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -126,7 +126,7 @@
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationSharp>30</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>20x102mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>56</armorPenetrationSharp>
+			<armorPenetrationSharp>53</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -40,19 +40,19 @@
 		<stackLimit>1000</stackLimit>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
-      <defName>Ammo_20x102mmNATO_AP</defName>
-      <label>20x102mm NATO cartridge (AP)</label>
-      <graphicData>
-        <texPath>Things/Ammo/HighCaliber/AP</texPath>
-        <graphicClass>Graphic_StackCount</graphicClass>
-      </graphicData>
-      <statBases>
-        <MarketValue>1.04</MarketValue>
-      </statBases>
-      <ammoClass>ArmorPiercing</ammoClass>
-      <cookOffProjectile>Bullet_20x102mmNATO_AP</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
+		<defName>Ammo_20x102mmNATO_AP</defName>
+		<label>20x102mm NATO cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.04</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_20x102mmNATO_AP</cookOffProjectile>
+	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_Incendiary</defName>
@@ -111,22 +111,22 @@
 		</projectile>
 	</ThingDef>
 
-    <ThingDef ParentName="Base20x102mmNATOBullet">
-      <defName>Bullet_20x102mmNATO_AP</defName>
-      <label>20x102mm NATO bullet (AP)</label>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <damageAmountBase>44</damageAmountBase>
-        <armorPenetrationSharp>26</armorPenetrationSharp>
-        <armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
-      </projectile>
-    </ThingDef>
+	<ThingDef ParentName="Base20x102mmNATOBullet">
+		<defName>Bullet_20x102mmNATO_AP</defName>
+		<label>20x102mm NATO bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>44</damageAmountBase>
+			<armorPenetrationSharp>34</armorPenetrationSharp>
+			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
 
 	<ThingDef ParentName="Base20x102mmNATOBullet">
 		<defName>Bullet_20x102mmNATO_Incendiary</defName>
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>26</armorPenetrationSharp>
+			<armorPenetrationSharp>34</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>20x102mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationSharp>17</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>46</armorPenetrationSharp>
+			<armorPenetrationSharp>60</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>
@@ -166,37 +166,37 @@
 
 	<!-- ==================== Recipes ========================== -->
 
-    <RecipeDef ParentName="AmmoRecipeBase">
-      <defName>MakeAmmo_20x102mmNATO_AP</defName>
-      <label>make 20x102mm NATO (AP) cartridge x200</label>
-      <description>Craft 200 20x102mm NATO (AP) cartridges.</description>
-      <jobString>Making 20x102mm NATO (AP) cartridges.</jobString>
-      <ingredients>
-        <li>
-          <filter>
-            <thingDefs>
-              <li>Steel</li>
-            </thingDefs>
-          </filter>
-          <count>104</count>
-        </li>
-      </ingredients>
-      <fixedIngredientFilter>
-        <thingDefs>
-          <li>Steel</li>
-        </thingDefs>
-      </fixedIngredientFilter>
-      <products>
-        <Ammo_20x102mmNATO_AP>200</Ammo_20x102mmNATO_AP>
-      </products>
-      <workAmount>10400</workAmount>
-    </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_20x102mmNATO_AP</defName>
+		<label>make 20x102mm NATO (AP) cartridge x200</label>
+		<description>Craft 200 20x102mm NATO (AP) cartridges.</description>
+		<jobString>Making 20x102mm NATO (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_20x102mmNATO_AP>200</Ammo_20x102mmNATO_AP>
+		</products>
+		<workAmount>10400</workAmount>
+	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x102mmNATO_Incendiary</defName>
 		<label>make 20x102mm NATO (AP-I) cartridge x200</label>
-		<description>Craft 200 .20x102mm NATO (AP-I) cartridges.</description>
-		<jobString>Making .20x102mm NATO (AP-I) cartridges.</jobString>
+		<description>Craft 200 20x102mm NATO (AP-I) cartridges.</description>
+		<jobString>Making 20x102mm NATO (AP-I) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -230,8 +230,8 @@
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x102mmNATO_HE</defName>
 		<label>make 20x102mm NATO (HE) cartridge x200</label>
-		<description>Craft 200 .20x102mm NATO (HE) cartridges.</description>
-		<jobString>Making .20x102mm NATO (HE) cartridges.</jobString>
+		<description>Craft 200 20x102mm NATO (HE) cartridges.</description>
+		<jobString>Making 20x102mm NATO (HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -265,8 +265,8 @@
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x102mmNATO_Sabot</defName>
 		<label>make 20x102mm NATO (Sabot) cartridge x200</label>
-		<description>Craft 200 .20x102mm NATO (Sabot) cartridges.</description>
-		<jobString>Making .20x102mm NATO (Sabot) cartridges.</jobString>
+		<description>Craft 200 20x102mm NATO (Sabot) cartridges.</description>
+		<jobString>Making 20x102mm NATO (Sabot) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -82,7 +82,6 @@
     <cookOffProjectile>Bullet_20x110mmHispano_HE</cookOffProjectile>
   </ThingDef>
 
-
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
     <defName>Ammo_20x110mmHispano_Sabot</defName>
     <label>20x110mm Hispano cartridge (Sabot)</label>
@@ -117,7 +116,7 @@
     <label>20mm Hispano bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -127,7 +126,7 @@
     <label>20mm Hispano bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -143,7 +142,7 @@
     <label>20mm Hispano bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>66</damageAmountBase>
-      <armorPenetrationSharp>20</armorPenetrationSharp>
+      <armorPenetrationSharp>15</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -160,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>254</speed>
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>70</armorPenetrationSharp>
+      <armorPenetrationSharp>53</armorPenetrationSharp>
       <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>
     </projectile>
   </ThingDef> 

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -116,7 +116,7 @@
     <label>20mm Hispano bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mm Hispano bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mm Hispano bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>66</damageAmountBase>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>14</armorPenetrationSharp>
       <armorPenetrationBlunt>869.04</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>254</speed>
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>53</armorPenetrationSharp>
+      <armorPenetrationSharp>49</armorPenetrationSharp>
       <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>
     </projectile>
   </ThingDef> 

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -116,7 +116,7 @@
     <label>20mm Mauser bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>26</armorPenetrationSharp>
+      <armorPenetrationSharp>24</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mm Mauser bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>26</armorPenetrationSharp>
+      <armorPenetrationSharp>24</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mm Mauser bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>57</damageAmountBase>
-      <armorPenetrationSharp>13</armorPenetrationSharp>
+      <armorPenetrationSharp>12</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>216</speed>
       <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>46</armorPenetrationSharp>
+      <armorPenetrationSharp>42</armorPenetrationSharp>
       <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -116,7 +116,7 @@
     <label>20mm Mauser bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>28</armorPenetrationSharp>
+      <armorPenetrationSharp>26</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mm Mauser bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>28</armorPenetrationSharp>
+      <armorPenetrationSharp>26</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mm Mauser bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>57</damageAmountBase>
-      <armorPenetrationSharp>14</armorPenetrationSharp>
+      <armorPenetrationSharp>13</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>216</speed>
       <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>49</armorPenetrationSharp>
+      <armorPenetrationSharp>46</armorPenetrationSharp>
       <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -116,7 +116,7 @@
     <label>20mmR ShVAK bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>32</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mmR ShVAK bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>32</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mmR ShVAK bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>56</damageAmountBase>
-      <armorPenetrationSharp>16</armorPenetrationSharp>
+      <armorPenetrationSharp>15</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>225</speed>
       <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>56</armorPenetrationSharp>
+      <armorPenetrationSharp>53</armorPenetrationSharp>
       <armorPenetrationBlunt>696.1</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -116,7 +116,7 @@
     <label>20mmR ShVAK bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>27</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mmR ShVAK bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>27</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mmR ShVAK bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>56</damageAmountBase>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>13</armorPenetrationSharp>
       <armorPenetrationBlunt>540</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>225</speed>
       <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>53</armorPenetrationSharp>
+      <armorPenetrationSharp>47</armorPenetrationSharp>
       <armorPenetrationBlunt>696.1</armorPenetrationBlunt>
     </projectile>
   </ThingDef>


### PR DESCRIPTION
## Changes

- Adjusted the armor penetration values of the 20mm rounds.

## Reasoning

- Looking at the armor penetration values of the 20mm NATO round, it seems that the current values are back-ported from the AP-HE penetration values which are sources from Wikipedia and the current 26/13 AP values are absurdly low in comparison to even 14.5mm or other smaller 20mm cartridges which are slower in some cases in comparison to the NATO one. The stated value is for a high explosive round which is not designed for penetration so it is not a good basis for the AP rounds.
With that in mind and considering the armor penetration values of the other 20mm round, I've gone with the guesstimate of 30/15/53mm of armor penetration which keeps the 20mm NATO round is line with other rounds of its family while keeping it from stepping on the toes of the other bigger rounds with more velocity and case length.

## Alternatives

- ~~Take a look at other 20mm rounds and rebalance them~~ Done.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors

