### PR TITLE
Suppression tweaks

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -982,5 +982,11 @@ namespace CombatExtended
             }
             return Mathf.Sqrt(dx * dx + dz * dz);
         }
+
+        public static Vector3 ToVec3Gridified(this Vector3 originalVec3)
+        {
+            float highestNormalCoord = Math.Max(originalVec3.normalized.x, originalVec3.normalized.z);
+            return new Vector3(originalVec3.x / highestNormalCoord, originalVec3.y, originalVec3.z / highestNormalCoord);
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -985,8 +985,16 @@ namespace CombatExtended
 
         public static Vector3 ToVec3Gridified(this Vector3 originalVec3)
         {
-            float highestNormalCoord = Math.Max(originalVec3.normalized.x, originalVec3.normalized.z);
-            return new Vector3(originalVec3.x / highestNormalCoord, originalVec3.y, originalVec3.z / highestNormalCoord);
+            Vector2 tempVec2 = new Vector2(originalVec3.normalized.x, originalVec3.normalized.z);
+            float factor = Math.Max(Mathf.Abs(tempVec2.x), Mathf.Abs(tempVec2.y));
+            // If factor <= 0.6f, something has definitely gone wrong;
+            if (factor <= 0.6f)
+            {
+                Log.Warning("CE calling ToVec3Gridified with a Vector3 that has a factor of no more than 0.6; returning original Vector3");
+                return originalVec3;
+            }
+            //Log.Warning("ToVec3Gridified " + (new Vector3(originalVec3.x / highestNormalCoord, originalVec3.y, originalVec3.z / highestNormalCoord)).ToString());
+            return new Vector3(originalVec3.x / factor, originalVec3.y, originalVec3.z / factor);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -987,10 +987,10 @@ namespace CombatExtended
         {
             Vector2 tempVec2 = new Vector2(originalVec3.normalized.x, originalVec3.normalized.z);
             float factor = Math.Max(Mathf.Abs(tempVec2.x), Mathf.Abs(tempVec2.y));
-            // If factor <= 0.6f, something has definitely gone wrong;
+            // If factor <= 0.6f, something has definitely gone wrong (or the vector is a zero vector);
             if (factor <= 0.6f)
             {
-                Log.Warning("CE calling ToVec3Gridified with a Vector3 that has a factor of no more than 0.6; returning original Vector3");
+                Log.Warning($"CE calling ToVec3Gridified with Vector3 {originalVec3} that has a factor of no more than 0.6; returning original Vector3");
                 return originalVec3;
             }
             //Log.Warning("ToVec3Gridified " + (new Vector3(originalVec3.x / highestNormalCoord, originalVec3.y, originalVec3.z / highestNormalCoord)).ToString());

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -989,10 +989,7 @@ namespace CombatExtended
             float factor = Math.Max(Mathf.Abs(tempVec2.x), Mathf.Abs(tempVec2.y));
             // If factor <= 0.6f, something has definitely gone wrong (or the vector is a zero vector);
             if (factor <= 0.6f)
-            {
-                Log.Warning($"CE calling ToVec3Gridified with Vector3 {originalVec3} that has a factor of no more than 0.6; returning original Vector3");
                 return originalVec3;
-            }
             //Log.Warning("ToVec3Gridified " + (new Vector3(originalVec3.x / highestNormalCoord, originalVec3.y, originalVec3.z / highestNormalCoord)).ToString());
             return new Vector3(originalVec3.x / factor, originalVec3.y, originalVec3.z / factor);
         }

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -14,10 +14,10 @@ namespace CombatExtended
     {
         #region Constants
 
-        //private const float minSuppressionDist = 5f;         // Minimum distance to be suppressed from, so melee won't be suppressed if it closes within this distance
+        //private const float minSuppressionDist = 5f;       // Minimum distance to be suppressed from, so melee won't be suppressed if it closes within this distance
         private const float maxSuppression = 1050f;          // Cap to prevent suppression from building indefinitely
-        private const int TicksForDecayStart = 120;          // How long since last suppression before decay starts
-        private const float SuppressionDecayRate = 5f;       // How much suppression decays per tick
+        private const int TicksForDecayStart = 30;           // How long since last suppression before decay starts
+        private const float SuppressionDecayRate = 4f;       // How much suppression decays per tick
         private const int TicksPerMote = 150;                // How many ticks between throwing a mote        
 
         private const int MinTicksUntilMentalBreak = 600;    // How long until pawn can have a mental break

--- a/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompSuppressable.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
     {
         #region Constants
 
-        private const float minSuppressionDist = 5f;         // Minimum distance to be suppressed from, so melee won't be suppressed if it closes within this distance
+        //private const float minSuppressionDist = 5f;         // Minimum distance to be suppressed from, so melee won't be suppressed if it closes within this distance
         private const float maxSuppression = 1050f;          // Cap to prevent suppression from building indefinitely
         private const int TicksForDecayStart = 120;          // How long since last suppression before decay starts
         private const float SuppressionDecayRate = 5f;       // How much suppression decays per tick
@@ -136,9 +136,9 @@ namespace CombatExtended
             get
             {
                 Pawn pawn = parent as Pawn;
-                return !pawn.Position.InHorDistOf(SuppressorLoc, minSuppressionDist)
-                    && !pawn.Downed
-                    && !pawn.InMentalState;
+                return !pawn.Downed
+                    && !pawn.InMentalState
+                    && !((pawn.stances?.curStance as Stance_Busy)?.verb?.IsMeleeAttack ?? false); // Pawns in melee ignore suppression;
             }
         }
 
@@ -192,9 +192,9 @@ namespace CombatExtended
             // Add suppression to current suppressor location if appropriate
             if (suppressorLoc == origin)
             {
-                locSuppressionAmount += amount;
+                locSuppressionAmount += suppressAmount;
             }
-            else if (locSuppressionAmount < SuppressionThreshold)
+            else if (locSuppressionAmount < SuppressionThreshold || suppressAmount > SuppressionThreshold)
             {
                 suppressorLoc = origin;
                 locSuppressionAmount = currentSuppression;

--- a/Source/CombatExtended/CombatExtended/DangerTracker.cs
+++ b/Source/CombatExtended/CombatExtended/DangerTracker.cs
@@ -62,7 +62,7 @@ namespace CombatExtended
                 if (cell.InBounds(map))
                     IncreaseAt(cell, (int)Mathf.Ceil(AdjWeights[i] * dangerAmount));
             }
-            if (Controller.settings.DebugMuzzleFlash) FlashCell(pos);
+            if (Controller.settings.DebugDisplayDangerBuildup) FlashCell(pos);
         }
 
         public void Notify_DangerRadiusAt(IntVec3 pos, float radius, float dangerAmount, bool falloff = true, bool requireLOS = true)
@@ -79,7 +79,7 @@ namespace CombatExtended
                 }
                 IncreaseAt(cell, (int)Mathf.Ceil(cellDanger));
 
-                if (Controller.settings.DebugMuzzleFlash)
+                if (Controller.settings.DebugDisplayDangerBuildup)
                 {
                     float value = DangerAt(cell);
                     if (value > 0f) map.debugDrawer.FlashCell(cell, value, $"{value}");

--- a/Source/CombatExtended/CombatExtended/DangerTracker.cs
+++ b/Source/CombatExtended/CombatExtended/DangerTracker.cs
@@ -8,11 +8,11 @@ namespace CombatExtended
 {
     public class DangerTracker : MapComponent
     {
-        private const int DANGER_TICKS = 450;
-        private const int DANGER_TICKS_BULLET_STEP = 200;
-        private const int DANGER_TICKS_SMOKE_STEP = 140;
-        private const int DANGER_TICKS_MAX = 800;
-        private const float DANGER_BULLET_MAX_DIST = 20f;
+        //private const int DANGER_TICKS = 450;
+        //private const int DANGER_TICKS_BULLET_STEP = 200;
+        private const int DANGER_TICKS_SMOKE_STEP = 150;
+        public const int DANGER_TICKS_MAX = 600; // 1s in real life = 60 ticks in game;
+        //private const float DANGER_BULLET_MAX_DIST = 20f;
 
         private const float WEIGHTS_DIG = 0.8f;
         private const float WEIGHTS_COL = 0.5f;
@@ -49,21 +49,42 @@ namespace CombatExtended
         }
 
         private int[] dangerArray;
-
         public DangerTracker(Map map) : base(map)
         {
             dangerArray = new int[map.cellIndices.NumGridCells];
         }
 
-        public void Notify_BulletAt(IntVec3 pos, float distance)
+        public void Notify_BulletAt(IntVec3 pos, float dangerAmount)
         {
             for (int i = 0; i < 9; i++)
             {
                 IntVec3 cell = pos + AdjCells[i];
                 if (cell.InBounds(map))
-                    IncreaseAt(cell, (int)((DANGER_TICKS_BULLET_STEP * AdjWeights[i]) * Mathf.Max(DANGER_BULLET_MAX_DIST - distance, 0) / DANGER_BULLET_MAX_DIST));
+                    IncreaseAt(cell, (int)Mathf.Ceil(AdjWeights[i] * dangerAmount));
             }
-            if (Controller.settings.DebugMuzzleFlash) FLashCell(pos);
+            if (Controller.settings.DebugMuzzleFlash) FlashCell(pos);
+        }
+
+        public void Notify_DangerRadiusAt(IntVec3 pos, float radius, float dangerAmount, bool falloff = true, bool requireLOS = true)
+        {
+            var radiusSqrd = radius * radius;
+            foreach (IntVec3 cell in GenRadial.RadialCellsAround(pos, radius, true))
+            {
+                if (!cell.InBounds(map) || (requireLOS && !GenSight.LineOfSight(pos, cell, this.map)))
+                    continue;
+                var cellDanger = dangerAmount;
+                if (falloff)
+                {
+                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / radiusSqrd));
+                }
+                IncreaseAt(cell, (int)Mathf.Ceil(cellDanger));
+
+                if (Controller.settings.DebugMuzzleFlash)
+                {
+                    float value = DangerAt(cell);
+                    if (value > 0f) map.debugDrawer.FlashCell(cell, value, $"{value}");
+                }
+            }
         }
 
         public void Notify_SmokeAt(IntVec3 pos)
@@ -74,12 +95,12 @@ namespace CombatExtended
                 if (cell.InBounds(map))
                     IncreaseAt(cell, (int)(DANGER_TICKS_SMOKE_STEP * AdjWeights[i]));
             }
-            if (Controller.settings.DebugMuzzleFlash) FLashCell(pos);
+            if (Controller.settings.DebugMuzzleFlash) FlashCell(pos);
         }
 
         public float DangerAt(IntVec3 pos)
         {
-            if (pos.InBounds(map)) return (float)Mathf.Clamp(dangerArray[map.cellIndices.CellToIndex(pos)] - GenTicks.TicksGame, 0, DANGER_TICKS_MAX) / DANGER_TICKS;
+            if (pos.InBounds(map)) return (float)Mathf.Clamp(dangerArray[map.cellIndices.CellToIndex(pos)] - GenTicks.TicksGame, 0, DANGER_TICKS_MAX) / (float)DANGER_TICKS_MAX;
             return 0f;
         }
 
@@ -97,7 +118,7 @@ namespace CombatExtended
                 dangerArray = new int[map.cellIndices.NumGridCells];
         }
 
-        private void FLashCell(IntVec3 pos)
+        private void FlashCell(IntVec3 pos)
         {
             for (int i = 0; i < 9; i++)
             {
@@ -115,12 +136,7 @@ namespace CombatExtended
             int index = map.cellIndices.CellToIndex(pos);
             int value = dangerArray[index];
             int ticks = GenTicks.TicksGame;
-            if (value - ticks <= 0)
-            {
-                dangerArray[index] = ticks + amount;
-                return;
-            }
-            dangerArray[index] = Mathf.Min(value + amount, DANGER_TICKS_MAX);
+            dangerArray[index] = Mathf.Clamp(value + amount, ticks + amount, ticks + DANGER_TICKS_MAX);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/DangerTracker.cs
+++ b/Source/CombatExtended/CombatExtended/DangerTracker.cs
@@ -11,7 +11,7 @@ namespace CombatExtended
         //private const int DANGER_TICKS = 450;
         //private const int DANGER_TICKS_BULLET_STEP = 200;
         private const int DANGER_TICKS_SMOKE_STEP = 150;
-        public const int DANGER_TICKS_MAX = 600; // 1s in real life = 60 ticks in game;
+        public const int DANGER_TICKS_MAX = 300; // 1s in real life = 60 ticks in game;
         //private const float DANGER_BULLET_MAX_DIST = 20f;
 
         private const float WEIGHTS_DIG = 0.8f;
@@ -62,22 +62,18 @@ namespace CombatExtended
                 if (cell.InBounds(map))
                     IncreaseAt(cell, (int)Mathf.Ceil(AdjWeights[i] * dangerAmount));
             }
-            if (Controller.settings.DebugDisplayDangerBuildup) FlashCell(pos);
+            if (Controller.settings.DebugDisplayDangerBuildup) FlashCells(pos);
         }
 
-        public void Notify_DangerRadiusAt(IntVec3 pos, float radius, float dangerAmount, bool falloff = true, bool requireLOS = true)
+        public void Notify_DangerRadiusAt(IntVec3 pos, float radius, float dangerAmount)
         {
-            var radiusSqrd = radius * radius;
+            //var radiusSqrd = radius * radius;
             foreach (IntVec3 cell in GenRadial.RadialCellsAround(pos, radius, true))
             {
-                if (!cell.InBounds(map) || (requireLOS && !GenSight.LineOfSight(pos, cell, this.map)))
+                if (!cell.InBounds(map) && !GenSight.LineOfSight(pos, cell, this.map))
                     continue;
-                var cellDanger = dangerAmount;
-                if (falloff)
-                {
-                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / radiusSqrd));
-                }
-                IncreaseAt(cell, (int)Mathf.Ceil(cellDanger));
+                //dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / radiusSqrd));
+                IncreaseAt(cell, (int)Mathf.Ceil(dangerAmount));
 
                 if (Controller.settings.DebugDisplayDangerBuildup)
                 {
@@ -95,7 +91,7 @@ namespace CombatExtended
                 if (cell.InBounds(map))
                     IncreaseAt(cell, (int)(DANGER_TICKS_SMOKE_STEP * AdjWeights[i]));
             }
-            if (Controller.settings.DebugMuzzleFlash) FlashCell(pos);
+            if (Controller.settings.DebugDisplayDangerBuildup) FlashCells(pos);
         }
 
         public float DangerAt(IntVec3 pos)
@@ -118,7 +114,7 @@ namespace CombatExtended
                 dangerArray = new int[map.cellIndices.NumGridCells];
         }
 
-        private void FlashCell(IntVec3 pos)
+        private void FlashCells(IntVec3 pos)
         {
             for (int i = 0; i < 9; i++)
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1000,7 +1000,7 @@ namespace CombatExtended
                 }
             }
             float distToOrigin = originInt.DistanceTo(positionInt);
-            if (shotHeight < CollisionVertical.WallCollisionHeight && distToOrigin > 3 && def.projectile.damageDef.harmsHealth)
+            if (ExactPosition.y < CollisionVertical.WallCollisionHeight && distToOrigin > 3 && def.projectile.damageDef.harmsHealth)
                 DangerTracker?.Notify_BulletAt(Position, def.projectile.damageAmountBase * projectileDangerFactor);
         }
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -879,7 +879,7 @@ namespace CombatExtended
         /// <param name="suppressionMultiplier">How much to multiply the projectile's damage by before using it as suppression</param>
         /// <param name="closerProjAsOrigin">Whether or not the ratio of distance from the projectile to the explosion radius + suppression radius
         /// should influence where the origin of the suppression is</param>
-        private void ApplySuppression(Pawn pawn, float suppressionMultiplier = 1f, bool closerProjAsOrigin = false)
+        protected void ApplySuppression(Pawn pawn, float suppressionMultiplier = 1f, bool closerProjAsOrigin = false)
         {
             if (!def.projectile.damageDef.harmsHealth)
                 return;
@@ -937,12 +937,6 @@ namespace CombatExtended
             base.Tick();
             if (landed)
             {
-                if (def.projectile.explosionDelay == 0 || !def.projectile.damageDef.harmsHealth)
-                    return;
-                var suppressThings = new List<Pawn>();
-                suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius));
-                foreach (var thing in suppressThings)
-                    ApplySuppression(thing, 1, true);
                 return;
             }
             LastPos = ExactPosition;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -35,7 +35,7 @@ namespace CombatExtended
         /// <summary>
         /// By how much is the damage of the projectile multiplied before being sent as danger amount.
         /// </summary>
-        protected const float projectileDangerFactor = 0.5f;
+        protected const float projectileDangerFactor = 1f;
 
         /// <summary>
         /// By how much is the damage of an explosive projectile is multiplied before being sent as danger amount.
@@ -1186,6 +1186,10 @@ namespace CombatExtended
                             0.2f, explosionSuppressionRadius) + 0.9f,
                         dangerAmount);
                 }
+            }
+            else
+            {
+                DangerTracker?.Notify_BulletAt(ExactPosition.ToIntVec3(), def.projectile.damageAmountBase * projectileDangerFactor);
             }
 
             Destroy();

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -35,7 +35,12 @@ namespace CombatExtended
         /// <summary>
         /// By how much is the damage of the projectile multiplied before being sent as danger amount.
         /// </summary>
-        protected const float dangerAmountFactor = 1f;
+        protected const float projectileDangerFactor = 0.5f;
+
+        /// <summary>
+        /// By how much is the damage of an explosive projectile is multiplied before being sent as danger amount.
+        /// </summary>
+        protected const float explosiveDangerFactor = 1f;
 
         /// <summary>
         /// Additional suppression multiplier for airborne projectiles with a fuse.
@@ -984,7 +989,7 @@ namespace CombatExtended
             }
             float distToOrigin = originInt.DistanceTo(positionInt);
             if (shotHeight < CollisionVertical.WallCollisionHeight && distToOrigin > 3 && def.projectile.damageDef.harmsHealth)
-                DangerTracker?.Notify_BulletAt(Position, def.projectile.damageAmountBase * dangerAmountFactor);
+                DangerTracker?.Notify_BulletAt(Position, def.projectile.damageAmountBase * projectileDangerFactor);
         }
 
         /// <summary>
@@ -1174,8 +1179,8 @@ namespace CombatExtended
                 if (def.projectile.damageDef.harmsHealth)
                 {
                     foreach (var thing in suppressThings)
-                        ApplySuppression(thing, explosionSuppressionFactor, true);
-                    var dangerAmount = def.projectile.damageAmountBase * dangerAmountFactor;
+                        ApplySuppression(thing, explosionSuppressionFactor);
+                    var dangerAmount = def.projectile.damageAmountBase * explosiveDangerFactor;
                     DangerTracker.Notify_DangerRadiusAt(Position,
                         Math.Max(explosionSuppressionRadius * Mathf.Sqrt(dangerAmount * SuppressionUtility.dangerAmountFactor) *
                             0.2f, explosionSuppressionRadius) + 0.9f,

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -882,8 +882,6 @@ namespace CombatExtended
         /// </summary>
         /// <param name="pawn">Which pawn to suppress</param>
         /// <param name="suppressionMultiplier">How much to multiply the projectile's damage by before using it as suppression</param>
-        /// <param name="closerProjAsOrigin">Whether or not the ratio of distance from the projectile to the explosion radius + suppression radius
-        /// should influence where the origin of the suppression is</param>
         protected void ApplySuppression(Pawn pawn, float suppressionMultiplier = 1f)
 
         {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -34,7 +34,7 @@ namespace CombatExtended
                     {
                         var suppressThings = new List<Pawn>();
                         suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map,
-                            SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f)));
+                            SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f)));
                         foreach (var thing in suppressThings)
                             ApplySuppression(thing, 1f - (ticksToDetonation / def.projectile.explosionDelay));
                     }
@@ -61,12 +61,7 @@ namespace CombatExtended
             ticksToDetonation = def.projectile.explosionDelay;
             if (def.projectile.damageDef.harmsHealth)
             {
-                var dangerAmount = def.projectile.damageAmountBase * explosiveDangerFactor + ticksToDetonation;
-                var explosionSuppressionRadius = def.projectile.explosionRadius + SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f);
-                DangerTracker.Notify_DangerRadiusAt(Position,
-                    Math.Max(explosionSuppressionRadius * Mathf.Sqrt(dangerAmount * SuppressionUtility.dangerAmountFactor) *
-                        0.2f, explosionSuppressionRadius) + 0.9f,
-                    dangerAmount);
+                DangerTracker.Notify_DangerRadiusAt(Position, def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f), def.projectile.damageAmountBase * explosionDangerFactor);
                 GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(this, this.def.projectile.damageDef, this.launcher?.Faction);
             }
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -3,6 +3,7 @@ using Verse;
 using RimWorld;
 using UnityEngine;
 using System.Collections.Generic;
+using CombatExtended.Utilities;
 
 namespace CombatExtended
 {
@@ -25,6 +26,17 @@ namespace CombatExtended
                 {
                     //Explosions are all handled in base
                     base.Impact(null);
+                    return;
+                }
+                if (landed)
+                {
+                    if (def.projectile.damageDef.harmsHealth)
+                    {
+                        var suppressThings = new List<Pawn>();
+                        suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f)));
+                        foreach (var thing in suppressThings)
+                            ApplySuppression(thing, 1f - (ticksToDetonation / def.projectile.explosionDelay), true);
+                    }
                 }
             }
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -36,7 +36,7 @@ namespace CombatExtended
                         suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map,
                             SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f)));
                         foreach (var thing in suppressThings)
-                            ApplySuppression(thing, 1f - (ticksToDetonation / def.projectile.explosionDelay), true);
+                            ApplySuppression(thing, 1f - (ticksToDetonation / def.projectile.explosionDelay));
                     }
                 }
             }
@@ -61,7 +61,7 @@ namespace CombatExtended
             ticksToDetonation = def.projectile.explosionDelay;
             if (def.projectile.damageDef.harmsHealth)
             {
-                var dangerAmount = def.projectile.damageAmountBase * dangerAmountFactor + ticksToDetonation;
+                var dangerAmount = def.projectile.damageAmountBase * explosiveDangerFactor + ticksToDetonation;
                 var explosionSuppressionRadius = def.projectile.explosionRadius + SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f);
                 DangerTracker.Notify_DangerRadiusAt(Position,
                     Math.Max(explosionSuppressionRadius * Mathf.Sqrt(dangerAmount * SuppressionUtility.dangerAmountFactor) *

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -46,7 +46,16 @@ namespace CombatExtended
             }
             landed = true;
             ticksToDetonation = def.projectile.explosionDelay;
-            GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(this, this.def.projectile.damageDef, this.launcher?.Faction);
+            if (def.projectile.damageDef.harmsHealth)
+            {
+                var dangerAmount = def.projectile.damageAmountBase * dangerAmountFactor;
+                var explosionSuppressionRadius = def.projectile.explosionRadius + SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f);
+                DangerTracker.Notify_DangerRadiusAt(Position,
+                    Math.Max(Mathf.Sqrt(explosionSuppressionRadius * explosionSuppressionRadius * dangerAmount * SuppressionUtility.dangerAmountFactor) *
+                        0.2f, explosionSuppressionRadius) + 0.5f,
+                    dangerAmount);
+                GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(this, this.def.projectile.damageDef, this.launcher?.Faction);
+            }
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -33,7 +33,8 @@ namespace CombatExtended
                     if (def.projectile.damageDef.harmsHealth)
                     {
                         var suppressThings = new List<Pawn>();
-                        suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f)));
+                        suppressThings.AddRange(ExactPosition.ToIntVec3().PawnsInRange(Map,
+                            SuppressionRadius + def.projectile.explosionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f)));
                         foreach (var thing in suppressThings)
                             ApplySuppression(thing, 1f - (ticksToDetonation / def.projectile.explosionDelay), true);
                     }
@@ -60,11 +61,11 @@ namespace CombatExtended
             ticksToDetonation = def.projectile.explosionDelay;
             if (def.projectile.damageDef.harmsHealth)
             {
-                var dangerAmount = def.projectile.damageAmountBase * dangerAmountFactor;
-                var explosionSuppressionRadius = def.projectile.explosionRadius + SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 1.5f : 0f);
+                var dangerAmount = def.projectile.damageAmountBase * dangerAmountFactor + ticksToDetonation;
+                var explosionSuppressionRadius = def.projectile.explosionRadius + SuppressionRadius + (def.projectile.applyDamageToExplosionCellsNeighbors ? 2.2f : 0f);
                 DangerTracker.Notify_DangerRadiusAt(Position,
-                    Math.Max(Mathf.Sqrt(explosionSuppressionRadius * explosionSuppressionRadius * dangerAmount * SuppressionUtility.dangerAmountFactor) *
-                        0.2f, explosionSuppressionRadius) + 0.5f,
+                    Math.Max(explosionSuppressionRadius * Mathf.Sqrt(dangerAmount * SuppressionUtility.dangerAmountFactor) *
+                        0.2f, explosionSuppressionRadius) + 0.9f,
                     dangerAmount);
                 GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(this, this.def.projectile.damageDef, this.launcher?.Faction);
             }

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -28,7 +28,8 @@ namespace CombatExtended
 	private bool genericammo = false;
         private bool partialstats = true;
 
-	private bool showExtraTooltips = false;
+
+        private bool showExtraTooltips = false;
 
 	private bool showExtraStats = false;
 
@@ -86,6 +87,8 @@ namespace CombatExtended
         private bool debugShowTreeCollisionChance = false;
         private bool debugShowSuppressionBuildup = false;
         private bool debugDrawInterceptChecks = false;
+        private bool debugDisplayDangerBuildup = false;
+        private bool debugDisplayCellCoverRating = false;
 
         public bool DebuggingMode => debuggingMode;
         public bool DebugVerbose => debugVerbose;
@@ -97,10 +100,12 @@ namespace CombatExtended
         public bool DebugShowTreeCollisionChance => debugShowTreeCollisionChance && debuggingMode;
         public bool DebugShowSuppressionBuildup => debugShowSuppressionBuildup && debuggingMode;
         public bool DebugGenClosetPawn => debugGenClosetPawn && debuggingMode;
+        public bool DebugDisplayDangerBuildup => debugDisplayDangerBuildup && debuggingMode;
+        public bool DebugDisplayCellCoverRating => debugDisplayCellCoverRating && debuggingMode;
         #endregion
 
-	#region Autopatcher
-	private bool debugAutopatcherLogger = false;
+        #region Autopatcher
+        private bool debugAutopatcherLogger = false;
 
 	public bool DebugAutopatcherLogger => debugAutopatcherLogger;
 
@@ -150,8 +155,10 @@ namespace CombatExtended
             Scribe_Values.Look(ref debugDrawTargetCoverChecks, "debugDrawTargetCoverChecks", false);
             Scribe_Values.Look(ref debugShowTreeCollisionChance, "debugShowTreeCollisionChance", false);
             Scribe_Values.Look(ref debugShowSuppressionBuildup, "debugShowSuppressionBuildup", false);
+            Scribe_Values.Look(ref debugDisplayDangerBuildup, "debugDisplayDangerBuildup", false);
+            Scribe_Values.Look(ref debugDisplayCellCoverRating, "debugDisplayCellCoverRating", false);
 #endif
-	    Scribe_Values.Look(ref debugAutopatcherLogger, "debugAutopatcherLogger", false);
+            Scribe_Values.Look(ref debugAutopatcherLogger, "debugAutopatcherLogger", false);
 	    
 	    Scribe_Values.Look(ref enableWeaponAutopatcher, "enableWeaponAutopatcher", true);
 	    Scribe_Values.Look(ref enableWeaponToughnessAutopatcher, "enableWeaponToughnessAutopatcher", true);
@@ -257,6 +264,8 @@ namespace CombatExtended
                 list.CheckboxLabeled("Display tree collision chances", ref debugShowTreeCollisionChance, "Projectiles will display chances of coliding with trees as they pass by.");
                 list.CheckboxLabeled("Display suppression buildup", ref debugShowSuppressionBuildup, "Pawns will display buildup numbers when taking suppression.");
                 list.CheckboxLabeled("Display light intensity affected by muzzle flash", ref debugMuzzleFlash);
+                list.CheckboxLabeled("Display danger buildup within cells", ref debugDisplayDangerBuildup);
+                list.CheckboxLabeled("Display cover rating of cells of suppressed pawns", ref debugDisplayCellCoverRating);
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -150,14 +150,6 @@ namespace CombatExtended
                     var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
                     cellRating = Mathf.Min(coverRating, 2f) * 8f;
                 }
-
-            }
-
-            for (int i = 0; i < interceptors.Count; i++)
-            {
-                CompProjectileInterceptor interceptor = interceptors[i];
-                if (interceptor.Active && interceptor.parent.Position.DistanceTo(cell) < interceptor.Props.radius)
-                    cellRating += 20f;
             }
 
             foreach (IntVec3 pos in pawn.Map.PartialLineOfSights(cell, shooterPos))
@@ -180,6 +172,13 @@ namespace CombatExtended
             }
 
             cellRating += 12f - (bonusCellRating * 8f);
+
+            for (int i = 0; i < interceptors.Count; i++)
+            {
+                CompProjectileInterceptor interceptor = interceptors[i];
+                if (interceptor.Active && interceptor.parent.Position.DistanceTo(cell) < interceptor.Props.radius)
+                    cellRating += 20f;
+            }
 
             // Avoid bullets and other danger sources.
             cellRating -= dangerTracker.DangerAt(cell) * DangerTracker.DANGER_TICKS_MAX * dangerAmountFactor;

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -148,7 +148,7 @@ namespace CombatExtended
                 {
                     pawnCrouchFillPercent = Mathf.Clamp(cover.def.fillPercent + pawnVisibleOverCoverFillPercent, pawnLowestCrouchFillPercent, pawnHeightFactor);
                     var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
-                    cellRating = Mathf.Min(coverRating, 2f) * 10f;
+                    cellRating = Mathf.Min(coverRating, 2f) * 8f;
                 }
 
             }
@@ -170,8 +170,8 @@ namespace CombatExtended
                 {
                     // A pawn crouches down only next to nearby cover, therefore they can hide behind distanced cover that is higher than their current crouch height;
                     var distancedCoverRating = cover.def.fillPercent / pawnCrouchFillPercent;
-                    if (distancedCoverRating * 10f > cellRating)
-                        cellRating = Mathf.Min(distancedCoverRating, 2f) * 10f;
+                    if (distancedCoverRating * 8f > cellRating)
+                        cellRating = Mathf.Min(distancedCoverRating, 2f) * 8f;
                 }
                 else
                 {
@@ -179,7 +179,7 @@ namespace CombatExtended
                 }
             }
 
-            cellRating += 1f + (1f - bonusCellRating) * 10f;
+            cellRating += 12f - (bonusCellRating * 8f);
 
             // Avoid bullets and other danger sources.
             cellRating -= dangerTracker.DangerAt(cell) * DangerTracker.DANGER_TICKS_MAX * dangerAmountFactor;
@@ -187,7 +187,7 @@ namespace CombatExtended
             //Check time to path to that location
             if (!pawn.Position.Equals(cell))
             {
-                cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) / 2f;
+                cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 4f;
                 // float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.NoPassClosedDoors).TotalCost;
                 float pathCost = (pawn.Position - cell).LengthHorizontal;
                 if (!GenSight.LineOfSight(pawn.Position, cell, pawn.Map))

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -11,7 +11,9 @@ namespace CombatExtended
 {
     public static class SuppressionUtility
     {
-        public const float maxCoverDist = 10f; //Maximum distance to run for cover to
+        private const float maxCoverDist = 10f; // Maximum distance to run for cover to;
+
+        public const float dangerAmountFactor = 0.25f; // Multiplier for danger amount at a cell while calculating how safe the cell is;
 
         private static LightingTracker lightingTracker;
 
@@ -53,7 +55,6 @@ namespace CombatExtended
             {
                 return null;
             }
-            float distToSuppressor = (pawn.Position - comp.SuppressorLoc).LengthHorizontal;
             IntVec3 coverPosition;
 
             //Try to find cover position to move up to
@@ -106,6 +107,7 @@ namespace CombatExtended
                 }
             }
             coverPosition = bestPos;
+            //Log.Warning("best cell at " + bestPos.ToString() + ' ' + bestRating.ToString());
             lightingTracker = null;
             return bestRating >= 0;
         }
@@ -117,38 +119,70 @@ namespace CombatExtended
             {
                 return -1;
             }
+            float cellRating = 0f, bonusCellRating = 1f, distToSuppressor = (pawn.Position - shooterPos).LengthHorizontal,
+                pawnHeightFactor = CE_Utility.GetCollisionBodyFactors(pawn).y,
+                pawnVisibleOverCoverFillPercent = pawnHeightFactor * (1f - CollisionVertical.BodyRegionMiddleHeight) + 0.01f,
+                pawnLowestCrouchFillPercent = pawnHeightFactor * CollisionVertical.BodyRegionBottomHeight + pawnVisibleOverCoverFillPercent,
+                pawnCrouchFillPercent = pawnLowestCrouchFillPercent;
 
-            float cellRating = 0;
+            Vector3 coverVec = (shooterPos - cell).ToVector3().normalized;
 
+            // Line of sight is extremely important;
             if (!GenSight.LineOfSight(shooterPos, cell, pawn.Map))
             {
-                cellRating += 4f;
+                cellRating = 20f;
             }
             else
             {
-                //Check if cell has cover in desired direction
-                Vector3 coverVec = (shooterPos - cell).ToVector3().normalized;
+                // Check if cell has cover in desired direction;
                 IntVec3 coverCell = (cell.ToVector3Shifted() + coverVec).ToIntVec3();
                 Thing cover = coverCell.GetCover(pawn.Map);
-                cellRating += GetCoverRating(cover) * 2;
+                // Recheck with priority given to diagonal cover;
+                if (cover == null || cover is Plant || cover is Gas)
+                {
+                    coverCell = (cell.ToVector3Shifted() + coverVec.ToVec3Gridified()).ToIntVec3();
+                    cover = coverCell.GetCover(pawn.Map);
+                }
+                // Only account for solid cover;
+                if (cover != null && !(cover is Plant || cover is Gas))
+                {
+                    pawnCrouchFillPercent = Mathf.Clamp(cover.def.fillPercent + pawnVisibleOverCoverFillPercent, pawnLowestCrouchFillPercent, pawnHeightFactor);
+                    var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
+                    cellRating = Mathf.Min(coverRating, 2f) * 10f;
+                }
+
             }
 
-            // Avoid bullets and other danger source
-            cellRating -= dangerTracker.DangerAt(cell) * 4;
+            for (int i = 0; i < interceptors.Count; i++)
+            {
+                CompProjectileInterceptor interceptor = interceptors[i];
+                if (interceptor.Active && interceptor.parent.Position.DistanceTo(cell) < interceptor.Props.radius)
+                    cellRating += 20f;
+            }
 
-            // better cover rating system
-            float coverLOSRating = 0;
             foreach (IntVec3 pos in pawn.Map.PartialLineOfSights(cell, shooterPos))
             {
                 Thing cover = pos.GetCover(pawn.Map);
                 if (cover == null)
                     continue;
-                if (cover is Gas)
-                    coverLOSRating += 2;
-                else if (cover.def.Fillage == FillCategory.Partial)
-                    coverLOSRating += 4;
+                // Check if the pawn already has hard cover and the cover currently is hard cover; then do custom formula for increasing cell rating;
+                if (!(cover is Gas || cover is Plant))
+                {
+                    // A pawn crouches down only next to nearby cover, therefore they can hide behind distanced cover that is higher than their current crouch height;
+                    var distancedCoverRating = cover.def.fillPercent / pawnCrouchFillPercent;
+                    if (distancedCoverRating * 10f > cellRating)
+                        cellRating = Mathf.Min(distancedCoverRating, 2f) * 10f;
+                }
+                else
+                {
+                    bonusCellRating *= 1f - GetCoverRating(cover);
+                }
             }
-            cellRating += Mathf.Min(coverLOSRating, 25);
+
+            cellRating += 1f + (1f - bonusCellRating) * 10f;
+
+            // Avoid bullets and other danger sources.
+            cellRating -= dangerTracker.DangerAt(cell) * DangerTracker.DANGER_TICKS_MAX * dangerAmountFactor;
 
             //Check time to path to that location
             if (!pawn.Position.Equals(cell))
@@ -160,21 +194,17 @@ namespace CombatExtended
                     pathCost *= 5;
                 cellRating = cellRating / pathCost;
             }
-            for (int i = 0; i < interceptors.Count; i++)
-            {
-                CompProjectileInterceptor interceptor = interceptors[i];
-                if (interceptor.Active && interceptor.parent.Position.DistanceTo(cell) < interceptor.Props.radius)
-                    cellRating += 10;
-            }
             return cellRating;
         }
 
         private static float GetCoverRating(Thing cover)
         {
-            if (cover == null) return 0;
-            if (cover is Gas) return 0.8f;
-            if (cover.def.category == ThingCategory.Plant) return cover.def.fillPercent; // Plant cover only has a random chance to block gunfire and is rated lower            
-            return 1;
+            // Higher values mean more effective at being considered cover.
+            if (cover == null) return 0f;
+            if (cover is Gas) return 0.2f;
+            // Plant cover has a random chance to block projectiles and span a long height, therefore efficiency stacks
+            if (cover.def.category == ThingCategory.Plant) return 0.45f * cover.def.fillPercent;
+            return 0f;
         }
 
         public static bool TryGetSmokeScreeningJob(Pawn pawn, IntVec3 suppressorLoc, out Job job)

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -148,7 +148,7 @@ namespace CombatExtended
                 {
                     pawnCrouchFillPercent = Mathf.Clamp(cover.def.fillPercent + pawnVisibleOverCoverFillPercent, pawnLowestCrouchFillPercent, pawnHeightFactor);
                     var coverRating = 1f - ((pawnCrouchFillPercent - cover.def.fillPercent) / pawnHeightFactor);
-                    cellRating = Mathf.Min(coverRating, 2f) * 8f;
+                    cellRating = Mathf.Min(coverRating, 1.5f) * 10f;
                 }
             }
 
@@ -162,8 +162,8 @@ namespace CombatExtended
                 {
                     // A pawn crouches down only next to nearby cover, therefore they can hide behind distanced cover that is higher than their current crouch height;
                     var distancedCoverRating = cover.def.fillPercent / pawnCrouchFillPercent;
-                    if (distancedCoverRating * 8f > cellRating)
-                        cellRating = Mathf.Min(distancedCoverRating, 2f) * 8f;
+                    if (distancedCoverRating * 10f > cellRating)
+                        cellRating = Mathf.Min(distancedCoverRating, 1.5f) * 10f;
                 }
                 else
                 {
@@ -171,7 +171,7 @@ namespace CombatExtended
                 }
             }
 
-            cellRating += 12f - (bonusCellRating * 8f);
+            cellRating += 10f - (bonusCellRating * 10f);
 
             for (int i = 0; i < interceptors.Count; i++)
             {
@@ -186,7 +186,7 @@ namespace CombatExtended
             //Check time to path to that location
             if (!pawn.Position.Equals(cell))
             {
-                cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 4f;
+                cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 5f;
                 // float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.NoPassClosedDoors).TotalCost;
                 float pathCost = (pawn.Position - cell).LengthHorizontal;
                 if (!GenSight.LineOfSight(pawn.Position, cell, pawn.Map))

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -91,6 +91,11 @@ namespace CombatExtended
                 Region pawnRegion = pawn.Position.GetRegion(pawn.Map);
                 List<Region> adjacentRegions = pawnRegion.Neighbors.ToList();
                 adjacentRegions.Add(pawnRegion);
+                List<Region> tempRegions = adjacentRegions.ListFullCopy();
+                foreach (Region region in tempRegions)
+                {
+                    adjacentRegions.AddRange(region.Neighbors.Except(adjacentRegions));
+                }
                 // Make sure only cells within bounds are evaluated
                 foreach (IntVec3 cell in cellList.Where(x => x.InBounds(pawn.Map)))
                 {
@@ -187,12 +192,16 @@ namespace CombatExtended
             if (!pawn.Position.Equals(cell))
             {
                 cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 5f;
-                // float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.NoPassClosedDoors).TotalCost;
+                //float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.PassDoors).TotalCost;
                 float pathCost = (pawn.Position - cell).LengthHorizontal;
                 if (!GenSight.LineOfSight(pawn.Position, cell, pawn.Map))
-                    pathCost *= 5;
+                    pathCost *= 5f;
+                pathCost++;
                 cellRating = cellRating / pathCost;
             }
+
+            if (Controller.settings.DebugDisplayCellCoverRating)
+                pawn.Map.debugDrawer.FlashCell(cell, cellRating, $"{cellRating}");
             return cellRating;
         }
 

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -115,7 +115,7 @@ namespace CombatExtended
             coverPosition = bestPos;
             //Log.Warning("best cell at " + bestPos.ToString() + ' ' + bestRating.ToString());
             lightingTracker = null;
-            return bestRating >= -999f;
+            return bestRating >= -999f && pawn.Position != coverPosition;
         }
 
         private static float GetCellCoverRatingForPawn(Pawn pawn, IntVec3 cell, IntVec3 shooterPos)


### PR DESCRIPTION
## Additions
1. Function to return a 3D vector which if used to trace a shape with vectors of the same length would trace a square instead of a circle;
2. Pawns change remembered suppression location if the local suppression exceeds their suppression threshold;
3. A function to add danger to cells in a radius around a center cell;
4. Debug toggle for displaying cell danger rating;
5. Debug toggle for displaying cell cover ratings for a pawn;
6. Danger multipliers for projectiles and explosions;
7. Fused explosives apply danger to cells after landing and apply suppression to pawns before exploding, with more suppression being applied depending on how close they are to exploding;

## Changes
8. Overhauled how cell cover rating is calculated and how pawns pick cells for running to cover.
9. Projectiles that do no health harm no longer suppress or add danger;
10. Explosives which deal have explosions that deal damage to neighboring cells have an increased suppression and danger applying radius;
11. Projectiles that are lower in height than the wall fill percent apply danger;
12. Fused explosives apply less suppression while in the air;
13. Changed how danger works.

## Reasoning
1. Helpful for detecting cover that is diagonal to the pawn;
2. Helpful for getting pawns to take cover from grenadiers;
3. Used for explosives applying danger to an area;
4. Separated it from the debug display muzzle flash toggle;
5. Was useful for debugging why pawns wouldn't consider going trough doors to take cover;
6. Useful for tweaking pawn reactions to danger;
7. Helps fused explosives to apply suppression, as if having a grenade right next to someone won't have them freak out the longer it doesn't explode;
8. Was necessary to have suppressed pawns act how they do in the video, overall I believe it is now smarter;
9. haha firefoam grenade deal 9999999 suppression;
10. Helps pawns to properly react to that and not stand on the edge of the explosion;
11. Used to be that if the initial projectile height was lower than the wall collision height, then it'd apply danger, this caused projectiles which were flying high in the air to apply danger to cells they travelled trough;
12. Hopefully balances out addition 7;
13. I never realized there was a danger tracker because of how little of an impact it appeared to have on suppressed pawn decision making, now danger from projectiles doesn't decrease the further they travel, as well as tweaked the max danger ticks a cell can have (it may have also been that the danger tracker was broken).

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] (For compatibility patches) ...with and without patched mod loaded;
- [ ] Playtested a colony.

## Old additional material
Proof of pawns reacting to stickbombs by running away:
https://user-images.githubusercontent.com/34545746/177002497-2e263045-0197-4131-9742-ce72a8ecfdb2.mp4

Screenshot (this means current behavior might differ) of a pawn reacting to a stickbomb by running away to break line of sight to it:
![image](https://user-images.githubusercontent.com/34545746/177002537-44fff82d-414e-4535-9c4e-ae46c7df0805.png)

Firefoam grenades dealing suppression before the change:
![image](https://user-images.githubusercontent.com/34545746/177002607-00e14f60-3a4f-4145-8ff1-af4488b8ff56.png)

Screenshot (this means current behavior might differ)  of a stickbomb applying danger to an area:
![image](https://user-images.githubusercontent.com/34545746/177002654-b70a4c7e-3fbc-4f37-9eda-f3dadd3150b8.png)