### PR TITLE
Patch New RH2 - Weapons Guns

### DIFF
--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
@@ -491,7 +491,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_408CheyenneTactical_FMJ</defaultProjectile>
 					<warmupTime>2.4</warmupTime>
-					<range>156</range>
+					<range>86</range>
 					<soundCast>RNShotIntervention</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>9</muzzleFlashScale>
@@ -507,6 +507,11 @@
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>AimedShot</aiAimMode>
 				</FireModes>
+
+				<weaponTags>
+					<li>Bipod_DMR</li>
+					<li>CE_AI_SR</li>
+				</weaponTags>
 
 				<!-- No additional CE weaponTags needed -->
 

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
@@ -469,6 +469,50 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- ========== Intervention AMR ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M200Intervention_AMR</defName>
+				<statBases>
+					<Mass>15.20</Mass>
+					<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>3.32</SightsEfficiency>
+					<ShotSpread>0.02</ShotSpread>
+					<SwayFactor>2.06</SwayFactor>
+					<Bulk>12.87</Bulk>
+					<WorkToMake>42500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>110</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_408CheyenneTactical_FMJ</defaultProjectile>
+					<warmupTime>2.4</warmupTime>
+					<range>156</range>
+					<soundCast>RNShotIntervention</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>7</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_408CheyenneTactical</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
 			<!-- == Shared patches for firearm melee tools == -->
 
 			<li Class="PatchOperationReplace">
@@ -482,7 +526,8 @@
 					defName="RNGun_LeeEnfield_BoltAction" or
 					defName="RNGun_M24A2_Sniper" or
 					defName="RNGun_M40A5_Sniper" or
-					defName="RNGun_SV98_Sniper"
+					defName="RNGun_SV98_Sniper" or
+					defName="RNGun_M200Intervention_AMR"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
@@ -449,7 +449,7 @@
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_338Lapua_FMJ</defaultProjectile>
 					<warmupTime>2.55</warmupTime>
-					<range>119</range>
+					<range>86</range>
 					<soundCast>RNShot_SRSSD</soundCast>
 					<soundCastTail>GunTail_Heavy</soundCastTail>
 					<muzzleFlashScale>9</muzzleFlashScale>
@@ -465,6 +465,11 @@
 					<aiUseBurstMode>FALSE</aiUseBurstMode>
 					<aiAimMode>AimedShot</aiAimMode>
 				</FireModes>
+
+				<weaponTags>
+					<li>Bipod_DMR</li>
+					<li>CE_AI_SR</li>
+				</weaponTags>
 
 				<!-- No additional CE weaponTags needed -->
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
@@ -54,6 +54,99 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- ========== OTs-03 SVU ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_SVU_DMR</defName>
+				<statBases>
+					<Mass>4.10</Mass>
+					<RangedWeapon_Cooldown>0.57</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>0.92</SwayFactor>
+					<Bulk>9.70</Bulk>
+					<WorkToMake>31000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>50</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+					<warmupTime>1.5</warmupTime>
+					<range>97</range>
+					<soundCast>RNShot_DMRSDGeneric_II</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_762x54mmR</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== SKS DMR ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_SKSModern_DMR</defName>
+				<statBases>
+					<Mass>3.85</Mass>
+					<RangedWeapon_Cooldown>0.57</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.06</ShotSpread>
+					<SwayFactor>1.01</SwayFactor>
+					<Bulk>10.18</Bulk>
+					<WorkToMake>29000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>15</Chemfuel>
+					<Steel>50</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+					<warmupTime>1.5</warmupTime>
+					<range>48</range>
+					<soundCast>RNShotSKS</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+
 			<!-- ========== PSL54 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -289,6 +382,94 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- ========== Mk 14 EBR ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_Mk14Mod0_DMR</defName>
+				<statBases>
+					<Mass>6.75</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.60</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.89</SwayFactor>
+					<Bulk>8.89</Bulk>
+					<WorkToMake>33500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>70</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.6</warmupTime>
+					<range>75</range>
+					<soundCast>RNShot_EBRGeneric</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>20</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== Desert Tech SRS ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_DesertTechSRS_DMR</defName>
+				<statBases>
+					<Mass>5.6</Mass>
+					<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>3.50</SightsEfficiency>
+					<ShotSpread>0.04</ShotSpread>
+					<SwayFactor>1.14</SwayFactor>
+					<Bulk>10.52</Bulk>
+					<WorkToMake>47000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>60</Steel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_338Lapua_FMJ</defaultProjectile>
+					<warmupTime>2.55</warmupTime>
+					<range>119</range>
+					<soundCast>RNShot_SRSSD</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_338Lapua</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
 			<!-- ========== Heckler & Koch PSG-1 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -445,7 +626,11 @@
 					defName="RNGun_M82A1_AMR" or
 					defName="RNGun_PSG1_DMR" or
 					defName="RNGun_VSSVintorez_DMR" or
-					defName="RNGun_WA2000_DMR"
+					defName="RNGun_WA2000_DMR" or
+					defName="RNGun_SVU_DMR" or
+					defName="RNGun_Mk14Mod0_DMR" or
+					defName="RNGun_SKSModern_DMR" or
+					defName="RNGun_DesertTechSRS_DMR"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Launchers.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Launchers.xml
@@ -206,6 +206,100 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<!-- ========== MBT LAW / NLAW ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_NLAW_RocketLauncher</defName>
+				<statBases>
+					<Mass>12.50</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>2.27</SwayFactor>
+					<Bulk>11.16</Bulk>
+					<WorkToMake>30500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>20</Chemfuel>
+					<Steel>75</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+					<FSX>9</FSX>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_150mmMBTLAWMissile</defaultProjectile>
+					<warmupTime>1.8</warmupTime>
+					<range>48</range>
+					<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+					<soundCast>RNShotLauncher</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
+			<!-- ========== FGM-148 Javelin ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_FGM148Javelin_RocketLauncher</defName>
+				<statBases>
+					<Mass>22.30</Mass>
+					<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.72</SightsEfficiency>
+					<ShotSpread>0.2</ShotSpread>
+					<SwayFactor>3.55</SwayFactor>
+					<Bulk>13.00</Bulk>
+					<WorkToMake>41500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>135</Steel>
+					<ComponentIndustrial>4</ComponentIndustrial>
+					<FSX>15</FSX>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_127mmJavelinMissile</defaultProjectile>
+					<warmupTime>2.5</warmupTime>
+					<range>156</range>
+					<soundCast>RNShotLauncher</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<onlyManualCast>true</onlyManualCast>
+					<stopBurstWithoutLos>false</stopBurstWithoutLos>
+					<muzzleFlashScale>15</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+
+				<!-- RH2 Weapons version of FGM-148 Javelin is single-use only -->
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<noSnapshot>true</noSnapshot>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+
+				<AllowWithRunAndGun>false</AllowWithRunAndGun>
+			</li>
+
 			<!-- == Shared patches for firearm melee tools == -->
 
 			<li Class="PatchOperationReplace">
@@ -253,7 +347,9 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 					defName="RNGun_M72LAW_RocketLauncher" or
-					defName="RNGun_RPG7_RocketLauncher"
+					defName="RNGun_RPG7_RocketLauncher" or
+					defName="RNGun_NLAW_RocketLauncher" or
+					defName="RNGun_FGM148Javelin_RocketLauncher"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle2_Style.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle2_Style.xml
@@ -195,6 +195,195 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- ========== M4A1 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_M4A1_Rifle</defName>
+				<statBases>
+					<Mass>2.90</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.1</ShotSpread>
+					<SwayFactor>1.13</SwayFactor>
+					<Bulk>7.56</Bulk>
+					<WorkToMake>32000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>50</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+					<Chemfuel>10</Chemfuel>
+				</costList>
+				<Properties>
+					<recoilAmount>1.58</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_MWARRifle</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<recoilPattern>Regular</recoilPattern>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_Rifle</li>
+				</weaponTags>
+			</li>
+
+			<!-- ========== F2000 ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_F2000_Rifle</defName>
+				<statBases>
+					<Mass>3.60</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.00</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.05</SwayFactor>
+					<Bulk>6.88</Bulk>
+					<WorkToMake>36500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>40</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.41</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericBullpup_III</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<!-- ========== ACR ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_ACR_Rifle</defName>
+				<statBases>
+					<Mass>3.30</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.24</SightsEfficiency>
+					<ShotSpread>0.09</ShotSpread>
+					<SwayFactor>1.32</SwayFactor>
+					<Bulk>7.16</Bulk>
+					<WorkToMake>35500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>40</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.55</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericAR</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_TAR-21_Rifle</defName>
+				<statBases>
+					<Mass>3.27</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.08</ShotSpread>
+					<SwayFactor>1.05</SwayFactor>
+					<Bulk>7.20</Bulk>
+					<WorkToMake>38500</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>40</Steel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.49</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>59</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>RNShot_GenericBullpup_III</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
 			<!-- ========== L119A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -621,7 +810,7 @@
 				</weaponTags>
 			</li>
 
-			<!-- ========== FAL Para========== -->
+			<!-- ========== FAL Para ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>RNGun_R1Para_Rifle</defName>
@@ -762,6 +951,49 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>RNGun_G3A2_Rifle</defName>
+			<statBases>
+				<WorkToMake>67500</WorkToMake>
+				<SightsEfficiency>1</SightsEfficiency>
+				<ShotSpread>0.08</ShotSpread>
+				<SwayFactor>1.46</SwayFactor>
+				<Bulk>10.23</Bulk>
+				<Mass>4.40</Mass>
+				<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			</statBases>
+			<costList>
+				<Steel>65</Steel>
+				<ComponentIndustrial>6</ComponentIndustrial>
+				<Chemfuel>10</Chemfuel>
+			</costList>
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>True</hasStandardCommand>
+				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+				<recoilAmount>2.00</recoilAmount>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+				<warmupTime>1.1</warmupTime>
+				<range>55</range>
+				<soundCast>RNShot_GenericDMR_II</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>12</muzzleFlashScale>
+			</Properties>
+
+			<AmmoUser>
+				<magazineSize>20</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+			</AmmoUser>
+
+			<FireModes>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+			</FireModes>
+			</li>
+
 
 			<!-- == Shared patches for firearm melee tools == -->
 
@@ -781,7 +1013,12 @@
 					defName="RNGun_R1Para_Rifle" or
 					defName="RNGun_FNFAL_Rifle" or
 					defName="RNGun_RomatFAL_Rifle" or
-					defName="RNGun_G36K_Rifle"
+					defName="RNGun_G36K_Rifle" or
+					defName="RNGun_M4A1_Rifle" or					
+					defName="RNGun_F2000_Rifle" or
+					defName="RNGun_G3A2_Rifle" or
+					defName="RNGun_ACR_Rifle" or
+					defName="RNGun_TAR-21_Rifle"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_SMG.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_SMG.xml
@@ -102,6 +102,53 @@
 				<!-- No additional CE weaponTags needed -->
 			</li>
 
+			<!-- ========== KRISS Vector ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_KrissVector_PDW</defName>
+				<statBases>
+					<Mass>3.20</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.10</SightsEfficiency>
+					<ShotSpread>0.1</ShotSpread>
+					<SwayFactor>1.14</SwayFactor>
+					<Bulk>6.06</Bulk>
+					<WorkToMake>32000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>5</Chemfuel>
+					<Steel>40</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.47</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>12</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<soundCast>RNShotMP7SMG</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+
+				<!-- No additional CE weaponTags needed -->
+			</li>
+
 			<!-- ========== MP5A2 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -559,7 +606,8 @@
 					defName="RNGun_ThompsonSubmachineGun_SMG" or
 					defName="RNGun_UMP45_SMG" or
 					defName="RNGun_PP19_SMG" or
-					defName="RNGun_Uzi_SMG"
+					defName="RNGun_Uzi_SMG" or
+					defName="RNGun_KrissVector_PDW"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Shotguns.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Shotguns.xml
@@ -564,6 +564,54 @@
 				</weaponTags>
 			</li>
 
+			<!-- ========== Pancor Jackhammer ========== -->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>RNGun_PancorJackhammer_Shotgun</defName>
+				<statBases>
+					<Mass>7.90</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<ShotSpread>0.14</ShotSpread>
+					<SwayFactor>1.58</SwayFactor>
+					<Bulk>7.87</Bulk>
+					<WorkToMake>33000</WorkToMake>
+				</statBases>
+				<costList>
+					<Chemfuel>10</Chemfuel>
+					<Steel>60</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.94</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>16</range>
+					<burstShotCount>3</burstShotCount>
+					<ticksBetweenBurstShots>15</ticksBetweenBurstShots>
+					<soundCast>RNShotUSAS</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+
+				<AmmoUser>
+					<magazineSize>10</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_12Gauge</ammoSet>
+				</AmmoUser>
+
+				<FireModes>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+					<aimedBurstShotCount>2</aimedBurstShotCount>
+				</FireModes>
+
+				<weaponTags>
+					<li>CE_AI_BROOM</li>
+				</weaponTags>
+			</li>
 
 			<!-- == Shared patches for firearm melee tools == -->
 
@@ -581,7 +629,8 @@
 					defName="RNGun_SPAS12_Shotgun" or
 					defName="RNGun_USAS12_Shotgun" or
 					defName="RNGun_M1014_Shotgun" or
-					defName="RNGun_SpartanMarine_Shotgun"
+					defName="RNGun_SpartanMarine_Shotgun" or
+					defName="RNGun_PancorJackhammer_Shotgun"
 				]/tools</xpath>
 				<value>
 					<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_SmolKnifes_CE.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_SmolKnifes_CE.xml
@@ -65,7 +65,7 @@
 				or defName="RNMeleeWeapon_Karambit_Knife" 
 				or defName="RNMeleeWeapon_M9Bayonet_Knife"]/statBases</xpath>
 		<value>
-      			<Bulk>1</Bulk>
+      		<Bulk>1</Bulk>
 			<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
 		</value>
 	</li>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_Swords_CE.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_Swords_CE.xml
@@ -205,6 +205,67 @@
 		</value>
 	</li> 
 
+	<!-- === Z-Killer Sword === -->
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="RNMeleeWeapon_ZKiller_Sword"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>1</power>
+					<cooldownTime>1.26</cooldownTime>
+					<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>blade</label>
+					<capacities>
+						<li>Cut</li>
+					</capacities>
+					<power>10</power>
+					<cooldownTime>1.18</cooldownTime>
+					<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.32</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>point</label>
+					<capacities>
+						<li>Stab</li>
+					</capacities>
+					<power>11</power>
+					<cooldownTime>1.26</cooldownTime>
+					<chanceFactor>1.33</chanceFactor>
+					<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+					<armorPenetrationSharp>0.42</armorPenetrationSharp>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="RNMeleeWeapon_ZKiller_Sword"]/statBases</xpath>
+		<value>
+      		<Bulk>3</Bulk>
+      		<MeleeCounterParryBonus>0.23</MeleeCounterParryBonus>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="RNMeleeWeapon_ZKiller_Sword"]</xpath>
+		<value>
+			<equippedStatOffsets>
+				<MeleeCritChance>0.30</MeleeCritChance>
+				<MeleeParryChance>0.25</MeleeParryChance>
+				<MeleeDodgeChance>0.08</MeleeDodgeChance>	
+			</equippedStatOffsets>
+		</value>
+	</li> 
+
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/Rm2_CE_AirSupport.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/Rm2_CE_AirSupport.xml
@@ -5,31 +5,37 @@
 		<li>[RH2] Rimmu-Nation² - Weapons</li>
 		</mods>
 		<match Class="PatchOperationSequence">
-		<operations>
+		  <operations>
 
-
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RN_SOFLAM_AirSupport"]/verbs</xpath>
-					<value>
-    <verbs>
-      <li>
-        <verbClass>Verb_Bombardment</verbClass>
-        <hasStandardCommand>true</hasStandardCommand>
-        <warmupTime>3</warmupTime>
-        <ai_AvoidFriendlyFireRadius>20</ai_AvoidFriendlyFireRadius>
-        <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-        <range>69.9</range>
-        <burstShotCount>1</burstShotCount>
-        <soundAiming>OrbitalTargeter_Aiming</soundAiming>
-        <soundCast>OrbitalTargeter_Fire</soundCast>
-        <onlyManualCast>true</onlyManualCast>
-        <targetParams>
-          <canTargetLocations>true</canTargetLocations>
-        </targetParams>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="RN_SOFLAM_AirSupport"]/verbs</xpath>
+        <value>
+          <verbs>
+            <li>
+              <verbClass>Verb_Bombardment</verbClass>
+              <hasStandardCommand>true</hasStandardCommand>
+              <warmupTime>3</warmupTime>
+              <ai_AvoidFriendlyFireRadius>20</ai_AvoidFriendlyFireRadius>
+              <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+              <range>69.9</range>
+              <burstShotCount>1</burstShotCount>
+              <soundAiming>OrbitalTargeter_Aiming</soundAiming>
+              <soundCast>OrbitalTargeter_Fire</soundCast>
+              <onlyManualCast>true</onlyManualCast>
+              <targetParams>
+                <canTargetLocations>true</canTargetLocations>
+              </targetParams>
+            </li>
+          </verbs>
+        </value>
       </li>
-    </verbs>
-					</value>
-				</li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[@Name="RN_OrbitalUtilityBase"]/statBases</xpath>
+        <value>
+          <Bulk>1.5</Bulk>
+        </value>
+      </li>
 
 			</operations>
 		</match>


### PR DESCRIPTION
## Additions
- Patch weapons using existing patch stats: SKS DMR, NLAW, Javelin, Intervention, OVU DMR, Mk14 EBR, M4A1, F2000, KRISS Vector, Desert Tech SRS, ACR, G3A2, Tar-21
- Patch weapons with new stats from Guns sheet: Pancor Jackhammer

## Changes
- Add bulk to SOFLAM so it doesn't get autopatched.
- Some whitespace changes for housekeeping.

## References
Closes #1602 

## Reasoning
Many of these weapons (or variants with only nominal differences) were already patched in various CP / RH integrated patches. Using these patches is both efficient and good for keeping things consistent. Stats for the Pancor Jackhammer were made using the Gun Sheet, generated using stats from the gun's wiki page.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
