### PR TITLE
Mech mini charge blaster turret tweaked

### DIFF
--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -23,12 +23,12 @@
           <recoilAmount>1.1</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>true</hasStandardCommand>
-          <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+          <defaultProjectile>Bullet_6x22mmCharged</defaultProjectile>
           <warmupTime>1.3</warmupTime>
           <range>55</range>
-          <minRange>2</minRange>
+          <minRange>1.9</minRange>
           <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-          <burstShotCount>10</burstShotCount>
+          <burstShotCount>5</burstShotCount>
           <soundCast>Shot_ChargeBlaster</soundCast>
           <soundCastTail>GunTail_Heavy</soundCastTail>
           <muzzleFlashScale>9</muzzleFlashScale>
@@ -39,7 +39,7 @@
         <li Class="CombatExtended.CompProperties_AmmoUser">
           <magazineSize>100</magazineSize>
           <reloadTime>7.8</reloadTime>
-          <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+          <ammoSet>AmmoSet_6x22mmCharged</ammoSet>
         </li>
         <li Class="CombatExtended.CompProperties_FireModes">
           <aiAimMode>SuppressFire</aiAimMode>
@@ -68,18 +68,18 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-		  <recoilAmount>1.28</recoilAmount>
-		  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		  <hasStandardCommand>true</hasStandardCommand>
-		  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-		  <warmupTime>1.3</warmupTime>
-		  <range>75</range>
-		  <minRange>3</minRange>
-		  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-		  <burstShotCount>20</burstShotCount>
-		  <soundCast>Shot_ChargeBlaster</soundCast>
-		  <soundCastTail>GunTail_Heavy</soundCastTail>
-		  <muzzleFlashScale>9</muzzleFlashScale>
+        <recoilAmount>1.28</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+        <warmupTime>1.3</warmupTime>
+        <range>75</range>
+        <minRange>2.9</minRange>
+        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+        <burstShotCount>20</burstShotCount>
+        <soundCast>Shot_ChargeBlaster</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
+        <muzzleFlashScale>9</muzzleFlashScale>
       </li>
     </verbs>
     <comps>
@@ -116,17 +116,17 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-		  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		  <hasStandardCommand>true</hasStandardCommand>
-		  <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
-		  <warmupTime>4.3</warmupTime>
-		  <range>86</range>
-		  <burstShotCount>1</burstShotCount>
-		  <soundCast>InfernoCannon_Fire</soundCast>
-		  <soundCastTail>GunTail_Light</soundCastTail>
-		  <muzzleFlashScale>14</muzzleFlashScale>
-		  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-		  <minRange>5</minRange>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+        <warmupTime>4.3</warmupTime>
+        <range>86</range>
+        <burstShotCount>1</burstShotCount>
+        <soundCast>InfernoCannon_Fire</soundCast>
+        <soundCastTail>GunTail_Light</soundCastTail>
+        <muzzleFlashScale>14</muzzleFlashScale>
+        <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+        <minRange>4.9</minRange>
       </li>
     </verbs>	
     <comps>


### PR DESCRIPTION
## Changes

- Changed the blaster turret to use the proper mech 6x22mm charge ammo instead of the human-built 6x24mm
- Changed the burst shot count of the turret from 10 to 5
- Changed the mech turret ranges to avoid in-game confusion caused by the weapon range display of the turret.

## Reasoning

- The vanilla counterpart of the blaster turret is a long range turret with single-shot bursts, the CE one is changed in this PR to better reflect that.
- Vanilla weapon ranges are set to values with a 0.9 on top to avoid the guns being able to hit targets at the edge of their allowed range, the mech turrets currently can shoot targets outside their displayed range because their range is set to 5 instead of 4.9 for example. This change helps the player to understand the actual range of the turrets and prevent their pawns be shot outside the displayed range when the visual representation indicates otherwise.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
