### PR TITLE
Modded turret tweaks

### DIFF
--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef ParentName="BaseBullet">
+  <ThingDef Name="Base5x35mmChargedBullet" ParentName="BaseBullet">
     <defName>Bullet_5x35mmCharged</defName>
     <label>5x35mm Charged bullet</label>
     <graphicData>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef ParentName="BaseBullet">
+  <ThingDef Name="Base6x22mmChargedBullet" ParentName="BaseBullet">
     <defName>Bullet_6x22mmCharged</defName>
     <label>6x22mm Charged bullet</label>
     <graphicData>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -87,10 +87,10 @@
 				<dropsCasings>false</dropsCasings>
 				<casingMoteDefname>Mote_BigShell</casingMoteDefname>
 				<damageDef>Bullet</damageDef>
-				<damageAmountBase>200</damageAmountBase>
+				<damageAmountBase>500</damageAmountBase>
 				<soundExplode>MortarBomb_Explode</soundExplode>
-				<armorPenetrationSharp>150</armorPenetrationSharp>
-				<armorPenetrationBlunt>10000</armorPenetrationBlunt>
+				<armorPenetrationSharp>200</armorPenetrationSharp>
+				<armorPenetrationBlunt>20000</armorPenetrationBlunt>
 			</projectile>
 			<comps>
 				<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -15,41 +15,64 @@
 
         <!-- ==================== AmmoSet ========================== -->
 
-        <CombatExtended.AmmoSetDef>
+		<CombatExtended.AmmoSetDef>
           <defName>AmmoSet_5x35mmHyper</defName>
           <label>5x35mm Hyper</label>
           <ammoTypes>
             <Ammo_5x35mmCharged>Bullet_5x35mmHyper</Ammo_5x35mmCharged>
           </ammoTypes>
-        </CombatExtended.AmmoSetDef>
+		</CombatExtended.AmmoSetDef>
 
         <!-- ================== Projectiles ================== -->
 
-        <ThingDef ParentName="Base6x24mmChargedBullet">
-          <defName>Bullet_5x35mmHyper</defName>
-          <label>5x35mm Hyper bullet</label>
-          <graphicData>
-            <texPath>Things/Projectile/ChargeLanceShot</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-            <shaderType>TransparentPostLight</shaderType>
-            <drawSize>(3,3)</drawSize>
-          </graphicData>
-          <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageDef>Bullet</damageDef>
-            <damageAmountBase>14</damageAmountBase>
-            <speed>280</speed>
-            <secondaryDamage>
-              <li>
-                <def>Bomb_Secondary</def>
-                <amount>2</amount>
-              </li>
-            </secondaryDamage>
-            <armorPenetrationSharp>36</armorPenetrationSharp>
-            <armorPenetrationBlunt>78.4</armorPenetrationBlunt>
-          </projectile>
-        </ThingDef>	
+		<ThingDef ParentName="Base5x35mmChargedBullet">
+			<defName>Bullet_5x35mmHyper</defName>
+			<label>5x35mm Hyper bullet</label>
+			<graphicData>
+				<texPath>Things/Projectile/ChargeLanceShot</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
+				<drawSize>(3,3)</drawSize>
+			</graphicData>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Bullet</damageDef>
+				<damageAmountBase>14</damageAmountBase>
+				<speed>280</speed>
+				<secondaryDamage>
+					<li>
+						<def>Bomb_Secondary</def>
+						<amount>2</amount>
+					</li>
+				</secondaryDamage>
+				<armorPenetrationSharp>36</armorPenetrationSharp>
+				<armorPenetrationBlunt>78.4</armorPenetrationBlunt>
+			</projectile>
+		</ThingDef>	
 
-		<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base90mmCannonShell">
+		<ThingDef ParentName="Base12x64mmChargedBullet">
+			<defName>Bullet_12x64mmHyper</defName>
+			<label>12x64mm Hyper bullet</label>
+			<graphicData>
+				<texPath>Things/Projectile/ChargeLanceShot</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				<shaderType>TransparentPostLight</shaderType>
+			</graphicData>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
+				<damageDef>Bullet</damageDef>
+				<damageAmountBase>48</damageAmountBase>
+				<speed>240</speed>
+				<secondaryDamage>
+					<li>
+						<def>Bomb_Secondary</def>
+						<amount>14</amount>
+					</li>
+				</secondaryDamage>
+				<armorPenetrationSharp>40</armorPenetrationSharp>
+				<armorPenetrationBlunt>576</armorPenetrationBlunt>
+			</projectile>
+		</ThingDef>
+
+		<ThingDef ParentName="Base90mmCannonShell">
 			<defName>VFE_Bullet_ChargeRailgun_CE</defName>
 			<label>charge railgun shot</label>
 			<graphicData>
@@ -59,24 +82,28 @@
 				<drawSize>4</drawSize>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>5000</damageAmountBase>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<armorPenetrationSharp>5000</armorPenetrationSharp>
-			<armorPenetrationBlunt>200000</armorPenetrationBlunt>
+				<speed>300</speed>
+				<flyOverhead>false</flyOverhead>
+				<dropsCasings>false</dropsCasings>
+				<casingMoteDefname>Mote_BigShell</casingMoteDefname>
+				<damageDef>Bullet</damageDef>
+				<damageAmountBase>5000</damageAmountBase>
+				<soundExplode>MortarBomb_Explode</soundExplode>
+				<armorPenetrationSharp>5000</armorPenetrationSharp>
+				<armorPenetrationBlunt>200000</armorPenetrationBlunt>
 			</projectile>
 			<comps>
-			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>800</damageAmountBase>
-				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>8</explosiveRadius>
-				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			</li>
-			<li Class="CombatExtended.CompProperties_Fragments">
-				<fragments>
-					<Fragment_Large>80</Fragment_Large>
-				</fragments>
-			</li>
+				<li Class="CombatExtended.CompProperties_ExplosiveCE">
+					<damageAmountBase>800</damageAmountBase>
+					<explosiveDamageType>Bomb</explosiveDamageType>
+					<explosiveRadius>8</explosiveRadius>
+					<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				</li>
+				<li Class="CombatExtended.CompProperties_Fragments">
+					<fragments>
+						<Fragment_Large>80</Fragment_Large>
+					</fragments>
+				</li>
 			</comps>
 		</ThingDef>
 	  

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -16,11 +16,11 @@
         <!-- ==================== AmmoSet ========================== -->
 
 		<CombatExtended.AmmoSetDef>
-          <defName>AmmoSet_5x35mmHyper</defName>
-          <label>5x35mm Hyper</label>
-          <ammoTypes>
-            <Ammo_5x35mmCharged>Bullet_5x35mmHyper</Ammo_5x35mmCharged>
-          </ammoTypes>
+			<defName>AmmoSet_5x35mmHyper</defName>
+			<label>5x35mm Hyper</label>
+			<ammoTypes>
+				<Ammo_5x35mmCharged>Bullet_5x35mmHyper</Ammo_5x35mmCharged>
+			</ammoTypes>
 		</CombatExtended.AmmoSetDef>
 
         <!-- ================== Projectiles ================== -->
@@ -87,21 +87,21 @@
 				<dropsCasings>false</dropsCasings>
 				<casingMoteDefname>Mote_BigShell</casingMoteDefname>
 				<damageDef>Bullet</damageDef>
-				<damageAmountBase>5000</damageAmountBase>
+				<damageAmountBase>200</damageAmountBase>
 				<soundExplode>MortarBomb_Explode</soundExplode>
-				<armorPenetrationSharp>5000</armorPenetrationSharp>
-				<armorPenetrationBlunt>200000</armorPenetrationBlunt>
+				<armorPenetrationSharp>150</armorPenetrationSharp>
+				<armorPenetrationBlunt>10000</armorPenetrationBlunt>
 			</projectile>
 			<comps>
 				<li Class="CombatExtended.CompProperties_ExplosiveCE">
-					<damageAmountBase>800</damageAmountBase>
+					<damageAmountBase>300</damageAmountBase>
 					<explosiveDamageType>Bomb</explosiveDamageType>
 					<explosiveRadius>8</explosiveRadius>
 					<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				</li>
 				<li Class="CombatExtended.CompProperties_Fragments">
 					<fragments>
-						<Fragment_Large>80</Fragment_Large>
+						<Fragment_Large>50</Fragment_Large>
 					</fragments>
 				</li>
 			</comps>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -8,6 +8,7 @@
 
     <match Class="PatchOperationSequence">
       <operations>
+
 			<!-- ========== Ship Charge Blaster ========== -->
 
 			<li Class="PatchOperationReplace">
@@ -119,7 +120,7 @@
 				</value>
 			</li>
 			
-			<!--It's supposed to presumably be the same threat as a HCB turret, so we'll have it use railgun sabot shots-->
+			<!--It's supposed to presumably be the same threat as a HCB turret, so we'll have it use 12x64mm Hyper shots-->
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>VFE_Gun_ChargeLanceCannon</defName>
@@ -134,14 +135,14 @@
 				<Properties>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
-				  <defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>
+				  <defaultProjectile>Bullet_12x64mmHyper</defaultProjectile>
 				  <warmupTime>4.2</warmupTime>
 				  <range>86</range>
 				  <burstShotCount>1</burstShotCount>
 				  <soundCast>ChargeLance_Fire</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>9</muzzleFlashScale>
-				  <minRange>5</minRange>
+				  <minRange>1.9</minRange>
 				</Properties>
 				<FireModes>
 				  <aiAimMode>AimedShot</aiAimMode>
@@ -215,7 +216,7 @@
 				  <soundCastTail>GunTail_Light</soundCastTail>
 				  <muzzleFlashScale>14</muzzleFlashScale>
 				  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-				  <minRange>5</minRange>
+				  <minRange>4.9</minRange>
 				  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 				  <recoilPattern>Mounted</recoilPattern>
 				</Properties>
@@ -410,6 +411,7 @@
 				  <soundCast>VFE_Shot_ChargeRailgun</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>16</muzzleFlashScale>
+				  <minRange>8.9</minRange>
 				</Properties>
 				<FireModes>
 				  <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -93,7 +93,6 @@
 				  <soundCast>Shot_ChargeBlaster</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>9</muzzleFlashScale>
-				  <minRange>4</minRange>
 				</Properties>
 				<AmmoUser>
 				  <magazineSize>100</magazineSize>
@@ -175,7 +174,6 @@
 				  <soundCast>ChargeLance_Fire</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>9</muzzleFlashScale>
-				  <minRange>2</minRange>
 				</Properties>
 				<AmmoUser>
 				  <magazineSize>50</magazineSize>
@@ -281,7 +279,7 @@
 				  <soundCastTail>GunTail_Light</soundCastTail>
 				  <muzzleFlashScale>14</muzzleFlashScale>
 				  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-				  <minRange>5</minRange>
+				  <minRange>4.9</minRange>
 				  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 				</Properties>
 				<AmmoUser>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -57,6 +57,16 @@
         </value>
       </li>
 
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
+        <value>
+          <placeWorkers Inherit="False">
+            <li>PlaceWorker_TurretTop</li>
+            <li>PlaceWorker_PreventInteractionSpotOverlap</li>
+          </placeWorkers>
+        </value>
+      </li>
+
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/statBases/RangedWeapon_Cooldown</xpath>
         <value>
@@ -134,6 +144,17 @@
         <value>
             <turretBurstCooldownTime>2.7</turretBurstCooldownTime>
         </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
+        <value>
+            <fillPercent>0.85</fillPercent>
+        </value>
+      </li>
+
+      <li Class="PatchOperationRemove">
+        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/placeWorkers/li[.="PlaceWorker_NotUnderRoof"]</xpath>
       </li>
 
       <li Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -146,13 +146,6 @@
         </value>
       </li>
 
-      <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
-        <value>
-            <fillPercent>0.85</fillPercent>
-        </value>
-      </li>
-
       <li Class="PatchOperationRemove">
         <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/placeWorkers/li[.="PlaceWorker_NotUnderRoof"]</xpath>
       </li>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -253,6 +253,10 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationRemove">
+			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/buildingTags</xpath>
+		</li>
+
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/turretBurstWarmupTime</xpath>
 			<value>
@@ -319,10 +323,12 @@
 			</value>
 		</li>
 	
-		<li Class="PatchOperationAdd">
+		<li Class="PatchOperationReplace">
 		  <xpath>/Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/weaponTags</xpath>
 		  <value>
-		    <li>TurretGun</li>
+		    <weaponTags>
+		      <li>Artillery_BaseDestroyer</li>
+		    </weaponTags>
 		  </value>
 		</li>
 

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -247,6 +247,13 @@
 		<!-- ========== Artillery - Base ========== -->
 
 		<li Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/statBases</xpath>
+			<value>
+				<Mass>5500</Mass>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building</xpath>
 			<value>
 				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -22,19 +22,32 @@
 		]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 		</li>
 
-		<!-- Replace vanilla thingClass -->
-		<li Class="PatchOperationReplace">
+		<!-- Remove Explosive comp -->
+		<li Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[
-			defName = "VFES_Turret_ChargeRailgunTurret" or 
-			defName = "VFES_Turret_ChargeTurret" or		
+			defName = "VFES_Turret_ChargeRailgunTurret" or
+			defName = "VFES_Turret_ChargeTurret" or
 			defName = "VFES_Turret_AutocannonDouble" or
 			defName = "VFES_Turret_EMPTurret" or
 			defName = "VFES_Turret_Flame" or
 			defName = "VFES_Turret_SentryGun" or
-			defName = "VFES_Turret_MilitaryTurret" or	
-			defName = "VFES_Turret_FloorTurret" or		      			
+			defName = "VFES_Turret_MilitaryTurret" or
+			defName = "VFES_Turret_TriRocket"
+		]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		</li>
+
+		<!-- Replace vanilla thingClass -->
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName = "VFES_Turret_ChargeRailgunTurret" or
+			defName = "VFES_Turret_ChargeTurret" or
+			defName = "VFES_Turret_AutocannonDouble" or
+			defName = "VFES_Turret_EMPTurret" or
+			defName = "VFES_Turret_Flame" or
+			defName = "VFES_Turret_SentryGun" or
+			defName = "VFES_Turret_MilitaryTurret" or
 			defName = "VFES_Turret_TriRocket" or
-			defName = "VFES_Turret_FloorTurret"		        		
+			defName = "VFES_Turret_FloorTurret"
 		]/thingClass</xpath>
 		<value>
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -298,6 +298,11 @@
 		  <reloadTime>7.8</reloadTime>
 		  <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
 		</AmmoUser>
+		<FireModes>
+		  <aiAimMode>AimedShot</aiAimMode>
+		  <noSnapshot>true</noSnapshot>
+		  <noSingleShot>true</noSingleShot>
+		</FireModes>
 		<weaponTags Inherit="false">
 		  <li>TurretGun</li>
 		</weaponTags>
@@ -377,6 +382,11 @@
 		  <reloadTime>9.2</reloadTime>
 		  <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 		</AmmoUser>
+		<FireModes>
+		  <aiAimMode>AimedShot</aiAimMode>
+		  <noSnapshot>true</noSnapshot>
+		  <noSingleShot>true</noSingleShot>
+		</FireModes>
 		<weaponTags Inherit="false">
 		  <li>TurretGun</li>
 		</weaponTags>
@@ -452,6 +462,11 @@
 		  <muzzleFlashScale>9</muzzleFlashScale>
 		  <recoilPattern>Mounted</recoilPattern>
 		</Properties>
+		<FireModes>
+		  <aiAimMode>AimedShot</aiAimMode>
+		  <noSnapshot>true</noSnapshot>
+		  <noSingleShot>true</noSingleShot>
+		</FireModes>
 		<weaponTags Inherit="false">
 		  <li>TurretGun</li>
 		</weaponTags>


### PR DESCRIPTION
## Changes

- Removed certain modded turret structures' explosive comp.
- Fixed the fire modes of the charge, sentry and EMP turret from VFE-Security.
- Fixed the 155mm from VFE-Security to preventing it from spawning in raids by accident.
- Adjusted the 155mm artillery's mass to 5500kg based on the 155mm howitzer.
- Fixed the field gun and cannon from VFE-Pirates not being able to be built under a roof.
- Tweaked VFE-Mechanoids ship and buildable turrets.
- Adjusted the ship charge railgun turret from VFE-Mechanoids to a more sane level of strong.

## Reasoning

- Vanilla and DLC turrets have their explosive comp removed so that they don't explode when damaged, some modded still had the comp which is removed via this PR.
- The Charge, sentry and EMP turret did not have a proper fire mode set same as other unmanned turrets which the PR fixes that by setting them to aimed-shot mode.
- Since the field gun and cannon from VFE-Pirates are direct-fire and not like a mortar, it only makes sense to allow them to be built under a rood similar to other direct-fire turrets.
- The ship charge lance used the 12mm railgun sabot as ammo which is very overkill, changed the ammo it uses to a newly added 12x64mm Hyper similar to 5x35mm Hyper which has better stats than a normal 12x64mm Charged round. The new round should be better balanced in comparison the the old one.
- Adjusted buildable and ship turret ranges from VFE-Mechanoids to better reflect their role and give a better visual representation of their actual range in-game similar to the other range changes in #1662.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
