### PR TITLE
Vanilla Base Generation Expanded patch

### DIFF
--- a/Patches/Vanilla Base Generation Expanded/SettlementDefs.xml
+++ b/Patches/Vanilla Base Generation Expanded/SettlementDefs.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Base Generation Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- === Remove the patched-out weapons === -->
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/KCSG.SettlementLayoutDef[
+						defName="VBGE_OutlanderDefence" or
+						defName="VBGE_PiratesDefence" or
+						defName="VBGE_EmpireDefence"
+					]/stockpileOptions/fillWithDefs/li[.="Gun_SmokeLauncher"]</xpath>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/KCSG.SettlementLayoutDef[
+						defName="VBGE_OutlanderDefence" or
+						defName="VBGE_PiratesDefence" or
+						defName="VBGE_EmpireDefence"
+					]/stockpileOptions/fillWithDefs/li[.="Gun_EmpLauncher"]</xpath>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/KCSG.SettlementLayoutDef[defName="VBGE_TribalDefence"]/stockpileOptions/fillWithDefs/li[.="ThrumboHorn"]</xpath>
+				</li>
+
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/KCSG.SettlementLayoutDef[defName="VBGE_TribalDefence"]/stockpileOptions/fillWithDefs/li[.="ElephantTusk"]</xpath>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

- Removed the EMP and smoke launcher which are removed in CE from settlement loot tables.
- Removed elephant tusks and thrumbo horns from tribal settlement defense structure loot table since they are not weapons anymore.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
