### PR TITLE
Yp updates

### DIFF
--- a/Patches/Rimsenal Collection/Core/Ammo_YP.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_YP.xml
@@ -36,9 +36,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Shredder</damageDef>
 			<speed>72</speed>
-			<dropsCasings>false</dropsCasings>
-			<pelletCount>2</pelletCount>
-			<spreadMult>5</spreadMult>		
+			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
 			<armorPenetrationSharp>24</armorPenetrationSharp>

--- a/Patches/Rimsenal Collection/Core/Ammo_YP.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_YP.xml
@@ -36,7 +36,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Shredder</damageDef>
 			<speed>72</speed>
-			<dropsCasings>false</dropsCasings>		
+			<dropsCasings>false</dropsCasings>
+			<pelletCount>2</pelletCount>
+			<spreadMult>2</spreadMult>		
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
 			<armorPenetrationSharp>24</armorPenetrationSharp>

--- a/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
@@ -176,7 +176,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="YP_BingJu"]/statBases</xpath>
 				<value>
-					<MeleeCounterParryBonus>1.4</MeleeCounterParryBonus>				
+					<MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>				
 					<Bulk>2.5</Bulk>
 				</value>
 			</li>
@@ -185,7 +185,7 @@
 				<value>
 					<equippedStatOffsets>
 						<MeleeCritChance>0.75</MeleeCritChance>
-						<MeleeParryChance>1.88</MeleeParryChance>
+						<MeleeParryChance>0.94</MeleeParryChance>
 						<MeleeDodgeChance>0.20</MeleeDodgeChance>	
 					</equippedStatOffsets>
 				</value>

--- a/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
@@ -190,6 +190,15 @@
 					</equippedStatOffsets>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="YP_BingJu"]</xpath>
+					<value>
+						<weaponTags />
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
 				<value>

--- a/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
@@ -190,6 +190,12 @@
 					</equippedStatOffsets>
 				</value>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
+				<value>
+					<li>CE_OneHandedWeapon</li> 
+				</value>
+			</li>
 
 			<!-- JI Assault Hammer -->			
 			<li Class="PatchOperationReplace">

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -314,6 +314,15 @@
 					</comps>					
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
+					<value>
+						<weaponTags />
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<value>

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -262,7 +262,7 @@
 				</value>
 			</li>
 			
-			<!-- ==========  YP Dual Wield Shard Pistols =========== -->
+			<!-- ==========  YP Shard Pistol =========== -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/statBases</xpath>
 				<value>
@@ -314,6 +314,14 @@
 					</comps>					
 				</value>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+				<value>
+				    <li>CE_Sidearm</li>
+					<li>CE_AI_Pistol</li>
+					<li>CE_OneHandedWeapon</li>				
+				</value>
+			</li>	
 
 			<!-- ==========  YP Microwave Emmiter =========== -->
 			<li Class="PatchOperationReplace">

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -268,7 +268,7 @@
 				<value>
 					<statBases>
 						<WorkToMake>50500</WorkToMake>
-						<SightsEfficiency>0.5</SightsEfficiency>
+						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.5</SwayFactor>
 						<Bulk>4.7</Bulk>
@@ -287,10 +287,9 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_PistolYP</defaultProjectile>
 						<warmupTime>0.5</warmupTime>
-						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<burstShotCount>8</burstShotCount>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>						
-						<range>12</range>
+						<range>13</range>
 						<soundCast>RS_ShotShard</soundCast>
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>3</muzzleFlashScale>
@@ -303,7 +302,7 @@
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
-							<magazineSize>32</magazineSize>
+							<magazineSize>24</magazineSize>
 							<reloadTime>4.5</reloadTime>
 							<ammoSet>AmmoSet_PistolYP</ammoSet>
 						</li>

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -262,17 +262,17 @@
 				</value>
 			</li>
 			
-			<!-- ==========  YP Shard Pistol =========== -->
+			<!-- ==========  YP Dual Wield Shard Pistols =========== -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>50500</WorkToMake>
-						<SightsEfficiency>0.8</SightsEfficiency>
+						<SightsEfficiency>0.5</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.5</SwayFactor>
-						<Bulk>2.35</Bulk>
-						<Mass>2.16</Mass>
+						<Bulk>4.7</Bulk>
+						<Mass>4.32</Mass>
 						<RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
 					</statBases>				
 				</value>
@@ -287,9 +287,10 @@
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_PistolYP</defaultProjectile>
 						<warmupTime>0.5</warmupTime>
+						<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
 						<burstShotCount>8</burstShotCount>
 						<ticksBetweenBurstShots>2</ticksBetweenBurstShots>						
-						<range>13</range>
+						<range>12</range>
 						<soundCast>RS_ShotShard</soundCast>
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>3</muzzleFlashScale>
@@ -302,7 +303,7 @@
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
-							<magazineSize>24</magazineSize>
+							<magazineSize>32</magazineSize>
 							<reloadTime>4.5</reloadTime>
 							<ammoSet>AmmoSet_PistolYP</ammoSet>
 						</li>
@@ -314,6 +315,7 @@
 					</comps>					
 				</value>
 			</li>
+			
 			<li Class="PatchOperationConditional">
 				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<nomatch Class="PatchOperationAdd">
@@ -327,8 +329,7 @@
 				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<value>
 				    <li>CE_Sidearm</li>
-					<li>CE_AI_Pistol</li>
-					<li>CE_OneHandedWeapon</li>				
+					<li>CE_AI_Pistol</li>			
 				</value>
 			</li>	
 

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -271,8 +271,8 @@
 						<SightsEfficiency>0.8</SightsEfficiency>
 						<ShotSpread>0.2</ShotSpread>
 						<SwayFactor>1.5</SwayFactor>
-						<Bulk>4.7</Bulk>
-						<Mass>4.32</Mass>
+						<Bulk>2.35</Bulk>
+						<Mass>2.16</Mass>
 						<RangedWeapon_Cooldown>0.2</RangedWeapon_Cooldown>
 					</statBases>				
 				</value>


### PR DESCRIPTION
## Changes

Changes to the YP dual wield Dagger which were reverted to single one handers.
Shard pistols got a tag, mostly because they switched to and fro from dual to single, and back to dual again unless _Dual Wield_ mod is installled, and since that isn't supported anyway, yeah...

## Reasoning

Doesn't make a lot of sense for them to have some of the doubled stats/characteristics after the adjustment. Now also one handed

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
