### PR TITLE
CE turret terrain affordance fix

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -181,6 +181,7 @@
       <li>PlaceWorker_TurretTop</li>
       <li>PlaceWorker_ShowTurretRadius</li>
     </placeWorkers>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
     <comps>
       <li Class="CompProperties_Power">
         <compClass>CompPowerTrader</compClass>
@@ -312,6 +313,7 @@
       <li>PlaceWorker_TurretTop</li>
       <li>PlaceWorker_ShowTurretRadius</li>
     </placeWorkers>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
     <researchPrerequisites>
       <li>CE_TurretHeavyWeapons</li>
       <li>PrecisionRifling</li>
@@ -398,6 +400,7 @@
       <li>PlaceWorker_TurretTop</li>
       <li>PlaceWorker_ShowTurretRadius</li>
     </placeWorkers>
+    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
     <size>(3,3)</size>
     <interactionCellOffset>(-1,0,-1)</interactionCellOffset>
     <minifiedDef>MinifiedThing</minifiedDef>


### PR DESCRIPTION
## Additions

- Added proper terrain affordance nodes to the turrets added by CE.

## Reasoning

- Just like other vanilla structures having a specific terrain affordance based on their mass and other things, turrets added by CE have to have the proper terrain affordance properties.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony