### PR TITLE
Alpha Animals leather heat armor tweaked

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
@@ -236,7 +236,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
-						<StuffPower_Armor_Heat>0.01</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -271,7 +271,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
-						<StuffPower_Armor_Heat>0.035</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
 					</value>
 				</li>
 				<li Class="PatchOperationConditional">
@@ -296,7 +296,7 @@
 					<value>
 						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 						<StuffPower_Armor_Blunt>0.045</StuffPower_Armor_Blunt>
-						<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+						<StuffPower_Armor_Heat>0.01</StuffPower_Armor_Heat>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
@@ -296,7 +296,6 @@
 					<value>
 						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 						<StuffPower_Armor_Blunt>0.045</StuffPower_Armor_Blunt>
-						<StuffPower_Armor_Heat>0.01</StuffPower_Armor_Heat>
 					</value>
 				</li>
 			</operations>


### PR DESCRIPTION
## Changes

- Tweaked a couple AA leathers that had incorrect heat armor values

## Reasoning

- The added wools by AA already have proper heat armor value inherited from WoolBase, the silks did not have proper heat armor values in proportion to their vanilla counterpart.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
