### PR TITLE
Allow shields to be comfortably used by nudists

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -7,6 +7,7 @@
       <li>Shields</li>
     </thingCategories>
     <apparel>
+      <countsAsClothingForNudity>false</countsAsClothingForNudity>
       <careIfWornByCorpse>false</careIfWornByCorpse>
       <bodyPartGroups>
         <li>LeftShoulder</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, nudists don't care about "wearing" shields anymore.

## Reasoning

- Cuz duh! Shields are worn in CE but are not actual clothing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
