### PR TITLE
Aa gigantelope hediff

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
@@ -58,50 +58,50 @@
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight1"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>2</CarryWeight>
-								<CarryBulk>2</CarryBulk>
+								<CarryWeight>1</CarryWeight>
+								<CarryBulk>1</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight2"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>10</CarryWeight>
-								<CarryBulk>4</CarryBulk>
+								<CarryWeight>5</CarryWeight>
+								<CarryBulk>5</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight3"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>14</CarryWeight>
-								<CarryBulk>6</CarryBulk>
+								<CarryWeight>7</CarryWeight>
+								<CarryBulk>7</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight4"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>20</CarryWeight>
-								<CarryBulk>8</CarryBulk>
+								<CarryWeight>10</CarryWeight>
+								<CarryBulk>10</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight5"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>30</CarryWeight>
-								<CarryBulk>12</CarryBulk>
+								<CarryWeight>15</CarryWeight>
+								<CarryBulk>15</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight6"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>40</CarryWeight>
-								<CarryBulk>16</CarryBulk>
+								<CarryWeight>20</CarryWeight>
+								<CarryBulk>20</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight7"]/stages/li/statOffsets</xpath>
 							<value>
-								<CarryWeight>60</CarryWeight>
-								<CarryBulk>22</CarryBulk>
+								<CarryWeight>30</CarryWeight>
+								<CarryBulk>30</CarryBulk>
 							</value>
 						</li>
 					</operations>

--- a/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
@@ -59,42 +59,49 @@
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight1"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>2</CarryWeight>
+								<CarryBulk>2</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight2"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>10</CarryWeight>
+								<CarryBulk>4</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight3"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>14</CarryWeight>
+								<CarryBulk>6</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight4"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>20</CarryWeight>
+								<CarryBulk>8</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight5"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>30</CarryWeight>
+								<CarryBulk>12</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight6"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>40</CarryWeight>
+								<CarryBulk>16</CarryBulk>
 							</value>
 						</li>
 						<li Class="PatchOperationAdd">
 							<xpath>Defs/HediffDef[defName="AA_CarryWeight7"]/stages/li/statOffsets</xpath>
 							<value>
 								<CarryWeight>60</CarryWeight>
+								<CarryBulk>22</CarryBulk>
 							</value>
 						</li>
 					</operations>

--- a/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/Alpha_Hediffs.xml
@@ -53,6 +53,50 @@
 								</statOffsets>
 							</value>
 						</li>
+						
+						<!-- ==== AA_Gigantelope Weights ==== -->
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight1"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>2</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight2"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>10</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight3"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>14</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight4"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>20</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight5"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>30</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight6"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>40</CarryWeight>
+							</value>
+						</li>
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/HediffDef[defName="AA_CarryWeight7"]/stages/li/statOffsets</xpath>
+							<value>
+								<CarryWeight>60</CarryWeight>
+							</value>
+						</li>
 					</operations>
 				</match>
 			</li>


### PR DESCRIPTION
## Additions

Added Bulk and CarryWeight based on gigantelope's hediff quality.
## Reasoning
I think gigantelopes should be a better muffalo for caravans. Currently there should be no reason to choose gigantelopes when you have muffalo in the map for caravans. Their only use is milk and meat for butcher. I could have changed the body size to match muffalo's but I thought this was better.

## Alternatives

I could have changed the body size to match muffalo's but I thought this was better.
The carry weight and bulk can be changed for balance. Carry weight I just doubled the carrying capacity on the hediff. Carry bulk... I did it without any formula consideration...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long): 10 minutes.
