### PR TITLE
Give binocs a melee tool

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Spotting.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Spotting.xml
@@ -54,6 +54,18 @@
         <ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
       </li>
     </verbs>
+    <tools>
+      <li Class="CombatExtended.ToolCE">
+        <label>Body</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>4</power>
+        <cooldownTime>1.5</cooldownTime>
+        <armorPenetrationBlunt>2.0</armorPenetrationBlunt>
+        <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+      </li>
+    </tools>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>0.87,0.87</DrawSize>


### PR DESCRIPTION
## Additions

- What it says on the tin.

## Reasoning

- Using binocs in melee combat freaks the melee targeting system out just like other weapons that used to not have a melee tool, this PR fixes the error by giving them an appropriate melee tool.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Tested the binocs in melee combat)
