### PR TITLE
Fix Rimsenal's YP weapons patch

### DIFF
--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -312,14 +312,14 @@
 							<aiUseBurstMode>True</aiUseBurstMode>
 							<aiAimMode>Snapshot</aiAimMode>	
 						</li>													
-					</comps>					
+					</comps>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationConditional">
-				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
+					<xpath>Defs/thingDef[defName="YP_SeolHwa"]</xpath>
 					<value>
 						<weaponTags />
 					</value>
@@ -329,9 +329,9 @@
 				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<value>
 				    <li>CE_Sidearm</li>
-					<li>CE_AI_Pistol</li>			
+					<li>CE_AI_Pistol</li>
 				</value>
-			</li>	
+			</li>
 
 			<!-- ==========  YP Microwave Emmiter =========== -->
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
## Changes

- Fixed a small typo in the YP weapons' patch causing the whole patch sequence to fail.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches)
