### PR TITLE
Tweak Rimatomics' Radiation mask's occupying layers

### DIFF
--- a/Patches/Dubs Rimatomics/Apparel_Atomic.xml
+++ b/Patches/Dubs Rimatomics/Apparel_Atomic.xml
@@ -48,6 +48,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]/apparel/layers</xpath>
+				<value>
+					<li>StrappedHead</li>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ThingDef[@Name="RadSuitMaskBase"]</xpath>
 				<value>


### PR DESCRIPTION
## Additions

- What it says on the tin, RA's masks now occupy the strapped layer as well

## Reasoning

- Gas masks can't be worn on top of radiation masks

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
