### PR TITLE
Update/Fix CE's default settings

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -15,7 +15,7 @@
   <!-- ========== General settings ========== -->
 
   <CE_Settings_ShowCasings_Title>Show shell casings</CE_Settings_ShowCasings_Title>
-  <CE_Settings_ShowCasings_Desc>Firing weapons will display a dropped casing effect. Disable to improve performance.</CE_Settings_ShowCasings_Desc>
+  <CE_Settings_ShowCasings_Desc>Firing weapons will display a dropped casing effect.</CE_Settings_ShowCasings_Desc>
 
   <CE_Settings_ShowTaunts_Title>Show combat taunts</CE_Settings_ShowTaunts_Title>
   <CE_Settings_ShowTaunts_Desc>Pawns will display text-based taunts during combat.</CE_Settings_ShowTaunts_Desc>
@@ -23,19 +23,19 @@
   <CE_Settings_AllowMeleeHunting_Title>Allow hunting with melee weapons</CE_Settings_AllowMeleeHunting_Title>
   <CE_Settings_AllowMeleeHunting_Desc>Hunters will still be allowed to hunt if they have a melee weapon equipped.</CE_Settings_AllowMeleeHunting_Desc>
   
-  <CE_Settings_SmokeEffects_Title>Smoke effects</CE_Settings_SmokeEffects_Title>
+  <CE_Settings_SmokeEffects_Title>Toggle black smoke system</CE_Settings_SmokeEffects_Title>
   <CE_Settings_SmokeEffects_Desc>Fire generates dangerous black smoke clouds, causing health complications to anyone not wearing protective gear.</CE_Settings_SmokeEffects_Desc>
 
   <CE_Settings_MergeExplosions_Title>Merge explosions</CE_Settings_MergeExplosions_Title>
   <CE_Settings_MergeExplosions_Desc>Nearby explosions are merged into eachother, significantly improving performance during a massive explosives cook-off. Strongly recommended to leave on.</CE_Settings_MergeExplosions_Desc>
 
-  <CE_Settings_TurretsBreakShields_Title>Disable Shield Belt While Manning Turrets</CE_Settings_TurretsBreakShields_Title>
+  <CE_Settings_TurretsBreakShields_Title>Disable shield belts while manning turrets</CE_Settings_TurretsBreakShields_Title>
   <CE_Settings_TurretsBreakShields_Desc> When enabled, shield belts will deactivate while colonists are manning turrets. If disabled, shield belts will instead remain active, offering additional protection.</CE_Settings_TurretsBreakShields_Desc>
 
-  <CE_Settings_ShowBackpacks_Title>Show Backpacks</CE_Settings_ShowBackpacks_Title>
+  <CE_Settings_ShowBackpacks_Title>Show backpacks</CE_Settings_ShowBackpacks_Title>
   <CE_Settings_ShowBackpacks_Desc>Enables / Disables the rendering of backpacks (all pawns)</CE_Settings_ShowBackpacks_Desc>
 
-  <CE_Settings_ShowWebbing_Title>Show Tactical Vests</CE_Settings_ShowWebbing_Title>
+  <CE_Settings_ShowWebbing_Title>Show tactical vests</CE_Settings_ShowWebbing_Title>
   <CE_Settings_ShowWebbing_Desc>Enables / Disables the rendering of tactical vests (all pawns)</CE_Settings_ShowWebbing_Desc>
 
   <CE_Settings_PartialStats_Title>Turn on partial armor</CE_Settings_PartialStats_Title>
@@ -49,7 +49,7 @@
   <CE_Settings_GenericAmmo>Use generic ammo system</CE_Settings_GenericAmmo>
   <CE_Settings_GenericAmmo_Desc>Instead of using full caliber system use several generic calibers, while retaining ammo types and ammo system. (requires game reload)</CE_Settings_GenericAmmo_Desc>
 	
-  <CE_Settings_EnableSimplifiedAmmo_Title>Simplified ammunition</CE_Settings_EnableSimplifiedAmmo_Title>
+  <CE_Settings_EnableSimplifiedAmmo_Title>Use simplified ammo types system</CE_Settings_EnableSimplifiedAmmo_Title>
   <CE_Settings_EnableSimplifiedAmmo_Desc>Reduces the number of ammo variants available.\nRemoves hollow point, sabot (bullets only), beanbag, slug, and armor piercing variants.\n\nWARNING: Changing this setting on an existing colony may cause bugs and instability, do so at your own risk. (requires game reload)</CE_Settings_EnableSimplifiedAmmo_Desc>
 
   <CE_Settings_RightClickAmmoSelect_Title>Right-click ammo selection</CE_Settings_RightClickAmmoSelect_Title>
@@ -64,20 +64,20 @@
   <CE_Settings_ShowCaliberOnGuns_Title>Display weapon caliber</CE_Settings_ShowCaliberOnGuns_Title>
   <CE_Settings_ShowCaliberOnGuns_Desc>Ammunition-using weapons will have their caliber appended behind their name.</CE_Settings_ShowCaliberOnGuns_Desc>
 
-	<CE_Settings_ReuseNeolithicProjectiles_Title>Re-use neolithic projectiles</CE_Settings_ReuseNeolithicProjectiles_Title>
-	<CE_Settings_ReuseNeolithicProjectiles_Desc>Neolithic projectiles will have a chance to drop on the floor on impact. They are automatically forbidden.</CE_Settings_ReuseNeolithicProjectiles_Desc>
+  <CE_Settings_ReuseNeolithicProjectiles_Title>Re-use neolithic projectiles</CE_Settings_ReuseNeolithicProjectiles_Title>
+  <CE_Settings_ReuseNeolithicProjectiles_Desc>Neolithic projectiles will have a chance to drop on the floor on impact. They are automatically forbidden.</CE_Settings_ReuseNeolithicProjectiles_Desc>
 
   <CE_Settings_RealisticCookOff_Title>Realistic cook-off</CE_Settings_RealisticCookOff_Title>
   <CE_Settings_RealisticCookOff_Desc>Ammunition stacks won't spawn damaging projectiles on cooking off.</CE_Settings_RealisticCookOff_Desc>
 
   <CE_Settings_ShowExtraTooltips_Desc>Enables extra tooltips for the cell under the mouse pointer (hold left-shift to view).</CE_Settings_ShowExtraTooltips_Desc>
-  <CE_Settings_ShowExtraTooltips_Title>Show Extra Tooltips</CE_Settings_ShowExtraTooltips_Title>
+  <CE_Settings_ShowExtraTooltips_Title>Show extra tooltips</CE_Settings_ShowExtraTooltips_Title>
 
   <CE_Settings_ShowExtraStats_Desc>Enables extra (internal, redundant, or confusing) stats in some info cards.</CE_Settings_ShowExtraStats_Desc>
-  <CE_Settings_ShowExtraStats_Title>Show Extra Stats</CE_Settings_ShowExtraStats_Title>
+  <CE_Settings_ShowExtraStats_Title>Show extra stats</CE_Settings_ShowExtraStats_Title>
 
   <CE_Settings_UnlimitNewParryDamage_Desc>If false, limits damage done to parrying weapons to the lesser of the hardness-based or 10% of parried damage.</CE_Settings_UnlimitNewParryDamage_Desc>
-  <CE_Settings_UnlimitNewParryDamage_Title>Unlimit Weapon Parry Damage</CE_Settings_UnlimitNewParryDamage_Title>
+  <CE_Settings_UnlimitNewParryDamage_Title>Unlimit weapon parry damage</CE_Settings_UnlimitNewParryDamage_Title>
 
   <!-- ========== Bipod settings ========== -->
 

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -17,12 +17,12 @@ namespace CombatExtended
         // General settings
         private bool bipodMechanics = true;
         private bool autosetup = true;
-        private bool showCasings = true;
-        private bool showTaunts = true;
+        private bool showCasings = false;
+        private bool showTaunts = false;
         private bool allowMeleeHunting = false;
         private bool smokeEffects = true;
         private bool mergeExplosions = true;
-        private bool turretsBreakShields = true;
+        private bool turretsBreakShields = false;
         private bool showBackpacks = true;
         private bool showTacticalVests = true;
 	private bool genericammo = false;
@@ -58,12 +58,12 @@ namespace CombatExtended
 
         // Ammo settings
         private bool enableAmmoSystem = true;
-        private bool rightClickAmmoSelect = false;
+        private bool rightClickAmmoSelect = true;
         private bool autoReloadOnChangeAmmo = true;
-        private bool autoTakeAmmo = true;
+        private bool autoTakeAmmo = false;
         private bool showCaliberOnGuns = true;
         private bool reuseNeolithicProjectiles = true;
-        private bool realisticCookOff = false;
+        private bool realisticCookOff = true;
         private bool enableSimplifiedAmmo = false;
 
         public bool EnableAmmoSystem => enableAmmoSystem;
@@ -104,8 +104,8 @@ namespace CombatExtended
 
 	public bool DebugAutopatcherLogger => debugAutopatcherLogger;
 
-	private bool enableApparelAutopatcher = true;
-	private bool enableWeaponAutopatcher = true;
+	private bool enableApparelAutopatcher = false;
+	private bool enableWeaponAutopatcher = false;
 	private bool enableWeaponToughnessAutopatcher = true;
 	private bool enableRaceAutopatcher = true;
 	private bool enablePawnKindAutopatcher = true;

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -125,12 +125,12 @@ namespace CombatExtended
         public override void ExposeData()
         {
             base.ExposeData();
-            Scribe_Values.Look(ref showCasings, "showCasings", true);
-            Scribe_Values.Look(ref showTaunts, "showTaunts", true);
+            Scribe_Values.Look(ref showCasings, "showCasings", false);
+            Scribe_Values.Look(ref showTaunts, "showTaunts", false);
             Scribe_Values.Look(ref allowMeleeHunting, "allowMeleeHunting", false);
             Scribe_Values.Look(ref smokeEffects, "smokeEffects", true);
             Scribe_Values.Look(ref mergeExplosions, "mergeExplosions", true);
-            Scribe_Values.Look(ref turretsBreakShields, "turretsBreakShields", true);
+            Scribe_Values.Look(ref turretsBreakShields, "turretsBreakShields", false);
             Scribe_Values.Look(ref showBackpacks, "showBackpacks", true);
             Scribe_Values.Look(ref showTacticalVests, "showTacticalVests", true);
             Scribe_Values.Look(ref partialstats, "PartialArmor", true);
@@ -153,20 +153,20 @@ namespace CombatExtended
 #endif
 	    Scribe_Values.Look(ref debugAutopatcherLogger, "debugAutopatcherLogger", false);
 	    
-	    Scribe_Values.Look(ref enableWeaponAutopatcher, "enableWeaponAutopatcher", true);
+	    Scribe_Values.Look(ref enableWeaponAutopatcher, "enableWeaponAutopatcher", false);
 	    Scribe_Values.Look(ref enableWeaponToughnessAutopatcher, "enableWeaponToughnessAutopatcher", true);
-	    Scribe_Values.Look(ref enableApparelAutopatcher, "enableApparelAutopatcher", true);
+	    Scribe_Values.Look(ref enableApparelAutopatcher, "enableApparelAutopatcher", false);
 	    Scribe_Values.Look(ref enableRaceAutopatcher, "enableRaceAutopatcher", true);
 	    Scribe_Values.Look(ref enablePawnKindAutopatcher, "enablePawnKindAutopatcher", true);
 
             // Ammo settings
             Scribe_Values.Look(ref enableAmmoSystem, "enableAmmoSystem", true);
-            Scribe_Values.Look(ref rightClickAmmoSelect, "rightClickAmmoSelect", false);
+            Scribe_Values.Look(ref rightClickAmmoSelect, "rightClickAmmoSelect", true);
             Scribe_Values.Look(ref autoReloadOnChangeAmmo, "autoReloadOnChangeAmmo", true);
-            Scribe_Values.Look(ref autoTakeAmmo, "autoTakeAmmo", true);
+            Scribe_Values.Look(ref autoTakeAmmo, "autoTakeAmmo", false);
             Scribe_Values.Look(ref showCaliberOnGuns, "showCaliberOnGuns", true);
             Scribe_Values.Look(ref reuseNeolithicProjectiles, "reuseNeolithicProjectiles", true);
-            Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", false);
+            Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", true);
             Scribe_Values.Look(ref enableSimplifiedAmmo, "enableSimplifiedAmmo", false);
 	    Scribe_Values.Look(ref genericammo, "genericAmmo", false);
 

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -22,7 +22,7 @@ namespace CombatExtended
         private bool allowMeleeHunting = false;
         private bool smokeEffects = true;
         private bool mergeExplosions = true;
-        private bool turretsBreakShields = false;
+        private bool turretsBreakShields = true;
         private bool showBackpacks = true;
         private bool showTacticalVests = true;
 	private bool genericammo = false;
@@ -60,7 +60,7 @@ namespace CombatExtended
         private bool enableAmmoSystem = true;
         private bool rightClickAmmoSelect = true;
         private bool autoReloadOnChangeAmmo = true;
-        private bool autoTakeAmmo = false;
+        private bool autoTakeAmmo = true;
         private bool showCaliberOnGuns = true;
         private bool reuseNeolithicProjectiles = true;
         private bool realisticCookOff = true;
@@ -130,7 +130,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref allowMeleeHunting, "allowMeleeHunting", false);
             Scribe_Values.Look(ref smokeEffects, "smokeEffects", true);
             Scribe_Values.Look(ref mergeExplosions, "mergeExplosions", true);
-            Scribe_Values.Look(ref turretsBreakShields, "turretsBreakShields", false);
+            Scribe_Values.Look(ref turretsBreakShields, "turretsBreakShields", true);
             Scribe_Values.Look(ref showBackpacks, "showBackpacks", true);
             Scribe_Values.Look(ref showTacticalVests, "showTacticalVests", true);
             Scribe_Values.Look(ref partialstats, "PartialArmor", true);
@@ -163,7 +163,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref enableAmmoSystem, "enableAmmoSystem", true);
             Scribe_Values.Look(ref rightClickAmmoSelect, "rightClickAmmoSelect", true);
             Scribe_Values.Look(ref autoReloadOnChangeAmmo, "autoReloadOnChangeAmmo", true);
-            Scribe_Values.Look(ref autoTakeAmmo, "autoTakeAmmo", false);
+            Scribe_Values.Look(ref autoTakeAmmo, "autoTakeAmmo", true);
             Scribe_Values.Look(ref showCaliberOnGuns, "showCaliberOnGuns", true);
             Scribe_Values.Look(ref reuseNeolithicProjectiles, "reuseNeolithicProjectiles", true);
             Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", true);

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -17,8 +17,8 @@ namespace CombatExtended
         // General settings
         private bool bipodMechanics = true;
         private bool autosetup = true;
-        private bool showCasings = false;
-        private bool showTaunts = false;
+        private bool showCasings = true;
+        private bool showTaunts = true;
         private bool allowMeleeHunting = false;
         private bool smokeEffects = true;
         private bool mergeExplosions = true;
@@ -125,8 +125,8 @@ namespace CombatExtended
         public override void ExposeData()
         {
             base.ExposeData();
-            Scribe_Values.Look(ref showCasings, "showCasings", false);
-            Scribe_Values.Look(ref showTaunts, "showTaunts", false);
+            Scribe_Values.Look(ref showCasings, "showCasings", true);
+            Scribe_Values.Look(ref showTaunts, "showTaunts", true);
             Scribe_Values.Look(ref allowMeleeHunting, "allowMeleeHunting", false);
             Scribe_Values.Look(ref smokeEffects, "smokeEffects", true);
             Scribe_Values.Look(ref mergeExplosions, "mergeExplosions", true);


### PR DESCRIPTION
## Changes

- Changed some of CE's default settings around from false to true and vice versa.
- Changed some of the setting descriptions for the better,

## Reasoning

- Both left and right clicking on the reload button brings up the ammo selection settings which enabling the "right-click ammo selection" settings allows for faster reloading by just left-clicking.
- Unrealistic cook-off can cause errors during game save state and switching between the setting during that state spawns broken projectiles that throw constant red errors and the only way to remove the errors is to manually find and remove the projectiles. Also bullets flying off everywhere is stupid and unrealistic.
- Weapon and Apparel autopatcher are both unreliable and not robust enough in their current state, so a default disabled state is a better option for now.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
