### PR TITLE
Fix ignorePartialLoSBlocker when target is in the open

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -356,6 +356,7 @@ namespace CombatExtended
                         {
                             targetRange.max = coverRange.max * 2;
                         }
+			targetHeight = VerbPropsCE.ignorePartialLoSBlocker ? 0 : targetRange.Average;
                     }
                     else if (currentTarget.Thing is Pawn Victim)
                     {
@@ -483,7 +484,7 @@ namespace CombatExtended
                        
 
                     }
-                    targetHeight = VerbPropsCE.ignorePartialLoSBlocker ? 0 : targetRange.Average;
+                    
                 }
                 if (projectilePropsCE.isInstant)
                 {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -293,6 +293,7 @@ namespace CombatExtended
         {
             if (!calculateMechanicalOnly)
             {
+		bool arcOverhead = false;
                 Vector3 u = caster.TrueCenter();
                 sourceLoc.Set(u.x, u.z);
 
@@ -357,6 +358,7 @@ namespace CombatExtended
                             targetRange.max = coverRange.max * 2;
                         }
 			targetHeight = VerbPropsCE.ignorePartialLoSBlocker ? 0 : targetRange.Average;
+			arcOverhead = true;
                     }
                     else if (currentTarget.Thing is Pawn Victim)
                     {
@@ -492,7 +494,7 @@ namespace CombatExtended
                 }
                 else
                 {
-                    angleRadians += ProjectileCE.GetShotAngle(ShotSpeed, (newTargetLoc - sourceLoc).magnitude, targetHeight - ShotHeight, Projectile.projectile.flyOverhead, projectilePropsCE.Gravity);
+                    angleRadians += ProjectileCE.GetShotAngle(ShotSpeed, (newTargetLoc - sourceLoc).magnitude, targetHeight - ShotHeight, Projectile.projectile.flyOverhead || arcOverhead, projectilePropsCE.Gravity);
                 }
             }
 


### PR DESCRIPTION


## Changes

ignorePartialLoSBlocker will only force targeting the feet if the target is behind cover.

## Reasoning

Per the name of the tag, it is only when LoS is at least partially blocked that it should do anything.

## Alternatives

Disable the behavior, which would make propelled grenades less effective against targets behind cover.

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
