### PR TITLE
Rework 80mm fuel cells from thermobaric to incendiary

### DIFF
--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -14,7 +14,7 @@
     <defName>AmmoSet_80x256mmFuel</defName>
     <label>80x256mm Fuel Cell</label>
     <ammoTypes>
-      <Ammo_80x256mmFuel_Thermobaric>Bullet_80x256mmFuel_Thermobaric</Ammo_80x256mmFuel_Thermobaric>
+      <Ammo_80x256mmFuel_Incendiary>Bullet_80x256mmFuel_Incendiary</Ammo_80x256mmFuel_Incendiary>
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 
@@ -36,8 +36,8 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="80x256mmFuelBase">
-    <defName>Ammo_80x256mmFuel_Thermobaric</defName>
-    <label>80x256mm fuel cell (Thermobaric)</label>
+    <defName>Ammo_80x256mmFuel_Incendiary</defName>
+    <label>80x256mm fuel cell (Incendiary)</label>
     <graphicData>
       <texPath>Things/Ammo/FuelCell/Large</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -45,13 +45,13 @@
     <statBases>
       <MarketValue>10.97</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
     </statBases>
-    <ammoClass>ThermobaricFuel</ammoClass>
-	<detonateProjectile>Bullet_80x256mmFuel_Thermobaric</detonateProjectile>
+    <ammoClass>GrenadeIncendiary</ammoClass>
+	<detonateProjectile>Bullet_80x256mmFuel_Incendiary</detonateProjectile>
 	<comps>
     <li Class="CompProperties_Explosive">
-        <explosiveRadius>1</explosiveRadius>
-		<damageAmountBase>20</damageAmountBase>
-        <explosiveDamageType>Thermobaric</explosiveDamageType>
+        <explosiveRadius>1.9</explosiveRadius>
+		<damageAmountBase>5</damageAmountBase>
+        <explosiveDamageType>PrometheumFlame</explosiveDamageType>
 		<explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
         <startWickHitPointsPercent>0.33</startWickHitPointsPercent>
 		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -63,24 +63,23 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Name="Base80x256mmFuelThermobaricBullet" ParentName="BaseBullet">
-    <defName>Bullet_80x256mmFuel_Thermobaric</defName>
-    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
-    <label>80x256mm fuel shell (Thermobaric)</label>
+  <ThingDef Name="Base80x256mmFuelIncendiaryBullet" ParentName="BaseBullet">
+    <defName>Bullet_80x256mmFuel_Incendiary</defName>
+    <label>80x256mm fuel shell (Incendiary)</label>
     <graphicData>
       <texPath>Things/Projectile/LauncherShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>Thermobaric</damageDef>
-      <damageAmountBase>309</damageAmountBase>
+      <damageDef>PrometheumFlame</damageDef>
+      <damageAmountBase>0</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <speed>60</speed>
       <flyOverhead>false</flyOverhead>
-      <explosionRadius>5.5</explosionRadius>
-      <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+      <explosionRadius>5.9</explosionRadius>
+      <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.5</preExplosionSpawnChance>
       <soundExplode>MortarIncendiary_Explode</soundExplode>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
@@ -89,6 +88,15 @@
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
     </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+        <damageAmountBase>150</damageAmountBase>
+        <explosiveDamageType>Thermobaric</explosiveDamageType>
+        <explosiveRadius>1.9</explosiveRadius>
+        <explosionSound>MortarIncendiary_Explode</explosionSound>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      </li>
+    </comps>
   </ThingDef>
 
   <!-- ==================== Recipes ========================== -->

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1218,7 +1218,7 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+      <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
       <warmupTime>4.3</warmupTime>
       <range>86</range>
       <burstShotCount>1</burstShotCount>

--- a/Patches/Doom Factions/DoomFactions_Ammo.xml
+++ b/Patches/Doom Factions/DoomFactions_Ammo.xml
@@ -47,7 +47,7 @@
 						<defName>AmmoSet_BFG</defName>
 						<label>Energy Cell</label>
 						<ammoTypes>
-							<Ammo_80x256mmFuel_Thermobaric>Bullet_UACBFG</Ammo_80x256mmFuel_Thermobaric>
+							<Ammo_80x256mmFuel_Incendiary>Bullet_UACBFG</Ammo_80x256mmFuel_Incendiary>
 						</ammoTypes>
 					</CombatExtended.AmmoSetDef>
 					

--- a/Patches/Girls Frontline Weapon Pack/ThingsDef_Misc/GFWeapons.xml
+++ b/Patches/Girls Frontline Weapon Pack/ThingsDef_Misc/GFWeapons.xml
@@ -765,7 +765,7 @@
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+					<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
 					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 					<warmupTime>1.9</warmupTime>
 					<range>48</range>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
@@ -19,7 +19,7 @@
 				<Properties>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+					<defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
 					<warmupTime>4.1</warmupTime>
 					<range>86</range>
 					<burstShotCount>1</burstShotCount>

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_MechWeapons_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_MechWeapons_Mech.xml
@@ -60,7 +60,7 @@
                     <Properties>
                         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                         <hasStandardCommand>true</hasStandardCommand>
-                        <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+                        <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
                         <warmupTime>4.5</warmupTime>
                         <range>82</range>
                         <ticksBetweenBurstShots>25</ticksBetweenBurstShots>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -133,7 +133,7 @@
 							<li>Plasteel</li>
 						</items>	
 						<secondItems>
-							<li>FSX</li>
+							<li>Prometheum</li>
 						</secondItems>
 						<thirdItems>
 							<li>ComponentIndustrial</li>
@@ -145,7 +145,7 @@
 						</amount>
 						<outputLimitControlled>true</outputLimitControlled>
 						<maxTotalOutput>100</maxTotalOutput>
-						<result>Ammo_80x256mmFuel_Thermobaric</result>	
+						<result>Ammo_80x256mmFuel_Incendiary</result>	
 						<yield>5</yield>		
 						<useQualityIncreasing>false</useQualityIncreasing>
 						<singleTimeIfNotQualityIncreasing>0.1</singleTimeIfNotQualityIncreasing>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -207,7 +207,7 @@
 				  <recoilAmount>3.5</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
-				  <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+				  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
 				  <warmupTime>4.3</warmupTime>
 				  <range>86</range>
 				  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -271,7 +271,7 @@
 				<Properties>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
-				  <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+				  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
 				  <warmupTime>4.3</warmupTime>
 				  <range>86</range>
 				  <burstShotCount>1</burstShotCount>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -591,7 +591,7 @@
 		<Properties>
 		  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		  <hasStandardCommand>true</hasStandardCommand>
-		  <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+		  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
 		  <warmupTime>3.5</warmupTime>
 		  <range>86</range>
 		  <burstShotCount>1</burstShotCount>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -118,7 +118,7 @@
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+        <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
         <warmupTime>4.3</warmupTime>
         <range>86</range>
         <burstShotCount>1</burstShotCount>

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1129,7 +1129,7 @@ namespace CombatExtended
                     if (explodePos.y < SuppressionRadius)
                         suppressThings.AddRange(explodePos.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius));
                 }
-                else if (explodingComp != null)
+                if (explodingComp != null)
                 {
                     explodingComp.Explode(this, explodePos, Map, 1f, dir, ignoredThings);
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1129,7 +1129,7 @@ namespace CombatExtended
                     if (explodePos.y < SuppressionRadius)
                         suppressThings.AddRange(explodePos.ToIntVec3().PawnsInRange(Map, SuppressionRadius + def.projectile.explosionRadius));
                 }
-                if (explodingComp != null)
+                else if (explodingComp != null)
                 {
                     explodingComp.Explode(this, explodePos, Map, 1f, dir, ignoredThings);
 


### PR DESCRIPTION
## Changes

- What it says on the tin, reworked 80mm fuel cells from thermobaric to incendiary with a small thermobaric explosion at the epicenter.

## Reasoning

- Infernopedes were designed in an era that the Termite mech used to not exist hence the pretty OP shell that they fire. This PR intends to tame their weapon to an extent so that they still remain a threat but they become closer to their vanilla role of incendiary crowd control unit rather than an instant delete button.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
