### PR TITLE
md revisions

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -24,7 +24,7 @@ $ start CombatExtended/Source/CombatExtended.sln
 ```
 `start` will open the sln file with whatever IDE you have set to open .sln files by default. You can also just open the sln file normally.
 
-After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
+This will lead to references being pulled from Nuget. The assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.
 
 ## Other options
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ If you want to build the assembly yourself, please see [Building](Building.md) f
 
 ### Armor
 **Armor Rebalance**
-- Vanilla percentage based armor system is gone. CE replaces it with a deflection-based model where projectiles have armor penetration which determines whether a bullet penetrates and how much it's damage is reduced. A rifle bullet will go straight through a synthread parka but will completely bounce off of legendary power armor.
+- CE replaces the vanilla armor system with a deflection-based model. Pojectiles have armor penetration which determines whether a bullet penetrates, and how much it's damage is reduced. 
+- A rifle bullet will go straight through a synthread parka. It will completely bounce off of legendary power armor.
 
 **Shields**
 - New shields provide additional protection against ranged fire. Basic melee shields can be made at the smithy and will block arrows, researching machining gives access to modern ballistic shields with improved coverage and protection against gunfire.


### PR DESCRIPTION
Revision 4
### Armor
**Armor Rebalance**
- Vanilla percentage based armor system is gone. CE replaces it with a deflection-based model where projectiles have armor penetration which determines whether a bullet penetrates and how much it's damage is reduced. A rifle bullet will go straight through a synthread parka but will completely bounce off of legendary power armor.

Changes 4
- CE replaces the vanilla armor system with a deflection-based model. Pojectiles have armor penetration which determines whether a bullet penetrates, and how much it's damage is reduced. 
- A rifle bullet will go straight through a synthread parka. It will completely bounce off of legendary power armor.

URL: https://github.com/Jep4/CombatExtended/blob/Development/README.md


Revision 5
After this, building is just building the solution, references will be pulled from Nuget, and the assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.

Changes 5
This will lead to references being pulled from Nuget. The assemblies should be automatically publicised by the msbuild task. The resulting assembly will be in `$(root)/Assemblies/CombatExtended.dll`.

URL: https://github.com/Jep4/CombatExtended/blob/Development/Building.md 