### PR TITLE
Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended CE Patch

### DIFF
--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
@@ -1,0 +1,803 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+		<operations>
+
+            <!--ARROWS-->
+		
+            <!--Remove the bows and their projectiles-->
+			<li Class="PatchOperationRemove">
+                <xpath>/Defs/ThingDef[defName="Bow_Grenade"] |
+                /Defs/ThingDef[defName="Arrow_Grenade"] |
+                /Defs/ThingDef[defName="Bow_Molotov"] |
+                /Defs/ThingDef[defName="Arrow_Molotov"] |
+                /Defs/ThingDef[defName="Bow_EMP"] |
+                /Defs/ThingDef[defName="Arrow_EMP"] |
+                /Defs/ThingDef[defName="Bow_Battery"] |
+                /Defs/ThingDef[defName="Arrow_Battery"]
+                </xpath>
+			</li>
+
+            <!-- Ammo Set -->
+            <!--Regular Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Arrow"]/ammoTypes</xpath>
+                <value>
+                    <Ammo_Arrow_Grenade>Projectile_Arrow_Grenade</Ammo_Arrow_Grenade>
+                    <Ammo_Arrow_Molotov>Projectile_Arrow_Molotov</Ammo_Arrow_Molotov>
+                    <Ammo_Arrow_EMP>Projectile_Arrow_EMP</Ammo_Arrow_EMP>
+                    <Ammo_Arrow_Battery>Projectile_Arrow_Battery</Ammo_Arrow_Battery>
+                </value>
+            </li>
+            
+            <!--Streamlined Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_StreamlinedArrow"]/ammoTypes</xpath>
+                <value>
+                    <Ammo_Arrow_Grenade>Projectile_StreamlinedArrow_Grenade</Ammo_Arrow_Grenade>
+                    <Ammo_Arrow_Molotov>Projectile_StreamlinedArrow_Molotov</Ammo_Arrow_Molotov>
+                    <Ammo_Arrow_EMP>Projectile_StreamlinedArrow_EMP</Ammo_Arrow_EMP>
+                    <Ammo_Arrow_Battery>Projectile_StreamlinedArrow_Battery</Ammo_Arrow_Battery>
+                </value>
+            </li>
+
+            <!--Great Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_GreatArrow"]/ammoTypes</xpath>
+                <value>
+                    <Ammo_GreatArrow_Grenade>Projectile_GreatArrow_Grenade</Ammo_GreatArrow_Grenade>
+                    <Ammo_GreatArrow_Molotov>Projectile_GreatArrow_Molotov</Ammo_GreatArrow_Molotov>
+                    <Ammo_GreatArrow_EMP>Projectile_GreatArrow_EMP</Ammo_GreatArrow_EMP>
+                    <Ammo_GreatArrow_Battery>Projectile_GreatArrow_Battery</Ammo_GreatArrow_Battery>
+                </value>
+            </li>
+
+            <!-- Ammo Categories-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+                    <CombatExtended.AmmoCategoryDef>
+                        <defName>ArrowGrenade</defName>
+                        <label>Bownade</label>
+                        <description>Pull the pin and immediately shoot the arrow, or else.</description>
+                    </CombatExtended.AmmoCategoryDef>
+                    
+                    <CombatExtended.AmmoCategoryDef>
+                        <defName>ArrowMolotov</defName>
+                        <label>Bowlotov</label>
+                        <description>No need for accuracy when your arrows explode.</description>
+                    </CombatExtended.AmmoCategoryDef>
+                    
+                    <CombatExtended.AmmoCategoryDef>
+                        <defName>ArrowEMP</defName>
+                        <label>BowMP</label>
+                        <description>Demonic servants of a sleeping god, meet 'demonic servant of a sleeping god'-stopper.</description>
+                    </CombatExtended.AmmoCategoryDef>
+                    
+                    <CombatExtended.AmmoCategoryDef>
+                        <defName>ArrowBattery</defName>
+                        <label>Bowttery</label>
+                        <description>When the guns are gone and you can't go on.</description>
+                    </CombatExtended.AmmoCategoryDef>
+                </value>
+            </li>
+
+            <!--Arrows (Ammunition)-->
+            <!--Regular & Streamlined Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+                        <defName>Ammo_Arrow_Grenade</defName>
+                        <label>arrow (grenade)</label>
+                        <graphicData>
+                            <texPath>Bownade</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowGrenade</ammoClass>
+                        <statBases>
+                            <MarketValue>12.35</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+                        <defName>Ammo_Arrow_Molotov</defName>
+                        <label>arrow (molotov)</label>
+                        <graphicData>
+                            <texPath>Bowlotov</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowMolotov</ammoClass>
+                        <statBases>
+                            <MarketValue>7.18</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+                        <defName>Ammo_Arrow_EMP</defName>
+                        <label>arrow (EMP)</label>
+                        <graphicData>
+                            <texPath>BowMP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowEMP</ammoClass>
+                        <statBases>
+                            <MarketValue>21.22</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
+                        <defName>Ammo_Arrow_Battery</defName>
+                        <label>arrow (battery)</label>
+                        <graphicData>
+                            <texPath>Bowttery</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowBattery</ammoClass>
+                        <statBases>
+                            <MarketValue>26.04</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                </value>
+            </li>
+
+            <!--Great Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+                        <defName>Ammo_GreatArrow_Grenade</defName>
+                        <label>great arrow (grenade)</label>
+                        <graphicData>
+                            <texPath>Bownade</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowGrenade</ammoClass>
+                        <statBases>
+                            <MarketValue>12.61</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+                        <defName>Ammo_GreatArrow_Molotov</defName>
+                        <label>great arrow (molotov)</label>
+                        <graphicData>
+                            <texPath>Bowlotov</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowMolotov</ammoClass>
+                        <statBases>
+                            <MarketValue>7.44</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+                        <defName>Ammo_GreatArrow_EMP</defName>
+                        <label>great arrow (EMP)</label>
+                        <graphicData>
+                            <texPath>BowMP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowEMP</ammoClass>
+                        <statBases>
+                            <MarketValue>21.48</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                    
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
+                        <defName>Ammo_GreatArrow_Battery</defName>
+                        <label>great arrow (battery)</label>
+                        <graphicData>
+                            <texPath>Bowttery</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <ammoClass>ArrowBattery</ammoClass>
+                        <statBases>
+                            <MarketValue>26.3</MarketValue>
+                        </statBases>
+                        <tradeTags>
+                            <li>CE_AutoEnableCrafting_CraftingSpot</li>
+                        </tradeTags>
+                    </ThingDef>
+                </value>
+            </li>
+
+            <!--Arrow Projectiles-->
+            <!--Regular Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_Arrow_Grenade</defName>
+                        <label>arrow (bownade)</label>
+                        <graphicData>
+                            <texPath>BownadeP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.5</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            <speed>18</speed>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_Fragments">
+                                <fragments>
+                                    <Fragment_Small>40</Fragment_Small>
+                                </fragments>
+                            </li>
+                        </comps>
+					</ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_Arrow_Molotov</defName>
+                        <label>arrow (bowlotov)</label>
+                        <graphicData>
+                            <texPath>BowlotovP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>PrometheumFlame</damageDef>
+                            <damageAmountBase>10</damageAmountBase>
+                            <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+                            <preExplosionSpawnChance>1</preExplosionSpawnChance>
+                            <speed>18</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_Arrow_EMP</defName>
+                        <label>arrow (bowMP)</label>
+                        <graphicData>
+                            <texPath>BowMPP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>3</explosionRadius>
+                            <damageDef>EMP</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <speed>18</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_Arrow_Battery</defName>
+                        <label>arrow (bowttery)</label>
+                        <graphicData>
+                            <texPath>BowtteryP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>200</damageAmountBase>
+                            <speed>18</speed>
+                        </projectile>
+                    </ThingDef>
+                
+                </value>
+            </li>
+
+            <!--Streamlined Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_StreamlinedArrow_Grenade</defName>
+                        <label>streamlined arrow (bownade)</label>
+                        <graphicData>
+                            <texPath>BownadeP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.5</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            <speed>20</speed>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_Fragments">
+                                <fragments>
+                                    <Fragment_Small>40</Fragment_Small>
+                                </fragments>
+                            </li>
+                        </comps>
+					</ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_StreamlinedArrow_Molotov</defName>
+                        <label>streamlined arrow (bowlotov)</label>
+                        <graphicData>
+                            <texPath>BowlotovP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>PrometheumFlame</damageDef>
+                            <damageAmountBase>10</damageAmountBase>
+                            <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+                            <preExplosionSpawnChance>1</preExplosionSpawnChance>
+                            <speed>20</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_StreamlinedArrow_EMP</defName>
+                        <label>streamlined arrow (bowMP)</label>
+                        <graphicData>
+                            <texPath>BowMPP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>3</explosionRadius>
+                            <damageDef>EMP</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <speed>20</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_StreamlinedArrow_Battery</defName>
+                        <label>streamlined arrow (bowttery)</label>
+                        <graphicData>
+                            <texPath>BowtteryP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>200</damageAmountBase>
+                            <speed>20</speed>
+                        </projectile>
+                    </ThingDef>
+                
+                </value>
+            </li>
+
+            <!--Great Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_GreatArrow_Grenade</defName>
+                        <label>great arrow (bownade)</label>
+                        <graphicData>
+                            <texPath>BownadeP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.5</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            <speed>18</speed>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_Fragments">
+                                <fragments>
+                                    <Fragment_Small>40</Fragment_Small>
+                                </fragments>
+                            </li>
+                        </comps>
+					</ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_GreatArrow_Molotov</defName>
+                        <label>great arrow (bowlotov)</label>
+                        <graphicData>
+                            <texPath>BowlotovP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>PrometheumFlame</damageDef>
+                            <damageAmountBase>10</damageAmountBase>
+                            <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+                            <preExplosionSpawnChance>1</preExplosionSpawnChance>
+                            <speed>18</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_GreatArrow_EMP</defName>
+                        <label>great arrow (bowMP)</label>
+                        <graphicData>
+                            <texPath>BowMPP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>3</explosionRadius>
+                            <damageDef>EMP</damageDef>
+                            <damageAmountBase>56</damageAmountBase>
+                            <explosionDelay>60</explosionDelay>
+                            <dropsCasings>true</dropsCasings>
+                            <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+                            <speed>20</speed>
+                        </projectile>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BaseArrowProjectile">
+                        <defName>Projectile_GreatArrow_Battery</defName>
+                        <label>great arrow (bowttery)</label>
+                        <graphicData>
+                            <texPath>BowtteryP</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <explosionRadius>1.1</explosionRadius>
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>200</damageAmountBase>
+                            <speed>18</speed>
+                        </projectile>
+                    </ThingDef>
+                
+                </value>
+            </li>
+
+            <!--Arrow Recipes-->
+            <!--Normal Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_Arrow_Grenade</defName>
+                    <label>make bownade x10</label>
+                    <description>Craft 10 bownade arrows.</description>
+                    <jobString>Making bownade arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeFrag</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeFrag</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_Arrow_Grenade>10</Ammo_Arrow_Grenade>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_Arrow_Molotov</defName>
+                    <label>make bowlotov x10</label>
+                    <description>Craft 10 bowlotov arrows.</description>
+                    <jobString>Making bowlotov arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeMolotov</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeMolotov</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_Arrow_Molotov>10</Ammo_Arrow_Molotov>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_Arrow_EMP</defName>
+                    <label>make bowMP x10</label>
+                    <description>Craft 10 bowMP arrows.</description>
+                    <jobString>Making bowMP arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeEMP</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeEMP</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_Arrow_EMP>10</Ammo_Arrow_EMP>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_Arrow_Battery</defName>
+                    <label>make bowMP x10</label>
+                    <description>Craft 10 bowttery arrows.</description>
+                    <jobString>Making bowttery arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Steel</li>
+                        </thingDefs>
+                        </filter>
+                        <count>20</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>ComponentIndustrial</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Steel</li>
+                        <li>ComponentIndustrial</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_Arrow_Battery>10</Ammo_Arrow_Battery>
+                    </products>
+                </RecipeDef>
+
+                </value>
+            </li>
+            
+            <!--Great Arrows-->
+            <li Class="PatchOperationAdd">
+                <xpath>/Defs</xpath>
+                <value>
+
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_GreatArrow_Grenade</defName>
+                    <label>make bownade x10</label>
+                    <description>Craft 10 bownade great arrows.</description>
+                    <jobString>Making bownade great arrows.</jobString>
+                    <workAmount>300</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>3</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeFrag</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeFrag</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_GreatArrow_Grenade>10</Ammo_GreatArrow_Grenade>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_GreatArrow_Molotov</defName>
+                    <label>make bowlotov x10</label>
+                    <description>Craft 10 bowlotov great arrows.</description>
+                    <jobString>Making bowlotov great arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>3</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeMolotov</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeMolotov</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_GreatArrow_Molotov>10</Ammo_GreatArrow_Molotov>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_GreatArrow_EMP</defName>
+                    <label>make bowMP x10</label>
+                    <description>Craft 10 bowMP great arrows.</description>
+                    <jobString>Making bowMP great arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>3</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Weapon_GrenadeEMP</li>
+                        </thingDefs>
+                        </filter>
+                        <count>10</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Weapon_GrenadeEMP</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_GreatArrow_EMP>10</Ammo_GreatArrow_EMP>
+                    </products>
+                </RecipeDef>
+                
+                <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                    <defName>MakeAmmo_GreatArrow_Battery</defName>
+                    <label>make bowMP x10</label>
+                    <description>Craft 10 bowttery great arrows.</description>
+                    <jobString>Making bowttery great arrows.</jobString>
+                    <workAmount>100</workAmount>
+                    <ingredients>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                        </thingDefs>
+                        </filter>
+                        <count>3</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>Steel</li>
+                        </thingDefs>
+                        </filter>
+                        <count>20</count>
+                    </li>
+                    <li>
+                        <filter>
+                        <thingDefs>
+                            <li>ComponentIndustrial</li>
+                        </thingDefs>
+                        </filter>
+                        <count>1</count>
+                    </li>
+                    </ingredients>
+                    <fixedIngredientFilter>
+                    <thingDefs>
+                        <li>WoodLog</li>
+                        <li>Steel</li>
+                        <li>ComponentIndustrial</li>
+                    </thingDefs>
+                    </fixedIngredientFilter>
+                    <products>
+                        <Ammo_GreatArrow_Battery>10</Ammo_GreatArrow_Battery>
+                    </products>
+                </RecipeDef>
+
+                </value>
+            </li>
+
+		</operations>
+	</match>
+	</Operation>
+</Patch>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
@@ -490,7 +490,7 @@
 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_Arrow_Grenade</defName>
-                    <label>make bownade x10</label>
+                    <label>make bownade arrows x10</label>
                     <description>Craft 10 bownade arrows.</description>
                     <jobString>Making bownade arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -525,7 +525,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_Arrow_Molotov</defName>
-                    <label>make bowlotov x10</label>
+                    <label>make bowlotov arrows x10</label>
                     <description>Craft 10 bowlotov arrows.</description>
                     <jobString>Making bowlotov arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -560,7 +560,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_Arrow_EMP</defName>
-                    <label>make bowMP x10</label>
+                    <label>make bowMP arrows x10</label>
                     <description>Craft 10 bowMP arrows.</description>
                     <jobString>Making bowMP arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -595,7 +595,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_Arrow_Battery</defName>
-                    <label>make bowMP x10</label>
+                    <label>make bowttery arrows x10</label>
                     <description>Craft 10 bowttery arrows.</description>
                     <jobString>Making bowttery arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -647,7 +647,7 @@
 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_GreatArrow_Grenade</defName>
-                    <label>make bownade x10</label>
+                    <label>make bownade great arrows x10</label>
                     <description>Craft 10 bownade great arrows.</description>
                     <jobString>Making bownade great arrows.</jobString>
                     <workAmount>300</workAmount>
@@ -682,7 +682,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_GreatArrow_Molotov</defName>
-                    <label>make bowlotov x10</label>
+                    <label>make bowlotov great arrows x10</label>
                     <description>Craft 10 bowlotov great arrows.</description>
                     <jobString>Making bowlotov great arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -717,7 +717,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_GreatArrow_EMP</defName>
-                    <label>make bowMP x10</label>
+                    <label>make bowMP great arrows x10</label>
                     <description>Craft 10 bowMP great arrows.</description>
                     <jobString>Making bowMP great arrows.</jobString>
                     <workAmount>100</workAmount>
@@ -752,7 +752,7 @@
                 
                 <RecipeDef ParentName="AmmoRecipeNeolithicBase">
                     <defName>MakeAmmo_GreatArrow_Battery</defName>
-                    <label>make bowMP x10</label>
+                    <label>make bowttery great arrows x10</label>
                     <description>Craft 10 bowttery great arrows.</description>
                     <jobString>Making bowttery great arrows.</jobString>
                     <workAmount>100</workAmount>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
@@ -107,6 +107,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.1</generateAllowChance> <!-- Should be a bit rarer than Plasteel -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
@@ -123,6 +124,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.1</generateAllowChance> <!-- Should be a bit rarer than a flame arrow -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
@@ -139,6 +141,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.05</generateAllowChance> <!-- Very rare? -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
@@ -155,6 +158,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.05</generateAllowChance> <!-- Very rare? -->
                     </ThingDef>
                 </value>
             </li>
@@ -177,6 +181,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.1</generateAllowChance> <!-- Should be a bit rarer than a plasteel arrow -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
@@ -193,6 +198,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.1</generateAllowChance> <!-- Should be a bit rarer than a flame arrow -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
@@ -209,6 +215,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.05</generateAllowChance> <!-- Very rare? -->
                     </ThingDef>
                     
                     <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoGreatArrowBase">
@@ -225,6 +232,7 @@
                         <tradeTags>
                             <li>CE_AutoEnableCrafting_CraftingSpot</li>
                         </tradeTags>
+						<generateAllowChance>0.05</generateAllowChance> <!-- Very rare? -->
                     </ThingDef>
                 </value>
             </li>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -48,13 +48,13 @@
                         </statBases>
                         <!--equippedAngleOffset>30</equippedAngleOffset-->
                         <stackLimit>25</stackLimit>
-                        <weaponTags>
-                            <li>NeolithicRangedHeavy</li>
-                            <li>CE_Pila</li>
+                        <weaponTags Inherit="false">
+                            <!--li>NeolithicRangedHeavy</li>
+                            <li>CE_Pila</li--> <!-- tribal tags -->
                             <li>CE_OneHandedWeapon</li>
-                            <!--li>IndustrialRangedHeavy</li> 
+                            <li>IndustrialRangedHeavy</li> 
                             <li>GrenadeDestructive</li>
-                            <li>EmpireGrenadeDestructive</li--> <!-- Not sure whether to inherit the tags from the base mod, setting it to default for pila for now -->
+                            <li>EmpireGrenadeDestructive</li> <!-- Base tags from the mod -->
                         </weaponTags>
                         <tradeability>All</tradeability>
                         <verbs>
@@ -64,7 +64,10 @@
                                 <defaultProjectile>PilumHE_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                         <tools>
@@ -119,7 +122,10 @@
                                 <defaultProjectile>PilumHI_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                     </ThingDef>
@@ -149,7 +155,10 @@
                                 <defaultProjectile>PilumEMP_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                     </ThingDef>
@@ -172,6 +181,7 @@
                             <Mass>2.00</Mass>
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
+						<generateAllowChance>0</generateAllowChance>
                         <verbs Inherit="false">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
@@ -179,7 +189,10 @@
                                 <defaultProjectile>PilumSmoke_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                     </ThingDef>
@@ -202,6 +215,7 @@
                             <Mass>2.00</Mass>
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
+						<generateAllowChance>0</generateAllowChance>
                         <verbs Inherit="false">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
@@ -209,7 +223,10 @@
                                 <defaultProjectile>PilumFirefoam_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                     </ThingDef>
@@ -232,6 +249,7 @@
                             <Mass>2.00</Mass>
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
+						<generateAllowChance>0.1</generateAllowChance> <!-- carried over from base mod, generate commonality 0.1 -->
                         <verbs Inherit="false">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
@@ -239,7 +257,10 @@
                                 <defaultProjectile>PilumAntigrain_Thrown</defaultProjectile>
                                 <warmupTime>0.8</warmupTime>
                                 <range>9</range>
-                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+								<targetParams>
+									<canTargetLocations>true</canTargetLocations>
+								</targetParams>
+                                <soundCast>Interact_BeatFire</soundCast>
                             </li>
                         </verbs>
                     </ThingDef>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -1,0 +1,707 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended</li>
+    </mods>
+
+    <match Class="PatchOperationSequence">
+		<operations>
+
+            <!--PILA/PILUM/JAVELIN-->
+            <!--Add the ammo to the AmmoSet (for javelin/Pila launchers like atlatl)-->
+			<!--li Class="PatchOperationAdd">
+				<xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Javelins"]/ammoTypes</xpath>
+				<value>
+		        	<PilaHighExplosive>PilumHE_Fired</PilaHighExplosive>
+		        	<PilaHighIncendiary>PilumHI_Fired</PilaHighIncendiary>
+		        	<PilaEMP>PilumEMP_Fired</PilaEMP>
+		        	<PilaSmoke>PilumSmoke_Fired</PilaSmoke>
+		        	<PilaFirefoam>PilumFirefoam_Fired</PilaFirefoam>
+		        	<PilaAntigrain>PilumAntigrain_Fired</PilaAntigrain>
+                </value>
+            </li-->
+
+            <!--Overwrite the Pilas added by the mod-->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs</xpath>
+				<value>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseWeaponAndAmmoNeolithic" Name="PilaStrappedBased">
+                        <defName>PilaHighExplosive</defName>
+                        <label>HEla</label>
+                        <description>This shell won't miss 9 tiles away from its target (It might miss 2 but that's still valid).</description>
+                        <graphicData>
+                            <texPath>HEla</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>62.35</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <!--equippedAngleOffset>30</equippedAngleOffset-->
+                        <stackLimit>25</stackLimit>
+                        <weaponTags>
+                            <li>NeolithicRangedHeavy</li>
+                            <li>CE_Pila</li>
+                            <li>CE_OneHandedWeapon</li>
+                            <!--li>IndustrialRangedHeavy</li> 
+                            <li>GrenadeDestructive</li>
+                            <li>EmpireGrenadeDestructive</li--> <!-- Not sure whether to inherit the tags from the base mod, setting it to default for pila for now -->
+                        </weaponTags>
+                        <tradeability>All</tradeability>
+                        <verbs>
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumHE_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>shaft</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>7</power>
+                                <cooldownTime>1.35</cooldownTime>
+                                <armorPenetrationBlunt>2.25</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>point</label>
+                                <capacities>
+                                    <li>Stab</li>
+                                </capacities>
+                                <power>15</power>
+                                <cooldownTime>1.37</cooldownTime>
+                                <chanceFactor>1.5</chanceFactor>
+                                <armorPenetrationBlunt>1.69</armorPenetrationBlunt>
+                                <armorPenetrationSharp>0.34</armorPenetrationSharp>
+                                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                        <ammoClass>Javelin</ammoClass>
+                    </ThingDef>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="PilaStrappedBased">
+                        <defName>PilaHighIncendiary</defName>
+                        <label>HIla</label>
+                        <description>No, there is no baby to reveal its gender with.</description>
+                        <graphicData>
+                            <texPath>HIla</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>49.6</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <verbs Inherit="false">
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumHI_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                    </ThingDef>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="PilaStrappedBased">
+                        <defName>PilaEMP</defName>
+                        <label>MPila</label>
+                        <description>Five feet apart from mechanoids (or whatever it is you're aiming at).</description>
+                        <graphicData>
+                            <texPath>MPila</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>119.68</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <verbs Inherit="false">
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumEMP_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                    </ThingDef>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="PilaStrappedBased">
+                        <defName>PilaSmoke</defName>
+                        <label>Smola</label>
+                        <description>Unfortunately, it is not, in fact, smokeleaf.</description>
+                        <graphicData>
+                            <texPath>Smola</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>44.29</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <verbs Inherit="false">
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumSmoke_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                    </ThingDef>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="PilaStrappedBased">
+                        <defName>PilaFirefoam</defName>
+                        <label>Fola</label>
+                        <description>"Only you can prevent forest fires!"</description>
+                        <graphicData>
+                            <texPath>Fola</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>44.29</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <verbs Inherit="false">
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumFirefoam_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                    </ThingDef>
+
+                    <ThingDef Class="CombatExtended.AmmoDef" ParentName="PilaStrappedBased">
+                        <defName>PilaAntigrain</defName>
+                        <label>Sayonala</label>
+                        <description>You can barely feel the singe.</description>
+                        <graphicData>
+                            <texPath>Fola</texPath>
+                            <graphicClass>Graphic_Single</graphicClass>
+                        </graphicData>
+                        <soundInteract>Interact_BeatFire</soundInteract>
+                        <statBases>
+                            <MarketValue>1507.26</MarketValue>
+                            <SightsEfficiency>0.45</SightsEfficiency>
+                            <ShotSpread>1.5</ShotSpread>
+                            <SwayFactor>2.5</SwayFactor>
+                            <Bulk>3.5</Bulk>
+                            <Mass>2.00</Mass>
+                            <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
+                        </statBases>
+                        <verbs Inherit="false">
+                            <li Class="CombatExtended.VerbPropertiesCE">
+                                <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
+                                <hasStandardCommand>true</hasStandardCommand>
+                                <defaultProjectile>PilumAntigrain_Thrown</defaultProjectile>
+                                <warmupTime>0.8</warmupTime>
+                                <range>9</range>
+                                <!--<soundCast>Interact_BeatFire</soundCast>-->
+                            </li>
+                        </verbs>
+                    </ThingDef>
+				</value>
+			</li>
+
+            <!--Add Projectiles-->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs</xpath>
+				<value>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumHE_Thrown</defName>
+                        <label>pilum with HE shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageAmountBase>14</damageAmountBase>
+                            <speed>16</speed>
+                            <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+                            <armorPenetrationSharp>4</armorPenetrationSharp>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                                <damageAmountBase>156</damageAmountBase>
+                                <explosiveDamageType>Bomb</explosiveDamageType>
+                                <explosiveRadius>2.5</explosiveRadius>
+                                <explosionSound>MortarBomb_Explode</explosionSound>
+                            </li>
+                            <li Class="CombatExtended.CompProperties_Fragments">
+                                <fragments>
+                                    <Fragment_Large>16</Fragment_Large>
+                                    <Fragment_Small>100</Fragment_Small>
+                                </fragments>
+                            </li>
+                        </comps>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumHI_Thrown</defName>
+                        <label>pilum with incendiary shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageAmountBase>14</damageAmountBase>
+                            <speed>16</speed>
+                            <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+                            <armorPenetrationSharp>4</armorPenetrationSharp>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                                <damageAmountBase>0</damageAmountBase>
+                                <explosiveDamageType>PrometheumFlame</explosiveDamageType>
+                                <explosiveRadius>6.5</explosiveRadius>
+                                <explosionSound>MortarBomb_Explode</explosionSound>
+                                <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+                                <preExplosionSpawnChance>0.20</preExplosionSpawnChance>
+                            </li>
+                        </comps>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumEMP_Thrown</defName>
+                        <label>pilum with EMP shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageAmountBase>14</damageAmountBase>
+                            <speed>16</speed>
+                            <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+                            <armorPenetrationSharp>4</armorPenetrationSharp>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                                <damageAmountBase>156</damageAmountBase>
+                                <explosiveDamageType>EMP</explosiveDamageType>
+                                <explosiveRadius>5.5</explosiveRadius>
+                            </li>
+                        </comps>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumSmoke_Thrown</defName>
+                        <label>pilum with smoke shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageAmountBase>14</damageAmountBase>
+                            <speed>16</speed>
+                            <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+                            <armorPenetrationSharp>4</armorPenetrationSharp>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                                <explosiveDamageType>Smoke</explosiveDamageType>
+                                <explosiveRadius>6</explosiveRadius>
+                                <explosionSound>Explosion_EMP</explosionSound>
+                                <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+                                <preExplosionSpawnChance>1</preExplosionSpawnChance>
+                                <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            </li>
+                        </comps>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumFirefoam_Thrown</defName>
+                        <label>pilum with smoke shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageAmountBase>14</damageAmountBase>
+                            <speed>16</speed>
+                            <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
+                            <armorPenetrationSharp>4</armorPenetrationSharp>
+                        </projectile>
+                        <comps>
+                            <li Class="CombatExtended.CompProperties_ExplosiveCE">
+                                <explosiveDamageType>Extinguish</explosiveDamageType>
+                                <explosiveRadius>9.5</explosiveRadius>
+                                <explosionSound>Explosion_EMP</explosionSound>
+                                <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
+                                <postExplosionSpawnChance>1</postExplosionSpawnChance>
+                                <postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
+                                <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            </li>
+                        </comps>
+                    </ThingDef>
+
+                    <ThingDef ParentName="BasePilumProjectile">
+                        <defName>PilumAntigrain_Thrown</defName>
+                        <label>pilum with antigrain shell on the tip</label>
+                        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+                            <damageDef>Bomb</damageDef>
+                            <damageAmountBase>800</damageAmountBase>
+                            <speed>16</speed>
+                            <explosionRadius>50</explosionRadius>
+                            <explosionChanceToStartFire>0.22</explosionChanceToStartFire>
+                            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+                            <explosionEffect>GiantExplosion</explosionEffect>
+                            <soundExplode>Explosion_GiantBomb</soundExplode>
+                        </projectile>
+                    </ThingDef>
+
+				</value>
+			</li>
+
+            <!--Add Recipes-->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs</xpath>
+				<value>
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaHighExplosive</defName>
+                        <label>make HEla x5</label>
+                        <description>Craft 5 HEla.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>2500</workAmount>	
+                        <jobString>Making HEla.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>6</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>19</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_HighExplosive</li>
+                            </thingDefs>
+                            </filter>
+                            <count>5</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_HighExplosive</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaHighExplosive>5</PilaHighExplosive>
+                        </products>
+                    </RecipeDef>
+                    
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaHighIncendiary</defName>
+                        <label>make HIla x5</label>
+                        <description>Craft 5 HIla.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>2500</workAmount>	
+                        <jobString>Making HIla.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>6</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>19</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_Incendiary</li>
+                            </thingDefs>
+                            </filter>
+                            <count>5</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_Incendiary</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaHighIncendiary>5</PilaHighIncendiary>
+                        </products>
+                    </RecipeDef>
+                    
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaEMP</defName>
+                        <label>make MPila x5</label>
+                        <description>Craft 5 MPila.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>2500</workAmount>	
+                        <jobString>Making MPila.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>6</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>19</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_EMP</li>
+                            </thingDefs>
+                            </filter>
+                            <count>5</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_EMP</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaEMP>5</PilaEMP>
+                        </products>
+                    </RecipeDef>
+                    
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaSmoke</defName>
+                        <label>make Smola x5</label>
+                        <description>Craft 5 Smola.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>2500</workAmount>	
+                        <jobString>Making Smola.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>6</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>19</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_Smoke</li>
+                            </thingDefs>
+                            </filter>
+                            <count>5</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_Smoke</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaSmoke>5</PilaSmoke>
+                        </products>
+                    </RecipeDef>
+                    
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaFirefoam</defName>
+                        <label>make Fola x5</label>
+                        <description>Craft 5 Fola.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>2500</workAmount>	
+                        <jobString>Making Fola.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>6</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>19</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_Firefoam</li>
+                            </thingDefs>
+                            </filter>
+                            <count>5</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_Firefoam</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaFirefoam>5</PilaFirefoam>
+                        </products>
+                    </RecipeDef>
+                    
+                    <RecipeDef ParentName="AmmoRecipeNeolithicBase">
+                        <defName>MakeAmmo_PilaAntigrain</defName>
+                        <label>make Sayonala</label>
+                        <description>Craft a Sayonala.</description>
+                        <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+                        <workSkill>Crafting</workSkill>
+                        <recipeUsers>
+                            <li>ElectricSmithy</li>
+                            <li>FueledSmithy</li>
+                            <li>CraftingSpot</li>
+                        </recipeUsers>
+                        <effectWorking>Smelt</effectWorking>
+                        <unfinishedThingDef>UnfinishedAmmo</unfinishedThingDef>
+                        <workAmount>500</workAmount>	
+                        <jobString>Making Sayonala.</jobString>
+                        <ingredients>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>WoodLog</li>
+                            </thingDefs>
+                            </filter>
+                            <count>1</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Steel</li>
+                            </thingDefs>
+                            </filter>
+                            <count>4</count>
+                        </li>
+                        <li>
+                            <filter>
+                            <thingDefs>
+                                <li>Shell_AntigrainWarhead</li>
+                            </thingDefs>
+                            </filter>
+                            <count>1</count>
+                        </li>
+                        </ingredients>
+                        <fixedIngredientFilter>
+                        <thingDefs>
+                            <li>WoodLog</li>
+                            <li>Steel</li>
+                            <li>Shell_AntigrainWarhead</li>
+                        </thingDefs>
+                        </fixedIngredientFilter>
+                        <products>
+                        <PilaAntigrain>1</PilaAntigrain>
+                        </products>
+                    </RecipeDef>
+                    
+				</value>
+			</li>
+
+		</operations>
+	</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
## Additions

Compatibility for Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended

## Reasoning

Arrows:
- The weapon names were turned into ammo category/type names while keeping its description
- The arrows are added to the bow, recurve bow and great bow ammosets
- For now, the arrows are basically just stone arrows with throw weapons' (grenade, etc.) damage
- Recipes are stone arrow's cost + the thrown weapon
- Explosion radius for the bowlotov and bowttery  follows the same as its base mod
- Turned bowttery into a Stickbomb of sorts. Its recipe uses the Stone arrow's cost + 20 steel and 1 component (from the base mod, which uses a recurve bow + 20 steel and component)
- Due to a lack of graphics for the arrows, the graphics used is the bow graphics.

Pila:
- The weapon's thingdefs are overwritten
- Used the CE's values for the pila as a base
- The recipes follow the same logic like the arrows : Pila's resource cost + the shell
- I couldn't decide whether to follow the same way as the arrows, so the projectiles ended up having the Pila's damage with a CombatExtended.CompProperties_ExplosiveCE Comps. Except for the sayonala.
- Mod's original weapon tags are commented for now, its weapon tags seems to use it as an industrial and a weapon for the Empire(?)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
