### PR TITLE
Readjust a couple Warcasket guns

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -32,8 +32,8 @@
               defName = "VFEP_WarcasketGun_GrenadeLauncher" or
               defName = "VFEP_WarcasketGun_HeavyFlamer" or
               defName = "VFEP_WarcasketGun_ChargeLance" or
-			        defName = "VFEP_WarcasketGun_HandheldCannon" or
-			        defName = "VFEP_WarcasketGun_ChargeBlaster"              
+              defName = "VFEP_WarcasketGun_HandheldCannon" or
+              defName = "VFEP_WarcasketGun_ChargeBlaster"              
             ]/tools
           </xpath>
           <value>
@@ -58,27 +58,27 @@
           <statBases>
             <Bulk>25</Bulk>
             <SwayFactor>1.80</SwayFactor>
-            <ShotSpread>0.10</ShotSpread>
+            <ShotSpread>0.08</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>
             <RangedWeapon_Cooldown>0.47</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
-            <recoilAmount>2.2</recoilAmount>
+            <recoilAmount>2.1</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
+            <defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
             <warmupTime>1.3</warmupTime>
-            <range>50</range>
+            <range>52</range>
             <soundCast>Shot_Autocannon</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>12</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>32</magazineSize>
+            <magazineSize>30</magazineSize>
             <reloadTime>8.5</reloadTime>
-            <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+            <ammoSet>AmmoSet_50BMG</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>AimedShot</aiAimMode>
@@ -101,7 +101,7 @@
             <defaultProjectile>Bullet_25x137mmNATO_AP</defaultProjectile>
             <warmupTime>4.6</warmupTime>
             <range>68</range>
-            <minRange>3</minRange>
+            <minRange>1.9</minRange>
             <soundCast>Shot_TurretSniper</soundCast>
             <soundCastTail>GunTail_Heavy</soundCastTail>
             <muzzleFlashScale>16</muzzleFlashScale>
@@ -217,7 +217,7 @@
             <ammoSet>AmmoSet_338Norma</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aimedBurstShotCount>15</aimedBurstShotCount>
+            <aimedBurstShotCount>20</aimedBurstShotCount>
             <aiUseBurstMode>FALSE</aiUseBurstMode>
             <aiAimMode>SuppressFire</aiAimMode>
           </FireModes>
@@ -311,14 +311,12 @@
             <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_CannonBall_Bursting</defaultProjectile>
-            <warmupTime>3.5</warmupTime>
+            <warmupTime>2.5</warmupTime>
             <range>126</range>
-            <minRange>16</minRange>
+            <minRange>5.9</minRange>
             <soundCast>VFEP_Shot_Cannon</soundCast>
             <soundCastTail>GunTail_Heavy</soundCastTail>
             <muzzleFlashScale>16</muzzleFlashScale>
-            <circularError>1.1</circularError>
-            <indirectFirePenalty>0.3</indirectFirePenalty>
             <targetParams>
               <canTargetLocations>true</canTargetLocations>
             </targetParams>


### PR DESCRIPTION
## Changes

- Tweaked some of the Warcasket guns for better balance.

## Reasoning

- Similar to how the slug rifle fires 25mm rounds instead of the 30mm or the handheld slug rifles from VWE-Heavy Weapons, it only makes sense to lower the autorifle's caliber from 20mm to .50 BMG since it's a smaller rifle in comparison to the autocannon turret's gun.
- Lowered the minimum range of the slug rifle since it's a smaller version of the slug turret wielded by a tall pawn in a Warcasket so it makes sense fro mthe pawn to be able to shoot closer to itself.
- The handheld cannon similar to the slug rifle is not a mortar to have such high minimum range, the current stats and nodes in its patch are copied from the handheld mortar in VWE-HW which is not the same as a handheld cannon.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
