### PR TITLE
Patch for Vanilla Psycasts Expanded

### DIFF
--- a/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
@@ -29,7 +29,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BerserkPulse"]/range</xpath>
                     <value>
-                        <range>17.25</range>
+                        <range>17.5</range>
                     </value>
                 </li>
 
@@ -78,37 +78,37 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BreatheFlame"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_BreatheFlame" or defName="VPE_Explosion"]/range</xpath>
                     <value>
                         <range>19</range>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Flameball" or defName="VPE_Explosion"]/range</xpath>
-                    <value>
-                        <range>25</range>
-                    </value>
-                </li>
-
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_EyeBlast" or defName="VPE_QuenchFlames"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Flameball"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_EyeBlast"]/range</xpath>
+                    <value>
+                        <range>30</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_MeteorShower"]/range</xpath>
                     <value>
-                        <range>45</range>
+                        <range>40</range>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_FireBeam" or defName="VPE_FlameTornado"]/range</xpath>
                     <value>
-                        <range>52</range>
+                        <range>51</range>
                     </value>
                 </li>
 
@@ -123,7 +123,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_IceShield"]/range</xpath>
                     <value>
-                        <range>12</range>
+                        <range>14.5</range>
                     </value>
                 </li>
 
@@ -157,9 +157,16 @@
 
                 <!-- ===== Harmonist Psycaster Path ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_PsychicGuidance"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_PsychicGuidance" or defName="VPE_LuckTransfer"]/range</xpath>
                     <value>
-                        <range>6</range>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_HealthSwap"]/range</xpath>
+                    <value>
+                        <range>17.5</range>
                     </value>
                 </li>
 
@@ -180,7 +187,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_LocationSwap"]/range</xpath>
                     <value>
-                        <range>34.5</range>
+                        <range>35</range>
                     </value>
                 </li>
 
@@ -195,7 +202,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Liferot"]/range</xpath>
                     <value>
-                        <range>17.25</range>
+                        <range>17.5</range>
                     </value>
                 </li>
 
@@ -215,7 +222,14 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Darkness" or defName="VPE_Decoy"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Decoy"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Darkness"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>

--- a/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Psycasts Expanded</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!-- ======= Ability Range Adjustment 'ARA ARA' ======= -->
+
+                <!-- ===== Archon Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_MindBreak"]/range</xpath>
+                    <value>
+                        <range>6</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BlindingPulse"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <!-- ===== ArchoTechist Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BerserkPulse"]/range</xpath>
+                    <value>
+                        <range>17.25</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Berserk"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Stun" or defName="VPE_PsychicShock" or defName="VPE_NeuralHeatDump" or defName="VPE_AggressiveHeatDump"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Burden"]/range</xpath>
+                    <value>
+                        <range>34.5</range>
+                    </value>
+                </li>
+
+                <!-- ===== Chronopath Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_PlantTimeskip" or defName="VPE_Age"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_TimeSphere"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <!-- ===== Conflagator Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_FireShield"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BreatheFlame"]/range</xpath>
+                    <value>
+                        <range>19</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Flameball" or defName="VPE_Explosion"]/range</xpath>
+                    <value>
+                        <range>25</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_EyeBlast" or defName="VPE_QuenchFlames"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_MeteorShower"]/range</xpath>
+                    <value>
+                        <range>45</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_FireBeam" or defName="VPE_FlameTornado"]/range</xpath>
+                    <value>
+                        <range>52</range>
+                    </value>
+                </li>
+
+                <!-- ===== Frostshaper Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_IceCrystal"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_IceShield"]/range</xpath>
+                    <value>
+                        <range>12</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_IceBreath"]/range</xpath>
+                    <value>
+                        <range>19</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_FrostRay"]/range</xpath>
+                    <value>
+                        <range>25</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_IceSpike" or defName="VPE_IceBlock" or defName="VPE_SnapFreeze"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_ColdZone"]/range</xpath>
+                    <value>
+                        <range>68</range>
+                    </value>
+                </li>
+
+                <!-- ===== Harmonist Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_PsychicGuidance"]/range</xpath>
+                    <value>
+                        <range>6</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Mindcontrol"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_TransmuteStone"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_LocationSwap"]/range</xpath>
+                    <value>
+                        <range>34.5</range>
+                    </value>
+                </li>
+
+                <!-- ===== Necropath Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_StealVitality"]/range</xpath>
+                    <value>
+                        <range>6</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Liferot"]/range</xpath>
+                    <value>
+                        <range>17.25</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Enthrall"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <!-- ===== Nightstalker Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Darkvision"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Darkness" or defName="VPE_Decoy"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <!-- ===== Protector Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Overshield"]/range</xpath>
+                    <value>
+                        <range>12</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Painblock" or defName="VPE_Skipshield"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Focus" or defName="VPE_Invisibility"]/range</xpath>
+                    <value>
+                        <range>32</range>
+                    </value>
+                </li>
+
+                <!-- ===== Skipmaster Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Skipdoor"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_MassChaosSkip"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_SolarPinhole" or defName="VPE_Chunkskip" or defName="VPE_Waterskip" or defName="VPE_ChaosSkip" or defName="VPE_Wallraise" or defName="VPE_Smokepop"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Skip"]/range</xpath>
+                    <value>
+                        <range>32</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Smokepop"]/radius</xpath>
+                    <value>
+                        <radius>4.0</radius>
+                    </value>
+                </li>
+
+                <!-- ===== Staticlord Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_StaticAura"]/range</xpath>
+                    <value>
+                        <range>8</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Vortex" or defName="VPE_Flashstorm"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Bolt"]/range</xpath>
+                    <value>
+                        <range>25</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_ChainBolt" or defName="VPE_Thunderbolt"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BallLightning"]/range</xpath>
+                    <value>
+                        <range>34.5</range>
+                    </value>
+                </li>
+
+                <!-- ===== Technomancer Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Haywire"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <!-- ===== Warlord Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_PowerLeap"]/range</xpath>
+                    <value>
+                        <range>19</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Beckon" or defName="VPE_Killskip" or defName="VPE_MassBeckon"]/range</xpath>
+                    <value>
+                        <range>23</range>
+                    </value>
+                </li>
+
+                <!-- ===== Wildspeaker Psycaster Path ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_BrambleMaze" or defName="VPE_CropBurst"]/range</xpath>
+                    <value>
+                        <range>28</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_ManhunterPulse" or defName="VPE_AnimalAllies"]/range</xpath>
+                    <value>
+                        <range>40</range>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_TreeSprout"]/range</xpath>
+                    <value>
+                        <range>42</range>
+                    </value>
+                </li>
+
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/AbilityDefs/AbilityDefs_Patch.xml
@@ -8,7 +8,7 @@
         <match Class="PatchOperationSequence">
             <operations>
 
-                <!-- ======= Ability Range Adjustment 'ARA ARA' ======= -->
+                <!-- ======= Ability Range Adjustment 'ARA ARAA~' ======= -->
 
                 <!-- ===== Archon Psycaster Path ===== -->
                 <li Class="PatchOperationReplace">
@@ -41,7 +41,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Stun" or defName="VPE_PsychicShock" or defName="VPE_NeuralHeatDump" or defName="VPE_AggressiveHeatDump"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Stun" or defName="VPE_PsychicShock" or defName="VPE_NeuralHeatDump" or defName="VPE_AggressiveHeatDump"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
@@ -56,7 +56,7 @@
 
                 <!-- ===== Chronopath Psycaster Path ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_PlantTimeskip" or defName="VPE_Age"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_PlantTimeskip" or defName="VPE_Age"]/range</xpath>
                     <value>
                         <range>8</range>
                     </value>
@@ -78,7 +78,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_BreatheFlame" or defName="VPE_Explosion"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BreatheFlame" or defName="VPE_Explosion"]/range</xpath>
                     <value>
                         <range>19</range>
                     </value>
@@ -106,7 +106,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_FireBeam" or defName="VPE_FlameTornado"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_FireBeam" or defName="VPE_FlameTornado"]/range</xpath>
                     <value>
                         <range>51</range>
                     </value>
@@ -142,7 +142,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_IceSpike" or defName="VPE_IceBlock" or defName="VPE_SnapFreeze"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_IceSpike" or defName="VPE_IceBlock" or defName="VPE_SnapFreeze"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
@@ -157,7 +157,7 @@
 
                 <!-- ===== Harmonist Psycaster Path ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_PsychicGuidance" or defName="VPE_LuckTransfer"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_PsychicGuidance" or defName="VPE_LuckTransfer"]/range</xpath>
                     <value>
                         <range>8</range>
                     </value>
@@ -244,14 +244,14 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Painblock" or defName="VPE_Skipshield"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Painblock" or defName="VPE_Skipshield"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Focus" or defName="VPE_Invisibility"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Focus" or defName="VPE_Invisibility"]/range</xpath>
                     <value>
                         <range>32</range>
                     </value>
@@ -273,7 +273,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_SolarPinhole" or defName="VPE_Chunkskip" or defName="VPE_Waterskip" or defName="VPE_ChaosSkip" or defName="VPE_Wallraise" or defName="VPE_Smokepop"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_SolarPinhole" or defName="VPE_Chunkskip" or defName="VPE_Waterskip" or defName="VPE_ChaosSkip" or defName="VPE_Wallraise" or defName="VPE_Smokepop"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
@@ -302,7 +302,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Vortex" or defName="VPE_Flashstorm"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Vortex" or defName="VPE_Flashstorm"]/range</xpath>
                     <value>
                         <range>23</range>
                     </value>
@@ -316,7 +316,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_ChainBolt" or defName="VPE_Thunderbolt"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_ChainBolt" or defName="VPE_Thunderbolt"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
@@ -346,7 +346,7 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_Beckon" or defName="VPE_Killskip" or defName="VPE_MassBeckon"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_Beckon" or defName="VPE_Killskip" or defName="VPE_MassBeckon"]/range</xpath>
                     <value>
                         <range>23</range>
                     </value>
@@ -354,14 +354,14 @@
 
                 <!-- ===== Wildspeaker Psycaster Path ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_BrambleMaze" or defName="VPE_CropBurst"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_BrambleMaze" or defName="VPE_CropBurst"]/range</xpath>
                     <value>
                         <range>28</range>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/VFECore.Abilities.AbilityDef[ defName="VPE_ManhunterPulse" or defName="VPE_AnimalAllies"]/range</xpath>
+                    <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VPE_ManhunterPulse" or defName="VPE_AnimalAllies"]/range</xpath>
                     <value>
                         <range>40</range>
                     </value>

--- a/Patches/Vanilla Psycasts Expanded/Bodies/Bodies_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/Bodies/Bodies_Patch.xml
@@ -14,21 +14,21 @@
 
                 <!-- === Rock Construct === -->
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_RockConstructBody"]/corePart/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockHead"]/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockHead"]/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockBody"]</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockBody"]</xpath>
                     <value>
                         <groups>
                             <li>CoveredByNaturalArmor</li>
@@ -38,21 +38,21 @@
 
                 <!-- === Metal Construct === -->
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_MetalConstructBody"]/corePart/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalHead"]/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalHead"]/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalBody"]</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalBody"]</xpath>
                     <value>
                         <groups>
                             <li>CoveredByNaturalArmor</li>
@@ -63,28 +63,28 @@
                 <!-- ===== Skeletal Body ===== -->
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_SkeletalBody"]/corePart/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_Skull"]/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_Skull"]/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalArm"]/groups</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalArm"]/groups</xpath>
                     <value>
                         <li>CoveredByNaturalArmor</li>
                     </value>
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalLeg"]</xpath>
+                    <xpath>Defs/BodyDef[defName="VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalLeg"]</xpath>
                     <value>
                         <groups>
                             <li>CoveredByNaturalArmor</li>

--- a/Patches/Vanilla Psycasts Expanded/Bodies/Bodies_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/Bodies/Bodies_Patch.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Psycasts Expanded</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!-- ======= Body Parts ======= -->
+
+                <!-- ===== Constructs ===== -->
+
+                <!-- === Rock Construct === -->
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockHead"]/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_RockConstructBody"]/corePart/parts/li[def = "VPE_RockBody"]</xpath>
+                    <value>
+                        <groups>
+                            <li>CoveredByNaturalArmor</li>
+                        </groups>
+                    </value>
+                </li>
+
+                <!-- === Metal Construct === -->
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalHead"]/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_MetalConstructBody"]/corePart/parts/li[def = "VPE_MetalBody"]</xpath>
+                    <value>
+                        <groups>
+                            <li>CoveredByNaturalArmor</li>
+                        </groups>
+                    </value>
+                </li>
+
+                <!-- ===== Skeletal Body ===== -->
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_Skull"]/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalArm"]/groups</xpath>
+                    <value>
+                        <li>CoveredByNaturalArmor</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/BodyDef[defName = "VPE_SkeletalBody"]/corePart/parts/li[def = "VPE_SkeletalLeg"]</xpath>
+                    <value>
+                        <groups>
+                            <li>CoveredByNaturalArmor</li>
+                        </groups>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -8,8 +8,9 @@
       <match Class="PatchOperationSequence">
          <operations>
 
-            <!-- ===== Warlord Psycast Hediff ===== -->
+            <!-- ===== Psycast Hediff ===== -->
 
+            <!-- === Warlord === -->
             <li Class="PatchOperationReplace">
                <xpath>Defs/HediffDef[defName="VPE_FiringFocus"]/stages/li/statFactors</xpath>
                <value>
@@ -23,7 +24,7 @@
                <xpath>Defs/HediffDef[defName="VPE_AdrenalineRush"]/stages/li</xpath>
                <value>
                   <statOffsets>
-                     <Suppressability>-0.20</Suppressability>
+                     <Suppressability>-0.25</Suppressability>
                   </statOffsets>
                </value>
             </li>
@@ -32,7 +33,29 @@
                <xpath>Defs/HediffDef[defName="VPE_GuidedShot"]/stages/li</xpath>
                <value>
                   <statOffsets>
-                     <ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+                     <ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
+                  </statOffsets>
+               </value>
+            </li>
+
+            <!-- === Harmonist === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/HediffDef[defName="VPE_Lucky"]/stages/li</xpath>
+               <value>
+                  <statOffsets>
+                     <ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
+                     <Suppressability>-1.0</Suppressability>
+                     <IncomingDamageFactor>-1.0</IncomingDamageFactor>
+                  </statOffsets>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/HediffDef[defName="VPE_UnLucky"]/stages/li</xpath>
+               <value>
+                  <statOffsets>
+                     <ShootingAccuracyPawn>-5.0</ShootingAccuracyPawn>
+                     <IncomingDamageFactor>2.0</IncomingDamageFactor>
                   </statOffsets>
                </value>
             </li>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -10,6 +10,14 @@
 
             <!-- ===== Psycast Hediff ===== -->
 
+            <!-- === Conflagrator === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/HediffDef[defName="VPE_FireShield"]/stages/li/statOffsets</xpath>
+               <value>
+                  <ArmorRating_Heat>3.0</ArmorRating_Heat>
+               </value>
+            </li>
+
             <!-- === Warlord === -->
             <li Class="PatchOperationReplace">
                <xpath>Defs/HediffDef[defName="VPE_FiringFocus"]/stages/li/statFactors</xpath>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+   <Operation Class="PatchOperationFindMod">
+      <mods>
+         <li>Vanilla Psycasts Expanded</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+         <operations>
+
+            <!-- ===== Warlord Psycast Hediff ===== -->
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/HediffDef[defName="VPE_FiringFocus"]/stages/li/statFactors</xpath>
+               <value>
+                  <statOffsets>
+                     <AimingDelayFactor>-0.50</AimingDelayFactor>
+                  </statOffsets>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/HediffDef[defName="VPE_AdrenalineRush"]/stages/li</xpath>
+               <value>
+                  <statOffsets>
+                     <Suppressability>-0.20</Suppressability>
+                  </statOffsets>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/HediffDef[defName="VPE_GuidedShot"]/stages/li</xpath>
+               <value>
+                  <statOffsets>
+                     <ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
+                  </statOffsets>
+               </value>
+            </li>
+
+         </operations>
+      </match>
+   </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -70,6 +70,16 @@
                </value>
             </li>
 
+            <!-- === Nightstalker === -->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/HediffDef[defName="VPE_Darkvision"]/stages/li/statFactors</xpath>
+               <value>
+                  <statOffsets>
+                     <NightVisionEfficiency>1.0</NightVisionEfficiency>
+                  </statOffsets>
+               </value>
+            </li>
+
          </operations>
       </match>
    </Operation>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -16,6 +16,7 @@
                <value>
                   <statOffsets>
                      <AimingDelayFactor>-0.50</AimingDelayFactor>
+                     <ReloadSpeed>1.0</ReloadSpeed>
                   </statOffsets>
                </value>
             </li>

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -40,25 +40,33 @@
 
             <!-- === Harmonist === -->
             <li Class="PatchOperationAdd">
-               <xpath>Defs/HediffDef[defName="VPE_Lucky"]/stages/li</xpath>
+               <xpath>Defs/HediffDef[defName="VPE_Lucky"]</xpath>
                <value>
-                  <statOffsets>
-                     <ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
-                     <MeleeHitChance>5</MeleeHitChance>
-                     <MeleeDodgeChance>5.0</MeleeDodgeChance>
-                     <IncomingDamageFactor>-1.0</IncomingDamageFactor>
-                  </statOffsets>
+                  <stages>
+                     <li>
+                        <statOffsets>
+                           <ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
+                           <MeleeHitChance>5</MeleeHitChance>
+                           <MeleeDodgeChance>5.0</MeleeDodgeChance>
+                           <IncomingDamageFactor>-1.0</IncomingDamageFactor>
+                        </statOffsets>
+                     </li>
+                  </stages>
                </value>
             </li>
 
             <li Class="PatchOperationAdd">
-               <xpath>Defs/HediffDef[defName="VPE_UnLucky"]/stages/li</xpath>
+               <xpath>Defs/HediffDef[defName="VPE_UnLucky"]</xpath>
                <value>
-                  <statOffsets>
-                     <ShootingAccuracyPawn>-5.0</ShootingAccuracyPawn>
-                     <MeleeHitChance>-5</MeleeHitChance>
-                     <MeleeDodgeChance>-5.0</MeleeDodgeChance>
-                  </statOffsets>
+                  <stages>
+                     <li>
+                        <statOffsets>
+                           <ShootingAccuracyPawn>-5.0</ShootingAccuracyPawn>
+                           <MeleeHitChance>-5</MeleeHitChance>
+                           <MeleeDodgeChance>-5.0</MeleeDodgeChance>
+                        </statOffsets>
+                     </li>
+                  </stages>
                </value>
             </li>
 

--- a/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/HediffDefs/Hediffs_Patch.xml
@@ -44,7 +44,8 @@
                <value>
                   <statOffsets>
                      <ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
-                     <Suppressability>-1.0</Suppressability>
+                     <MeleeHitChance>5</MeleeHitChance>
+                     <MeleeDodgeChance>5.0</MeleeDodgeChance>
                      <IncomingDamageFactor>-1.0</IncomingDamageFactor>
                   </statOffsets>
                </value>
@@ -55,7 +56,8 @@
                <value>
                   <statOffsets>
                      <ShootingAccuracyPawn>-5.0</ShootingAccuracyPawn>
-                     <IncomingDamageFactor>2.0</IncomingDamageFactor>
+                     <MeleeHitChance>-5</MeleeHitChance>
+                     <MeleeDodgeChance>-5.0</MeleeDodgeChance>
                   </statOffsets>
                </value>
             </li>

--- a/Patches/Vanilla Psycasts Expanded/PawnKinds/EmpirePawnKinds_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/PawnKinds/EmpirePawnKinds_Patch.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+   <Operation Class="PatchOperationFindMod">
+      <mods>
+         <li>Vanilla Psycasts Expanded</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+         <operations>
+
+            <!-- ===== Pawnkinds ===== -->
+
+            <!-- === Empire Warlord Ranged === -->
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/PawnKindDef[defName="Empire_Caster_Warlord_Ranged"]</xpath>
+               <value>
+                  <li Class="CombatExtended.LoadoutPropertiesExtension">
+                     <primaryMagazineCount>
+                        <min>4</min>
+                        <max>6</max>
+                     </primaryMagazineCount>
+                     <sidearms>
+                        <li>
+                           <generateChance>0.5</generateChance>
+                           <sidearmMoney>
+                              <min>400</min>
+                              <max>600</max>
+                           </sidearmMoney>
+                           <weaponTags>
+                              <li>CE_Sidearm_Melee</li>
+                           </weaponTags>
+                        </li>
+                     </sidearms>
+                  </li>
+               </value>
+            </li>
+
+         </operations>
+      </match>
+   </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Psycasts Expanded</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!-- ======= Projectile Adjustment ======= -->
+
+                <!-- ===== Conflagator ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_Flameball"]/projectile/speed</xpath>
+                    <value>
+                        <speed>25</speed>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile/speed</xpath>
+                    <value>
+                        <speed>48</speed>
+                    </value>
+                </li>
+
+                <!-- ===== Staticlord ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_Bolt"]/projectile/extraDamages/li/amount</xpath>
+                    <value>
+                        <amount>12</amount>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_BallLightning"]/projectile/speed</xpath>
+                    <value>
+                        <speed>8</speed>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_BallLightning"]/projectile/damageAmountBase</xpath>
+                    <value>
+                        <damageAmountBase>12</damageAmountBase>
+                    </value>
+                </li>
+
+                <!-- ===== Frostshaper ===== -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_IceBreathe"]/projectile/speed</xpath>
+                    <value>
+                        <speed>48</speed>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -32,18 +32,6 @@
                     </value>
                 </li>
 
-                <li Class="PatchOperationAdd">
-                    <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile</xpath>
-                    <value>
-                        <extraDamages>
-                            <li>
-                                <def>PrometheumFlame</def>
-                                <amount>4</amount>
-                            </li>
-                        </extraDamages>
-                    </value>
-                </li>
-
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile/speed</xpath>
                     <value>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -11,10 +11,36 @@
                 <!-- ======= Projectile Adjustment ======= -->
 
                 <!-- ===== Conflagator ===== -->
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="VPE_Flameball"]/projectile</xpath>
+                    <value>
+                        <damageAmountBase>5</damageAmountBase>
+                    </value>
+                </li>
+
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="VPE_Flameball"]/projectile/speed</xpath>
                     <value>
                         <speed>25</speed>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile/damageAmountBase</xpath>
+                    <value>
+                        <damageAmountBase>9</damageAmountBase>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile</xpath>
+                    <value>
+                        <extraDamages>
+                            <li>
+                                <def>PrometheumFlame</def>
+                                <amount>1</amount>
+                            </li>
+                        </extraDamages>
                     </value>
                 </li>
 
@@ -26,12 +52,6 @@
                 </li>
 
                 <!-- ===== Staticlord ===== -->
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="VPE_Bolt"]/projectile/extraDamages/li/amount</xpath>
-                    <value>
-                        <amount>12</amount>
-                    </value>
-                </li>
 
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="VPE_BallLightning"]/projectile/speed</xpath>
@@ -52,6 +72,13 @@
                     <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_IceBreathe"]/projectile/speed</xpath>
                     <value>
                         <speed>48</speed>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_IceSpike"]/projectile/damageAmountBase</xpath>
+                    <value>
+                        <damageAmountBase>15</damageAmountBase>
                     </value>
                 </li>
 

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -14,21 +14,21 @@
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[defName="VPE_Flameball"]/projectile</xpath>
                     <value>
-                        <damageAmountBase>5</damageAmountBase>
+                        <damageAmountBase>10</damageAmountBase>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="VPE_Flameball"]/projectile/speed</xpath>
                     <value>
-                        <speed>25</speed>
+                        <speed>30</speed>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile/damageAmountBase</xpath>
                     <value>
-                        <damageAmountBase>9</damageAmountBase>
+                        <damageAmountBase>12</damageAmountBase>
                     </value>
                 </li>
 
@@ -38,7 +38,7 @@
                         <extraDamages>
                             <li>
                                 <def>PrometheumFlame</def>
-                                <amount>1</amount>
+                                <amount>4</amount>
                             </li>
                         </extraDamages>
                     </value>
@@ -47,7 +47,7 @@
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/VFECore.ExpandableProjectileDef[defName="VPE_FireBreath"]/projectile/speed</xpath>
                     <value>
-                        <speed>48</speed>
+                        <speed>53</speed>
                     </value>
                 </li>
 

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+   <Operation Class="PatchOperationFindMod">
+      <mods>
+         <li>Vanilla Psycasts Expanded</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+         <operations>
+
+            <!-- ===== Apparel ===== -->
+
+            <!-- === Eltex Mask === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/statBases</xpath>
+               <value>
+                  <Bulk>2</Bulk>
+                  <WornBulk>1</WornBulk>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/statBases/ArmorRating_Sharp</xpath>
+               <value>
+                  <ArmorRating_Sharp>0.10</ArmorRating_Sharp>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/statBases/ArmorRating_Blunt</xpath>
+               <value>
+                  <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/equippedStatOffsets</xpath>
+               <value>
+                  <Suppressability>-0.10</Suppressability>
+               </value>
+            </li>
+
+            <!-- === Eltex Cape === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases</xpath>
+               <value>
+                  <Bulk>7</Bulk>
+                  <WornBulk>2</WornBulk>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases/ArmorRating_Sharp</xpath>
+               <value>
+                  <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases/ArmorRating_Blunt</xpath>
+               <value>
+                  <ArmorRating_Blunt>0.22</ArmorRating_Blunt>
+               </value>
+            </li>
+
+            <!-- === Plate Armor Prestige === -->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/Mass</xpath>
+               <value>
+                  <Bulk>52.5</Bulk>
+                  <WornBulk>8</WornBulk>
+                  <Mass>8</Mass>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/StuffEffectMultiplierArmor</xpath>
+               <value>
+                  <StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+               <value>
+                  <StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/equippedStatOffsets/MoveSpeed</xpath>
+               <value>
+                  <MeleeDodgeChance>-0.08</MeleeDodgeChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>/Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]</xpath>
+               <value>
+                  <li Class="CombatExtended.PartialArmorExt">
+                     <stats>
+                        <li>
+                           <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                           <parts>
+                              <li>Arm</li>
+                           </parts>
+                        </li>
+                        <li>
+                           <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                           <parts>
+                              <li>Arm</li>
+                           </parts>
+                        </li>
+                     </stats>
+                  </li>
+               </value>
+            </li>
+
+            <!-- === Psyring === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Psyring"]/statBases</xpath>
+               <value>
+                  <Bulk>1</Bulk>
+                  <WornBulk>1</WornBulk>
+               </value>
+            </li>
+
+         </operations>
+      </match>
+   </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
@@ -22,21 +22,21 @@
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/statBases/ArmorRating_Sharp</xpath>
                <value>
-                  <ArmorRating_Sharp>0.10</ArmorRating_Sharp>
+                  <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
                </value>
             </li>
 
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/statBases/ArmorRating_Blunt</xpath>
                <value>
-                  <ArmorRating_Blunt>0.15</ArmorRating_Blunt>
+                  <ArmorRating_Blunt>1.0</ArmorRating_Blunt>
                </value>
             </li>
 
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexMask"]/equippedStatOffsets</xpath>
                <value>
-                  <Suppressability>-0.10</Suppressability>
+                  <Suppressability>-0.20</Suppressability>
                </value>
             </li>
 
@@ -44,53 +44,54 @@
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases</xpath>
                <value>
-                  <Bulk>7</Bulk>
-                  <WornBulk>2</WornBulk>
+                  <Bulk>5</Bulk>
+                  <WornBulk>1.5</WornBulk>
                </value>
             </li>
 
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases/ArmorRating_Sharp</xpath>
                <value>
-                  <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+                  <StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
                </value>
             </li>
 
-            <li Class="PatchOperationReplace">
+            <li Class="PatchOperationRemove">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases/ArmorRating_Blunt</xpath>
-               <value>
-                  <ArmorRating_Blunt>0.22</ArmorRating_Blunt>
-               </value>
+            </li>
+
+            <li Class="PatchOperationRemove">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_EltexCape"]/statBases/ArmorRating_Heat</xpath>
             </li>
 
             <!-- === Plate Armor Prestige === -->
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/Mass</xpath>
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases</xpath>
                <value>
-                  <Bulk>52.5</Bulk>
-                  <WornBulk>8</WornBulk>
-                  <Mass>8</Mass>
+                  <Bulk>100</Bulk>
+                  <WornBulk>15</WornBulk>
                </value>
             </li>
 
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/StuffEffectMultiplierArmor</xpath>
                <value>
-                  <StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
-               <value>
-                  <StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+                  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
                </value>
             </li>
 
             <li Class="PatchOperationReplace">
                <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/equippedStatOffsets/MoveSpeed</xpath>
                <value>
-                  <MeleeDodgeChance>-0.08</MeleeDodgeChance>
+                  <MeleeDodgeChance>-0.15</MeleeDodgeChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/apparel/bodyPartGroups</xpath>
+               <value>
+                  <li>Hands</li>
+                  <li>Feet</li>
                </value>
             </li>
 
@@ -99,18 +100,54 @@
                <value>
                   <li Class="CombatExtended.PartialArmorExt">
                      <stats>
-                        <li>
-                           <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-                           <parts>
-                              <li>Arm</li>
-                           </parts>
-                        </li>
-                        <li>
-                           <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-                           <parts>
-                              <li>Arm</li>
-                           </parts>
-                        </li>
+                       <li>
+                        <ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+                        <parts>
+                           <li>Neck</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+                        <parts>
+                           <li>Neck</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+                        <parts>
+                           <li>Leg</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+                        <parts>
+                           <li>Leg</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                        <parts>
+                           <li>Arm</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                        <parts>
+                           <li>Arm</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+                        <parts>
+                           <li>Hand</li>
+                        </parts>
+                       </li>
+                       <li>
+                        <ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+                        <parts>
+                           <li>Hand</li>
+                        </parts>
+                       </li>
                      </stats>
                   </li>
                </value>
@@ -120,8 +157,8 @@
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[defName="VPE_Psyring"]/statBases</xpath>
                <value>
-                  <Bulk>1</Bulk>
-                  <WornBulk>1</WornBulk>
+                  <Bulk>0.5</Bulk>
+                  <WornBulk>0.1</WornBulk>
                </value>
             </li>
 

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Weapons_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Weapons_Patch.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+   <Operation Class="PatchOperationFindMod">
+      <mods>
+         <li>Vanilla Psycasts Expanded</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+         <operations>
+
+            <!-- ===== Eltex Weapon ===== -->
+
+            <!-- === Eltex Dagger === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/statBases</xpath>
+               <value>
+                  <Bulk>3</Bulk>
+                  <MeleeCounterParryBonus>0.25</MeleeCounterParryBonus>
+               </value>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/equippedStatOffsets</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]</xpath>
+                  <value>
+                     <equippedStatOffsets>
+                        <MeleeCritChance>0.15</MeleeCritChance>
+                        <MeleeParryChance>0.30</MeleeParryChance>
+                        <MeleeDodgeChance>0.30</MeleeDodgeChance>
+                     </equippedStatOffsets>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/equippedStatOffsets</xpath>
+                  <value>
+                     <MeleeCritChance>0.15</MeleeCritChance>
+                     <MeleeParryChance>0.30</MeleeParryChance>
+                     <MeleeDodgeChance>0.30</MeleeDodgeChance>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/weaponTags</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]</xpath>
+                  <value>
+                     <weaponTags>
+                        <li>CE_OneHandedWeapon</li>
+                     </weaponTags>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/weaponTags</xpath>
+                  <value>
+                     <li>CE_OneHandedWeapon</li>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexDagger"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>handle</label>
+                        <capacities>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>2</power>
+                        <cooldownTime>1.69</cooldownTime>
+                        <chanceFactor>0.05</chanceFactor>
+                        <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>point</label>
+                        <capacities>
+                           <li>Stab</li>
+                        </capacities>
+                        <power>13</power>
+                        <cooldownTime>1.46</cooldownTime>
+                        <chanceFactor>0.50</chanceFactor>
+                        <armorPenetrationBlunt>0.35</armorPenetrationBlunt>
+                        <armorPenetrationSharp>1.20</armorPenetrationSharp>
+                        <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>edge</label>
+                        <capacities>
+                           <li>Cut</li>
+                        </capacities>
+                        <power>16</power>
+                        <cooldownTime>1.36</cooldownTime>
+                        <chanceFactor>0.45</chanceFactor>
+                        <armorPenetrationBlunt>0.95</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.58</armorPenetrationSharp>
+                        <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <!-- === Eltex Mace === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/statBases</xpath>
+               <value>
+                  <Bulk>4</Bulk>
+                  <MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+               </value>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/equippedStatOffsets</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]</xpath>
+                  <value>
+                     <equippedStatOffsets>
+                        <MeleeCritChance>0.42</MeleeCritChance>
+                        <MeleeParryChance>0.24</MeleeParryChance>
+                        <MeleeDodgeChance>0.2</MeleeDodgeChance>
+                     </equippedStatOffsets>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/equippedStatOffsets</xpath>
+                  <value>
+                     <MeleeCritChance>0.42</MeleeCritChance>
+                     <MeleeParryChance>0.24</MeleeParryChance>
+                     <MeleeDodgeChance>0.2</MeleeDodgeChance>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/weaponTags</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]</xpath>
+                  <value>
+                     <weaponTags>
+                        <li>CE_OneHandedWeapon</li>
+                     </weaponTags>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/weaponTags</xpath>
+                  <value>
+                     <li>CE_OneHandedWeapon</li>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexMace"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>handle</label>
+                        <capacities>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>2</power>
+                        <cooldownTime>1.59</cooldownTime>
+                        <chanceFactor>0.10</chanceFactor>
+                        <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>17</power>
+                        <cooldownTime>2.1</cooldownTime>
+                        <chanceFactor>0.90</chanceFactor>
+                        <armorPenetrationBlunt>6.925</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <!-- === Eltex Sword === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/statBases</xpath>
+               <value>
+                  <Bulk>5</Bulk>
+                  <MeleeCounterParryBonus>0.6</MeleeCounterParryBonus>
+               </value>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/equippedStatOffsets</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]</xpath>
+                  <value>
+                     <equippedStatOffsets>
+                        <MeleeCritChance>0.40</MeleeCritChance>
+                        <MeleeParryChance>0.60</MeleeParryChance>
+                        <MeleeDodgeChance>0.30</MeleeDodgeChance>
+                     </equippedStatOffsets>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/equippedStatOffsets</xpath>
+                  <value>
+                     <MeleeCritChance>0.40</MeleeCritChance>
+                     <MeleeParryChance>0.60</MeleeParryChance>
+                     <MeleeDodgeChance>0.30</MeleeDodgeChance>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationConditional">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/weaponTags</xpath>
+               <nomatch Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]</xpath>
+                  <value>
+                     <weaponTags>
+                        <li>CE_OneHandedWeapon</li>
+                     </weaponTags>
+                  </value>
+               </nomatch>
+
+               <match Class="PatchOperationAdd">
+                  <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/weaponTags</xpath>
+                  <value>
+                     <li>CE_OneHandedWeapon</li>
+                  </value>
+               </match>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_MeleeWeapon_EltexSword"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>handle</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>3</power>
+                        <cooldownTime>1.59</cooldownTime>
+                        <chanceFactor>0.05</chanceFactor>
+                        <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>point</label>
+                        <capacities>
+                           <li>Stab</li>
+                        </capacities>
+                        <power>18</power>
+                        <cooldownTime>1.46</cooldownTime>
+                        <chanceFactor>0.50</chanceFactor>
+                        <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+                        <armorPenetrationSharp>1.40</armorPenetrationSharp>
+                        <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>edge</label>
+                        <capacities>
+                           <li>Cut</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>1.59</cooldownTime>
+                        <chanceFactor>0.45</chanceFactor>
+                        <armorPenetrationBlunt>1.1</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.58</armorPenetrationSharp>
+                        <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <!-- ===== Misc ===== -->
+
+            <!-- === Heat Pearls === -->
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_HeatPearls"]/verbs/li/range</xpath>
+               <value>
+                  <range>17.9</range>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="VPE_HeatPearls"]/verbs/li/forcedMissRadius</xpath>
+               <value>
+                  <forcedMissRadius>0.9</forcedMissRadius>
+               </value>
+            </li>
+
+         </operations>
+      </match>
+   </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Races/Races_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Races/Races_Patch.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Vanilla Psycasts Expanded</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!-- ===== Psychic Construct ===== -->
+
+                <li Class="PatchOperationAddModExtension">
+                    <xpath>Defs/ThingDef[ defName="VPE_SteelConstruct" or defName="VPE_RockConstruct" or defName="VPE_SummonedSkeleton"]</xpath>
+                    <value>
+                        <li Class="CombatExtended.RacePropertiesExtensionCE">
+                            <bodyShape>Humanoid</bodyShape>
+                        </li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[ defName="VPE_SteelConstruct" or defName="VPE_RockConstruct"]/statBases</xpath>
+                    <value>
+                        <CarryWeight>5</CarryWeight>
+                        <CarryBulk>20</CarryBulk>
+                        <AimingAccuracy>1.0</AimingAccuracy>
+                        <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+                        <MeleeDodgeChance>0.19</MeleeDodgeChance>
+                        <MeleeCritChance>0.22</MeleeCritChance>
+                        <MeleeParryChance>0.09</MeleeParryChance>
+                        <MaxHitPoints>200</MaxHitPoints>
+                        <SmokeSensitivity>0</SmokeSensitivity>
+                    </value>
+                </li>
+
+                <!-- === Steel Construct === -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_SteelConstruct"]/statBases/ArmorRating_Sharp</xpath>
+                    <value>
+                        <ArmorRating_Sharp>2.6</ArmorRating_Sharp>
+                        <ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_SteelConstruct"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>head</label>
+                                <capacities>
+                                    <li>Cut</li>
+                                </capacities>
+                                <power>15</power>
+                                <cooldownTime>4.16</cooldownTime>
+                                <armorPenetrationSharp>1.74</armorPenetrationSharp>
+                                <armorPenetrationBlunt>0.91</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <!-- === Rock Construct === -->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_RockConstruct"]/statBases/ArmorRating_Blunt</xpath>
+                    <value>
+                        <ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+                        <ArmorRating_Blunt>2.6</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_RockConstruct"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>head</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>15</power>
+                                <cooldownTime>4.16</cooldownTime>
+                                <armorPenetrationSharp>0.91</armorPenetrationSharp>
+                                <armorPenetrationBlunt>1.74</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                                <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <!-- ===== Skeleton ===== -->
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_SummonedSkeleton"]/statBases/ArmorRating_Sharp</xpath>
+                    <value>
+                        <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+                        <ArmorRating_Blunt>1</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="VPE_SummonedSkeleton"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>left fist</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>13</power>
+                                <cooldownTime>2</cooldownTime>
+                                <armorPenetrationSharp>0</armorPenetrationSharp>
+                                <armorPenetrationBlunt>1.44</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>right fist</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>13</power>
+                                <cooldownTime>2</cooldownTime>
+                                <armorPenetrationSharp>0</armorPenetrationSharp>
+                                <armorPenetrationBlunt>1.44</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Races/Races_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Races/Races_Patch.xml
@@ -11,7 +11,7 @@
                 <!-- ===== Psychic Construct ===== -->
 
                 <li Class="PatchOperationAddModExtension">
-                    <xpath>Defs/ThingDef[ defName="VPE_SteelConstruct" or defName="VPE_RockConstruct" or defName="VPE_SummonedSkeleton"]</xpath>
+                    <xpath>Defs/ThingDef[defName="VPE_SteelConstruct" or defName="VPE_RockConstruct" or defName="VPE_SummonedSkeleton"]</xpath>
                     <value>
                         <li Class="CombatExtended.RacePropertiesExtensionCE">
                             <bodyShape>Humanoid</bodyShape>
@@ -20,7 +20,7 @@
                 </li>
 
                 <li Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[ defName="VPE_SteelConstruct" or defName="VPE_RockConstruct"]/statBases</xpath>
+                    <xpath>Defs/ThingDef[defName="VPE_SteelConstruct" or defName="VPE_RockConstruct"]/statBases</xpath>
                     <value>
                         <CarryWeight>5</CarryWeight>
                         <CarryBulk>20</CarryBulk>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Range adjustment for all psycasts

## Reasoning

Why did you choose to implement things this way, e.g.
- because space magic cool

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)

##Issue Notes
- Currently, the Overshield and Guardian Skipbarrier from Protector Psycaster Path, and Shield Animals or even Shrineshield from Wildspeaker Psycast Path are unable to intercept projectiles (in Vanilla they do just fine)

- Warlord's Guideshot Psycast is able to increase ranged weapon's range, but they will remain the same range even if the duration ends unless forced to unequip the weapon to reset their normal range value

