### PR TITLE
NoSwitch tag XML implementation

### DIFF
--- a/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
+++ b/Patches/Advanced Mechanoid Warfare/Patches/Patch_Ranged.xml
@@ -70,6 +70,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -123,6 +124,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -198,6 +200,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -265,6 +268,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -300,6 +304,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			<li Class="PatchOperationReplace">
@@ -357,6 +364,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -393,6 +401,9 @@
 						<reloadTime>7</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -426,6 +437,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Stalker</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			<li Class="PatchOperationRemove">
@@ -467,6 +481,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_UMW</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			
@@ -532,6 +549,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 			
@@ -567,6 +585,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Lens</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 
@@ -599,6 +620,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Vapor</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -672,6 +696,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Lens</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -705,6 +732,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			
@@ -739,6 +769,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Headhunter</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			
@@ -773,6 +806,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -806,6 +842,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -839,6 +878,9 @@
 						<reloadTime>7</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -872,6 +914,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -905,6 +950,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Nomad</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -938,6 +986,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Stalker</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -970,6 +1021,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 
@@ -1001,6 +1053,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Stalker</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1033,6 +1088,9 @@
 						<reloadTime>3</reloadTime>
 						<ammoSet>AmmoSet_Stalker</ammoSet>
 					</AmmoUser>
+					<weaponTags>
+						<li>NoSwitch</li>
+					</weaponTags>
 			</li>
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -1066,6 +1124,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>CE_AI_Launcher</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 			</li>
 

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_RangedMechanoid.xml
@@ -80,7 +80,8 @@
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
 			<weaponTags>
-				<li>AA_MechanoidGun</li>
+			  <li>AA_MechanoidGun</li>
+			  <li>NoSwitch</li>
 			</weaponTags>
 			</li>
 
@@ -116,7 +117,8 @@
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
 			<weaponTags>
-				<li>AA_MechanoidDemolisherCharges</li>
+			  <li>AA_MechanoidDemolisherCharges</li>
+			  <li>NoSwitch</li>
 			</weaponTags>
 			</li>
 
@@ -160,7 +162,8 @@
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
 			<weaponTags>
-				<li>AA_MechanoidFlamethrower</li>
+			  <li>AA_MechanoidFlamethrower</li>
+			  <li>NoSwitch</li>
 			</weaponTags>
 			</li>
 
@@ -195,7 +198,8 @@
 			  <aiAimMode>Snapshot</aiAimMode>
 			</FireModes>
 			<weaponTags>
-				<li>AA_MechanoidCryoweapon</li>
+			  <li>AA_MechanoidCryoweapon</li>
+			  <li>NoSwitch</li>
 			</weaponTags>
 			</li>
 				
@@ -216,7 +220,7 @@
 							<speed>40</speed>
 							<damageDef>Frostbite</damageDef>
 							<damageAmountBase>3</damageAmountBase>
-							<explosionRadius>2</explosionRadius>						
+							<explosionRadius>1.9</explosionRadius>						
 							<soundExplode>AA_Cryogun</soundExplode>
 							<armorPenetrationSharp>0</armorPenetrationSharp>
 							<armorPenetrationBlunt>0</armorPenetrationBlunt>			

--- a/Patches/Anty the war Ant/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Anty the war Ant/ThingDefs_Misc/Weapons.xml
@@ -282,6 +282,14 @@
 				</FireModes>
 			</li>
 			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="AT_AcidLineRifle"]/weaponTags</xpath>
+				<value>
+				  <li>NoSwitch</li>
+				</value>
+			</li>
+
+			
 			<!-- ========== Launcher =========== -->
 			
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Patches/Bori Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Bori Race/ThingDefs_Misc/Weapons.xml
@@ -459,6 +459,14 @@
 					<aiAimMode>AimedShot</aiAimMode>
 				</FireModes>
 			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="BD_ChargeRifle"]/weaponTags</xpath>
+				<value>
+				  <li>NoSwitch</li>
+				</value>
+			</li>
+
 			
 			<!-- ========== Charge SMG =========== -->
 			

--- a/Patches/Bulgarian Imperial Uniforms/RangedIndustrial.xml
+++ b/Patches/Bulgarian Imperial Uniforms/RangedIndustrial.xml
@@ -156,6 +156,7 @@
           <weaponTags>
             <li>SimpleGun</li>
             <li>CE_AI_Rifle</li>
+            <li>NoSwitch</li>
           </weaponTags>
           <AllowWithRunAndGun>false</AllowWithRunAndGun>
         </li>

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -864,6 +864,7 @@
 					<weaponTags>
 						<li>CE_AI_Rifle</li>
 						<li>IndustrialGunAdvanced</li>
+						<li>NoSwitch</li>
 					</weaponTags>
 					<researchPrerequisite>Stage0b_RA</researchPrerequisite>
 					<AllowWithRunAndGun>false</AllowWithRunAndGun>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1172,6 +1172,7 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Suppressive</li>
+      <li>NoSwitch</li>
     </weaponTags>
   </Operation>
 
@@ -1239,6 +1240,7 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
     </weaponTags>
   </Operation>
 
@@ -1306,6 +1308,7 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
     </weaponTags>
   </Operation>
 
@@ -1370,6 +1373,7 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Rifle</li>
+      <li>NoSwitch</li>
     </weaponTags>
   </Operation>
 

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -225,6 +225,7 @@
 			</FireModes>
 			<weaponTags>
 				<li>IndustrialGunAdvanced</li>
+				<li>NoSwitch</li>
 			</weaponTags>
 			<researchPrerequisite>Stage0b_KA</researchPrerequisite>
 		  </li>

--- a/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
+++ b/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
@@ -81,6 +81,14 @@
 			</tools>
 			</value>
 		</li>
+    
+    <li Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="KIT_Gun_BayonetMusket"]/weaponTags</xpath>
+      <value>
+        <li>NoSwitch</li>
+      </value>
+    </li>
+
 
 		<!-- ========== Guns ========== -->
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Patches/Kit's Industrial Weapons/KitsIndustrial_Guns.xml
+++ b/Patches/Kit's Industrial Weapons/KitsIndustrial_Guns.xml
@@ -287,6 +287,7 @@
 			</FireModes>
 			<weaponTags>
 				<li>CE_AI_Rifle</li>
+				<li>NoSwitch</li>
 			</weaponTags>
 			<AllowWithRunAndGun>false</AllowWithRunAndGun>
 		</li>

--- a/Patches/Logann/Wolv_Weapons.xml
+++ b/Patches/Logann/Wolv_Weapons.xml
@@ -49,6 +49,7 @@
 		<weaponTags>
 			<li>CE_AI_AssaultWeapon</li>
 			<li>WolvWep</li>
+			<li>NoSwitch</li>
 		</weaponTags>
 	</li>
 

--- a/Patches/Mechanized Armor Set/Ammo_&_Apparel_Defs.xml
+++ b/Patches/Mechanized Armor Set/Ammo_&_Apparel_Defs.xml
@@ -202,7 +202,15 @@
 									<FireModes>
 										<aiAimMode>AimedShot</aiAimMode>
 									</FireModes>
-									</li>				
+								</li>
+
+								<li Class="PatchOperationAdd">
+									<xpath>Defs/ThingDef[defName="Mechanized_Musket"]/weaponTags</xpath>
+									<value>
+										<li>NoSwitch</li>
+									</value>
+								</li>
+									
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Grenades_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Grenades_MechanoidsExtraordinaire.xml
@@ -45,6 +45,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_AI_Launcher</li>
+					<li>NoSwitch</li>
 				</weaponTags>
 			</li>
 		</operations>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Misc/Weapons_Guns_MechanoidsExtraordinaire.xml
@@ -37,6 +37,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_AI_Launcher</li>
+					<li>NoSwitch</li>
 				</weaponTags>
 			</li>
 		</operations>

--- a/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -44,6 +44,7 @@
 					</FireModes>
 					<weaponTags>
 					  <li>CE_AI_Suppressive</li>
+					  <li>NoSwitch</li>
 					</weaponTags>
 				</li>
 
@@ -80,6 +81,9 @@
 					  <aiAimMode>SuppressFire</aiAimMode>
 					  <noSingleShot>true</noSingleShot>
 					</FireModes>
+					<weaponTags>
+					  <li>NoSwitch</li>
+					</weaponTags>
 				</li>
 			</operations>
 		</match>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -43,8 +43,10 @@
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>
-					<li>NoSwitch</li>
 				</FireModes>
+				<weaponTags>
+					<li>NoSwitch</li>
+				</weaponTags>
 			</li>
 			
 			<!-- ========== Melee Attacks =========== -->

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -43,6 +43,7 @@
 				</AmmoUser>
 				<FireModes>
 					<aiAimMode>AimedShot</aiAimMode>
+					<li>NoSwitch</li>
 				</FireModes>
 			</li>
 			

--- a/Patches/Moyo light in the abyss/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Moyo light in the abyss/ThingDefs_Misc/Weapons.xml
@@ -484,6 +484,7 @@
 			</FireModes>
 			<weaponTags>
 			  <li>CE_AI_AR</li>
+			  <li>NoSwitch</li>
 			</weaponTags>
 		</li>
 		

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -491,6 +491,15 @@
 			  </tools>
 			</value>
 		  </li>
+
+		  
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="RK_Rifle" or defName="RK_SniperRifle" or defName="RK_FlechetteRifle" or defName="RK_FlechetteSniperRifle" or defName="RK_Rifle_line"]/tools</xpath>
+			<value>
+				<li>NoSwitch</li>
+			</value>
+		</li>
+
 		  
 		</operations>
 		</match>

--- a/Patches/Nihal/ThingDefs_Weapons/Weapons.xml
+++ b/Patches/Nihal/ThingDefs_Weapons/Weapons.xml
@@ -515,6 +515,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>NiHalRifle</li>
+					<li>NoSwitch</li>
 				</weaponTags>
 			</li>
 

--- a/Patches/Red Army/RedArmy_Weapons.xml
+++ b/Patches/Red Army/RedArmy_Weapons.xml
@@ -490,6 +490,7 @@
           <weaponTags>
             <li>CE_AI_Rifle</li>
             <li>SovietScoutInfantry</li>
+            <li>NoSwitch</li>
           </weaponTags>
           <researchPrerequisite>
             <researchPrerequisite>SovietMidWarTech</researchPrerequisite>

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_MechWeapons_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_MechWeapons_Mech.xml
@@ -82,6 +82,7 @@
                     </FireModes>
                     <weaponTags>
                         <li>MechanoidGunHeavy</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -118,6 +119,7 @@
                     </FireModes>
                     <weaponTags>
                         <li>MechanoidGunLongRange</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -153,6 +155,7 @@
                     </FireModes>
                     <weaponTags>
                         <li>MechanoidGunHeavy</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_SpacerWeapons_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_SpacerWeapons_Mech.xml
@@ -140,6 +140,7 @@
                     <weaponTags>
                         <li>MechanoidGunSmall</li>
                         <li>SpacerGun</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -184,6 +185,7 @@
                     <weaponTags>
                         <li>MechanoidGunMedium</li>
                         <li>SpacerGun</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -223,6 +225,7 @@
                     <weaponTags>
                         <li>MechanoidGunSmall</li>
                         <li>SpacerGun</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -260,6 +263,7 @@
                     <weaponTags>
                         <li>MechanoidGunMedium</li>
                         <li>SpacerGun</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -300,6 +304,7 @@
                     <weaponTags>
                         <li>MechanoidGunSmall</li>
                         <li>MechanoidGunCoil</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 
@@ -336,6 +341,7 @@
                     </FireModes>
                     <weaponTags>
                         <li>MechanoidGunCoil</li>
+                        <li>NoSwitch</li>
                     </weaponTags>
                 </li>
 

--- a/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Weapons_Reapers.xml
@@ -8,209 +8,219 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
-      <!-- ========== Melee Tools ========== -->
+			      <!-- ========== Melee Tools ========== -->
 
-      <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="RE_Gun_CannibalCaster" or defName="RE_Gun_MarauderRifle"]/tools</xpath>
-        <value>
-          <tools>
-            <li Class="CombatExtended.ToolCE">
-              <label>stock</label>
-              <capacities>
-                <li>Blunt</li>
-              </capacities>
-              <power>8</power>
-              <cooldownTime>1.55</cooldownTime>
-              <chanceFactor>1.5</chanceFactor>
-              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-              <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-            </li>
-            <li Class="CombatExtended.ToolCE">
-              <label>barrel</label>
-              <capacities>
-                <li>Blunt</li>
-              </capacities>
-              <power>5</power>
-              <cooldownTime>2.02</cooldownTime>
-              <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-              <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-            </li>
-            <li Class="CombatExtended.ToolCE">
-              <label>muzzle</label>
-              <capacities>
-                <li>Poke</li>
-              </capacities>
-              <power>8</power>
-              <cooldownTime>1.55</cooldownTime>
-              <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-              <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-            </li>
-          </tools>
-        </value>
-      </li>
+			      <li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="RE_Gun_CannibalCaster" or defName="RE_Gun_MarauderRifle"]/tools</xpath>
+				<value>
+				  <tools>
+				    <li Class="CombatExtended.ToolCE">
+				      <label>stock</label>
+				      <capacities>
+					<li>Blunt</li>
+				      </capacities>
+				      <power>8</power>
+				      <cooldownTime>1.55</cooldownTime>
+				      <chanceFactor>1.5</chanceFactor>
+				      <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				      <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				    </li>
+				    <li Class="CombatExtended.ToolCE">
+				      <label>barrel</label>
+				      <capacities>
+					<li>Blunt</li>
+				      </capacities>
+				      <power>5</power>
+				      <cooldownTime>2.02</cooldownTime>
+				      <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+				      <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				    </li>
+				    <li Class="CombatExtended.ToolCE">
+				      <label>muzzle</label>
+				      <capacities>
+					<li>Poke</li>
+				      </capacities>
+				      <power>8</power>
+				      <cooldownTime>1.55</cooldownTime>
+				      <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+				      <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				    </li>
+				  </tools>
+				</value>
+			      </li>
 
-      <li Class="PatchOperationReplace">
-        <xpath>Defs/ThingDef[
-        defName="RE_Gun_GoliathCannon" or
-        defName="RE_Gun_ColossusArtillery"
-        ]/tools</xpath>
-        <value>
-          <tools>
-            <li Class="CombatExtended.ToolCE">
-              <label>barrel</label>
-              <capacities>
-                <li>Blunt</li>
-              </capacities>
-              <power>18</power>
-              <cooldownTime>3.44</cooldownTime>
-              <armorPenetrationBlunt>8.8</armorPenetrationBlunt>
-              <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-            </li>
-          </tools>
-        </value>
-      </li>
+			      <li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[
+				defName="RE_Gun_GoliathCannon" or
+				defName="RE_Gun_ColossusArtillery"
+				]/tools</xpath>
+				<value>
+				  <tools>
+				    <li Class="CombatExtended.ToolCE">
+				      <label>barrel</label>
+				      <capacities>
+					<li>Blunt</li>
+				      </capacities>
+				      <power>18</power>
+				      <cooldownTime>3.44</cooldownTime>
+				      <armorPenetrationBlunt>8.8</armorPenetrationBlunt>
+				      <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				    </li>
+				  </tools>
+				</value>
+			      </li>
 
-      <!-- ========== Goliath Cannnon ========== -->
-      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
-        <defName>RE_Gun_GoliathCannon</defName>
-        <statBases>
-          <Mass>35.00</Mass>
-          <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-          <SightsEfficiency>1</SightsEfficiency>
-          <ShotSpread>0.01</ShotSpread>
-          <SwayFactor>1.33</SwayFactor>
-          <Bulk>13.00</Bulk>
-        </statBases>
-        <Properties>
-          <recoilAmount>1.28</recoilAmount>
-          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-          <hasStandardCommand>true</hasStandardCommand>
-          <defaultProjectile>Bullet_Goliath</defaultProjectile>
-          <warmupTime>1.30</warmupTime>
-          <range>75</range>
-          <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
-          <burstShotCount>25</burstShotCount>
-          <soundCast>RE_Shot_GoliathCannon</soundCast>
-          <soundCastTail>GunTail_Heavy</soundCastTail>
-          <muzzleFlashScale>14</muzzleFlashScale>
-        </Properties>
-        <AmmoUser>
-          <magazineSize>200</magazineSize>
-          <reloadTime>9.1</reloadTime>
-        </AmmoUser>
-        <FireModes>
-          <aimedBurstShotCount>12</aimedBurstShotCount>
-          <aiAimMode>AimedShot</aiAimMode>
-        </FireModes>
-        <weaponTags>
-          <li>CE_AI_Suppressive</li>
-        </weaponTags>
-      </li>
+			      <!-- ========== Goliath Cannnon ========== -->
+			      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_GoliathCannon</defName>
+				<statBases>
+				  <Mass>35.00</Mass>
+				  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				  <SightsEfficiency>1</SightsEfficiency>
+				  <ShotSpread>0.01</ShotSpread>
+				  <SwayFactor>1.33</SwayFactor>
+				  <Bulk>13.00</Bulk>
+				</statBases>
+				<Properties>
+				  <recoilAmount>1.28</recoilAmount>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>true</hasStandardCommand>
+				  <defaultProjectile>Bullet_Goliath</defaultProjectile>
+				  <warmupTime>1.30</warmupTime>
+				  <range>75</range>
+				  <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+				  <burstShotCount>25</burstShotCount>
+				  <soundCast>RE_Shot_GoliathCannon</soundCast>
+				  <soundCastTail>GunTail_Heavy</soundCastTail>
+				  <muzzleFlashScale>14</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>200</magazineSize>
+				  <reloadTime>9.1</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aimedBurstShotCount>12</aimedBurstShotCount>
+				  <aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+				  <li>CE_AI_Suppressive</li>
+				  <li>NoSwitch</li>
+				</weaponTags>
+			      </li>
 
-      <!-- ========== Cannibal Caster ========== -->
-      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
-        <defName>RE_Gun_CannibalCaster</defName>
-        <statBases>
-          <SightsEfficiency>1.0</SightsEfficiency>
-          <ShotSpread>0.11</ShotSpread>
-          <SwayFactor>1.30</SwayFactor>
-          <Bulk>8</Bulk>
-          <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
-        </statBases>
-        <Properties>
-          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-          <hasStandardCommand>True</hasStandardCommand>
-          <defaultProjectile>Bullet_Cannibal_Basic</defaultProjectile>
-          <warmupTime>1.1</warmupTime>
-          <range>50</range>
-          <burstShotCount>5</burstShotCount>
-          <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-          <soundCast>RE_Shot_CannibalCaster</soundCast>
-          <soundCastTail>GunTail_Medium</soundCastTail>
-          <muzzleFlashScale>9</muzzleFlashScale>
-          <recoilPattern>Regular</recoilPattern>
-          <recoilAmount>1.68</recoilAmount>
-        </Properties>
-        <AmmoUser>
-          <magazineSize>35</magazineSize>
-          <reloadTime>4.0</reloadTime>
-        </AmmoUser>
-        <FireModes>
-          <aiUseBurstMode>True</aiUseBurstMode>
-          <aiAimMode>AimedShot</aiAimMode>
-          <aimedBurstShotCount>3</aimedBurstShotCount>
-        </FireModes>
-      </li>
+			      <!-- ========== Cannibal Caster ========== -->
+			      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_CannibalCaster</defName>
+				<statBases>
+				  <SightsEfficiency>1.0</SightsEfficiency>
+				  <ShotSpread>0.11</ShotSpread>
+				  <SwayFactor>1.30</SwayFactor>
+				  <Bulk>8</Bulk>
+				  <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>True</hasStandardCommand>
+				  <defaultProjectile>Bullet_Cannibal_Basic</defaultProjectile>
+				  <warmupTime>1.1</warmupTime>
+				  <range>50</range>
+				  <burstShotCount>5</burstShotCount>
+				  <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+				  <soundCast>RE_Shot_CannibalCaster</soundCast>
+				  <soundCastTail>GunTail_Medium</soundCastTail>
+				  <muzzleFlashScale>9</muzzleFlashScale>
+				  <recoilPattern>Regular</recoilPattern>
+				  <recoilAmount>1.68</recoilAmount>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>35</magazineSize>
+				  <reloadTime>4.0</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aiUseBurstMode>True</aiUseBurstMode>
+				  <aiAimMode>AimedShot</aiAimMode>
+				  <aimedBurstShotCount>3</aimedBurstShotCount>
+				</FireModes>
+				<weaponTags>
+				  <li>NoSwitch</li>
+				</weaponTags>
+			      </li>
 
-      <!-- ========== Marauder ========== -->
-      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
-        <defName>RE_Gun_MarauderRifle</defName>
-        <statBases>
-          <SightsEfficiency>1.25</SightsEfficiency>
-          <ShotSpread>0.07</ShotSpread>
-          <SwayFactor>1.20</SwayFactor>
-          <Bulk>10</Bulk>
-          <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-        </statBases>
-        <Properties>
-          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-          <hasStandardCommand>True</hasStandardCommand>
-          <defaultProjectile>Bullet_Marauder</defaultProjectile>
-          <burstShotCount>8</burstShotCount>
-          <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-          <warmupTime>1.0</warmupTime>
-          <range>55</range>
-          <soundCast>RE_Shot_MarauderRifle</soundCast>
-          <soundCastTail>GunTail_Medium</soundCastTail>
-          <muzzleFlashScale>9</muzzleFlashScale>
-          <recoilAmount>1.24</recoilAmount>
-        </Properties>
-        <AmmoUser>
-          <magazineSize>50</magazineSize>
-          <reloadTime>3.5</reloadTime>
-        </AmmoUser>
-        <FireModes>
-          <aiUseBurstMode>FALSE</aiUseBurstMode>
-          <aiAimMode>AimedShot</aiAimMode>
-          <aimedBurstShotCount>4</aimedBurstShotCount>
-        </FireModes>
-      </li>
+			      <!-- ========== Marauder ========== -->
+			      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_MarauderRifle</defName>
+				<statBases>
+				  <SightsEfficiency>1.25</SightsEfficiency>
+				  <ShotSpread>0.07</ShotSpread>
+				  <SwayFactor>1.20</SwayFactor>
+				  <Bulk>10</Bulk>
+				  <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>True</hasStandardCommand>
+				  <defaultProjectile>Bullet_Marauder</defaultProjectile>
+				  <burstShotCount>8</burstShotCount>
+				  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+				  <warmupTime>1.0</warmupTime>
+				  <range>55</range>
+				  <soundCast>RE_Shot_MarauderRifle</soundCast>
+				  <soundCastTail>GunTail_Medium</soundCastTail>
+				  <muzzleFlashScale>9</muzzleFlashScale>
+				  <recoilAmount>1.24</recoilAmount>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>50</magazineSize>
+				  <reloadTime>3.5</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aiUseBurstMode>FALSE</aiUseBurstMode>
+				  <aiAimMode>AimedShot</aiAimMode>
+				  <aimedBurstShotCount>4</aimedBurstShotCount>
+				</FireModes>
+				<weaponTags>
+				  <li>NoSwitch</li>
+				</weaponTags>
+			      </li>
 
-      <!-- ========== Colossus Artillery ========== -->
-      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
-        <defName>RE_Gun_ColossusArtillery</defName>
-        <statBases>
-          <Mass>50.00</Mass>
-          <RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
-          <SightsEfficiency>1</SightsEfficiency>
-          <ShotSpread>0.01</ShotSpread>
-          <SwayFactor>0.82</SwayFactor>
-          <Bulk>20.00</Bulk>
-        </statBases>
-        <Properties>
-          <verbClass>CombatExtended.Verb_ShootCE</verbClass>
-          <hasStandardCommand>True</hasStandardCommand>
-          <defaultProjectile>Bullet_Collosus</defaultProjectile>
-          <burstShotCount>1</burstShotCount>
-          <warmupTime>5.5</warmupTime>
-          <ai_AvoidFriendlyFireRadius>5.9</ai_AvoidFriendlyFireRadius>
-          <requireLineOfSight>false</requireLineOfSight>
-          <range>92</range>
-          <minRange>5.9</minRange>
-          <soundCast>RE_Shot_ColossusArtillery</soundCast>
-          <soundCastTail>GunTail_Heavy</soundCastTail>
-          <muzzleFlashScale>40</muzzleFlashScale>
-          <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>          
-        </Properties>
-        <AmmoUser>
-          <magazineSize>1</magazineSize>
-          <reloadTime>7.6</reloadTime>
-        </AmmoUser>
-        <FireModes>
-          <aiUseBurstMode>FALSE</aiUseBurstMode>
-          <aiAimMode>AimedShot</aiAimMode>
-        </FireModes>
-      </li>
+			      <!-- ========== Colossus Artillery ========== -->
+			      <li Class='CombatExtended.PatchOperationMakeGunCECompatible'>
+				<defName>RE_Gun_ColossusArtillery</defName>
+				<statBases>
+				  <Mass>50.00</Mass>
+				  <RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
+				  <SightsEfficiency>1</SightsEfficiency>
+				  <ShotSpread>0.01</ShotSpread>
+				  <SwayFactor>0.82</SwayFactor>
+				  <Bulk>20.00</Bulk>
+				</statBases>
+				<Properties>
+				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				  <hasStandardCommand>True</hasStandardCommand>
+				  <defaultProjectile>Bullet_Collosus</defaultProjectile>
+				  <burstShotCount>1</burstShotCount>
+				  <warmupTime>5.5</warmupTime>
+				  <ai_AvoidFriendlyFireRadius>5.9</ai_AvoidFriendlyFireRadius>
+				  <requireLineOfSight>false</requireLineOfSight>
+				  <range>92</range>
+				  <minRange>5.9</minRange>
+				  <soundCast>RE_Shot_ColossusArtillery</soundCast>
+				  <soundCastTail>GunTail_Heavy</soundCastTail>
+				  <muzzleFlashScale>40</muzzleFlashScale>
+				  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>          
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>1</magazineSize>
+				  <reloadTime>7.6</reloadTime>
+				</AmmoUser>
+				<FireModes>
+				  <aiUseBurstMode>FALSE</aiUseBurstMode>
+				  <aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+				  <li>NoSwitch</li>
+				</weaponTags>
+			      </li>
 
 			</operations>		
 		</match>

--- a/Patches/Rim-Effect Core/Mech_Weapons.xml
+++ b/Patches/Rim-Effect Core/Mech_Weapons.xml
@@ -9,43 +9,43 @@
 			<operations>
 
 			<!-- Make the YMIR usable -->
-  <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[@Name="RE_Gun_MechHeavyMassAccelerator"]/tools</xpath>
-    <value>
-      <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>stock</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>36</power>
-          <cooldownTime>3</cooldownTime>
-          <armorPenetrationBlunt>148</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>barrel</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>43</power>
-          <cooldownTime>2.88</cooldownTime>
-          <armorPenetrationBlunt>100</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>muzzle</label>
-          <capacities>
-            <li>Poke</li>
-          </capacities>
-          <power>38</power>
-          <cooldownTime>2.48</cooldownTime>
-          <armorPenetrationBlunt>90</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-        </li>
-      </tools>
-    </value>
-  </li>
+		  <li Class="PatchOperationReplace">
+		    <xpath>/Defs/ThingDef[@Name="RE_Gun_MechHeavyMassAccelerator"]/tools</xpath>
+		    <value>
+		      <tools>
+			<li Class="CombatExtended.ToolCE">
+			  <label>stock</label>
+			  <capacities>
+			    <li>Blunt</li>
+			  </capacities>
+			  <power>36</power>
+			  <cooldownTime>3</cooldownTime>
+			  <armorPenetrationBlunt>148</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+			  <label>barrel</label>
+			  <capacities>
+			    <li>Blunt</li>
+			  </capacities>
+			  <power>43</power>
+			  <cooldownTime>2.88</cooldownTime>
+			  <armorPenetrationBlunt>100</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+			  <label>muzzle</label>
+			  <capacities>
+			    <li>Poke</li>
+			  </capacities>
+			  <power>38</power>
+			  <cooldownTime>2.48</cooldownTime>
+			  <armorPenetrationBlunt>90</armorPenetrationBlunt>
+			  <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+		      </tools>
+		    </value>
+		  </li>
 
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -65,8 +65,8 @@
 			  <defaultProjectile>RE_YmirBullet</defaultProjectile>
 			  <warmupTime>1.4</warmupTime>
 			  <range>75</range>
-        			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
-        			<burstShotCount>16</burstShotCount>
+        		  <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+        		  <burstShotCount>16</burstShotCount>
 			  <minRange>1.5</minRange>
 			  <soundCast>RE_Shot_YMIRCannon</soundCast>
       			<soundCastTail>GunTail_Heavy</soundCastTail>
@@ -78,8 +78,11 @@
 			</AmmoUser>
 			<FireModes>
 			  <aiAimMode>AimedShot</aiAimMode>
-      			<aimedBurstShotCount>8</aimedBurstShotCount>
+      			  <aimedBurstShotCount>8</aimedBurstShotCount>
 			</FireModes>
+			<weaponTags>
+				<li>NoSwitch</li>
+			</weaponTags>
 			</li>
 			
 

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Charge_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Charge_CE.xml
@@ -381,6 +381,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>AdvancedGun</li>
+					<li>NoSwitch</li>
 				</weaponTags>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -423,6 +423,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
+					<li>NoSwitch</li>
 				</weaponTags>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
+++ b/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
@@ -510,6 +510,7 @@
     </FireModes>
 	<weaponTags>
     <li>CE_AI_Rifle</li>
+	<li>NoSwitch</li>
 	</weaponTags>
 	</li>
 
@@ -1079,6 +1080,7 @@
 	 <FireModes />
 	<weaponTags>
 	 <li>CE_AI_Rifle</li>
+	 <li>NoSwitch</li>
 	</weaponTags>
 	</li>
 
@@ -1153,6 +1155,7 @@
 	</FireModes>
 	<weaponTags>
 	 <li>CE_AI_Rifle</li>
+	 <li>NoSwitch</li>
 	</weaponTags>
 	</li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -58,8 +58,11 @@
       </AmmoUser>      
       <FireModes>
         <aiAimMode>AimedShot</aiAimMode>
-		<aimedBurstShotCount>5</aimedBurstShotCount>
+        <aimedBurstShotCount>5</aimedBurstShotCount>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
@@ -114,6 +117,9 @@
         <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiAimMode>SuppressFire</aiAimMode>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
@@ -173,6 +179,9 @@
         <aiAimMode>SuppressFire</aiAimMode>
         <noSingleShot>true</noSingleShot>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
@@ -263,6 +272,9 @@
         <aimedBurstShotCount>3</aimedBurstShotCount>
         <aiUseBurstMode>TRUE</aiUseBurstMode>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
 	
 	  <!--Increased burst count and 20% reduced recoil-->
@@ -300,6 +312,9 @@
         <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiUseBurstMode>TRUE</aiUseBurstMode>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
 
     <!-- ========== Inferno spewer ========== -->
@@ -341,6 +356,9 @@
         <aiAimMode>SuppressFire</aiAimMode>
         <noSingleShot>true</noSingleShot>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
 
     <!-- ========== Advanced inferno spewer ========== -->
@@ -382,6 +400,9 @@
         <aiAimMode>SuppressFire</aiAimMode>
         <noSingleShot>true</noSingleShot>
       </FireModes>
+      <weaponTags>
+        <li>NoSwitch</li>
+      </weaponTags>
     </li>
 	
     <!-- ========== Remove VFE Advanced Needle Gun and patch in replacement. ========== -->
@@ -416,6 +437,7 @@
           <destroyOnDrop>true</destroyOnDrop>    
           <weaponTags>
             <li>VFE_AdvMechanoidGunLongRange</li>  
+            <li>NoSwitch</li>
           </weaponTags>
           <verbs>
           <li Class="CombatExtended.VerbPropertiesCE">
@@ -512,6 +534,7 @@
       </FireModes>
       <weaponTags>
         <li>VFE_Gun_AdvancedChargeLance</li>
+        <li>NoSwitch</li>
       </weaponTags>
     </li>
 
@@ -571,6 +594,7 @@
 		</FireModes>
 		<weaponTags>
 		  <li>VFE_AdvMechanoidGunHeavy</li>
+		  <li>NoSwitch</li>
 		</weaponTags>
 	</li>
 	
@@ -612,6 +636,7 @@
 		</FireModes>
 		<weaponTags>
 		  <li>VFE_AdvMechanoidGunHeavy</li>
+		  <li>NoSwitch</li>
 		</weaponTags>
 	</li>
     
@@ -651,6 +676,7 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Launcher</li>
+      <li>NoSwitch</li>
     </weaponTags>
   </li>
 

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
@@ -285,11 +285,12 @@
 					<li Class="CombatExtended.ToolCE">
 					  <label>bayonet</label>
 					  <capacities>
-						<li>Poke</li>
+						<li>Stab</li>
 					  </capacities>
 					  <power>10</power>
 					  <cooldownTime>1.6</cooldownTime>
-					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					  <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+					  <armorPenetrationSharp>0.5</armorPenetrationSharp>
 					</li>
 					<li Class="CombatExtended.ToolCE">
 					  <label>stock</label>

--- a/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
+++ b/Patches/WWII Soviet Faction/WWIISovietFaction_CE_Patch_RangedIndustrial.xml
@@ -94,6 +94,13 @@
 				<AllowWithRunAndGun>false</AllowWithRunAndGun>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Gun_WWII_MosinNagant_Bayonet"]/weaponTags</xpath>
+				<value>
+				  <li>NoSwitch</li>
+				</value>
+			</li>
+
 			<!-- ========== PPsh-41 ========== -->
 
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -272,9 +279,34 @@
 			<!-- == Shared patches for firearm melee tools == -->
 
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Gun_WWII_MosinNagant_Bayonet"]/tools</xpath>
+				<value>
+				  <tools>
+					<li Class="CombatExtended.ToolCE">
+					  <label>bayonet</label>
+					  <capacities>
+						<li>Poke</li>
+					  </capacities>
+					  <power>10</power>
+					  <cooldownTime>1.6</cooldownTime>
+					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+					  <label>stock</label>
+					  <capacities>
+						<li>Blunt</li>
+					  </capacities>
+					  <power>8</power>
+					  <cooldownTime>1.8</cooldownTime>
+					  <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+					</li>
+				  </tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 					defName="Gun_WWII_MosinNagant_Normal" or
-					defName="Gun_WWII_MosinNagant_Bayonet" or
 					defName="Gun_WWII_PPShSMG" or
 					defName="Gun_DP-28_LMG" or
 					defName="Gun_WWII_Svt-40_Rifle"


### PR DESCRIPTION
## Additions

- Added the NoSwitch tag to Mechanoids weapons.

## Reasoning

- Mechs be it colony built, hostile or hacked are not smart enough to reequip their guns o their own and can't be forced to do so either, the NoSwitch tag makes sure that their guns are not stowed away when out of ammo so that after the implementation of #1690 the player can give them more ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
