### PR TITLE
"Give Ammo" XML implementation

### DIFF
--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -71,7 +71,7 @@
 		<li>Precipitation, wind direction and speed all have a significant effect on fire spread. Beware of being downwind from a bush fire.</li>
 		<li>Fires in confined spaces will create clouds of lethal smoke, capable of rapidly incapacitating anyone caught in it. Use gas masks to protect yourself.</li>
 		<li>Use loadouts to determine what your colonists should carry in their inventory. Use the equipment tab to access items.</li>
-		<li>Your colonists can be manually ordered to give ammo to other friendly pawns, use that to your advantage.</li>
+		<li>In a pinch, you can order your colonists to give ammo to other friendly pawns.</li>
 	  
 	  <!-- Building -->
 		<li>Embrasures provide a safer, but not impenetrable, cover to lay down machinegun fire on assailants. Be sure to wear a helmet when peeking over them!</li>

--- a/Defs/Misc/TipSetDefs/Tips.xml
+++ b/Defs/Misc/TipSetDefs/Tips.xml
@@ -71,6 +71,7 @@
 		<li>Precipitation, wind direction and speed all have a significant effect on fire spread. Beware of being downwind from a bush fire.</li>
 		<li>Fires in confined spaces will create clouds of lethal smoke, capable of rapidly incapacitating anyone caught in it. Use gas masks to protect yourself.</li>
 		<li>Use loadouts to determine what your colonists should carry in their inventory. Use the equipment tab to access items.</li>
+		<li>Your colonists can be manually ordered to give ammo to other friendly pawns, use that to your advantage.</li>
 	  
 	  <!-- Building -->
 		<li>Embrasures provide a safer, but not impenetrable, cover to lay down machinegun fire on assailants. Be sure to wear a helmet when peeking over them!</li>

--- a/Defs/Tutor/Concepts_NotedOpportunistic.xml
+++ b/Defs/Tutor/Concepts_NotedOpportunistic.xml
@@ -4,24 +4,24 @@
 	<!--===================== Concepts taught through the learning readout, when opportunities arise ===================-->
 
   <!-- defName and highlight tags for reloading concepts must be identical for reload gizmo to recognize them -->
-	<ConceptDef>
-		<defName>CE_ReusableNeolithicProjectiles</defName>
-		<label>CE: Reusable projectiles</label>
-		<priority>50</priority>
-		<needsOpportunity>True</needsOpportunity>
-		<helpText>Some projectiles can be re-used after they impact something. This applies to such projectiles as arrows, great arrows, slingshot stones and crossbow bolts. Re-usable ammo is initially forbidden, and re-usability follows a tiered progression: stone arrows will break on impact more often than plasteel ones.\n\nIf you prefer to go without this feature, turn off "Re-use neolithic projectiles" in the mod settings menu (Settings -> Mod settings -> CombatExtended).</helpText>
-	</ConceptDef>
+  <ConceptDef>
+    <defName>CE_ReusableNeolithicProjectiles</defName>
+    <label>CE: Reusable projectiles</label>
+    <priority>50</priority>
+    <needsOpportunity>True</needsOpportunity>
+    <helpText>Some projectiles can be re-used after they impact something. This applies to such projectiles as arrows, great arrows, slingshot stones and crossbow bolts. Re-usable ammo is initially forbidden, and re-usability follows a tiered progression: stone arrows will break on impact more often than plasteel ones.\n\nIf you prefer to go without this feature, turn off "Re-use neolithic projectiles" in the mod settings menu (Settings -> Mod settings -> CombatExtended).</helpText>
+  </ConceptDef>
 	
-	<ConceptDef>
-		<defName>CE_Reload</defName>
-		<label>CE: Reloading guns</label>
-		<priority>50</priority>
-		<needsOpportunity>True</needsOpportunity>
-		<helpText>Guns have limited magazine capacity and display their current ammo amount when selecting the gun or its wielder. Once a magazine is empty your colonist needs to spend time reloading. This can take quite a long time for some weapons and consumes ammo from the shooter's inventory.\n\nIn addition to the magazine count guns display their currently loaded ammo type. Different types of ammo can have significantly different performance. It's important to select the appropriate ammo for the enemy you're fighting.\n\nYou can manually order a reload or change the selected ammo type by selecting a colonist and clicking the RELOAD button. This will bring up a menu with a reload command and a list of ammo types in the colonist's inventory.\n\nThe 'Unload' command can be used to dump the currently loaded ammo into the inventory. Ordering a reload with a partially filled magazine will do this automatically.</helpText>
-		<highlightTags>
-			<li>CE_Reload</li>
-		</highlightTags>
-	</ConceptDef>
+  <ConceptDef>
+    <defName>CE_Reload</defName>
+    <label>CE: Reloading guns</label>
+    <priority>50</priority>
+    <needsOpportunity>True</needsOpportunity>
+    <helpText>Guns have limited magazine capacity and display their current ammo amount when selecting the gun or its wielder. Once a magazine is empty your colonist needs to spend time reloading. This can take quite a long time for some weapons and consumes ammo from the shooter's inventory.\n\nIn addition to the magazine count guns display their currently loaded ammo type. Different types of ammo can have significantly different performance. It's important to select the appropriate ammo for the enemy you're fighting.\n\nYou can manually order a reload or change the selected ammo type by selecting a colonist and clicking the RELOAD button. This will bring up a menu with a reload command and a list of ammo types in the colonist's inventory.\n\nThe 'Unload' command can be used to dump the currently loaded ammo into the inventory. Ordering a reload with a partially filled magazine will do this automatically.</helpText>
+    <highlightTags>
+      <li>CE_Reload</li>
+    </highlightTags>
+  </ConceptDef>
 
   <ConceptDef>
     <defName>CE_ReloadNoMag</defName>
@@ -187,5 +187,12 @@
     <priority>50</priority>
     <helpText>After getting 8 melee skill it is possible to target body part areas in melee fighting, with the drawback of lower chance to hit (0.8x for bottom, 0.7x for top). After reaching 16 melee skill it also becomes possible to aim for exact specific body parts in those areas.\n\ when targetting specific body part (part, not height), the selected part won't be always hit. The chance to actually hit it is (((part coverage) * (attacker melee skill - 15) * manipulation) - ((Defender melee skill / 50) * moving), if the attack misses the bodypart it hits selected height area.</helpText>
   </ConceptDef>
-  
+
+  <ConceptDef>
+    <defName>CE_GiveAmmo</defName>
+    <label>CE: Giving ammo</label>
+    <priority>50</priority>
+    <helpText>Your colonists can be manually ordered to give ammo to other friendly pawns, be it humanoid or mechanoid, if and only if they are holding the same ammo type as the other pawn's gun is chambered in. You can right-click on the recipient while the giver pawn is selected and choose how much of which ammo type to give, the rest is automatically done.</helpText>
+  </ConceptDef>
+
 </Defs>

--- a/Defs/Tutor/Concepts_NotedOpportunistic.xml
+++ b/Defs/Tutor/Concepts_NotedOpportunistic.xml
@@ -192,7 +192,7 @@
     <defName>CE_GiveAmmo</defName>
     <label>CE: Giving ammo</label>
     <priority>50</priority>
-    <helpText>Your colonists can be manually ordered to give ammo to other friendly pawns, be it humanoid or mechanoid, if and only if they are holding the same ammo type as the other pawn's gun is chambered in. You can right-click on the recipient while the giver pawn is selected and choose how much of which ammo type to give, the rest is automatically done.</helpText>
+    <helpText>Your drafted colonists can be manually ordered to give ammo to other friendly pawns, be it humanoid or mechanoid, if they are carrying ammo the recepient's gun can fire. Select the giver pawn and right-click on the recipient, then choose how much of which ammo type to give.</helpText>
   </ConceptDef>
 
 </Defs>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -89,6 +89,9 @@
 			  <compClass>CombatExtended.CompPawnGizmo</compClass>
 			</li>
 			<li Class="CombatExtended.CompProperties_Suppressable" />
+			<li>
+			  <compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -34,6 +34,9 @@
 			<li>
 				<compClass>CombatExtended.CompPawnGizmo</compClass>
 			</li>
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
 		</value>
 	</Operation>
 
@@ -108,17 +111,6 @@
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 			</tools>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]</xpath>
-		<value>
-			<comps>
-				<li>
-					<compClass>CombatExtended.CompAmmoGiver</compClass>
-				</li>
-			</comps>
 		</value>
 	</Operation>
 

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
@@ -24,7 +24,7 @@
                     <xpath>Defs/ThingDef[ defName="RM_AncientDroid_Combat" or defName="RM_AncientDroid_Worker" or defName="RM_Droid_Guardian" or defName="RM_Droid_Spartan"]/statBases</xpath>
                     <value>
                         <CarryWeight>50</CarryWeight>
-                        <CarryBulk>20</CarryBulk>
+                        <CarryBulk>30</CarryBulk>
                         <AimingAccuracy>1.0</AimingAccuracy>
                         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
                         <MeleeDodgeChance>0.19</MeleeDodgeChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -36,7 +36,7 @@
         <SightsEfficiency>1</SightsEfficiency>
         <ShotSpread>0.07</ShotSpread>
         <SwayFactor>0.82</SwayFactor>
-        <Bulk>10.00</Bulk>
+        <Bulk>8.00</Bulk>
       </statBases>
       <Properties>
         <recoilAmount>0.76</recoilAmount>
@@ -90,7 +90,7 @@
       <defName>VFE_Gun_RaiderMechanoidGun</defName>
       <statBases>
         <Mass>12</Mass>
-        <Bulk>22</Bulk>
+        <Bulk>16</Bulk>
         <SwayFactor>1.6</SwayFactor>
         <ShotSpread>0.1</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -55,6 +55,7 @@
       <AmmoUser>
         <magazineSize>50</magazineSize>
         <reloadTime>7.8</reloadTime>
+	<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
       </AmmoUser>      
       <FireModes>
         <aiAimMode>AimedShot</aiAimMode>
@@ -90,19 +91,19 @@
       <statBases>
         <Mass>12</Mass>
         <Bulk>22</Bulk>
-        <SwayFactor>4.00</SwayFactor>
-        <ShotSpread>0.01</ShotSpread>
+        <SwayFactor>1.6</SwayFactor>
+        <ShotSpread>0.1</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>
         <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
       </statBases>
       <Properties>
-        <recoilAmount>1.66</recoilAmount>
+        <recoilAmount>1.75</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
+        <defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
         <warmupTime>1.6</warmupTime>
-        <range>54</range>
-        <ticksBetweenBurstShots>11</ticksBetweenBurstShots>
+        <range>62</range>
+        <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
         <soundCast>MediumMG</soundCast>
         <soundCastTail>GunTail_Medium</soundCastTail>
@@ -112,10 +113,11 @@
       <AmmoUser>
         <magazineSize>80</magazineSize>
         <reloadTime>7.8</reloadTime>
+	<ammoSet>AmmoSet_50BMG</ammoSet>
       </AmmoUser>
       <FireModes>
         <aimedBurstShotCount>5</aimedBurstShotCount>
-        <aiAimMode>SuppressFire</aiAimMode>
+        <aiAimMode>AimedShot</aiAimMode>
       </FireModes>
       <weaponTags>
         <li>NoSwitch</li>
@@ -173,6 +175,7 @@
       <AmmoUser>
         <magazineSize>60</magazineSize>
         <reloadTime>5</reloadTime>
+	<ammoSet>AmmoSet_Flamethrower</ammoSet>
       </AmmoUser>
       <FireModes>
         <aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -105,8 +105,8 @@
         <range>62</range>
         <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
-        <soundCast>MediumMG</soundCast>
-        <soundCastTail>GunTail_Medium</soundCastTail>
+        <soundCast>HeavyMG</soundCast>
+        <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>10</muzzleFlashScale>
         <recoilPattern>Mounted</recoilPattern>
       </Properties>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -90,7 +90,7 @@
       <defName>VFE_Gun_RaiderMechanoidGun</defName>
       <statBases>
         <Mass>12</Mass>
-        <Bulk>16</Bulk>
+        <Bulk>18</Bulk>
         <SwayFactor>1.6</SwayFactor>
         <ShotSpread>0.1</ShotSpread>
         <SightsEfficiency>1.0</SightsEfficiency>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -8,15 +8,38 @@
 
     <match Class="PatchOperationSequence">
       <operations>
-	  
+
+	<li Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			</li>
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
+		</value>
+	</li>
+
+
 	  <!-- Advanced mechs retain their original heat armor to represent proper sealing of sensitive electronics. Minor improvement to EMP resistance as well-->
 	  
-	  <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
+	<li Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
       <value>
         <ArmorRating_Electric>0.10</ArmorRating_Electric>
       </value>
-      </li>
+    </li>
 
     <!-- ========== VFE Advanced Centipede ========== -->
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -123,7 +123,7 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
-        <CarryBulk>20</CarryBulk>
+        <CarryBulk>30</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
         <MeleeDodgeChance>0.19</MeleeDodgeChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -8,7 +8,29 @@
 
     <match Class="PatchOperationSequence">
       <operations>
-	  
+
+	<li Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+	</li>
+
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="VFE_Mechanoid"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			</li>
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
+		</value>
+	</li>
+
 	  <!--Consistency with vanilla mechs-->
 	  
     <li Class="PatchOperationReplace">


### PR DESCRIPTION
## Additions

- Implement the Give Ammo system in XML

## Changes

- Rechamber the Autocannon wielded by the Raider mech from .338 Norma to .50 BMG now that the gun is not infinite-ammo anymore.
- Adjusted the CarryBulk of the buildable mechs and their guns' bulk to improve their ammo carrying capabilities.
- Give AmmoSets to guns wielded by buildable mechs which used to be infinite-ammo

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
