### PR TITLE
Reduce fist blunt armor penetration for Rotti pets from Ratkins

### DIFF
--- a/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
+++ b/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
@@ -42,7 +42,7 @@
 						<cooldownTime>2.01</cooldownTime>
 						<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 						<armorPenetrationSharp>0.01</armorPenetrationSharp>
-						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
 					</li>
 						<li Class="CombatExtended.ToolCE">
 						<label>right claw</label>
@@ -53,7 +53,7 @@
 						<cooldownTime>2.01</cooldownTime>
 						<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 						<armorPenetrationSharp>0.01</armorPenetrationSharp>
-						<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+						<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
 					</li>
 					<li Class="CombatExtended.ToolCE">
 						<capacities>

--- a/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
+++ b/Patches/NewRatkinPlus/ThingDefs_Races/Race_Rotti.xml
@@ -42,7 +42,7 @@
 						<cooldownTime>2.01</cooldownTime>
 						<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 						<armorPenetrationSharp>0.01</armorPenetrationSharp>
-						<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						<armorPenetrationBlunt>0.015</armorPenetrationBlunt>
 					</li>
 						<li Class="CombatExtended.ToolCE">
 						<label>right claw</label>
@@ -53,7 +53,7 @@
 						<cooldownTime>2.01</cooldownTime>
 						<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 						<armorPenetrationSharp>0.01</armorPenetrationSharp>
-						<armorPenetrationBlunt>0.1</armorPenetrationBlunt>
+						<armorPenetrationBlunt>0.015</armorPenetrationBlunt>
 					</li>
 					<li Class="CombatExtended.ToolCE">
 						<capacities>


### PR DESCRIPTION
## Changes

Reduced blunt armor penetration of claws in Rotti pet rodents from the Ratkins mod.

## Reasoning

Rottis (0.5) are smaller than their Ratkin (0.8) masters, and should be proportionally weaker in their scratch attacks, while being marginally better than ordinary rats.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony for 30 mins, with simulated combat between Rottis and regular rats