### PR TITLE
Fix incorrect ammo class and missing melee tools for Orassans mod

### DIFF
--- a/Patches/Orassans/Ammo/MissileAmmo.xml
+++ b/Patches/Orassans/Ammo/MissileAmmo.xml
@@ -89,7 +89,7 @@
 			<Bulk>10.8</Bulk>
 			<Mass>4</Mass>
 		</statBases>
-		<ammoClass>RocketHEAT</ammoClass>
+		<ammoClass>RailgunSabot</ammoClass>
 		<detonateProjectile>Bullet_OrassanMissileShell_APSabot</detonateProjectile>
 	</ThingDef>
 

--- a/Patches/Orassans/ThingDefs_Weapons/Weapons.xml
+++ b/Patches/Orassans/ThingDefs_Weapons/Weapons.xml
@@ -53,7 +53,8 @@
 						defName = "Gun_OrassanSniper" or
 						defName = "Gun_OrassanDMR" or
 						defName = "Gun_OrassanGMG" or
-						defName = "Gun_OrassanBattleRifle"
+						defName = "Gun_OrassanBattleRifle" or
+						defName = "Gun_OrassanGrenadeLauncher"
 						]/tools
 					</xpath>
 					<value>
@@ -764,6 +765,8 @@
 					</value>
 				</li>
 				
+				<!-- === Orassan Combat Knife === -->
+				
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="OrassanCombatKnife"]/statBases</xpath>
 					<value>
@@ -832,6 +835,66 @@
 					</value>
 				</li>
 
+				<!-- === Orassan Telescoping Warhammer === -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="OrassanWarHammer"]/statBases</xpath>
+					<value>
+					<Bulk>1</Bulk>
+					<MeleeCounterParryBonus>1.4</MeleeCounterParryBonus>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="OrassanWarHammer"]</xpath>
+					<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.40</MeleeCritChance>
+					</equippedStatOffsets>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="OrassanWarHammer"]/weaponTags</xpath>
+					<value>
+					<li>CE_Sidearm_Melee</li>
+					<li>CE_OneHandedWeapon</li>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="OrassanWarHammer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>0.8</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>5</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>17</power>
+								<cooldownTime>1.2</cooldownTime>
+								<chanceFactor>0.30</chanceFactor>
+								<!-- Designed to damage most powered armor -->
+								<armorPenetrationBlunt>60</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<!-- === Cat's Eye berry juice (bottle) === -->
+				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Catberryjuice"]/tools</xpath>
 					<value>


### PR DESCRIPTION
## Changes

- Fix incorrect ammo class for Orassan AP sabot missile
- Fix missing CE melee tools for Orassan weapons

## References

- Fixes outstanding issues from #1671 

## Reasoning

- Orassan telescoping warhammer has high blunt damage, as the original mod author (DianaWinters) intended for it to be capable of overcoming the blunt armor resistance of most space marine / cataphract armor, despite the weapon's small size.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony for 2 hours, with extensive testing between an Orassan armed with a OE warhammer and a human pawn wearing regular Powered Armor
