### PR TITLE
Add a new combat drug called Psycho

### DIFF
--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -8,14 +8,14 @@
     <descriptionHyperlinks>
       <HediffDef>PsychoHigh</HediffDef>
       <HediffDef>PsychiteTolerance</HediffDef>
-	  <HediffDef>PsychoCrash</HediffDef>
+      <HediffDef>PsychoCrash</HediffDef>
       <HediffDef>PsychiteAddiction</HediffDef>
       <HediffDef>ChemicalDamageSevere</HediffDef>
     </descriptionHyperlinks>
     <graphicData>
       <texPath>Things/Item/Drug/Yayo</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
-	  <color>(95,125,95)</color>
+      <color>(95,125,95)</color>
       <drawSize>0.75</drawSize>
     </graphicData>
     <rotatable>false</rotatable>
@@ -117,7 +117,7 @@
           </hediffGivers>
         </li>
         <li>
-		  <minSeverity>0.05</minSeverity>
+          <minSeverity>0.05</minSeverity>
           <label>coming down</label>
           <painFactor>0.75</painFactor>
           <restFallFactor>0.75</restFallFactor>
@@ -243,7 +243,7 @@
       <li>
         <minSeverity>0.2</minSeverity>
         <label>serious</label>
-		<vomitMtbDays>0.5</vomitMtbDays>
+        <vomitMtbDays>0.5</vomitMtbDays>
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
@@ -254,7 +254,7 @@
       <li>
         <minSeverity>0.4</minSeverity>
         <label>lethal</label>
-		<painFactor>0.1</painFactor>
+        <painFactor>0.1</painFactor>
         <vomitMtbDays>0.2</vomitMtbDays>
           <capMods>
             <li>
@@ -266,7 +266,7 @@
       <li>
         <minSeverity>0.8</minSeverity>
         <label>initial</label>
-		<vomitMtbDays>0.5</vomitMtbDays>
+        <vomitMtbDays>0.5</vomitMtbDays>
           <capMods>
             <li>
               <capacity>Consciousness</capacity>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -72,7 +72,7 @@
       <soundWorking>Recipe_Drug</soundWorking>
     </recipeMaker>
     <costList>
-      <PsychoidLeaves>16</PsychoidLeaves>
+      <PsychoidLeaves>20</PsychoidLeaves>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -26,7 +26,6 @@
     </statBases>
     <generateCommonality>0.25</generateCommonality>
     <techLevel>Neolithic</techLevel>
-    <minRewardCount>10</minRewardCount>
     <ingestible>
       <foodType>Processed</foodType>
       <joyKind>Chemical</joyKind>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -82,7 +82,7 @@
         <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
         <listOrder>150</listOrder>
         <overdoseSeverityOffset>0.25~0.50</overdoseSeverityOffset>
-        <largeOverdoseChance>0.1</largeOverdoseChance>
+        <largeOverdoseChance>0.05</largeOverdoseChance>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -24,7 +24,7 @@
       <MarketValue>7</MarketValue>
       <Mass>0.05</Mass>
     </statBases>
-    <generateCommonality>0.5</generateCommonality>
+    <generateCommonality>0.25</generateCommonality>
     <techLevel>Neolithic</techLevel>
     <minRewardCount>10</minRewardCount>
     <ingestible>
@@ -110,7 +110,7 @@
           <hediffGivers>
             <li Class="HediffGiver_Random">
               <hediff>PsychoCrash</hediff>
-              <mtbDays>0.05</mtbDays>
+              <mtbDays>0.025</mtbDays>
               <partsToAffect>
                 <li>Brain</li>
               </partsToAffect>
@@ -143,7 +143,7 @@
         <li>
           <minSeverity>0.15</minSeverity>
           <label>full-on high</label>
-          <painFactor>0</painFactor>
+          <painFactor>0.1</painFactor>
           <restFallFactor>0.33</restFallFactor>
           <capMods>
             <li>
@@ -160,7 +160,7 @@
             </li>
           </capMods>
           <statFactors>
-            <Suppressability>0</Suppressability>
+            <Suppressability>0.1</Suppressability>
           </statFactors>
         </li>
         <li>
@@ -248,13 +248,13 @@
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
-              <offset>-0.5</offset>
+              <offset>-0.4</offset>
             </li>
           </capMods>
       </li>
       <li>
         <minSeverity>0.4</minSeverity>
-        <label>lethal</label>
+        <label>extreme</label>
         <painFactor>0.1</painFactor>
         <vomitMtbDays>0.2</vomitMtbDays>
           <capMods>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -4,7 +4,7 @@
   <ThingDef ParentName="MakeableDrugBase">
     <defName>Psycho</defName>
     <label>psycho</label>
-    <description>A refined powdery preparation of the psychite drug. When snorted, it produces a rapid euphoric high, dramatically reduces the user's need for rest, and suppresses pain. Like all forms of psychite, it is addictive, though it is not as addictive as the cruder flake.\n\nBecause of its high cost and refined appearance, many cultures associate yayo with degenerate wealth. Whether in the throneroom or the boardroom, many hare-brained policy schemes have been developed during yayo-fueled binge parties.</description>
+    <description>A very refined and concentrated powdery preparation of the psychite drug. When snorted, it produces a very rapid euphoric high, dramatically reduces the user's need for rest, blocks pain, inceases movement speed and heightens the user's consciousness. Like all forms of psychite, it is addictive, though it is even more addictive than the other variants.\n\nBecause of the crude process of the production of this drug and it being very concentrated, aside from it being very addictive and having a high overdose chance, it can have a very nastry crash period. It is advised that this drug should only be taken in dire situations and as a last resort.</description>
     <descriptionHyperlinks>
       <HediffDef>PsychoHigh</HediffDef>
       <HediffDef>PsychiteTolerance</HediffDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -72,7 +72,7 @@
       <soundWorking>Recipe_Drug</soundWorking>
     </recipeMaker>
     <costList>
-      <PsychoidLeaves>20</PsychoidLeaves>
+      <PsychoidLeaves>16</PsychoidLeaves>
     </costList>
     <comps>
       <li Class="CompProperties_Drug">
@@ -83,7 +83,7 @@
         <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
         <listOrder>150</listOrder>
         <overdoseSeverityOffset>0.25~0.50</overdoseSeverityOffset>
-        <largeOverdoseChance>0.05</largeOverdoseChance>
+        <largeOverdoseChance>0.033</largeOverdoseChance>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -105,7 +105,7 @@
           <hediffGivers>
             <li Class="HediffGiver_Random">
               <hediff>PsychoCrash</hediff>
-              <mtbDays>0.02</mtbDays>
+              <mtbDays>0.01</mtbDays>
               <partsToAffect>
                 <li>Brain</li>
               </partsToAffect>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -29,7 +29,7 @@
     <ingestible>
       <foodType>Processed</foodType>
       <joyKind>Chemical</joyKind>
-      <joy>1.0</joy>
+      <joy>0.5</joy>
       <drugCategory>Hard</drugCategory>
       <baseIngestTicks>60</baseIngestTicks>
       <ingestSound>Ingest_Snort</ingestSound>
@@ -50,16 +50,13 @@
         </li>
         <li Class="IngestionOutcomeDoer_OffsetNeed">
           <need>Rest</need>
-          <offset>0.6</offset>
+          <offset>0.4</offset>
           <toleranceChemical>Psychite</toleranceChemical>
         </li>
         <li Class="IngestionOutcomeDoer_GiveHediff">
           <hediffDef>PsychiteTolerance</hediffDef>
           <severity>0.1</severity>
           <divideByBodySize>true</divideByBodySize>
-        </li>
-        <li Class="IngestionOutcomeDoer_OffsetPsyfocus">
-          <offset>0.25</offset>
         </li>
       </outcomeDoers>
     </ingestible>
@@ -76,7 +73,7 @@
     <comps>
       <li Class="CompProperties_Drug">
         <chemical>Psychite</chemical>
-        <addictiveness>0.2</addictiveness>
+        <addictiveness>0.1</addictiveness>
         <existingAddictionSeverityOffset>0.25</existingAddictionSeverityOffset>
         <needLevelOffset>1.0</needLevelOffset>
         <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
@@ -108,7 +105,7 @@
           <hediffGivers>
             <li Class="HediffGiver_Random">
               <hediff>PsychoCrash</hediff>
-              <mtbDays>0.025</mtbDays>
+              <mtbDays>0.02</mtbDays>
               <partsToAffect>
                 <li>Brain</li>
               </partsToAffect>
@@ -144,7 +141,7 @@
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
-              <offset>0.20</offset>
+              <offset>0.15</offset>
             </li>
             <li>
               <capacity>Sight</capacity>
@@ -170,18 +167,18 @@
     <stages>
       <li>
         <label>coming down from psycho</label>
-        <description>Something is wrong.</description>
+        <description>Something is wrong...</description>
         <baseMoodEffect>0</baseMoodEffect>
       </li>
       <li>
         <label>barely high on psycho</label>
         <description>I still feel so good.</description>
-        <baseMoodEffect>10</baseMoodEffect>
+        <baseMoodEffect>5</baseMoodEffect>
       </li>
       <li>
         <label>high on psycho</label>
         <description>I AM GOD!</description>
-        <baseMoodEffect>30</baseMoodEffect>
+        <baseMoodEffect>10</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>
@@ -202,47 +199,38 @@
     <stages>
       <li>
         <label>recovering</label>
-          <capMods>
-            <li>
-              <capacity>Consciousness</capacity>
-              <offset>-0.2</offset>
-            </li>
-          </capMods>
+        <vomitMtbDays>0.4</vomitMtbDays>
+        <painOffset>0.1</painOffset>
+        <capMods>
+          <li>
+            <capacity>Consciousness</capacity>
+            <postFactor>0.8</postFactor>
+          </li>
+        </capMods>
       </li>
       <li>
+        <label>major</label>
         <minSeverity>0.2</minSeverity>
-        <label>serious</label>
         <vomitMtbDays>0.5</vomitMtbDays>
-          <capMods>
-            <li>
-              <capacity>Consciousness</capacity>
-              <offset>-0.4</offset>
-            </li>
-          </capMods>
+        <painOffset>0.3</painOffset>
+        <capMods>
+          <li>
+            <capacity>Consciousness</capacity>
+            <postFactor>0.4</postFactor>
+          </li>
+        </capMods>
       </li>
       <li>
-        <minSeverity>0.4</minSeverity>
-        <label>extreme</label>
-        <painFactor>0.1</painFactor>
-        <vomitMtbDays>0.2</vomitMtbDays>
-          <capMods>
-            <li>
-              <capacity>Consciousness</capacity>
-              <offset>-0.4</offset>
-              <setMax>0.1</setMax>
-            </li>
-          </capMods>
-      </li>
-      <li>
-        <minSeverity>0.8</minSeverity>
         <label>initial</label>
-        <vomitMtbDays>0.5</vomitMtbDays>
-          <capMods>
-            <li>
-              <capacity>Consciousness</capacity>
-              <offset>-0.1</offset>
-            </li>
-          </capMods>
+        <minSeverity>0.8</minSeverity>
+        <vomitMtbDays>0.2</vomitMtbDays>
+        <painOffset>0.1</painOffset>
+        <capMods>
+          <li>
+            <capacity>Consciousness</capacity>
+            <postFactor>0.7</postFactor>
+          </li>
+        </capMods>
       </li>
     </stages>
   </HediffDef>
@@ -254,19 +242,14 @@
     <validWhileDespawned>true</validWhileDespawned>
     <stages>
       <li>
-        <label>mild psycho comedown</label>
+        <label>recovering from psycho comedown</label>
         <description>Let's not do this again...</description>
-        <baseMoodEffect>-5</baseMoodEffect>
+        <baseMoodEffect>-2</baseMoodEffect>
       </li>
       <li>
-        <label>serious psycho comedown</label>
-        <description>I might survive this after all.</description>
+        <label>major psycho comedown</label>
+        <description>I might be dying.</description>
         <baseMoodEffect>-10</baseMoodEffect>
-      </li>
-      <li>
-        <label>lethal psycho comedown</label>
-        <description>It feels like I'm dying.</description>
-        <baseMoodEffect>-20</baseMoodEffect>
       </li>
       <li>
         <label>initial psycho comedown</label>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -260,6 +260,7 @@
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
+              <offset>-0.4</offset>
               <setMax>0.1</setMax>
             </li>
           </capMods>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -76,7 +76,7 @@
     <comps>
       <li Class="CompProperties_Drug">
         <chemical>Psychite</chemical>
-        <addictiveness>0.25</addictiveness>
+        <addictiveness>0.2</addictiveness>
         <existingAddictionSeverityOffset>0.25</existingAddictionSeverityOffset>
         <needLevelOffset>1.0</needLevelOffset>
         <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
@@ -99,12 +99,49 @@
     <isBad>false</isBad>
     <comps>
       <li Class="HediffCompProperties_SeverityPerDay">
-        <severityPerDay>-3.0</severityPerDay>
+        <severityPerDay>-2.5</severityPerDay>
         <showHoursToRecover>true</showHoursToRecover>
       </li>
     </comps>
       <stages>
         <li>
+          <label>crash</label>
+          <hediffGivers>
+            <li Class="HediffGiver_Random">
+              <hediff>PsychoCrash</hediff>
+              <mtbDays>0.05</mtbDays>
+              <partsToAffect>
+                <li>Brain</li>
+              </partsToAffect>
+            </li>
+          </hediffGivers>
+        </li>
+        <li>
+		  <minSeverity>0.05</minSeverity>
+          <label>coming down</label>
+          <painFactor>0.75</painFactor>
+          <restFallFactor>0.75</restFallFactor>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>0.05</offset>
+            </li>
+            <li>
+              <capacity>Sight</capacity>
+              <offset>0.05</offset>
+            </li>
+            <li>
+              <capacity>Moving</capacity>
+              <offset>0.1</offset>
+            </li>
+          </capMods>
+          <statFactors>
+            <Suppressability>0.75</Suppressability>
+          </statFactors>
+        </li>
+        <li>
+          <minSeverity>0.15</minSeverity>
+          <label>full-on high</label>
           <painFactor>0</painFactor>
           <restFallFactor>0.33</restFallFactor>
           <capMods>
@@ -125,6 +162,29 @@
             <Suppressability>0</Suppressability>
           </statFactors>
         </li>
+        <li>
+          <minSeverity>0.9375</minSeverity>
+          <label>kicking in</label>
+          <painFactor>0.5</painFactor>
+          <restFallFactor>0.5</restFallFactor>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>0.1</offset>
+            </li>
+            <li>
+              <capacity>Sight</capacity>
+              <offset>0.1</offset>
+            </li>
+            <li>
+              <capacity>Moving</capacity>
+              <offset>0.2</offset>
+            </li>
+          </capMods>
+          <statFactors>
+            <Suppressability>0.5</Suppressability>
+          </statFactors>
+        </li>
       </stages>
   </HediffDef>
 
@@ -135,9 +195,24 @@
     <validWhileDespawned>true</validWhileDespawned>
     <stages>
       <li>
+        <label>coming down from psycho</label>
+        <description>Something is wrong.</description>
+        <baseMoodEffect>0</baseMoodEffect>
+      </li>
+      <li>
+        <label>barely high on psycho</label>
+        <description>I still feel so good.</description>
+        <baseMoodEffect>20</baseMoodEffect>
+      </li>
+      <li>
         <label>high on psycho</label>
         <description>I AM GOD!</description>
         <baseMoodEffect>50</baseMoodEffect>
+      </li>
+      <li>
+        <label>almost high on psycho</label>
+        <description>I feel like a god.</description>
+        <baseMoodEffect>40</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>
@@ -147,7 +222,7 @@
     <label>psycho crash</label>
     <labelNoun>a psycho crash</labelNoun>
     <description>A very unpleasant delayed after-effect of psycho intake.</description>
-    <hediffClass>Hediff_Hangover</hediffClass>
+    <hediffClass>HediffWithComps</hediffClass>
     <initialSeverity>1</initialSeverity>
     <scenarioCanAdd>false</scenarioCanAdd>
     <comps>
@@ -157,7 +232,6 @@
     </comps>
     <stages>
       <li>
-        <minSeverity>0</minSeverity>
         <label>recovering</label>
           <capMods>
             <li>
@@ -167,7 +241,7 @@
           </capMods>
       </li>
       <li>
-        <minSeverity>0.25</minSeverity>
+        <minSeverity>0.2</minSeverity>
         <label>serious</label>
 		<vomitMtbDays>0.5</vomitMtbDays>
           <capMods>
@@ -177,15 +251,26 @@
             </li>
           </capMods>
       </li>
-      <!-- starts low because it isn't visible until alcohol hediff is gone-->
       <li>
-        <minSeverity>0.5</minSeverity>
+        <minSeverity>0.4</minSeverity>
         <label>lethal</label>
+		<painFactor>0.1</painFactor>
         <vomitMtbDays>0.2</vomitMtbDays>
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
               <setMax>0.1</setMax>
+            </li>
+          </capMods>
+      </li>
+      <li>
+        <minSeverity>0.8</minSeverity>
+        <label>initial</label>
+		<vomitMtbDays>0.5</vomitMtbDays>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>-0.1</offset>
             </li>
           </capMods>
       </li>
@@ -199,19 +284,24 @@
     <validWhileDespawned>true</validWhileDespawned>
     <stages>
       <li>
-        <label>mild comedown</label>
-        <description>Let's not do this again.</description>
+        <label>mild psycho comedown</label>
+        <description>Let's not do this again...</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
       <li>
-        <label>serious comedown</label>
+        <label>serious psycho comedown</label>
         <description>I might survive this after all.</description>
         <baseMoodEffect>-10</baseMoodEffect>
       </li>
       <li>
-        <label>lethal comedown</label>
+        <label>lethal psycho comedown</label>
         <description>It feels like I'm dying.</description>
         <baseMoodEffect>-20</baseMoodEffect>
+      </li>
+      <li>
+        <label>initial psycho comedown</label>
+        <description>I don't feel so good.</description>
+        <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -24,6 +24,7 @@
       <MarketValue>7</MarketValue>
       <Mass>0.05</Mass>
     </statBases>
+    <generateCommonality>0.5</generateCommonality>
     <techLevel>Neolithic</techLevel>
     <minRewardCount>10</minRewardCount>
     <ingestible>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -142,7 +142,7 @@
     </stages>
   </ThoughtDef>
   
- <HediffDef>
+  <HediffDef>
     <defName>PsychoCrash</defName>
     <label>psycho crash</label>
     <labelNoun>a psycho crash</labelNoun>
@@ -162,17 +162,18 @@
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
-              <offset>-0.1</offset>
+              <offset>-0.2</offset>
             </li>
           </capMods>
       </li>
       <li>
         <minSeverity>0.25</minSeverity>
         <label>serious</label>
+		<vomitMtbDays>0.5</vomitMtbDays>
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
-              <offset>-0.35</offset>
+              <offset>-0.5</offset>
             </li>
           </capMods>
       </li>
@@ -184,7 +185,7 @@
           <capMods>
             <li>
               <capacity>Consciousness</capacity>
-              <offset>-0.75</offset>
+              <setMax>0.1</setMax>
             </li>
           </capMods>
       </li>
@@ -211,9 +212,6 @@
         <label>lethal comedown</label>
         <description>It feels like I'm dying.</description>
         <baseMoodEffect>-20</baseMoodEffect>
-      </li>
-      <li>
-        <visible>false</visible>
       </li>
     </stages>
   </ThoughtDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -105,7 +105,6 @@
     </comps>
       <stages>
         <li>
-          <label>crash</label>
           <hediffGivers>
             <li Class="HediffGiver_Random">
               <hediff>PsychoCrash</hediff>
@@ -118,7 +117,6 @@
         </li>
         <li>
           <minSeverity>0.05</minSeverity>
-          <label>coming down</label>
           <painFactor>0.75</painFactor>
           <restFallFactor>0.75</restFallFactor>
           <capMods>
@@ -141,7 +139,6 @@
         </li>
         <li>
           <minSeverity>0.15</minSeverity>
-          <label>full-on high</label>
           <painFactor>0.1</painFactor>
           <restFallFactor>0.33</restFallFactor>
           <capMods>
@@ -162,29 +159,6 @@
             <Suppressability>0.1</Suppressability>
           </statFactors>
         </li>
-        <li>
-          <minSeverity>0.9375</minSeverity>
-          <label>kicking in</label>
-          <painFactor>0.5</painFactor>
-          <restFallFactor>0.5</restFallFactor>
-          <capMods>
-            <li>
-              <capacity>Consciousness</capacity>
-              <offset>0.1</offset>
-            </li>
-            <li>
-              <capacity>Sight</capacity>
-              <offset>0.1</offset>
-            </li>
-            <li>
-              <capacity>Moving</capacity>
-              <offset>0.2</offset>
-            </li>
-          </capMods>
-          <statFactors>
-            <Suppressability>0.5</Suppressability>
-          </statFactors>
-        </li>
       </stages>
   </HediffDef>
 
@@ -202,17 +176,12 @@
       <li>
         <label>barely high on psycho</label>
         <description>I still feel so good.</description>
-        <baseMoodEffect>20</baseMoodEffect>
+        <baseMoodEffect>10</baseMoodEffect>
       </li>
       <li>
         <label>high on psycho</label>
         <description>I AM GOD!</description>
-        <baseMoodEffect>50</baseMoodEffect>
-      </li>
-      <li>
-        <label>almost high on psycho</label>
-        <description>I feel like a god.</description>
-        <baseMoodEffect>40</baseMoodEffect>
+        <baseMoodEffect>30</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -4,7 +4,7 @@
   <ThingDef ParentName="MakeableDrugBase">
     <defName>Psycho</defName>
     <label>psycho</label>
-    <description>A very refined and concentrated powdery preparation of the psychite drug. When snorted, it produces a very rapid euphoric high, dramatically reduces the user's need for rest, blocks pain, inceases movement speed and heightens the user's consciousness. Like all forms of psychite, it is addictive, though it is even more addictive than the other variants.\n\nBecause of the crude process of the production of this drug and it being very concentrated, aside from it being very addictive and having a high overdose chance, it can have a very nastry crash period. It is advised that this drug should only be taken in dire situations and as a last resort.</description>
+    <description>A coarse, powdery preparation of concentrated psychite. When snorted, it produces an intense feeling of euphoria and invigoration, dramatically reducing the user's perception of pain and sharpening their senses for a short time. The high is followed by an equally intense and very unpleasant crash. Owing to its high potency and crude preparation, psycho is even more dangerous and addictive than other drugs derived from psychoid leave.\n\nMany tribal warriors take psycho before entering battle, heightening their senses and allowing them to briefly ignore otherwise incapacitating wounds.</description>
     <descriptionHyperlinks>
       <HediffDef>PsychoHigh</HediffDef>
       <HediffDef>PsychiteTolerance</HediffDef>
@@ -167,17 +167,17 @@
     <stages>
       <li>
         <label>coming down from psycho</label>
-        <description>Something is wrong...</description>
+        <description>Things are slowing down and my head is starting to pound.</description>
         <baseMoodEffect>0</baseMoodEffect>
       </li>
       <li>
-        <label>barely high on psycho</label>
+        <label>fading psycho high</label>
         <description>I still feel so good.</description>
         <baseMoodEffect>5</baseMoodEffect>
       </li>
       <li>
-        <label>high on psycho</label>
-        <description>I AM GOD!</description>
+        <label>psycho high</label>
+        <description>I feel powerful and ready for anything.</description>
         <baseMoodEffect>10</baseMoodEffect>
       </li>
     </stages>
@@ -242,18 +242,18 @@
     <validWhileDespawned>true</validWhileDespawned>
     <stages>
       <li>
-        <label>recovering from psycho comedown</label>
-        <description>Let's not do this again...</description>
+        <label>fading psycho comedown</label>
+        <description>Ugh. My head is pounding, but at least I can think straight again.</description>
         <baseMoodEffect>-2</baseMoodEffect>
       </li>
       <li>
         <label>major psycho comedown</label>
-        <description>I might be dying.</description>
+        <description>I feel awful. My mind feels sluggish and I can barely keep my balance.</description>
         <baseMoodEffect>-10</baseMoodEffect>
       </li>
       <li>
         <label>initial psycho comedown</label>
-        <description>I don't feel so good.</description>
+        <description>I don't feel so good. My vision is blurry and my hands are starting to shake.</description>
         <baseMoodEffect>-5</baseMoodEffect>
       </li>
     </stages>

--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -1,0 +1,221 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingDef ParentName="MakeableDrugBase">
+    <defName>Psycho</defName>
+    <label>psycho</label>
+    <description>A refined powdery preparation of the psychite drug. When snorted, it produces a rapid euphoric high, dramatically reduces the user's need for rest, and suppresses pain. Like all forms of psychite, it is addictive, though it is not as addictive as the cruder flake.\n\nBecause of its high cost and refined appearance, many cultures associate yayo with degenerate wealth. Whether in the throneroom or the boardroom, many hare-brained policy schemes have been developed during yayo-fueled binge parties.</description>
+    <descriptionHyperlinks>
+      <HediffDef>PsychoHigh</HediffDef>
+      <HediffDef>PsychiteTolerance</HediffDef>
+	  <HediffDef>PsychoCrash</HediffDef>
+      <HediffDef>PsychiteAddiction</HediffDef>
+      <HediffDef>ChemicalDamageSevere</HediffDef>
+    </descriptionHyperlinks>
+    <graphicData>
+      <texPath>Things/Item/Drug/Yayo</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+	  <color>(95,125,95)</color>
+      <drawSize>0.75</drawSize>
+    </graphicData>
+    <rotatable>false</rotatable>
+    <statBases>
+      <WorkToMake>600</WorkToMake>
+      <MarketValue>7</MarketValue>
+      <Mass>0.05</Mass>
+    </statBases>
+    <techLevel>Neolithic</techLevel>
+    <minRewardCount>10</minRewardCount>
+    <ingestible>
+      <foodType>Processed</foodType>
+      <joyKind>Chemical</joyKind>
+      <joy>1.0</joy>
+      <drugCategory>Hard</drugCategory>
+      <baseIngestTicks>60</baseIngestTicks>
+      <ingestSound>Ingest_Snort</ingestSound>
+      <ingestHoldOffsetStanding>
+        <northDefault>
+          <offset>(0.07,0,0)</offset>
+        </northDefault>
+      </ingestHoldOffsetStanding>
+      <ingestHoldUsesTable>false</ingestHoldUsesTable>
+      <ingestCommandString>Snort {0}</ingestCommandString>
+      <ingestReportString>Snorting {0}.</ingestReportString>
+      <useEatingSpeedStat>false</useEatingSpeedStat>
+      <outcomeDoers>
+        <li Class="IngestionOutcomeDoer_GiveHediff">
+          <hediffDef>PsychoHigh</hediffDef>
+          <severity>1.0</severity>
+          <toleranceChemical>Psychite</toleranceChemical>
+        </li>
+        <li Class="IngestionOutcomeDoer_OffsetNeed">
+          <need>Rest</need>
+          <offset>0.6</offset>
+          <toleranceChemical>Psychite</toleranceChemical>
+        </li>
+        <li Class="IngestionOutcomeDoer_GiveHediff">
+          <hediffDef>PsychiteTolerance</hediffDef>
+          <severity>0.1</severity>
+          <divideByBodySize>true</divideByBodySize>
+        </li>
+        <li Class="IngestionOutcomeDoer_OffsetPsyfocus">
+          <offset>0.25</offset>
+        </li>
+      </outcomeDoers>
+    </ingestible>
+    <recipeMaker>
+      <recipeUsers>
+        <li>CraftingSpot</li>
+        <li>DrugLab</li>
+      </recipeUsers>
+      <soundWorking>Recipe_Drug</soundWorking>
+    </recipeMaker>
+    <costList>
+      <PsychoidLeaves>16</PsychoidLeaves>
+    </costList>
+    <comps>
+      <li Class="CompProperties_Drug">
+        <chemical>Psychite</chemical>
+        <addictiveness>0.25</addictiveness>
+        <existingAddictionSeverityOffset>0.25</existingAddictionSeverityOffset>
+        <needLevelOffset>1.0</needLevelOffset>
+        <isCombatEnhancingDrug>true</isCombatEnhancingDrug>
+        <listOrder>150</listOrder>
+        <overdoseSeverityOffset>0.25~0.50</overdoseSeverityOffset>
+        <largeOverdoseChance>0.1</largeOverdoseChance>
+      </li>
+    </comps>
+  </ThingDef>
+
+  <HediffDef>
+    <defName>PsychoHigh</defName>
+    <label>high on psycho</label>
+    <labelNoun>a psycho high</labelNoun>
+    <description>Active psycho in the bloodstream. Generates a very intense euphoric high.</description>
+    <hediffClass>Hediff_High</hediffClass>
+    <defaultLabelColor>(1,0,0.5)</defaultLabelColor>
+    <scenarioCanAdd>true</scenarioCanAdd>
+    <maxSeverity>1.0</maxSeverity>
+    <isBad>false</isBad>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-3.0</severityPerDay>
+        <showHoursToRecover>true</showHoursToRecover>
+      </li>
+    </comps>
+      <stages>
+        <li>
+          <painFactor>0</painFactor>
+          <restFallFactor>0.33</restFallFactor>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>0.20</offset>
+            </li>
+            <li>
+              <capacity>Sight</capacity>
+              <offset>0.20</offset>
+            </li>
+            <li>
+              <capacity>Moving</capacity>
+              <offset>0.33</offset>
+            </li>
+          </capMods>
+          <statFactors>
+            <Suppressability>0</Suppressability>
+          </statFactors>
+        </li>
+      </stages>
+  </HediffDef>
+
+  <ThoughtDef>
+    <defName>PsychoHigh</defName>
+    <workerClass>ThoughtWorker_Hediff</workerClass>
+    <hediff>PsychoHigh</hediff>
+    <validWhileDespawned>true</validWhileDespawned>
+    <stages>
+      <li>
+        <label>high on psycho</label>
+        <description>I AM GOD!</description>
+        <baseMoodEffect>50</baseMoodEffect>
+      </li>
+    </stages>
+  </ThoughtDef>
+  
+ <HediffDef>
+    <defName>PsychoCrash</defName>
+    <label>psycho crash</label>
+    <labelNoun>a psycho crash</labelNoun>
+    <description>A very unpleasant delayed after-effect of psycho intake.</description>
+    <hediffClass>Hediff_Hangover</hediffClass>
+    <initialSeverity>1</initialSeverity>
+    <scenarioCanAdd>false</scenarioCanAdd>
+    <comps>
+      <li Class="HediffCompProperties_SeverityPerDay">
+        <severityPerDay>-0.5</severityPerDay>
+      </li>
+    </comps>
+    <stages>
+      <li>
+        <minSeverity>0</minSeverity>
+        <label>recovering</label>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>-0.1</offset>
+            </li>
+          </capMods>
+      </li>
+      <li>
+        <minSeverity>0.25</minSeverity>
+        <label>serious</label>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>-0.35</offset>
+            </li>
+          </capMods>
+      </li>
+      <!-- starts low because it isn't visible until alcohol hediff is gone-->
+      <li>
+        <minSeverity>0.5</minSeverity>
+        <label>lethal</label>
+        <vomitMtbDays>0.2</vomitMtbDays>
+          <capMods>
+            <li>
+              <capacity>Consciousness</capacity>
+              <offset>-0.75</offset>
+            </li>
+          </capMods>
+      </li>
+    </stages>
+  </HediffDef>
+
+  <ThoughtDef>
+    <defName>Crashed</defName>
+    <workerClass>ThoughtWorker_Hediff</workerClass>
+    <hediff>PsychoCrash</hediff>
+    <validWhileDespawned>true</validWhileDespawned>
+    <stages>
+      <li>
+        <label>mild comedown</label>
+        <description>Let's not do this again.</description>
+        <baseMoodEffect>-5</baseMoodEffect>
+      </li>
+      <li>
+        <label>serious comedown</label>
+        <description>I might survive this after all.</description>
+        <baseMoodEffect>-10</baseMoodEffect>
+      </li>
+      <li>
+        <label>lethal comedown</label>
+        <description>It feels like I'm dying.</description>
+        <baseMoodEffect>-20</baseMoodEffect>
+      </li>
+      <li>
+        <visible>false</visible>
+      </li>
+    </stages>
+  </ThoughtDef>
+
+</Defs>

--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -142,7 +142,7 @@
     <weaponTags>
       <li>Gun</li>
     </weaponTags>
-    <combatEnhancingDrugsChance>0.5</combatEnhancingDrugsChance>
+    <combatEnhancingDrugsChance>0.3</combatEnhancingDrugsChance>
     <combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>
     <modExtensions>
       <li Class="CombatExtended.LoadoutPropertiesExtension">

--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -142,6 +142,8 @@
     <weaponTags>
       <li>Gun</li>
     </weaponTags>
+    <combatEnhancingDrugsChance>0.5</combatEnhancingDrugsChance>
+    <combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>
     <modExtensions>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -910,7 +910,7 @@
         @Name="TribalChiefBase"
       ]</xpath>
       <value>
-        <combatEnhancingDrugsChance>0.5</combatEnhancingDrugsChance>
+        <combatEnhancingDrugsChance>0.3</combatEnhancingDrugsChance>
         <combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>
       </value>
   </Operation>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -907,7 +907,7 @@
     <xpath>/Defs/PawnKindDef[
         defName="Tribal_Berserker" or
         defName="Tribal_HeavyArcher" or
-        @Name="Tribal_ChiefMelee"
+        @Name="TribalChiefBase"
       ]</xpath>
       <value>
         <combatEnhancingDrugsChance>0.5</combatEnhancingDrugsChance>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -901,6 +901,20 @@
    </match>
   </Operation>
 
+  <!-- Combat drugs for tribals  -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/PawnKindDef[
+        defName="Tribal_Berserker" or
+        defName="Tribal_HeavyArcher" or
+        @Name="Tribal_ChiefMelee"
+      ]</xpath>
+      <value>
+        <combatEnhancingDrugsChance>0.5</combatEnhancingDrugsChance>
+        <combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>
+      </value>
+  </Operation>
+
   <!-- Stranger in Black -->
   <Operation Class="PatchOperationAddModExtension">
     <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]</xpath>


### PR DESCRIPTION
## Additions

- Added a new crude combat enhancing drug called "Psycho".
- Enable high tier tribal pawns to carry combat enhancing drugs.

## References

- Contributes towards #1526 

## Reasoning

- A new combat drug that is readily available, relatively expensive to make but cheap to sell. Good stat bonuses but very bad side-effects. Highly addictive with relatively high chance of overdose, a last resort option for the player colony but a combat boost for high tier tribal pawns.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
