### PR TITLE
Fortifications Industrial Tile Bombardment Update

### DIFF
--- a/Patches/Fortifications - Industrial/FT_Artillery.xml
+++ b/Patches/Fortifications - Industrial/FT_Artillery.xml
@@ -24,7 +24,6 @@
 			<xpath>
 			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/comps/li[@Class = "CompProperties_Refuelable"] |
 			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/inspectorTabs |
-			Defs/ThingDef[defName="FT_TurretPrince"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"] |
 			Defs/ThingDef[defName="FT_TurretHexMortar" or defName="FT_TurretPrince"]/building/buildingTags/li[text()="Artillery_BaseDestroyer"]
 			</xpath>
 		</li>
@@ -271,11 +270,7 @@
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/inspectorTabs</xpath>
 				</li>
-	  
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/comps/li[@Class="VFESecurity.CompProperties_LongRangeArtillery"]</xpath>
-				</li>
-	  
+
 				<li Class="PatchOperationRemove">
 					<xpath>Defs/ThingDef[defName="FT_TurretEmpero"]/building/buildingTags</xpath>
 				</li>


### PR DESCRIPTION
## Changes
- Removed the patch for removing VFE: Security's World Tile bombardment as it is now compatible

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
