### PR TITLE
Fix NoSwitch tag for Ratkin ranged weapons

### DIFF
--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -494,7 +494,7 @@
 
 		  
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="RK_Rifle" or defName="RK_SniperRifle" or defName="RK_FlechetteRifle" or defName="RK_FlechetteSniperRifle" or defName="RK_Rifle_line"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="RK_Rifle" or defName="RK_SniperRifle" or defName="RK_FlechetteRifle" or defName="RK_FlechetteSniperRifle" or defName="RK_Rifle_line"]/weaponTags</xpath>
 			<value>
 				<li>NoSwitch</li>
 			</value>


### PR DESCRIPTION
## Changes

Fixed patch operation adding `NoSwitch` to correctly target the `weaponTags` node of Ratkin ranged weapons, rather than the (erroneous) `tools` node.

## References

- Fixes an outstanding issue for #1713

## Reasoning

The current patch causes load errors from startup, and prevents Ratkin NPCs from spawning on game maps.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without Ratkin mod loaded
- [x] Playtested a colony for ten minutes
