### PR TITLE
Tweak buildable mechs

### DIFF
--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
@@ -27,6 +27,7 @@
                         <CarryBulk>30</CarryBulk>
                         <AimingAccuracy>1.0</AimingAccuracy>
                         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
+                        <ReloadSpeed>1</ReloadSpeed>
                         <MeleeDodgeChance>0.19</MeleeDodgeChance>
                         <MeleeCritChance>0.22</MeleeCritChance>
                         <MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -116,8 +116,8 @@
 	<ammoSet>AmmoSet_50BMG</ammoSet>
       </AmmoUser>
       <FireModes>
-        <aimedBurstShotCount>5</aimedBurstShotCount>
         <aiAimMode>AimedShot</aiAimMode>
+        <aimedBurstShotCount>5</aimedBurstShotCount>
       </FireModes>
       <weaponTags>
         <li>NoSwitch</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -71,6 +71,8 @@
     <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Turret"]/statBases</xpath>
       <value>
+        <CarryWeight>100</CarryWeight>
+        <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
         <ReloadSpeed>1</ReloadSpeed>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -50,13 +50,6 @@
       </value>
     </li>
 
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>0.20</baseBodySize>
-      </value>
-    </li>
-
     <li Class="PatchOperationAddModExtension">
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret"or defName="VFE_Mechanoids_Autobroadcaster"]</xpath>
       <value>
@@ -67,11 +60,24 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases</xpath>
+      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0</MeleeDodgeChance>
         <MeleeCritChance>0.01</MeleeCritChance>
         <MeleeParryChance>0</MeleeParryChance>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Turret"]/statBases</xpath>
+      <value>
+        <AimingAccuracy>1.0</AimingAccuracy>
+        <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
+        <ReloadSpeed>1</ReloadSpeed>
+        <MeleeDodgeChance>0</MeleeDodgeChance>
+        <MeleeCritChance>0.01</MeleeCritChance>
+        <MeleeParryChance>0</MeleeParryChance>
+	<NightVisionEfficiency>0.40</NightVisionEfficiency>
       </value>
     </li>
 
@@ -126,6 +132,7 @@
         <CarryBulk>30</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
+        <ReloadSpeed>1</ReloadSpeed>
         <MeleeDodgeChance>0.19</MeleeDodgeChance>
         <MeleeCritChance>0.22</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>


### PR DESCRIPTION
## Changes

- Removed the bodysize patch for the threaded mechs because it was a flat nerf to their carry capacity stats not allowing them to carry ammo.
- Added a reload speed node to the buildable mechs because they start with 0 shooting skill which nerfs their reload speed to 0.75.
- Added proper combat related stats to the mobile turret now that it is functional.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
