### PR TITLE
Adjust turret gun mass values

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -51,6 +51,7 @@
       <SwayFactor>0.72</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
       <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
+      <Mass>5</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -93,6 +94,7 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>0.98</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>30</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -135,6 +137,7 @@
       <ShotSpread>0.03</ShotSpread>
       <SwayFactor>0.86</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>10</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -177,6 +180,7 @@
       <ShotSpread>0.1</ShotSpread>
       <SwayFactor>1.42</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>50</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -227,6 +231,7 @@
       <SwayFactor>1.14</SwayFactor>
       <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
       <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
+      <Mass>50</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -271,6 +276,7 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.6</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>35</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -317,6 +323,7 @@
       <ShotSpread>0.04</ShotSpread>
       <SwayFactor>0.96</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <Mass>12</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -364,6 +371,7 @@
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.14</SwayFactor>
       <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
+      <Mass>500</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
@@ -411,6 +419,7 @@
       <ShotSpread>0.15</ShotSpread>
       <SwayFactor>0.92</SwayFactor>
       <RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+      <Mass>13</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">


### PR DESCRIPTION
## Additions

- Added proper mass nodes to vanilla and CE-added turret guns.

## Reasoning

- Currently the turret guns added by CE only have a mass of 1kg which is not appropriate when all turret guns have a mass value in vanilla game.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
