### PR TITLE
Fix Gunlink's stats

### DIFF
--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -85,7 +85,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAttributeAdd">
-    <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
+    <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/costList</xpath>
     <attribute>Inherit</attribute>
       <value>false</value>
   </Operation>
@@ -93,7 +93,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/equippedStatOffsets</xpath>
     <value>
-      <equippedStatOffsets>
+      <equippedStatOffsets Inherit="False">
         <AimingAccuracy>0.6</AimingAccuracy>
         <ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
       </equippedStatOffsets>


### PR DESCRIPTION
## Changes

- What it says on the tin, fixed Gunlink's stat offsets and recipe materials. 

## Reasoning

- Inheritance issues caused by the parent being def `ApparelArmorHelmetReconBase`.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
