### PR TITLE
High caliber AP rounds and housekeeping

### DIFF
--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -133,7 +133,7 @@
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>40</damageAmountBase>
-      <armorPenetrationSharp>20</armorPenetrationSharp>
+      <armorPenetrationSharp>15</armorPenetrationSharp>
       <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -143,7 +143,7 @@
     <label>12.7x108mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -153,7 +153,7 @@
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
       <armorPenetrationBlunt>348.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -169,7 +169,7 @@
     <label>12.7x108mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>39</damageAmountBase>
-      <armorPenetrationSharp>20</armorPenetrationSharp>
+      <armorPenetrationSharp>15</armorPenetrationSharp>
       <armorPenetrationBlunt>296.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -186,7 +186,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>234</speed>
 	    <damageAmountBase>20</damageAmountBase>
-	    <armorPenetrationSharp>70</armorPenetrationSharp>
+	    <armorPenetrationSharp>53</armorPenetrationSharp>
 	    <armorPenetrationBlunt>339.48</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -242,7 +242,7 @@
     <products>
       <Ammo_127x108mm_AP>200</Ammo_127x108mm_AP>
     </products>
-    <workAmount>6300</workAmount>
+    <workAmount>5200</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -15,11 +15,12 @@
     <label>12.7x108mm Soviet</label>
     <ammoTypes>
       <Ammo_127x108mm_FMJ>Bullet_127x108mm_FMJ</Ammo_127x108mm_FMJ>
+      <Ammo_127x108mm_AP>Bullet_127x108mm_AP</Ammo_127x108mm_AP>
       <Ammo_127x108mm_Incendiary>Bullet_127x108mm_Incendiary</Ammo_127x108mm_Incendiary>
       <Ammo_127x108mm_HE>Bullet_127x108mm_HE</Ammo_127x108mm_HE>
-			<Ammo_127x108mm_Sabot>Bullet_127x108mm_Sabot</Ammo_127x108mm_Sabot>	         
+      <Ammo_127x108mm_Sabot>Bullet_127x108mm_Sabot</Ammo_127x108mm_Sabot>	         
     </ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
+    <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -52,6 +53,20 @@
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
+    <defName>Ammo_127x108mm_AP</defName>
+    <label>12.7x108mm cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.52</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_127x108mm_AP</cookOffProjectile>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
@@ -124,6 +139,16 @@
   </ThingDef>
 
   <ThingDef ParentName="Base127x108mmBullet">
+    <defName>Bullet_127x108mm_AP</defName>
+    <label>12.7x108mm bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>26</damageAmountBase>
+      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_Incendiary</defName>
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -160,9 +185,9 @@
     <label>12.7x108mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>234</speed>
-      <damageAmountBase>20</damageAmountBase>
-      <armorPenetrationSharp>70</armorPenetrationSharp>
-      <armorPenetrationBlunt>339.48</armorPenetrationBlunt>
+	    <damageAmountBase>20</damageAmountBase>
+	    <armorPenetrationSharp>70</armorPenetrationSharp>
+	    <armorPenetrationBlunt>339.48</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -192,6 +217,32 @@
       <Ammo_127x108mm_FMJ>200</Ammo_127x108mm_FMJ>
     </products>
     <workAmount>5200</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_127x108mm_AP</defName>
+    <label>make 12.7x108mm (AP) cartridge x200</label>
+    <description>Craft 200 12.7x108mm (AP) cartridges.</description>
+    <jobString>Making 12.7x108mm (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>52</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_127x108mm_AP>200</Ammo_127x108mm_AP>
+    </products>
+    <workAmount>6300</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -130,7 +130,7 @@
 		<label>13.2mm TuF bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>40</damageAmountBase>
-			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -140,7 +140,7 @@
 		<label>13.2mm TuF bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>44</armorPenetrationSharp>
+			<armorPenetrationSharp>28</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -150,7 +150,7 @@
 		<label>13.2x92mmSR TuF bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>44</armorPenetrationSharp>
+			<armorPenetrationSharp>28</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -166,7 +166,7 @@
 		<label>13.2x92mmSR TuF bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>40</damageAmountBase>
-			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -183,7 +183,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>236</speed>
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>77</armorPenetrationSharp>
+			<armorPenetrationSharp>49</armorPenetrationSharp>
 			<armorPenetrationBlunt>406.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_132x92mmSRTuF_AP>200</Ammo_132x92mmSRTuF_AP>
 		</products>
-		<workAmount>7000</workAmount>
+		<workAmount>5800</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -16,8 +16,8 @@
 		<ammoTypes>
 			<Ammo_132x92mmSRTuF_FMJ>Bullet_132x92mmSRTuF_FMJ</Ammo_132x92mmSRTuF_FMJ>
 			<Ammo_132x92mmSRTuF_AP>Bullet_132x92mmSRTuF_AP</Ammo_132x92mmSRTuF_AP>
-      		<Ammo_132x92mmSRTuF_HE>Bullet_132x92mmSRTuF_HE</Ammo_132x92mmSRTuF_HE>
-      		<Ammo_132x92mmSRTuF_Incendiary>Bullet_132x92mmSRTuF_Incendiary</Ammo_132x92mmSRTuF_Incendiary>
+			<Ammo_132x92mmSRTuF_HE>Bullet_132x92mmSRTuF_HE</Ammo_132x92mmSRTuF_HE>
+			<Ammo_132x92mmSRTuF_Incendiary>Bullet_132x92mmSRTuF_Incendiary</Ammo_132x92mmSRTuF_Incendiary>
 			<Ammo_132x92mmSRTuF_Sabot>Bullet_132x92mmSRTuF_Sabot</Ammo_132x92mmSRTuF_Sabot>	    
 		</ammoTypes>
 		<similarTo>AmmoSet_AntiMateriel</similarTo>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -15,6 +15,7 @@
 		<label>13.2x92mmSR TuF</label>
 		<ammoTypes>
 			<Ammo_132x92mmSRTuF_FMJ>Bullet_132x92mmSRTuF_FMJ</Ammo_132x92mmSRTuF_FMJ>
+			<Ammo_132x92mmSRTuF_AP>Bullet_132x92mmSRTuF_AP</Ammo_132x92mmSRTuF_AP>
       		<Ammo_132x92mmSRTuF_HE>Bullet_132x92mmSRTuF_HE</Ammo_132x92mmSRTuF_HE>
       		<Ammo_132x92mmSRTuF_Incendiary>Bullet_132x92mmSRTuF_Incendiary</Ammo_132x92mmSRTuF_Incendiary>
 			<Ammo_132x92mmSRTuF_Sabot>Bullet_132x92mmSRTuF_Sabot</Ammo_132x92mmSRTuF_Sabot>	    
@@ -27,13 +28,13 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo132x92mmSRTuFBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Outdated large caliber bullet used in anti-materiel rifles.</description>
 		<statBases>
-		<Mass>0.142</Mass>
-		<Bulk>0.09</Bulk>
+			<Mass>0.142</Mass>
+			<Bulk>0.09</Bulk>
 		</statBases>
-	<tradeTags>
-		<li>CE_AutoEnableTrade</li>
-		<li>CE_AutoEnableCrafting</li>
-	</tradeTags>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
 		<thingCategories>
 			<li>Ammo132x92mmSRTuF</li>
 		</thingCategories>
@@ -54,14 +55,28 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
+		<defName>Ammo_132x92mmSRTuF_AP</defName>
+		<label>13.2x92mmSR TuF cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.58</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_132x92mmSRTuF_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_Incendiary</defName>
 		<label>13.2x92mmSR TuF cartridge (AP-I)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.77</MarketValue>   
+			<MarketValue>0.77</MarketValue>   
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_132x92mmSRTuF_Incendiary</cookOffProjectile>
@@ -71,11 +86,11 @@
 		<defName>Ammo_132x92mmSRTuF_HE</defName>
 		<label>13.2x92mmSR TuF cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>1.15</MarketValue>
+			<MarketValue>1.15</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_132x92mmSRTuF_HE</cookOffProjectile>
@@ -85,12 +100,12 @@
 		<defName>Ammo_132x92mmSRTuF_Sabot</defName>
 		<label>13.2x92mmSR TuF cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.63</MarketValue>
-		<Mass>0.12</Mass>
+			<MarketValue>0.63</MarketValue>
+			<Mass>0.12</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_132x92mmSRTuF_Sabot</cookOffProjectile>
@@ -121,18 +136,28 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base132x92mmSRTuFBullet">
+		<defName>Bullet_132x92mmSRTuF_AP</defName>
+		<label>13.2mm TuF bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>25</damageAmountBase>
+			<armorPenetrationSharp>44</armorPenetrationSharp>
+			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_Incendiary</defName>
 		<label>13.2x92mmSR TuF bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>25</damageAmountBase>
-		<armorPenetrationSharp>44</armorPenetrationSharp>
-		<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Flame_Secondary</def>
-			<amount>16</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>25</damageAmountBase>
+			<armorPenetrationSharp>44</armorPenetrationSharp>
+			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Flame_Secondary</def>
+				<amount>16</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -140,15 +165,15 @@
 		<defName>Bullet_132x92mmSRTuF_HE</defName>
 		<label>13.2x92mmSR TuF bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>40</damageAmountBase>
-		<armorPenetrationSharp>22</armorPenetrationSharp>
-		<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Bomb_Secondary</def>
-			<amount>24</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>40</damageAmountBase>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bomb_Secondary</def>
+				<amount>24</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -157,9 +182,9 @@
 		<label>13.2x92mmSR TuF bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>236</speed>
-		<damageAmountBase>21</damageAmountBase>
-		<armorPenetrationSharp>77</armorPenetrationSharp>
-		<armorPenetrationBlunt>406.94</armorPenetrationBlunt>
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>77</armorPenetrationSharp>
+			<armorPenetrationBlunt>406.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   
@@ -189,6 +214,32 @@
 			<Ammo_132x92mmSRTuF_FMJ>200</Ammo_132x92mmSRTuF_FMJ>
 		</products>
 		<workAmount>5800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_132x92mmSRTuF_AP</defName>
+		<label>make 13.2x92mmSR TuF (AP) cartridge x350</label>
+		<description>Craft 350 13.2x92mmSR TuF (AP) cartridges.</description>
+		<jobString>Making 13.2x92mmSR TuF (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>58</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_132x92mmSRTuF_AP>200</Ammo_132x92mmSRTuF_AP>
+		</products>
+		<workAmount>7000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_145x114mm_AP>200</Ammo_145x114mm_AP>
     </products>
-    <workAmount>9000</workAmount>
+    <workAmount>7600</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -18,7 +18,7 @@
       <Ammo_145x114mm_AP>Bullet_145x114mm_AP</Ammo_145x114mm_AP>
       <Ammo_145x114mm_Incendiary>Bullet_145x114mm_Incendiary</Ammo_145x114mm_Incendiary>
       <Ammo_145x114mm_HE>Bullet_145x114mm_HE</Ammo_145x114mm_HE>
-	  <Ammo_145x114mm_Sabot>Bullet_145x114mm_Sabot</Ammo_145x114mm_Sabot>	  
+      <Ammo_145x114mm_Sabot>Bullet_145x114mm_Sabot</Ammo_145x114mm_Sabot>	  
     </ammoTypes>
     <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -15,11 +15,12 @@
     <label>14.5x114mm</label>
     <ammoTypes>
       <Ammo_145x114mm_FMJ>Bullet_145x114mm_FMJ</Ammo_145x114mm_FMJ>
+      <Ammo_145x114mm_AP>Bullet_145x114mm_AP</Ammo_145x114mm_AP>
       <Ammo_145x114mm_Incendiary>Bullet_145x114mm_Incendiary</Ammo_145x114mm_Incendiary>
       <Ammo_145x114mm_HE>Bullet_145x114mm_HE</Ammo_145x114mm_HE>
 	  <Ammo_145x114mm_Sabot>Bullet_145x114mm_Sabot</Ammo_145x114mm_Sabot>	  
     </ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
+    <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->
@@ -52,6 +53,20 @@
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_145x114mm_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
+    <defName>Ammo_145x114mm_AP</defName>
+    <label>14.5x114mm cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.76</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_145x114mm_AP</cookOffProjectile>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
@@ -122,6 +137,16 @@
   </ThingDef>
 
   <ThingDef ParentName="Base145x114mmBullet">
+    <defName>Bullet_145x114mm_AP</defName>
+    <label>14.5x114mm bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>33</damageAmountBase>
+      <armorPenetrationSharp>36</armorPenetrationSharp>
+      <armorPenetrationBlunt>634</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_Incendiary</defName>
     <label>14.5x114mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -163,6 +188,7 @@
       <armorPenetrationBlunt>820.360</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
+
   <!-- ==================== Recipes ========================== -->
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -189,6 +215,32 @@
       <Ammo_145x114mm_FMJ>200</Ammo_145x114mm_FMJ>
     </products>
     <workAmount>7600</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_145x114mm_AP</defName>
+    <label>make 14.5x114mm (AP) cartridge x200</label>
+    <description>Craft 200 14.5x114mm (AP) cartridges.</description>
+    <jobString>Making 14.5x114mm (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>76</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_145x114mm_AP>200</Ammo_145x114mm_AP>
+    </products>
+    <workAmount>9000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -15,11 +15,12 @@
     <label>15.2x169mm</label>
     <ammoTypes>
       <Ammo_152x169mm_FMJ>Bullet_152x169mm_FMJ</Ammo_152x169mm_FMJ>
-			<Ammo_152x169mm_Incendiary>Bullet_152x169mm_Incendiary</Ammo_152x169mm_Incendiary>
-			<Ammo_152x169mm_HE>Bullet_152x169mm_HE</Ammo_152x169mm_HE>
-			<Ammo_152x169mm_Sabot>Bullet_152x169mm_Sabot</Ammo_152x169mm_Sabot>	       
+      <Ammo_152x169mm_AP>Bullet_152x169mm_AP</Ammo_152x169mm_AP>
+      <Ammo_152x169mm_Incendiary>Bullet_152x169mm_Incendiary</Ammo_152x169mm_Incendiary>
+      <Ammo_152x169mm_HE>Bullet_152x169mm_HE</Ammo_152x169mm_HE>
+      <Ammo_152x169mm_Sabot>Bullet_152x169mm_Sabot</Ammo_152x169mm_Sabot>	       
     </ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
+    <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->
@@ -55,14 +56,28 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
+		<defName>Ammo_152x169mm_AP</defName>
+		<label>15.2x169mm cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.6</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_152x169mm_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
 		<defName>Ammo_152x169mm_Incendiary</defName>
 		<label>15.2x169mm cartridge (AP-I)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.73</MarketValue>
+			<MarketValue>0.73</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_152x169mm_Incendiary</cookOffProjectile>
@@ -72,11 +87,11 @@
 		<defName>Ammo_152x169mm_HE</defName>
 		<label>15.2x169mm cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>1.01</MarketValue>
+			<MarketValue>1.01</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_152x169mm_HE</cookOffProjectile>
@@ -86,8 +101,8 @@
 		<defName>Ammo_152x169mm_Sabot</defName>
 		<label>15.2x169mm cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.64</MarketValue>
@@ -121,18 +136,28 @@
     </ThingDef>
 
     <ThingDef ParentName="Base152x169mmBullet">
+      <defName>Bullet_152x169mm_AP</defName>
+      <label>15.2x169mm bullet (AP)</label>
+      <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageAmountBase>36</damageAmountBase>
+        <armorPenetrationSharp>35</armorPenetrationSharp>
+        <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
+      </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base152x169mmBullet">
       <defName>Bullet_152x169mm_Incendiary</defName>
       <label>15.2x169mm bullet (AP-I)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>35</armorPenetrationSharp>
-      <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-      <secondaryDamage>
-        <li>
-        <def>Flame_Secondary</def>
-        <amount>22</amount>
-        </li>
-      </secondaryDamage>
+		  <damageAmountBase>36</damageAmountBase>
+		  <armorPenetrationSharp>35</armorPenetrationSharp>
+		  <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			<def>Flame_Secondary</def>
+			<amount>22</amount>
+			</li>
+		  </secondaryDamage>
       </projectile>
     </ThingDef>
     
@@ -140,15 +165,15 @@
       <defName>Bullet_152x169mm_HE</defName>
       <label>15.2x169mm bullet (HE)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>56</damageAmountBase>
-      <armorPenetrationSharp>17</armorPenetrationSharp>
-      <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-      <secondaryDamage>
-        <li>
-        <def>Bomb_Secondary</def>
-        <amount>34</amount>
-        </li>
-      </secondaryDamage>
+		  <damageAmountBase>56</damageAmountBase>
+		  <armorPenetrationSharp>17</armorPenetrationSharp>
+		  <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			<def>Bomb_Secondary</def>
+			<amount>34</amount>
+			</li>
+		  </secondaryDamage>
       </projectile>
     </ThingDef>
 
@@ -157,9 +182,9 @@
       <label>15.2x169mm bullet (Sabot)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <speed>435</speed>
-      <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>60</armorPenetrationSharp>
-      <armorPenetrationBlunt>943.76</armorPenetrationBlunt>
+	    <damageAmountBase>30</damageAmountBase>
+	    <armorPenetrationSharp>60</armorPenetrationSharp>
+	    <armorPenetrationBlunt>943.76</armorPenetrationBlunt>
       </projectile>
     </ThingDef>
 
@@ -189,6 +214,32 @@
         <Ammo_152x169mm_FMJ>200</Ammo_152x169mm_FMJ>
       </products>
       <workAmount>6000</workAmount>
+    </RecipeDef>
+
+    <RecipeDef ParentName="AmmoRecipeBase">
+      <defName>MakeAmmo_152x169mm_AP</defName>
+      <label>make 15.2x169mm (AP) cartridge x200</label>
+      <description>Craft 200 15.2x169mm (AP) cartridges.</description>
+      <jobString>Making 15.2x169mm (AP) cartridges.</jobString>
+      <ingredients>
+        <li>
+          <filter>
+            <thingDefs>
+              <li>Steel</li>
+            </thingDefs>
+          </filter>
+          <count>60</count>
+        </li>
+      </ingredients>
+      <fixedIngredientFilter>
+        <thingDefs>
+          <li>Steel</li>
+        </thingDefs>
+      </fixedIngredientFilter>
+      <products>
+        <Ammo_152x169mm_AP>200</Ammo_152x169mm_AP>
+      </products>
+      <workAmount>6800</workAmount>
     </RecipeDef>
 
     <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -239,7 +239,7 @@
       <products>
         <Ammo_152x169mm_AP>200</Ammo_152x169mm_AP>
       </products>
-      <workAmount>6800</workAmount>
+      <workAmount>6000</workAmount>
     </RecipeDef>
 
     <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -15,11 +15,12 @@
 		<label>2-Bore</label>
 		<ammoTypes>
 			<Ammo_2Bore_FMJ>Bullet_2Bore_FMJ</Ammo_2Bore_FMJ>
+			<Ammo_2Bore_AP>Bullet_2Bore_AP</Ammo_2Bore_AP>
 			<Ammo_2Bore_Incendiary>Bullet_2Bore_Incendiary</Ammo_2Bore_Incendiary>
 			<Ammo_2Bore_HE>Bullet_2Bore_HE</Ammo_2Bore_HE>
 			<Ammo_2Bore_Sabot>Bullet_2Bore_Sabot</Ammo_2Bore_Sabot>	   			
 		</ammoTypes>
-    <similarTo>AmmoSet_AntiMateriel</similarTo>
+		<similarTo>AmmoSet_AntiMateriel</similarTo>
 	</CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->
@@ -52,6 +53,20 @@
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_2Bore_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
+		<defName>Ammo_2Bore_AP</defName>
+		<label>2-Bore cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.91</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_2Bore_AP</cookOffProjectile>
 	</ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
@@ -116,8 +131,18 @@
 		<label>2-Bore bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>57</damageAmountBase>
-      <armorPenetrationSharp>12</armorPenetrationSharp>
-      <armorPenetrationBlunt>345.26</armorPenetrationBlunt>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>345.26</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base2BoreBullet">
+		<defName>Bullet_2Bore_AP</defName>
+		<label>2-Bore bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>36</damageAmountBase>
+			<armorPenetrationSharp>24</armorPenetrationSharp>
+			<armorPenetrationBlunt>345.26</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -158,9 +183,9 @@
     <label>2-Bore bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>117</speed>
-      <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>44</armorPenetrationSharp>
-      <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
+	    <damageAmountBase>30</damageAmountBase>
+	    <armorPenetrationSharp>44</armorPenetrationSharp>
+	    <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -190,6 +215,32 @@
 			<Ammo_2Bore_FMJ>200</Ammo_2Bore_FMJ>
 		</products>
     <workAmount>19200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_2Bore_AP</defName>
+		<label>make 2-Bore (AP) cartridge x200</label>
+		<description>Craft 100 2-Bore (AP) cartridges.</description>
+		<jobString>Making 2-Bore (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>192</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_2Bore_AP>200</Ammo_2Bore_AP>
+		</products>
+    <workAmount>23800</workAmount>
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -240,7 +240,7 @@
 		<products>
 			<Ammo_2Bore_AP>200</Ammo_2Bore_AP>
 		</products>
-    <workAmount>23800</workAmount>
+    <workAmount>19200</workAmount>
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -17,9 +17,9 @@
       <Ammo_20x110mmHispano_AP>Bullet_20x110mmHispano_AP</Ammo_20x110mmHispano_AP>
       <Ammo_20x110mmHispano_Incendiary>Bullet_20x110mmHispano_Incendiary</Ammo_20x110mmHispano_Incendiary>
       <Ammo_20x110mmHispano_HE>Bullet_20x110mmHispano_HE</Ammo_20x110mmHispano_HE>
-	    <Ammo_20x110mmHispano_Sabot>Bullet_20x110mmHispano_Sabot</Ammo_20x110mmHispano_Sabot>	        
+      <Ammo_20x110mmHispano_Sabot>Bullet_20x110mmHispano_Sabot</Ammo_20x110mmHispano_Sabot>	        
     </ammoTypes>
-		<similarTo>AmmoSet_Autocannon</similarTo>
+    <similarTo>AmmoSet_Autocannon</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -158,11 +158,12 @@
     <label>14.5x114mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>254</speed>
-      <damageAmountBase>35</damageAmountBase>
-      <armorPenetrationSharp>49</armorPenetrationSharp>
-      <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>
+	    <damageAmountBase>35</damageAmountBase>
+	    <armorPenetrationSharp>49</armorPenetrationSharp>
+	    <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>
     </projectile>
-  </ThingDef> 
+  </ThingDef>
+
   <!-- ==================== Recipes ========================== -->
 
   <RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -158,9 +158,9 @@
     <label>20x128mm Oerlikon bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>311</speed>
-      <damageAmountBase>20</damageAmountBase>
-      <armorPenetrationSharp>63</armorPenetrationSharp>
-      <armorPenetrationBlunt>1642.44</armorPenetrationBlunt>
+	    <damageAmountBase>20</damageAmountBase>
+	    <armorPenetrationSharp>63</armorPenetrationSharp>
+	    <armorPenetrationBlunt>1642.44</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -132,16 +132,16 @@
 		<defName>Bullet_20x138mmB_HE</defName>
 		<label>20x138mmB bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>68</damageAmountBase>
-		<armorPenetrationSharp>20</armorPenetrationSharp>
-		<armorPenetrationBlunt>972</armorPenetrationBlunt>
-		<speed>180</speed>
-		<secondaryDamage>
-			<li>
-				<def>Bomb_Secondary</def>
-				<amount>41</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>68</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>972</armorPenetrationBlunt>
+			<speed>180</speed>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>41</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -150,9 +150,9 @@
     <label>20x138mmB bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>270</speed>
-      <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>70</armorPenetrationSharp>
-      <armorPenetrationBlunt>1257.52</armorPenetrationBlunt>
+	    <damageAmountBase>36</damageAmountBase>
+	    <armorPenetrationSharp>70</armorPenetrationSharp>
+	    <armorPenetrationBlunt>1257.52</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -17,9 +17,9 @@
       <Ammo_20x82mmMauser_AP>Bullet_20x82mmMauser_AP</Ammo_20x82mmMauser_AP>
       <Ammo_20x82mmMauser_Incendiary>Bullet_20x82mmMauser_Incendiary</Ammo_20x82mmMauser_Incendiary>
       <Ammo_20x82mmMauser_HE>Bullet_20x82mmMauser_HE</Ammo_20x82mmMauser_HE>
-	    <Ammo_20x82mmMauser_Sabot>Bullet_20x82mmMauser_Sabot</Ammo_20x82mmMauser_Sabot>	       
+      <Ammo_20x82mmMauser_Sabot>Bullet_20x82mmMauser_Sabot</Ammo_20x82mmMauser_Sabot>	       
     </ammoTypes>
-		<similarTo>AmmoSet_Autocannon</similarTo>
+    <similarTo>AmmoSet_Autocannon</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -158,9 +158,9 @@
     <label>20mm Mauser bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>216</speed>
-      <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>42</armorPenetrationSharp>
-      <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
+	    <damageAmountBase>30</damageAmountBase>
+	    <armorPenetrationSharp>42</armorPenetrationSharp>
+	    <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -17,9 +17,9 @@
       <Ammo_20x99mmRShVAK_AP>Bullet_20x99mmRShVAK_AP</Ammo_20x99mmRShVAK_AP>
       <Ammo_20x99mmRShVAK_Incendiary>Bullet_20x99mmRShVAK_Incendiary</Ammo_20x99mmRShVAK_Incendiary>
       <Ammo_20x99mmRShVAK_HE>Bullet_20x99mmRShVAK_HE</Ammo_20x99mmRShVAK_HE>
-	    <Ammo_20x99mmRShVAK_Sabot>Bullet_20x99mmRShVAK_Sabot</Ammo_20x99mmRShVAK_Sabot>	      
+      <Ammo_20x99mmRShVAK_Sabot>Bullet_20x99mmRShVAK_Sabot</Ammo_20x99mmRShVAK_Sabot>	      
     </ammoTypes>
-		<similarTo>AmmoSet_Autocannon</similarTo>
+    <similarTo>AmmoSet_Autocannon</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -158,9 +158,9 @@
     <label>20mmR ShVAK bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>225</speed>
-      <damageAmountBase>30</damageAmountBase>
-      <armorPenetrationSharp>47</armorPenetrationSharp>
-      <armorPenetrationBlunt>696.1</armorPenetrationBlunt>
+	    <damageAmountBase>30</damageAmountBase>
+	    <armorPenetrationSharp>47</armorPenetrationSharp>
+	    <armorPenetrationBlunt>696.1</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_300WinchesterMagnum_AP>200</Ammo_300WinchesterMagnum_AP>
     </products>
-    <workAmount>2000</workAmount>
+    <workAmount>1600</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -15,11 +15,12 @@
     <label>.300 Winchester Magnum</label>
     <ammoTypes>
       <Ammo_300WinchesterMagnum_FMJ>Bullet_300WinchesterMagnum_FMJ</Ammo_300WinchesterMagnum_FMJ>
-			<Ammo_300WinchesterMagnum_Incendiary>Bullet_300WinchesterMagnum_Incendiary</Ammo_300WinchesterMagnum_Incendiary>
-			<Ammo_300WinchesterMagnum_HE>Bullet_300WinchesterMagnum_HE</Ammo_300WinchesterMagnum_HE>
-			<Ammo_300WinchesterMagnum_Sabot>Bullet_300WinchesterMagnum_Sabot</Ammo_300WinchesterMagnum_Sabot>	   
+      <Ammo_300WinchesterMagnum_AP>Bullet_300WinchesterMagnum_AP</Ammo_300WinchesterMagnum_AP>
+      <Ammo_300WinchesterMagnum_Incendiary>Bullet_300WinchesterMagnum_Incendiary</Ammo_300WinchesterMagnum_Incendiary>
+      <Ammo_300WinchesterMagnum_HE>Bullet_300WinchesterMagnum_HE</Ammo_300WinchesterMagnum_HE>
+      <Ammo_300WinchesterMagnum_Sabot>Bullet_300WinchesterMagnum_Sabot</Ammo_300WinchesterMagnum_Sabot>	   
     </ammoTypes>
-		<similarTo>AmmoSet_RifleMagnum</similarTo>
+    <similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -54,6 +55,20 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
+    <defName>Ammo_300WinchesterMagnum_AP</defName>
+    <label>.300 Winchester Magnum cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.16</MarketValue>
+    </statBases>
+  	<ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_300WinchesterMagnum_AP</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
     <defName>Ammo_300WinchesterMagnum_Incendiary</defName>
     <label>.300 Winchester Magnum cartridge (AP-I)</label>
     <graphicData>
@@ -71,11 +86,11 @@
 		<defName>Ammo_300WinchesterMagnum_HE</defName>
 		<label>.300 Winchester Magnum cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.37</MarketValue>
+			<MarketValue>0.37</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_300WinchesterMagnum_HE</cookOffProjectile>
@@ -85,8 +100,8 @@
 		<defName>Ammo_300WinchesterMagnum_Sabot</defName>
 		<label>.300 Winchester Magnum cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.19</MarketValue>
@@ -106,7 +121,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>200</speed>
-		<dropsCasings>true</dropsCasings>
+      <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 
@@ -116,6 +131,16 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>23</damageAmountBase>
       <armorPenetrationSharp>10</armorPenetrationSharp>
+      <armorPenetrationBlunt>107</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base300WinchesterMagnumBullet">
+    <defName>Bullet_300WinchesterMagnum_AP</defName>
+    <label>.300 Winchester Magnum bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>14</damageAmountBase>
+      <armorPenetrationSharp>20</armorPenetrationSharp>
       <armorPenetrationBlunt>107</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -189,6 +214,32 @@
       <Ammo_300WinchesterMagnum_FMJ>200</Ammo_300WinchesterMagnum_FMJ>
     </products>
     <workAmount>1600</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_300WinchesterMagnum_AP</defName>
+    <label>make .300 Winchester Magnum (AP) cartridge x200</label>
+    <description>Craft 200 .300 Winchester Magnum (AP) cartridges.</description>
+    <jobString>Making .300 Winchester Magnum (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>16</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_300WinchesterMagnum_AP>200</Ammo_300WinchesterMagnum_AP>
+    </products>
+    <workAmount>2000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -15,12 +15,12 @@
     <label>.338 Lapua Magnum</label>
     <ammoTypes>
       <Ammo_338Lapua_FMJ>Bullet_338Lapua_FMJ</Ammo_338Lapua_FMJ>
-<!--       <Ammo_338Lapua_HP>Bullet_338Lapua_HP</Ammo_338Lapua_HP> -->
+      <Ammo_338Lapua_AP>Bullet_338Lapua_AP</Ammo_338Lapua_AP>
       <Ammo_338Lapua_Incendiary>Bullet_338Lapua_Incendiary</Ammo_338Lapua_Incendiary>
-	    <Ammo_338Lapua_HE>Bullet_338Lapua_HE</Ammo_338Lapua_HE>
-	    <Ammo_338Lapua_Sabot>Bullet_338Lapua_Sabot</Ammo_338Lapua_Sabot>
+      <Ammo_338Lapua_HE>Bullet_338Lapua_HE</Ammo_338Lapua_HE>
+      <Ammo_338Lapua_Sabot>Bullet_338Lapua_Sabot</Ammo_338Lapua_Sabot>
     </ammoTypes>
-		<similarTo>AmmoSet_RifleMagnum</similarTo>
+    <similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->
@@ -54,19 +54,19 @@
     <cookOffProjectile>Bullet_338Lapua_FMJ</cookOffProjectile>
   </ThingDef>
 
-<!--   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
-    <defName>Ammo_338Lapua_HP</defName>
-    <label>.338 Lapua Magnum cartridge (HP)</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
+    <defName>Ammo_338Lapua_AP</defName>
+    <label>.338 Lapua Magnum cartridge (AP)</label>
     <graphicData>
-      <texPath>Things/Ammo/HighCaliber/HE</texPath>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
       <MarketValue>0.2</MarketValue>
     </statBases>
-    <ammoClass>HollowPoint</ammoClass>
-    <cookOffProjectile>Bullet_338Lapua_HP</cookOffProjectile>
-  </ThingDef> -->
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_338Lapua_AP</cookOffProjectile>
+  </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
     <defName>Ammo_338Lapua_Incendiary</defName>
@@ -135,15 +135,15 @@
     </projectile>
   </ThingDef>
 
-<!--   <ThingDef ParentName="Base338LapuaBullet">
-    <defName>Bullet_338Lapua_HP</defName>
-    <label>.338 Lapua Magnum bullet (HP)</label>
+  <ThingDef ParentName="Base338LapuaBullet">
+    <defName>Bullet_338Lapua_AP</defName>
+    <label>.338 Lapua Magnum bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>33</damageAmountBase>
-      <armorPenetrationSharp>6</armorPenetrationSharp>
+      <damageAmountBase>16</damageAmountBase>
+      <armorPenetrationSharp>22</armorPenetrationSharp>
       <armorPenetrationBlunt>134.160</armorPenetrationBlunt>
     </projectile>
-  </ThingDef> -->
+  </ThingDef>
 
   <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_Incendiary</defName>
@@ -184,7 +184,7 @@
       <damageAmountBase>14</damageAmountBase>
       <armorPenetrationSharp>39</armorPenetrationSharp>
       <armorPenetrationBlunt>173.980</armorPenetrationBlunt>
-     <speed>273</speed>	  
+      <speed>273</speed>	  
     </projectile>
   </ThingDef>
 
@@ -216,11 +216,11 @@
     <workAmount>2000</workAmount>
   </RecipeDef>
 
-<!--   <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_338Lapua_HP</defName>
-    <label>make .338 Lapua Magnum (HP) cartridge x200</label>
-    <description>Craft 200 .338 Lapua Magnum (HP) cartridges.</description>
-    <jobString>Making .338 Lapua Magnum (HP) cartridges.</jobString>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_338Lapua_AP</defName>
+    <label>make .338 Lapua Magnum (AP) cartridge x200</label>
+    <description>Craft 200 .338 Lapua Magnum (AP) cartridges.</description>
+    <jobString>Making .338 Lapua Magnum (AP) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -237,10 +237,10 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_338Lapua_HP>200</Ammo_338Lapua_HP>
+      <Ammo_338Lapua_AP>200</Ammo_338Lapua_AP>
     </products>
-    <workAmount>2000</workAmount>
-  </RecipeDef> -->
+    <workAmount>2400</workAmount>
+  </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_338Lapua_Incendiary</defName>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_338Lapua_AP>200</Ammo_338Lapua_AP>
     </products>
-    <workAmount>2400</workAmount>
+    <workAmount>2000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -15,12 +15,12 @@
     <label>.338 Norma Magnum</label>
     <ammoTypes>
       <Ammo_338Norma_FMJ>Bullet_338Norma_FMJ</Ammo_338Norma_FMJ>
-<!--  <Ammo_338Norma_HP>Bullet_338Norma_HP</Ammo_338Norma_HP>-->
+      <Ammo_338Norma_AP>Bullet_338Norma_AP</Ammo_338Norma_AP>
       <Ammo_338Norma_Incendiary>Bullet_338Norma_Incendiary</Ammo_338Norma_Incendiary>
-	    <Ammo_338Norma_HE>Bullet_338Norma_HE</Ammo_338Norma_HE>
-	    <Ammo_338Norma_Sabot>Bullet_338Norma_Sabot</Ammo_338Norma_Sabot>      
+      <Ammo_338Norma_HE>Bullet_338Norma_HE</Ammo_338Norma_HE>
+      <Ammo_338Norma_Sabot>Bullet_338Norma_Sabot</Ammo_338Norma_Sabot>      
     </ammoTypes>
-		<similarTo>AmmoSet_RifleMagnum</similarTo>
+    <similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -54,19 +54,19 @@
     <cookOffProjectile>Bullet_338Norma_FMJ</cookOffProjectile>
   </ThingDef>
 
-  <!-- <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
-    <defName>Ammo_338Norma_HP</defName>
-    <label>.338 Norma Magnum cartridge (HP)</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
+    <defName>Ammo_338Norma_AP</defName>
+    <label>.338 Norma Magnum cartridge (AP)</label>
     <graphicData>
-      <texPath>Things/Ammo/HighCaliber/HE</texPath>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.24</MarketValue>
+      <MarketValue>0.2</MarketValue>
     </statBases>
-  	<ammoClass>HollowPoint</ammoClass>
-    <cookOffProjectile>Bullet_338Norma_HP</cookOffProjectile>
-  </ThingDef> -->
+  	<ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_338Norma_AP</cookOffProjectile>
+  </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
     <defName>Ammo_338Norma_Incendiary</defName>
@@ -121,7 +121,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>243</speed>
-			<dropsCasings>true</dropsCasings>
+      <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 
@@ -135,14 +135,15 @@
     </projectile>
   </ThingDef>
 
-  <!-- <ThingDef ParentName="Base338NormaBullet">
-    <defName>Bullet_338Norma_HP</defName>
-    <label>.338 Norma Magnum bullet (HP)</label>
+  <ThingDef ParentName="Base338NormaBullet">
+    <defName>Bullet_338Norma_AP</defName>
+    <label>.338 Norma Magnum bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>34</damageAmountBase>
-			<armorPenetrationBase>0.566</armorPenetrationBase>
+      <damageAmountBase>16</damageAmountBase>
+      <armorPenetrationSharp>22</armorPenetrationSharp>
+      <armorPenetrationBlunt>126.66</armorPenetrationBlunt>
     </projectile>
-  </ThingDef> -->
+  </ThingDef>
 
   <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_Incendiary</defName>
@@ -215,11 +216,11 @@
     <workAmount>2000</workAmount>
   </RecipeDef>
 
-  <!-- <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_338Norma_HP</defName>
-    <label>make .338 Norma Magnum (HP) cartridge x350</label>
-    <description>Craft 350 .338 Norma Magnum (HP) cartridges.</description>
-    <jobString>Making .338 Norma Magnum (HP) cartridges.</jobString>
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_338Norma_AP</defName>
+    <label>make .338 Norma Magnum (AP) cartridge x200</label>
+    <description>Craft 200 .338 Norma Magnum (AP) cartridges.</description>
+    <jobString>Making .338 Norma Magnum (AP) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -227,7 +228,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>22</count>
+        <count>20</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -236,10 +237,10 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_338Norma_HP>350</Ammo_338Norma_HP>
+      <Ammo_338Norma_AP>200</Ammo_338Norma_AP>
     </products>
-    <workAmount>9750</workAmount>
-  </RecipeDef> -->
+    <workAmount>2400</workAmount>
+  </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_338Norma_Incendiary</defName>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_338Norma_AP>200</Ammo_338Norma_AP>
     </products>
-    <workAmount>2400</workAmount>
+    <workAmount>2000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_408CheyenneTactical_AP>200</Ammo_408CheyenneTactical_AP>
     </products>
-    <workAmount>3600</workAmount>
+    <workAmount>3200</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -15,11 +15,12 @@
     <label>.408 Cheyenne Tactical</label>
     <ammoTypes>
       <Ammo_408CheyenneTactical_FMJ>Bullet_408CheyenneTactical_FMJ</Ammo_408CheyenneTactical_FMJ>
+      <Ammo_408CheyenneTactical_AP>Bullet_408CheyenneTactical_AP</Ammo_408CheyenneTactical_AP>
       <Ammo_408CheyenneTactical_Incendiary>Bullet_408CheyenneTactical_Incendiary</Ammo_408CheyenneTactical_Incendiary>
-			<Ammo_408CheyenneTactical_HE>Bullet_408CheyenneTactical_HE</Ammo_408CheyenneTactical_HE>
-			<Ammo_408CheyenneTactical_Sabot>Bullet_408CheyenneTactical_Sabot</Ammo_408CheyenneTactical_Sabot>	         
+      <Ammo_408CheyenneTactical_HE>Bullet_408CheyenneTactical_HE</Ammo_408CheyenneTactical_HE>
+      <Ammo_408CheyenneTactical_Sabot>Bullet_408CheyenneTactical_Sabot</Ammo_408CheyenneTactical_Sabot>	         
     </ammoTypes>
-		<similarTo>AmmoSet_RifleMagnum</similarTo>
+    <similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -54,6 +55,20 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
+    <defName>Ammo_408CheyenneTactical_AP</defName>
+    <label>.408 Cheyenne Tactical cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.32</MarketValue>
+    </statBases>
+  	<ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_408CheyenneTactical_AP</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
     <defName>Ammo_408CheyenneTactical_Incendiary</defName>
     <label>.408 Cheyenne Tactical cartridge (AP-I)</label>
     <graphicData>
@@ -71,11 +86,11 @@
 		<defName>Ammo_408CheyenneTactical_HE</defName>
 		<label>.408 Cheyenne Tactical cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.58</MarketValue>
+			<MarketValue>0.58</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_408CheyenneTactical_HE</cookOffProjectile>
@@ -85,8 +100,8 @@
 		<defName>Ammo_408CheyenneTactical_Sabot</defName>
 		<label>.408 Cheyenne Tactical cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.37</MarketValue>
@@ -116,6 +131,16 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>34</damageAmountBase>
       <armorPenetrationSharp>12</armorPenetrationSharp>
+      <armorPenetrationBlunt>242</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base408CheyenneTacticalBullet">
+    <defName>Bullet_408CheyenneTactical_AP</defName>
+    <label>.408 Cheyenne Tactical bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>21</damageAmountBase>
+      <armorPenetrationSharp>24</armorPenetrationSharp>
       <armorPenetrationBlunt>242</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -189,6 +214,32 @@
       <Ammo_408CheyenneTactical_FMJ>200</Ammo_408CheyenneTactical_FMJ>
     </products>
     <workAmount>3200</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_408CheyenneTactical_AP</defName>
+    <label>make .408 Cheyenne Tactical (AP) cartridge x200</label>
+    <description>Craft 200 .408 Cheyenne Tactical (AP) cartridges.</description>
+    <jobString>Making .408 Cheyenne Tactical (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_408CheyenneTactical_AP>200</Ammo_408CheyenneTactical_AP>
+    </products>
+    <workAmount>3600</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_470NitroExpress_AP>500</Ammo_470NitroExpress_AP>
 		</products>
-    <workAmount>7600</workAmount>		
+    <workAmount>6000</workAmount>		
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -15,8 +15,7 @@
     <label>.470 Nitro Express</label>
     <ammoTypes>
 		<Ammo_470NitroExpress_FMJ>Bullet_470NitroExpress_FMJ</Ammo_470NitroExpress_FMJ>
-<!-- 		<Ammo_470NitroExpress_AP>Bullet_470NitroExpress_AP</Ammo_470NitroExpress_AP>
-		<Ammo_470NitroExpress_HP>Bullet_470NitroExpress_HP</Ammo_470NitroExpress_HP> -->
+		<Ammo_470NitroExpress_AP>Bullet_470NitroExpress_AP</Ammo_470NitroExpress_AP>
 		<Ammo_470NitroExpress_Incendiary>Bullet_470NitroExpress_Incendiary</Ammo_470NitroExpress_Incendiary>
 		<Ammo_470NitroExpress_HE>Bullet_470NitroExpress_HE</Ammo_470NitroExpress_HE>
 		<Ammo_470NitroExpress_Sabot>Bullet_470NitroExpress_Sabot</Ammo_470NitroExpress_Sabot>		
@@ -55,11 +54,11 @@
     <cookOffProjectile>Bullet_470NitroExpress_FMJ</cookOffProjectile>
   </ThingDef>
 
-<!-- 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
 		<defName>Ammo_470NitroExpress_AP</defName>
 		<label>.470 Nitro Express cartridge (AP)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -68,20 +67,6 @@
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_470NitroExpress_AP</cookOffProjectile>
 	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
-		<defName>Ammo_470NitroExpress_HP</defName>
-		<label>.470 Nitro Express cartridge (HP)</label>
-		<graphicData>
-			<texPath>Things/Ammo/Rifle/HP</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.24</MarketValue>
-		</statBases>
-		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_470NitroExpress_HP</cookOffProjectile>
-	</ThingDef> -->
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
     <defName>Ammo_470NitroExpress_Incendiary</defName>
@@ -150,7 +135,7 @@
     </projectile>
   </ThingDef>
 
-<!-- 	<ThingDef ParentName="Base470NitroExpressBullet">
+ 	<ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_AP</defName>
 		<label>.470 Nitro Express bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -159,16 +144,6 @@
 			<armorPenetrationBlunt>139.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
-
-	<ThingDef ParentName="Base470NitroExpressBullet">
-		<defName>Bullet_470NitroExpress_HP</defName>
-		<label>.470 Nitro Express bullet (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
-			<armorPenetrationBlunt>139.4</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef> -->
 
 	  <ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_Incendiary</defName>
@@ -241,7 +216,7 @@
     <workAmount>6000</workAmount>
   </RecipeDef>
 
-<!-- 	<RecipeDef ParentName="AmmoRecipeBase">
+ 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_470NitroExpress_AP</defName>
 		<label>make .470 Nitro Express (AP) cartridge x500</label>
 		<description>Craft 500 .470 Nitro Express (AP) cartridges.</description>
@@ -264,34 +239,8 @@
 		<products>
 			<Ammo_470NitroExpress_AP>500</Ammo_470NitroExpress_AP>
 		</products>
-    <workAmount>6000</workAmount>		
+    <workAmount>7600</workAmount>		
 	</RecipeDef>
-
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_470NitroExpress_HP</defName>
-		<label>make .470 Nitro Express (HP) cartridge x500</label>
-		<description>Craft 500 .470 Nitro Express (HP) cartridges.</description>
-		<jobString>Making .470 Nitro Express (HP) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>60</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_470NitroExpress_HP>500</Ammo_470NitroExpress_HP>
-		</products>
-    <workAmount>6000</workAmount>		
-	</RecipeDef> -->
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_Incendiary</defName>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -15,11 +15,12 @@
     <label>.50 BMG</label>
     <ammoTypes>
       <Ammo_50BMG_FMJ>Bullet_50BMG_FMJ</Ammo_50BMG_FMJ>
+      <Ammo_50BMG_AP>Bullet_50BMG_AP</Ammo_50BMG_AP>
       <Ammo_50BMG_Incendiary>Bullet_50BMG_Incendiary</Ammo_50BMG_Incendiary>
       <Ammo_50BMG_HE>Bullet_50BMG_HE</Ammo_50BMG_HE>
       <Ammo_50BMG_Sabot>Bullet_50BMG_Sabot</Ammo_50BMG_Sabot>	  
     </ammoTypes>
-		<similarTo>AmmoSet_AntiMateriel</similarTo>
+    <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->
@@ -52,6 +53,20 @@
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_50BMG_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
+    <defName>Ammo_50BMG_AP</defName>
+    <label>.50 BMG cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.48</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_50BMG_AP</cookOffProjectile>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
@@ -118,6 +133,16 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>41</damageAmountBase>
       <armorPenetrationSharp>14</armorPenetrationSharp>
+      <armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base50BMGBullet">
+    <defName>Bullet_50BMG_AP</defName>
+    <label>.50 BMG bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>25</damageAmountBase>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>334.380</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -191,6 +216,32 @@
       <Ammo_50BMG_FMJ>200</Ammo_50BMG_FMJ>
     </products>
     <workAmount>4800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_50BMG_AP</defName>
+    <label>make .50 BMG (AP) cartridge x200</label>
+    <description>Craft 200 .50 BMG (AP) cartridges.</description>
+    <jobString>Making .50 BMG (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>48</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50BMG_AP>200</Ammo_50BMG_AP>
+    </products>
+    <workAmount>5500</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -241,7 +241,7 @@
     <products>
       <Ammo_50BMG_AP>200</Ammo_50BMG_AP>
     </products>
-    <workAmount>5500</workAmount>
+    <workAmount>4800</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_55Boys_AP>200</Ammo_55Boys_AP>
 		</products>
-		<workAmount>7000</workAmount>
+		<workAmount>5600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -15,6 +15,7 @@
 		<label>.55 Boys</label>
 		<ammoTypes>
 			<Ammo_55Boys_FMJ>Bullet_55Boys_FMJ</Ammo_55Boys_FMJ>
+			<Ammo_55Boys_AP>Bullet_55Boys_AP</Ammo_55Boys_AP>
 			<Ammo_55Boys_Incendiary>Bullet_55Boys_Incendiary</Ammo_55Boys_Incendiary>
 			<Ammo_55Boys_HE>Bullet_55Boys_HE</Ammo_55Boys_HE>
 			<Ammo_55Boys_Sabot>Bullet_55Boys_Sabot</Ammo_55Boys_Sabot>	  
@@ -27,13 +28,13 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo55BoysBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Outdated large caliber bullet used in anti-materiel rifles.</description>
 		<statBases>
-		<Mass>0.133</Mass>
-		<Bulk>0.13</Bulk>
+			<Mass>0.133</Mass>
+			<Bulk>0.13</Bulk>
 		</statBases>
-	<tradeTags>
-		<li>CE_AutoEnableTrade</li>
-		<li>CE_AutoEnableCrafting</li>
-	</tradeTags>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
 		<thingCategories>
 			<li>Ammo55Boys</li>
 		</thingCategories>
@@ -54,14 +55,28 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
+		<defName>Ammo_55Boys_AP</defName>
+		<label>.55 Boys cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.56</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_55Boys_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_Incendiary</defName>
 		<label>.55 Boys cartridge (AP-I)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>0.78</MarketValue>
+			<MarketValue>0.78</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_55Boys_Incendiary</cookOffProjectile>
@@ -71,11 +86,11 @@
 		<defName>Ammo_55Boys_HE</defName>
 		<label>.55 Boys cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>1.23</MarketValue>
+			<MarketValue>1.23</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_55Boys_HE</cookOffProjectile>
@@ -85,8 +100,8 @@
 		<defName>Ammo_55Boys_Sabot</defName>
 		<label>.55 Boys cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>2.14</MarketValue>
@@ -121,18 +136,28 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base55BoysBullet">
+		<defName>Bullet_55Boys_AP</defName>
+		<label>.55 Boys bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>30</damageAmountBase>
+			<armorPenetrationSharp>38</armorPenetrationSharp>
+			<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_Incendiary</defName>
 		<label>.55 Boys bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>30</damageAmountBase>
-		<armorPenetrationSharp>38</armorPenetrationSharp>
-		<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Flame_Secondary</def>
-			<amount>19</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>30</damageAmountBase>
+			<armorPenetrationSharp>38</armorPenetrationSharp>
+			<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Flame_Secondary</def>
+				<amount>19</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 	
@@ -140,15 +165,15 @@
 		<defName>Bullet_55Boys_HE</defName>
 		<label>.55 Boys bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>48</damageAmountBase>
-		<armorPenetrationSharp>19</armorPenetrationSharp>
-		<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Bomb_Secondary</def>
-			<amount>29</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>48</damageAmountBase>
+			<armorPenetrationSharp>19</armorPenetrationSharp>
+			<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bomb_Secondary</def>
+				<amount>29</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -157,9 +182,9 @@
 		<label>.55 Boys bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>266</speed>
-		<damageAmountBase>25</damageAmountBase>
-		<armorPenetrationSharp>66</armorPenetrationSharp>
-		<armorPenetrationBlunt>611.36</armorPenetrationBlunt>
+			<damageAmountBase>25</damageAmountBase>
+			<armorPenetrationSharp>66</armorPenetrationSharp>
+			<armorPenetrationBlunt>611.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   
@@ -188,7 +213,33 @@
 		<products>
 			<Ammo_55Boys_FMJ>200</Ammo_55Boys_FMJ>
 		</products>
-    <workAmount>5600</workAmount>
+		<workAmount>5600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_55Boys_AP</defName>
+		<label>make .55 Boys (AP) cartridge x200</label>
+		<description>Craft 200 .55 Boys (AP) cartridges.</description>
+		<jobString>Making .55 Boys (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>56</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_55Boys_AP>200</Ammo_55Boys_AP>
+		</products>
+		<workAmount>7000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_600NitroExpress_AP>200</Ammo_600NitroExpress_AP>
     </products>
-    <workAmount>5600</workAmount>
+    <workAmount>4400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -15,11 +15,12 @@
     <label>.600 Nitro Express</label>
     <ammoTypes>
       <Ammo_600NitroExpress_FMJ>Bullet_600NitroExpress_FMJ</Ammo_600NitroExpress_FMJ>
+      <Ammo_600NitroExpress_AP>Bullet_600NitroExpress_AP</Ammo_600NitroExpress_AP>
       <Ammo_600NitroExpress_Incendiary>Bullet_600NitroExpress_Incendiary</Ammo_600NitroExpress_Incendiary>
-			<Ammo_600NitroExpress_HE>Bullet_600NitroExpress_HE</Ammo_600NitroExpress_HE>
-			<Ammo_600NitroExpress_Sabot>Bullet_600NitroExpress_Sabot</Ammo_600NitroExpress_Sabot>	
+      <Ammo_600NitroExpress_HE>Bullet_600NitroExpress_HE</Ammo_600NitroExpress_HE>
+      <Ammo_600NitroExpress_Sabot>Bullet_600NitroExpress_Sabot</Ammo_600NitroExpress_Sabot>	
     </ammoTypes>
-		<similarTo>AmmoSet_RifleMagnum</similarTo>
+    <similarTo>AmmoSet_RifleMagnum</similarTo>
   </CombatExtended.AmmoSetDef>
   
   <!-- ==================== Ammo ========================== -->
@@ -54,6 +55,20 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
+    <defName>Ammo_600NitroExpress_AP</defName>
+    <label>.600 Nitro Express cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.44</MarketValue>
+    </statBases>
+  	<ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_600NitroExpress_AP</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
     <defName>Ammo_600NitroExpress_Incendiary</defName>
     <label>.600 Nitro Express cartridge (AP-I)</label>
     <graphicData>
@@ -71,11 +86,11 @@
 		<defName>Ammo_600NitroExpress_HE</defName>
 		<label>.600 Nitro Express cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>1.01</MarketValue>
+			<MarketValue>1.01</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_600NitroExpress_HE</cookOffProjectile>
@@ -85,8 +100,8 @@
 		<defName>Ammo_600NitroExpress_Sabot</defName>
 		<label>.600 Nitro Express cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>0.47</MarketValue>
@@ -116,6 +131,16 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>38</damageAmountBase>
       <armorPenetrationSharp>11</armorPenetrationSharp>
+      <armorPenetrationBlunt>222.96</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base600NitroExpressBullet">
+    <defName>Bullet_600NitroExpress_AP</defName>
+    <label>.600 Nitro Express bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>24</damageAmountBase>
+      <armorPenetrationSharp>22</armorPenetrationSharp>
       <armorPenetrationBlunt>222.96</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -191,6 +216,31 @@
     <workAmount>4400</workAmount>
   </RecipeDef>
 
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_600NitroExpress_AP</defName>
+    <label>make .600 Nitro Express (AP) cartridge x200</label>
+    <description>Craft 200 .600 Nitro Express (AP) cartridges.</description>
+    <jobString>Making .600 Nitro Express (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>44</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_600NitroExpress_AP>200</Ammo_600NitroExpress_AP>
+    </products>
+    <workAmount>5600</workAmount>
+  </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_600NitroExpress_Incendiary</defName>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -15,9 +15,10 @@
     <label>7.92x94mm Patronen</label>
     <ammoTypes>
       <Ammo_792x94mmPatronen_FMJ>Bullet_792x94mmPatronen_FMJ</Ammo_792x94mmPatronen_FMJ>
+      <Ammo_792x94mmPatronen_AP>Bullet_792x94mmPatronen_AP</Ammo_792x94mmPatronen_AP>
       <Ammo_792x94mmPatronen_Incendiary>Bullet_792x94mmPatronen_Incendiary</Ammo_792x94mmPatronen_Incendiary>
       <Ammo_792x94mmPatronen_HE>Bullet_792x94mmPatronen_HE</Ammo_792x94mmPatronen_HE>
-	    <Ammo_792x94mmPatronen_Sabot>Bullet_792x94mmPatronen_Sabot</Ammo_792x94mmPatronen_Sabot>	  
+      <Ammo_792x94mmPatronen_Sabot>Bullet_792x94mmPatronen_Sabot</Ammo_792x94mmPatronen_Sabot>	  
     </ammoTypes>
     <similarTo>AmmoSet_AntiMateriel</similarTo>
   </CombatExtended.AmmoSetDef>
@@ -52,6 +53,20 @@
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_792x94mmPatronen_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
+    <defName>Ammo_792x94mmPatronen_AP</defName>
+    <label>7.92x94mm Patronen cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.50</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_792x94mmPatronen_AP</cookOffProjectile>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
@@ -122,6 +137,16 @@
   </ThingDef>
 
   <ThingDef ParentName="Base792x94mmPatronenBullet">
+    <defName>Bullet_792x94mmPatronen_AP</defName>
+    <label>7.92x94mm Patronen bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>19</damageAmountBase>
+      <armorPenetrationSharp>44</armorPenetrationSharp>
+      <armorPenetrationBlunt>213.06</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base792x94mmPatronenBullet">
     <defName>Bullet_792x94mmPatronen_Incendiary</defName>
     <label>7.92x94mm Patronen bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
@@ -163,6 +188,7 @@
       <armorPenetrationBlunt>276.06</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
+
   <!-- ==================== Recipes ========================== -->
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -189,6 +215,32 @@
       <Ammo_792x94mmPatronen_FMJ>200</Ammo_792x94mmPatronen_FMJ>
     </products>
     <workAmount>5000</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_792x94mmPatronen_AP</defName>
+    <label>make 7.92x94mm Patronen (AP) cartridge x200</label>
+    <description>Craft 200 7.92x94mm Patronen (AP) cartridges.</description>
+    <jobString>Making 7.92x94mm Patronen (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_792x94mmPatronen_AP>200</Ammo_792x94mmPatronen_AP>
+    </products>
+    <workAmount>5400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_792x94mmPatronen_AP>200</Ammo_792x94mmPatronen_AP>
     </products>
-    <workAmount>5400</workAmount>
+    <workAmount>5000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_950JDJ_AP>200</Ammo_950JDJ_AP>
 		</products>
-		<workAmount>17600</workAmount>
+		<workAmount>13000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -15,6 +15,7 @@
 		<label>.950 JDJ</label>
 		<ammoTypes>
 			<Ammo_950JDJ_FMJ>Bullet_950JDJ_FMJ</Ammo_950JDJ_FMJ>
+			<Ammo_950JDJ_AP>Bullet_950JDJ_AP</Ammo_950JDJ_AP>
       		<Ammo_50JDJ_Incendiary>Bullet_50JDJ_Incendiary</Ammo_50JDJ_Incendiary>
 			<Ammo_50JDJ_HE>Bullet_50JDJ_HE</Ammo_50JDJ_HE>
 			<Ammo_50JDJ_Sabot>Bullet_50JDJ_Sabot</Ammo_50JDJ_Sabot>				
@@ -54,14 +55,28 @@
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
+		<defName>Ammo_950JDJ_AP</defName>
+		<label>.950 JDJ cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.29</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_950JDJ_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_50JDJ_Incendiary</defName>
 		<label>.950 JDJ cartridge (AP-I)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>2.05</MarketValue>
+			<MarketValue>2.05</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_50JDJ_Incendiary</cookOffProjectile>
@@ -71,11 +86,11 @@
 		<defName>Ammo_50JDJ_HE</defName>
 		<label>.950 JDJ cartridge (HE)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/HE</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-		<MarketValue>3.52</MarketValue>
+			<MarketValue>3.52</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_50JDJ_HE</cookOffProjectile>
@@ -85,8 +100,8 @@
 		<defName>Ammo_50JDJ_Sabot</defName>
 		<label>.950 JDJ cartridge (Sabot)</label>
 		<graphicData>
-		<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-		<graphicClass>Graphic_StackCount</graphicClass>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
 			<MarketValue>1.55</MarketValue>
@@ -114,9 +129,19 @@
 		<defName>Bullet_950JDJ_FMJ</defName>
 		<label>.950 JDJ bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>75</damageAmountBase>
-		<armorPenetrationSharp>18</armorPenetrationSharp>
-		<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
+			<damageAmountBase>75</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base950JDJBullet">
+		<defName>Bullet_950JDJ_AP</defName>
+		<label>.950 JDJ bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>47</damageAmountBase>
+			<armorPenetrationSharp>36</armorPenetrationSharp>
+			<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -124,15 +149,15 @@
 		<defName>Bullet_50JDJ_Incendiary</defName>
 		<label>.950 JDJ bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>47</damageAmountBase>
-		<armorPenetrationSharp>36</armorPenetrationSharp>
-		<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Flame_Secondary</def>
-			<amount>29</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>47</damageAmountBase>
+			<armorPenetrationSharp>36</armorPenetrationSharp>
+			<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Flame_Secondary</def>
+				<amount>29</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -140,15 +165,15 @@
 		<defName>Bullet_50JDJ_HE</defName>
 		<label>.950 JDJ bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<damageAmountBase>75</damageAmountBase>
-		<armorPenetrationSharp>18</armorPenetrationSharp>
-		<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
-		<secondaryDamage>
-			<li>
-			<def>Bomb_Secondary</def>
-			<amount>45</amount>
-			</li>
-		</secondaryDamage>
+			<damageAmountBase>75</damageAmountBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+				<def>Bomb_Secondary</def>
+				<amount>45</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
@@ -156,10 +181,10 @@
 		<defName>Bullet_50JDJ_Sabot</defName>
 		<label>.950 JDJ bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<speed>201</speed>
-		<damageAmountBase>40</damageAmountBase>
-		<armorPenetrationSharp>63</armorPenetrationSharp>
-		<armorPenetrationBlunt>1341.42</armorPenetrationBlunt>
+			<speed>201</speed>
+			<damageAmountBase>40</damageAmountBase>
+			<armorPenetrationSharp>63</armorPenetrationSharp>
+			<armorPenetrationBlunt>1341.42</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -188,7 +213,33 @@
 		<products>
 			<Ammo_950JDJ_FMJ>200</Ammo_950JDJ_FMJ>
 		</products>
-    <workAmount>13000</workAmount>
+		<workAmount>13000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_950JDJ_AP</defName>
+		<label>make .950 JDJ (AP) cartridge x200</label>
+		<description>Craft 200 .950 JDJ (AP) cartridges.</description>
+		<jobString>Making .950 JDJ (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>130</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_950JDJ_AP>200</Ammo_950JDJ_AP>
+		</products>
+		<workAmount>17600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -16,7 +16,7 @@
 		<ammoTypes>
 			<Ammo_950JDJ_FMJ>Bullet_950JDJ_FMJ</Ammo_950JDJ_FMJ>
 			<Ammo_950JDJ_AP>Bullet_950JDJ_AP</Ammo_950JDJ_AP>
-      		<Ammo_50JDJ_Incendiary>Bullet_50JDJ_Incendiary</Ammo_50JDJ_Incendiary>
+			<Ammo_50JDJ_Incendiary>Bullet_50JDJ_Incendiary</Ammo_50JDJ_Incendiary>
 			<Ammo_50JDJ_HE>Bullet_50JDJ_HE</Ammo_50JDJ_HE>
 			<Ammo_50JDJ_Sabot>Bullet_50JDJ_Sabot</Ammo_50JDJ_Sabot>				
 		</ammoTypes>


### PR DESCRIPTION
## Additions

- What it says on the tin, added AP ammo types to the high caliber ammo sets that lacked them.

## Changes

- Some housekeeping.
- Adjusted 12.7x108mm armor penetration based on http://roe.ru/eng/catalog/land-forces/strelkovoe-oruzhie/pistol-cartridges/57-bzt-542m/
- Did the same AP adjustment for the 13.2x92mm TuF round as well since it is a slower, older/obsolete and heavier round.

## Reasoning

- Because most of the left-out cartridges already have AP ammo types in real life which they lacked in CE and normal AP rounds are helpful to those that forsake advanced ammunition.
- 12.7x108mm performs mostly the same than the .50BMG, 20mm armor penetration for the FMJ round in the spreadsheet is not based on a source, The BZT-44 round which is an AP-IT round is 15mm with 90% chance of penetration at 100 meters. Setting the FMJ round to 15mm of armor penetration would be good enough.

## Special thanks

- I wanna hereby thank a couple of the keys on my keyboard mainly the "A", "P" and the Backspace keys which without them none of this would have been possible.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
