### PR TITLE
Give the Riot mech melee hit chance

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -79,7 +79,7 @@
         <MeleeDodgeChance>0</MeleeDodgeChance>
         <MeleeCritChance>0.01</MeleeCritChance>
         <MeleeParryChance>0</MeleeParryChance>
-	<NightVisionEfficiency>0.40</NightVisionEfficiency>
+        <NightVisionEfficiency>0.40</NightVisionEfficiency>
       </value>
     </li>
 
@@ -139,7 +139,14 @@
         <MeleeCritChance>0.22</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
-	<NightVisionEfficiency>0.60</NightVisionEfficiency>
+        <NightVisionEfficiency>0.60</NightVisionEfficiency>
+      </value>
+    </li>
+
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot"]/statBases</xpath>
+      <value>
+        <MeleeHitChance>6</MeleeHitChance>
       </value>
     </li>
 
@@ -251,7 +258,7 @@
       </value>
     </li>
 	
-	<!-- ==========VFE Strider ========== -->
+	<!-- ========== VFE Strider ========== -->
 
     <li Class="PatchOperationAddModExtension">
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]</xpath>
@@ -272,7 +279,6 @@
         <MeleeDodgeChance>0.02</MeleeDodgeChance>
         <MeleeCritChance>0.17</MeleeCritChance>
         <MeleeParryChance>0.45</MeleeParryChance>
-        <AimingDelayFactor>1.65</AimingDelayFactor>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
     </li>


### PR DESCRIPTION
## Additions

- Gave the Riot mech from VFE-Mechs some melee hit chance stat to help with them spawning with 0 melee skill. 6 melee hit chance is similar to the pawn having 6 skills in melee, roughly the same as 6.7 that scythers have.

## Alternatives

- Find a way to give them proper melee skill instead of a workaround, which seems like not an easy task,

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
