### PR TITLE
Compatibility patch for 'Nakin Race' and pawnkind patch for 'Kobold Factions' 

### DIFF
--- a/Patches/Kobold Factions/Kobold_Kamikaze_Pawnkind.xml
+++ b/Patches/Kobold Factions/Kobold_Kamikaze_Pawnkind.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+	<li>Kobold Factions</li>
+	</mods>
+		<match Class="PatchOperationSequence">
+		 <operations>
+			<!--Medieval Kobold with Sticky Bomb -->
+<li Class="PatchOperationAdd">
+	 <xpath>Defs</xpath>
+	 <value>
+		<PawnKindDef>
+			<defName>Kobold_Kamikaze</defName>
+			<race>Alien_Kobold</race>
+			<label>Blaster</label>
+			<combatPower>65</combatPower>
+			<defaultFactionType>LTS_MedboldEmpireFriendly</defaultFactionType>
+			<backstoryCategories>
+				<li>MedboldBackstory</li>
+			</backstoryCategories>
+			<maxGenerationAge>10</maxGenerationAge>
+			<chemicalAddictionChance>0.05</chemicalAddictionChance>
+			<invNutrition>1.8</invNutrition>
+			<invFoodDef>Pemmican</invFoodDef>
+			<canBeSapper>true</canBeSapper>
+			<gearHealthRange>
+				<min>0.5</min>
+				<max>1.8</max>
+			</gearHealthRange>
+			<apparelMoney>
+				<min>180</min>
+				<max>350</max>
+			</apparelMoney>
+			<apparelRequired>
+				<li>Apparel_Pants</li>
+				<li>Apparel_TribalBackpack</li>
+			</apparelRequired>
+			<apparelTags>
+				<li>IndustrialBasic</li>
+			</apparelTags>
+			<weaponMoney>
+				<min>120</min>
+			<max>400</max>
+			</weaponMoney>
+			<weaponTags>
+				<li>CE_GrenadeNeolithic</li>
+			</weaponTags>
+			<techHediffsMoney>
+				<min>50</min>
+				<max>800</max>
+			</techHediffsMoney>
+			<techHediffsTags>
+				<li>Poor</li>
+				<li>Simple</li>
+			</techHediffsTags>
+		<techHediffsChance>0.33</techHediffsChance>
+		<disallowedTraits>
+			<li>Brawler</li>
+		</disallowedTraits>
+		<initialWillRange>2~4</initialWillRange>
+		<initialResistanceRange>14~22</initialResistanceRange>
+		<modExtensions>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>18</max>
+				</primaryMagazineCount>
+	<!-- No sidearms, these guys are literally just sticky-bomb launchers-->
+			</li>
+		</modExtensions>
+		</PawnKindDef>
+	</value>
+  </li>
+  <!-- Adding Kobold Kamikazes -->
+			<li Class="PatchOperationAdd"> <!-- Combat -->
+				<xpath>Defs/FactionDef[@Name="Medbold_FactionBase"]/pawnGroupMakers/li[1]/options</xpath>
+				<value>
+					<Kobold_Kamikaze>10</Kobold_Kamikaze>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd"> <!--Peaceful-->
+			<xpath>Defs/FactionDef[@Name="Medbold_FactionBase"]/pawnGroupMakers/li[2]/options</xpath>
+			<value>
+				<Kobold_Kamikaze>5</Kobold_Kamikaze>
+			</value>
+			</li>
+			<li Class="PatchOperationAdd"> <!--Trader-->
+			<xpath>Defs/FactionDef[@Name="Medbold_FactionBase"]/pawnGroupMakers/li[3]/guards</xpath>
+			<value>
+				<Kobold_Kamikaze>7</Kobold_Kamikaze>
+			</value>
+			</li>
+			<li Class="PatchOperationAdd"> <!-- Settlement -->
+				<xpath>Defs/FactionDef[@Name="Medbold_FactionBase"]/pawnGroupMakers/li[4]/options</xpath>
+				<value>
+					<Kobold_Kamikaze>20</Kobold_Kamikaze>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd"> <!--Adding Kamikaze ONLY raid -->
+			<xpath>Defs/FactionDef[@Name="Medbold_FactionBase"]/pawnGroupMakers</xpath>
+			<value>
+				<li>
+                    <kindDef>Combat</kindDef>
+					 <commonality>30</commonality>
+                    <options>
+                        <Kobold_Kamikaze>20</Kobold_Kamikaze>
+                    </options>
+                </li>
+			</value>
+			</li>
+		 </operations>
+		 </match>
+	</Operation>
+</Patch>

--- a/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
+++ b/Patches/Kobold Factions/Medieval_Kobold_Pawnkind.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	 <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Kobold Factions</li>
+    </mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<li Class="PatchOperationAdd">
+			<xpath>Defs/PawnKindDef[ @Name="MedboldBase"]/apparelRequired</xpath>
+				<value>
+					<li>Apparel_TribalBackpack</li>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[ defName="LTS_MedboldScout" or defName="LTS_MedboldRanger" or defName="LTS_MedboldLord"]</xpath>
+			<value>
+				<li Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+					<min>15</min>
+					<max>30</max>
+					</primaryMagazineCount>
+			  </li>
+			</value>
+		  </li>
+			
+		</operations>
+		</match>	
+	</Operation>
+</Patch>

--- a/Patches/Nakin Race/Nakin_Bionics.xml
+++ b/Patches/Nakin Race/Nakin_Bionics.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- Nakin Claw -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="Nakin_ARClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+						<!-- Compared to a Power Claw, Deals more damage, is slower, no movement penalty, slightly more Sharp Penetration and slightly less Blunt Penetration | Is exclusive to Nakins-->
+							<li Class="CombatExtended.ToolCE">
+								<label>claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>30</power>
+								<cooldownTime>2</cooldownTime>
+								<armorPenetrationSharp>1.2</armorPenetrationSharp>
+								<armorPenetrationBlunt>3</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<!-- Nakin Bionic Arm -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/HediffDef[defName="Bionic_Nakin_Arm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+					<value>
+						<tools>
+						<!-- Is exclusive to Nakins-->
+							<li Class="CombatExtended.ToolCE">
+								<label>claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>20</power>
+								<cooldownTime>2</cooldownTime>
+								<armorPenetrationSharp>0.85</armorPenetrationSharp>
+								<armorPenetrationBlunt>3.2</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Nakin Race/Nakin_Body.xml
+++ b/Patches/Nakin Race/Nakin_Body.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			<!-- Body Armor Patch-->
+				      <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+							<li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					   <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Eye"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Nakin_Shoulder"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+						<li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def= "Nakin_Shoulder"]/parts/li[def ="Arm"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Nakin_Shoulder"]/parts/li[def ="Arm"]/parts/li[def = "Nakin_Hand"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Nakin_Shoulder"]/parts/li[def ="Arm"]/parts/li[def = "Nakin_Hand"]/parts/li[def = "Finger"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+						<li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Waist"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+						<value>
+						  <li>CoveredByNaturalArmor</li>
+						</value>
+					  </li>
+					  <li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Tail"]</xpath>
+						<value>
+						<groups>
+						  <li>CoveredByNaturalArmor</li>
+						 </groups>
+						</value>
+					  </li><li Class="PatchOperationAdd">
+						<xpath>Defs/BodyDef[defName = "Nakin_body"]/corePart/parts/li[def = "Nakin_Tentacle"]</xpath>
+						<value>
+						<groups>
+						  <li>CoveredByNaturalArmor</li>
+						 </groups>
+						</value>
+					  </li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Nakin Race/Nakin_Items.xml
+++ b/Patches/Nakin Race/Nakin_Items.xml
@@ -10,35 +10,23 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Leather_Nakin"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
-						<StuffPower_Armor_Sharp>0.55</StuffPower_Armor_Sharp>
+						<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Leather_Nakin"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
-						<StuffPower_Armor_Blunt>0.25</StuffPower_Armor_Blunt>
+						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 
 			
-			<!-- Nakin Glasses -->
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>0.6</ArmorRating_Sharp>
-					</value>
-				</li>
+<!-- Nakin Glasses -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases</xpath>
 					<value>
-						<Bulk>0.5</Bulk>
-						<WornBulk>0.5</WornBulk>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>0.9</ArmorRating_Blunt>
+						<Bulk>0</Bulk>
+						<WornBulk>0</WornBulk>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -49,6 +37,15 @@
 						</layers>
 					</value>
 				</li>			
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_NakinGlasses"]/equippedStatOffsets</xpath>
+					<value>
+					  <equippedStatOffsets>
+						<AimingAccuracy>0.3</AimingAccuracy>
+						<ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
+					  </equippedStatOffsets>
+					</value>
+				  </li>
 				
 				
 				<!-- Nakin Tactical Ballistc Goggles-->
@@ -62,22 +59,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<ArmorRating_Sharp>2</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/equippedStatOffsets</xpath>
-					<value>
-					  <equippedStatOffsets>
-						<AimingAccuracy>0.3</AimingAccuracy>
-						<ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
-					  </equippedStatOffsets>
-					</value>
-				  </li>
-				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>9</ArmorRating_Blunt>
+						<ArmorRating_Blunt>6</ArmorRating_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -95,7 +83,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/apparel/layers</xpath>
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/apparel/layers</xpath>
 					<value>
 						<layers>
 							<li>StrappedHead</li>

--- a/Patches/Nakin Race/Nakin_Items.xml
+++ b/Patches/Nakin Race/Nakin_Items.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			<!-- Nakin Leather | values to represent the Race's natural toughness-->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Leather_Nakin"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<value>
+						<StuffPower_Armor_Sharp>0.55</StuffPower_Armor_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Leather_Nakin"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<value>
+						<StuffPower_Armor_Blunt>0.25</StuffPower_Armor_Blunt>
+					</value>
+				</li>
+
+			
+			<!-- Nakin Glasses -->
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.6</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.9</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>StrappedHead</li>
+						</layers>
+					</value>
+				</li>			
+				
+				
+				<!-- Nakin Tactical Ballistc Goggles-->
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases</xpath>
+					<value>
+						<Bulk>0.5</Bulk>
+						<WornBulk>0.5</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/equippedStatOffsets</xpath>
+					<value>
+					  <equippedStatOffsets>
+						<AimingAccuracy>0.3</AimingAccuracy>
+						<ShootingAccuracyPawn>5.0</ShootingAccuracyPawn>
+					  </equippedStatOffsets>
+					</value>
+				  </li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>9</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.366</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/costList</xpath>
+					<value>
+						<DevilstrandCloth>15</DevilstrandCloth>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>StrappedHead</li>
+						</layers>
+					</value>
+				</li>			
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/equippedStatOffsets</xpath>
+					<value>
+					  <equippedStatOffsets>
+						<AimingAccuracy>0.6</AimingAccuracy>
+						<ShootingAccuracyPawn>10.0</ShootingAccuracyPawn>
+					  </equippedStatOffsets>
+					</value>
+				  </li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Nakin Race/Nakin_Items.xml
+++ b/Patches/Nakin Race/Nakin_Items.xml
@@ -21,7 +21,7 @@
 				</li>
 
 			
-<!-- Nakin Glasses -->
+			<!-- Nakin Glasses -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGlasses"]/statBases</xpath>
 					<value>
@@ -47,7 +47,6 @@
 					</value>
 				  </li>
 				
-				
 				<!-- Nakin Tactical Ballistc Goggles-->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases</xpath>
@@ -62,6 +61,7 @@
 						<ArmorRating_Sharp>2</ArmorRating_Sharp>
 					</value>
 				</li>
+				
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
@@ -81,15 +81,14 @@
 						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>
-
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/apparel/layers</xpath>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Apparel_NakinGogglesA"]/apparel</xpath>
 					<value>
 						<layers>
 							<li>StrappedHead</li>
 						</layers>
 					</value>
-				</li>			
+				</li>		
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="Apparel_NakinGogglesA"]/equippedStatOffsets</xpath>
 					<value>

--- a/Patches/Nakin Race/Nakin_Pawnkind.xml
+++ b/Patches/Nakin Race/Nakin_Pawnkind.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+				  <xpath>Defs/PawnKindDef[@Name="NakinPawnKindBase"]</xpath>
+				  <value>
+					 <apparelRequired>
+						<li>Apparel_Backpack</li>
+					 </apparelRequired>
+				  </value>
+				  </li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>			

--- a/Patches/Nakin Race/Nakin_Race.xml
+++ b/Patches/Nakin Race/Nakin_Race.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]</xpath>
+				<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+				</value>
+			</li>
+						<!-- Body Armor Values (Had no reference to use. Vanilla values were 0.1 Sharp/ 0.2 Blunt -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases</xpath>
+				<!-- Nakin are Melee focused and are not good at using ranged weapons-->
+				<value>
+					<AimingAccuracy>0.7</AimingAccuracy>
+					<MeleeCritChance>1.3</MeleeCritChance>
+					<MeleeParryChance>1.3</MeleeParryChance>
+					<ReloadSpeed>2.0</ReloadSpeed>
+					<Suppressability>0.50</Suppressability>
+					<SmokeSensitivity>1</SmokeSensitivity>
+					<NightVisionEfficiency>0.2</NightVisionEfficiency>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/statBases/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeDodgeChance>1.5</MeleeDodgeChance>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left craw</label> <!-- It's literally called "left craw" in the files -->
+						<capacities>
+							<li>Scratch</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>2</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.15</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right craw</label> 
+						<capacities>
+							<li>Scratch</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>2</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.15</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>20</power>
+						<cooldownTime>2</cooldownTime>
+						<chanceFactor>0.07</chanceFactor>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>0.7</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.4</armorPenetrationSharp>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>11</power>
+						<cooldownTime>2</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+					</li>
+					</tools>
+			</value>
+			</li>
+					
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/comps</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]</xpath>
+					<value>
+						<comps />
+					</value>
+				</nomatch>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="NakinRace"]/comps</xpath>
+				<value>
+					<li>
+					<compClass>CombatExtended.CompPawnGizmo</compClass>
+					</li>
+					<li Class="CombatExtended.CompProperties_Suppressable" />
+				</value>
+			</li>					
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Nakin Race/Nakin_Scenario.xml
+++ b/Patches/Nakin Race/Nakin_Scenario.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class ="PatchOperationFindMod">
+		<mods>
+		<li>NakinRace</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/ScenarioDef[defName="NakinCrashlanded"]/scenario/parts</xpath>
+				<value>
+					<li Class="ScenPart_StartingThing_Defined">
+						<def>StartingThing_Defined</def>
+						<thingDef>Ammo_303British_FMJ</thingDef>
+						<count>50</count>
+					</li>
+				</value>
+			</li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>	

--- a/Patches/Nakin Race/Nakin_Scenario.xml
+++ b/Patches/Nakin Race/Nakin_Scenario.xml
@@ -16,6 +16,17 @@
 					</li>
 				</value>
 			</li>
+			<li Class="PatchOperationRemove">
+			<xpath>Defs/ScenarioDef[defName="NakinCrashlanded"]/scenario/parts/li[thingDef="Apparel_AdvancedHelmet"]</xpath>
+			</li>
+				
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[defName="NakinCrashlanded"]/scenario/parts/li[thingDef="Apparel_FlakVest"]</xpath>
+			</li>
+				
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ScenarioDef[defName="NakinCrashlanded"]/scenario/parts/li[thingDef="Apparel_FlakPants"]</xpath>
+			</li>
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Additions
Patches for Nakin Race and pawnkind patches for kobolds from Kobold Factions

## Changes
Patch for Nakin is straight foward, the only value I changed was from Nakin goggles, that gave +2 to Aim, increased to +5.


Added a Sticky-bomb pawnkind to Medieval kobolds alongside a *fix* for kobolds as they were not carrying tribal backpack by default

## Reasoning

For Nakins, they start with a base -1000% to Weapon Handling, and their goggles are suppose to help them aim, but with just +2 to Weapon Handling, it was not having any significant impact. Increasing to +5 gives Nakin ranged units a fighting chance while not removing the utility of the advanced Nakin goggles. 

For Kobolds, their small size and low tech make them laughable in CE, specially with no sticky bomb pawns. Introducing Kobold Bombers + a new raid kind with **just** Kobold Bombers will hopefully increase their relevance.
## Alternatives

  I was thinking about either removing or reducing their capability of being suppressed (because Kobolds are not smart and could live for hundred of years if they had a bit of self-preservation), but I feel like sticky bomb should be enough.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (8 hours)
