### PR TITLE
Add setting for wall damage generating fragments

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -79,6 +79,9 @@
   <CE_Settings_UnlimitNewParryDamage_Desc>If false, limits damage done to parrying weapons to the lesser of the hardness-based or 10% of parried damage.</CE_Settings_UnlimitNewParryDamage_Desc>
   <CE_Settings_UnlimitNewParryDamage_Title>Unlimit weapon parry damage</CE_Settings_UnlimitNewParryDamage_Title>
 
+  <CE_Settings_FragmentsFromWalls_Desc>If true, damaging walls can generate fragments</CE_Settings_FragmentsFromWalls_Desc>
+  <CE_Settings_FragmentsFromWalls_Title>Fragments From Walls</CE_Settings_FragmentsFromWalls_Title>
+
   <!-- ========== Bipod settings ========== -->
 
   <CE_Settings_BipodSettings>Bipod settings</CE_Settings_BipodSettings>

--- a/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFragments.cs
@@ -28,7 +28,7 @@ namespace CombatExtended
 
         public CompProperties_Fragments PropsCE => (CompProperties_Fragments)props;
 
-        private static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange)
+        public static IEnumerator FragRoutine(Vector3 pos, Map map, float height, Thing instigator, ThingDefCountClass frag, float fragSpeedFactor, float fragShadowChance, FloatRange fragAngleRange, FloatRange fragXZAngleRange, float minCollisionDistance = 0f, bool canTargetSelf = true)
         {
             var cell = pos.ToIntVec3();
             var exactOrigin = new Vector2(pos.x, pos.z);
@@ -42,8 +42,8 @@ namespace CombatExtended
                 var projectile = (ProjectileCE)ThingMaker.MakeThing(frag.thingDef);
                 GenSpawn.Spawn(projectile, cell, map);
 
-                projectile.canTargetSelf = true;
-                projectile.minCollisionDistance = 0f;
+                projectile.canTargetSelf = canTargetSelf;
+                projectile.minCollisionDistance = minCollisionDistance;
                 projectile.castShadow = (Rand.Value < fragShadowChance);
                 projectile.logMisses = false;
                 projectile.Launch(

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -35,6 +35,8 @@ namespace CombatExtended
 
 	private bool unlimitParryDamage = false;
 
+	private bool fragmentsFromWalls = false;
+
         public bool ShowCasings => showCasings;
 
         public bool BipodMechanics => bipodMechanics;
@@ -121,6 +123,8 @@ namespace CombatExtended
 	public bool EnableRaceAutopatcher => enableRaceAutopatcher;
 	public bool EnablePawnKindAutopatcher => enablePawnKindAutopatcher;
 
+	public bool FragmentsFromWalls => fragmentsFromWalls;
+
 	#endregion
 
         private bool lastAmmoSystemStatus;
@@ -183,6 +187,8 @@ namespace CombatExtended
             Scribe_Values.Look(ref bipodMechanics, "bipodMechs", true);
             Scribe_Values.Look(ref autosetup, "autosetup", true);
 
+	    Scribe_Values.Look(ref fragmentsFromWalls, "fragmentsFromWalls", false);
+
             lastAmmoSystemStatus = enableAmmoSystem;    // Store this now so we can monitor for changes
         }
 
@@ -208,6 +214,8 @@ namespace CombatExtended
 	    list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
 
 	    list.CheckboxLabeled("CE_Settings_UnlimitNewParryDamage_Title".Translate(), ref unlimitParryDamage, "CE_Settings_UnlimitNewParryDamage_Desc".Translate());
+
+	    list.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
 
             // Only Allow these settings to be changed in the main menu since doing while a
             // map is loaded will result in rendering issues.

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -215,7 +215,6 @@ namespace CombatExtended
 
 	    list.CheckboxLabeled("CE_Settings_UnlimitNewParryDamage_Title".Translate(), ref unlimitParryDamage, "CE_Settings_UnlimitNewParryDamage_Desc".Translate());
 
-	    list.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
 
             // Only Allow these settings to be changed in the main menu since doing while a
             // map is loaded will result in rendering issues.
@@ -223,6 +222,7 @@ namespace CombatExtended
             {
                 list.CheckboxLabeled("CE_Settings_ShowBackpacks_Title".Translate(), ref showBackpacks, "CE_Settings_ShowBackpacks_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_ShowWebbing_Title".Translate(), ref showTacticalVests, "CE_Settings_ShowWebbing_Desc".Translate());
+		list.CheckboxLabeled("CE_Settings_FragmentsFromWalls_Title".Translate(), ref fragmentsFromWalls, "CE_Settings_FragmentsFromWalls_Desc".Translate());
             }
             else
             {

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
@@ -41,6 +41,7 @@ namespace CombatExtended.HarmonyCE
 			num *= dinfo.Def.buildingDamageFactorPassable;
 		    }
 		    float hitPoints = victim.HitPoints;
+		    float maxHitPoints = victim.MaxHitPoints;
 		    bool max = false;
 		    if (num > hitPoints)
 		    {
@@ -62,29 +63,48 @@ namespace CombatExtended.HarmonyCE
 			smallFragment = DefDatabase<ThingDef>.AllDefsListForReading.Where(d => d.defName == "Fragment_Small").First();
 			largeFragment = DefDatabase<ThingDef>.AllDefsListForReading.Where(d => d.defName == "Fragment_Large").First();
 		    }
-		    var xzRange = new FloatRange(dinfo.Angle + 90, dinfo.Angle + 270);
-		    if (max) {
-			pos = victim.Position.ToVector3Shifted();
-			xzRange = new FloatRange(0, 360);
-		    }
+		    var frontArc = new FloatRange(dinfo.Angle + 90, dinfo.Angle + 270); 
+		    var backArc = new FloatRange(dinfo.Angle - 60, dinfo.Angle + 60);
 
 		    var map = victim.Map;
 		    var height = new FloatRange(0, new CollisionVertical(victim).Max).RandomInRange;
+		    if (max)
+		    {
+			backArc = new FloatRange(dinfo.Angle - 90, dinfo.Angle + 90);
+		    }
 
 		    if (smallFragments > 0)
 		    {
-			var fr = CompFragments.FragRoutine(pos,
-							   map,
-							   height,
-							   victim,
-							   new ThingDefCountClass(smallFragment, smallFragments),
-							   1,
-							   0.2f,
-							   new FloatRange(0.5f, 5),
-							   xzRange,
-							   1f,
-							   false);
-			while (fr.MoveNext()) { }
+			int reflectedFrags = (int) (smallFragments * (hitPoints / maxHitPoints));
+			smallFragments -= reflectedFrags;
+			if (reflectedFrags > 0) {
+			    var fr = CompFragments.FragRoutine(pos,
+							       map,
+							       height,
+							       victim,
+							       new ThingDefCountClass(smallFragment, smallFragments),
+							       1,
+							       0.2f,
+							       new FloatRange(0.5f, 5),
+							       frontArc,
+							       1f,
+							       false);
+			    while (fr.MoveNext()) { }
+			}
+			{
+			    var fr = CompFragments.FragRoutine(pos,
+							       map,
+							       height,
+							       victim,
+							       new ThingDefCountClass(smallFragment, smallFragments),
+							       1,
+							       0.2f,
+							       new FloatRange(0.5f, 5),
+							       backArc,
+							       1f,
+							       false);
+			    while (fr.MoveNext()) { }
+			}
 
 		    }
 		    if (largeFragments > 0)
@@ -97,7 +117,7 @@ namespace CombatExtended.HarmonyCE
 							   1,
 							   0.2f,
 							   new FloatRange(0.5f, 5),
-							   xzRange,
+							   backArc,
 							   1f,
 							   false);
 			

--- a/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
+++ b/Source/CombatExtended/Harmony/Harmony_DamageWorker.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using System.Reflection.Emit;
+using Verse;
+using RimWorld;
+using UnityEngine;
+using HarmonyLib;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(DamageWorker), nameof(DamageWorker.Apply))]
+    internal static class Harmony_DamageWorker_Apply
+    {
+	private static ThingDef smallFragment = null;
+	private static ThingDef largeFragment = null;
+	public static bool Prefix(DamageWorker __instance, DamageInfo dinfo, Thing victim)
+	{
+	    if (!Controller.settings.FragmentsFromWalls)
+	    {
+		return true;
+	    }
+	    if (victim.def.useHitPoints && dinfo.Def.harmsHealth && dinfo.Def != DamageDefOf.Mining)
+	    {
+		if (victim.def.category == ThingCategory.Building)
+		{
+		    bool isSharp = dinfo.Def.armorCategory == DamageArmorCategoryDefOf.Sharp;
+		    Vector3 pos;
+		    pos = victim.Position.ToVector3Shifted();
+		    float num = dinfo.Amount;
+
+		    num *= dinfo.Def.buildingDamageFactor;
+		    if (victim.def.passability == Traversability.Impassable)
+		    {
+			num *= dinfo.Def.buildingDamageFactorImpassable;
+		    }
+		    else
+		    {
+			num *= dinfo.Def.buildingDamageFactorPassable;
+		    }
+		    float hitPoints = victim.HitPoints;
+		    bool max = false;
+		    if (num > hitPoints)
+		    {
+			max = true;
+		    }
+		    int fragmentDamage = (int) (Mathf.Max(num/10f, Mathf.Clamp01(num / hitPoints) * num));
+		    if (isSharp)
+		    {
+			fragmentDamage /= 2;
+		    }
+
+		    int largeFragments = fragmentDamage / 37;
+		    int smallFragments = (fragmentDamage % 37) / 9;
+		    
+		    smallFragments += 4 * ((largeFragments / 2) + largeFragments % 2);
+		    largeFragments /= 2;
+		    if (smallFragment == null)
+		    {
+			smallFragment = DefDatabase<ThingDef>.AllDefsListForReading.Where(d => d.defName == "Fragment_Small").First();
+			largeFragment = DefDatabase<ThingDef>.AllDefsListForReading.Where(d => d.defName == "Fragment_Large").First();
+		    }
+		    var xzRange = new FloatRange(dinfo.Angle + 90, dinfo.Angle + 270);
+		    if (max) {
+			pos = victim.Position.ToVector3Shifted();
+			xzRange = new FloatRange(0, 360);
+		    }
+
+		    var map = victim.Map;
+		    var height = new FloatRange(0, new CollisionVertical(victim).Max).RandomInRange;
+
+		    if (smallFragments > 0)
+		    {
+			var fr = CompFragments.FragRoutine(pos,
+							   map,
+							   height,
+							   victim,
+							   new ThingDefCountClass(smallFragment, smallFragments),
+							   1,
+							   0.2f,
+							   new FloatRange(0.5f, 5),
+							   xzRange,
+							   1f,
+							   false);
+			while (fr.MoveNext()) { }
+
+		    }
+		    if (largeFragments > 0)
+		    {
+			var fr = CompFragments.FragRoutine(pos,
+							   map,
+							   height,
+							   victim,
+							   new ThingDefCountClass(largeFragment, largeFragments),
+							   1,
+							   0.2f,
+							   new FloatRange(0.5f, 5),
+							   xzRange,
+							   1f,
+							   false);
+			
+			while (fr.MoveNext()) {}
+			
+		    }		    
+		}
+	    }
+	    return true;
+	}
+    }
+}


### PR DESCRIPTION
## Additions

Explosives (or other large sources) damaging walls can now generate fragments.

## Reasoning

Turning a stone wall into a pile of stones *should* send some of them flying with enough force to do damage.
It is gated behind a mod option as it can be a bit expensive to run.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (hours)
