### PR TITLE
Set the scan distance for ammo to the same as the scan distance for turrets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -21,7 +21,7 @@ namespace CombatExtended
         /// <summary>
         /// The radius around a given turret in which to search for corresponding ammo.
         /// </summary>
-        private const float AmmoSearchRadius = 20;
+        private const float AmmoSearchRadius = 40;
 
         const int ticksBetweenChecks = 600;    //Divide by 60 for seconds
 


### PR DESCRIPTION


## Changes

Mech ammo beacons use the same radius to check for turrets and to check for loose ammo.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #1689 

## Reasoning

Mech ammo beacons could find a turret and drop ammo for it, then fail to find the dropped ammo, resulting in an endless supply of ammo.

- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
