### PR TITLE
Don't reset fire mods when dropping guns.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -83,8 +83,6 @@ namespace CombatExtended
                 return Caster as Pawn;
             }
         }
-        private Faction _factionFireMode = null;
-        private bool _initCurrentFireMode = false;
 
         private bool IsTurretMannable = false;
 
@@ -104,41 +102,24 @@ namespace CombatExtended
         {
             get
             {
-                if ((!_initCurrentFireMode || _factionFireMode != Caster.Faction) && useAIModes && Props.aiUseBurstMode && availableFireModes.Contains(FireMode.BurstFire))
-                {
-                    _initCurrentFireMode = true;
-                    _factionFireMode = Caster.Faction;
-                    currentFireModeInt = FireMode.BurstFire;
-                }
                 return currentFireModeInt;
             }
             set
             {
-                _factionFireMode = Caster.Faction;
                 currentFireModeInt = value;
             }
         }
-        private Faction _factionAimMode = null;
-        private bool _initCurrentAimMode = false;
         public AimMode CurrentAimMode
         {
             get
             {
-                if ((!_initCurrentAimMode || _factionAimMode != Caster.Faction) && useAIModes && availableAimModes.Contains(Props.aiAimMode))
-                {
-                    _initCurrentAimMode = true;
-                    _factionAimMode = Caster.Faction;
-                    currentAimModeInt = Props.aiAimMode;
-                }
                 return currentAimModeInt;
             }
             set
             {
-                _factionAimMode = Caster.Faction;
                 currentAimModeInt = value;
             }
         }
-        private bool useAIModes => Caster.Faction != Faction.OfPlayer;
 
         #endregion
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -19,6 +19,7 @@ namespace CombatExtended
         private List<AimMode> availableAimModes = new List<AimMode>(Enum.GetNames(typeof(AimMode)).Length) { AimMode.AimedShot };
         private FireMode currentFireModeInt;
         private AimMode currentAimModeInt;
+	private bool newComp = true;
         public TargettingMode targetMode = TargettingMode.torso;
 
         #endregion
@@ -137,6 +138,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref currentFireModeInt, "currentFireMode", FireMode.AutoFire);
             Scribe_Values.Look(ref currentAimModeInt, "currentAimMode", AimMode.AimedShot);
             Scribe_Values.Look(ref targetMode, "currentTargettingMode", TargettingMode.torso);
+	    Scribe_Values.Look(ref newComp, "newComp", false);
         }
 
         public void InitAvailableFireModes()
@@ -169,8 +171,9 @@ namespace CombatExtended
             }
 
             // Sanity check in case def changed
-            if (!availableFireModes.Contains(currentFireModeInt) || !availableAimModes.Contains(currentAimModeInt))
+            if (newComp || !availableFireModes.Contains(currentFireModeInt) || !availableAimModes.Contains(currentAimModeInt))
             {
+		newComp = false;
                 ResetModes();
             }
         }
@@ -221,11 +224,11 @@ namespace CombatExtended
         /// </summary>
         public void ResetModes()
         {
-            //Required since availableFireModes.Capacity is set but its contents aren't so ElementAt(0) causes errors in some instances
+	    //Required since availableFireModes.Capacity is set but its contents aren't so ElementAt(0) causes errors in some instances
             if (availableFireModes.Count > 0)
                 currentFireModeInt = availableFireModes.ElementAt(0);
 
-            currentAimModeInt = availableAimModes.ElementAt(0);
+            currentAimModeInt = Props.aiAimMode;
         }
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_FireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_FireModes.cs
@@ -8,7 +8,7 @@ namespace CombatExtended
         public bool aiUseBurstMode = false;
         public bool noSingleShot = false;
         public bool noSnapshot = false;
-        public AimMode aiAimMode = AimMode.Snapshot;
+        public AimMode aiAimMode = AimMode.AimedShot;
 
         public CompProperties_FireModes()
         {

--- a/Source/CombatExtended/CombatExtended/Enums/AimMode.cs
+++ b/Source/CombatExtended/CombatExtended/Enums/AimMode.cs
@@ -7,8 +7,8 @@ namespace CombatExtended
 {
     public enum AimMode : byte
     {
-        SuppressFire = 0,
-        Snapshot = 1,
-        AimedShot = 2,
+        AimedShot = 0,
+        SuppressFire = 1,
+        Snapshot = 2,
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -235,18 +235,6 @@ namespace CombatExtended
         }
 
         /// <summary>
-        /// Reset selected fire mode back to default when gun is dropped
-        /// </summary>
-        public override void Notify_EquipmentLost()
-        {
-            base.Notify_EquipmentLost();
-            if (CompFireModes != null)
-            {
-                CompFireModes.ResetModes();
-            }
-        }
-
-        /// <summary>
         /// Checks to see if enemy is blind before shooting
         /// </summary>
         public override bool CanHitTargetFrom(IntVec3 root, LocalTargetInfo targ)


### PR DESCRIPTION

## Changes

Guns remember their fire mode settings


## Reasoning

The AI can switch fire mods when it should , no reason to reset it for AI pawns.  Players usually want their pawns' weapons to stay as set.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (minutes)
