### PR TITLE
make downed pawns even shorter than crouched ones

### DIFF
--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -798,7 +798,7 @@ namespace CombatExtended
                 factors.x *= shape.widthLaying / shape.width;
                 factors.y *= shape.heightLaying / shape.height;
 		if (pawn.Downed) {
-		    factor.y *= shape.heightLaying;
+		    factors.y *= shape.heightLaying;
 		}
             }
 

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -784,7 +784,7 @@ namespace CombatExtended
 
             var factors = BoundsInjector.ForPawn(pawn);
 
-            if (pawn.GetPosture() != PawnPosture.Standing)
+            if (pawn.GetPosture() != PawnPosture.Standing || pawn.Downed)
             {
                 RacePropertiesExtensionCE props = pawn.def.GetModExtension<RacePropertiesExtensionCE>() ?? new RacePropertiesExtensionCE();
 
@@ -797,6 +797,9 @@ namespace CombatExtended
 
                 factors.x *= shape.widthLaying / shape.width;
                 factors.y *= shape.heightLaying / shape.height;
+		if (pawn.Downed) {
+		    factor.y *= shape.heightLaying;
+		}
             }
 
             return factors;


### PR DESCRIPTION


## Changes

Downed pawns are now shorter than crouching ones.

## Reasoning

Crouching pawns are between 0.25 and 0.5 their base height depending on body type.  Currently, downed pawns are the same height as crouched pawns.  This leads to downed but alive pawns soaking bullets aimed at crouching pawns.  This applies the same percent-reduction in pawn height that standing->crouching gives to go from crouching->prone

## Alternatives

Define a prone height for each body type.  Requires xml changes, including in any sub-mods that add their own body types.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
