### PR TITLE
allow retargeting to nearby pawns along same line

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -794,6 +794,10 @@ namespace CombatExtended
 		    lastTarget = currentTarget;
 		    lastTargetPos = currentTarget.Cell;
 		    shootingAtDowned = false;
+		    if (caster is Building_TurretGunCE bt) {
+			float curRotation = (currentTarget.Cell.ToVector3Shifted() - bt.DrawPos).AngleFlat();
+			bt.top.CurRotation = curRotation;
+		    }
 		    return true;
 		}
 		return false;


### PR DESCRIPTION
## Changes

When a target is downed by burst / full-auto fire, if there is another pawn belonging to the *same* faction, and it is an enemy faction, the shooter will retarget to the next pawn.

## Reasoning

Once the target drops, they may break line of sight.  Additionally, if the target *dies*, the shooter stops shooting and can pick the next target.  Which means it is better if the shooter magically knows their target died vs just dropped.  This allows the shooting pawn to retarget if the pawn is downed, and certain conditions are met, which means the minigun and similar full-auto weapons can "walk" a line of targets.  This especially matters with weapons like the Kinetic Lance, which dumps half its mag per burst and full mag per auto, and which often down pawns at medium range without killing them.

## Alternatives

Force pawns to waste ammo.
Stop pawns shooting when the target is downed, same as if the target dies.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
