### PR TITLE
Vanilla guns' fire mode tweaks

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -150,6 +150,7 @@
     </AmmoUser>
     <FireModes>
       <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_Sidearm</li>
@@ -203,6 +204,7 @@
     </AmmoUser>
     <FireModes>
       <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_Sidearm</li>
@@ -256,7 +258,9 @@
       <reloadTime>0.85</reloadTime>
       <ammoSet>AmmoSet_12Gauge</ammoSet>
     </AmmoUser>
-    <FireModes />
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
     <weaponTags>
       <li>CE_AI_BROOM</li>
     </weaponTags>
@@ -314,7 +318,9 @@
       <reloadTime>4</reloadTime>
       <ammoSet>AmmoSet_12Gauge</ammoSet>
     </AmmoUser>
-    <FireModes />
+    <FireModes>
+      <aiAimMode>Snapshot</aiAimMode>
+    </FireModes>
     <weaponTags>
       <li>CE_AI_BROOM</li>
     </weaponTags>
@@ -533,6 +539,7 @@
     <FireModes>
       <aimedBurstShotCount>3</aimedBurstShotCount>
       <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_SMG</li>
@@ -591,6 +598,7 @@
     <FireModes>
       <aimedBurstShotCount>3</aimedBurstShotCount>
       <aiUseBurstMode>FALSE</aiUseBurstMode>
+      <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_SMG</li>


### PR DESCRIPTION
## Additions

- Set some of the vanilla guns that did not have preset fire mode to Snapshot

## Reasoning

- Default fire mode will be set to aimed shot which necessitates guns that should be fired is a rapid fashion to be set to snap shot.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
