### PR TITLE
Rebalance mechanoid heavy weapons

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1161,7 +1161,7 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
+      <warmupTime>2.0</warmupTime>
       <range>75</range>
       <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
       <burstShotCount>20</burstShotCount>
@@ -1218,7 +1218,7 @@
     <defName>Gun_InfernoCannon</defName>
     <statBases>
       <Mass>300.00</Mass>
-      <RangedWeapon_Cooldown>2.53</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>0.82</SwayFactor>
@@ -1227,8 +1227,8 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-      <warmupTime>4.3</warmupTime>
+      <defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+      <warmupTime>3.5</warmupTime>
       <range>86</range>
       <burstShotCount>1</burstShotCount>
       <soundCast>InfernoCannon_Fire</soundCast>


### PR DESCRIPTION
## Changes

- Adjusted the HCB based on the gun spreadsheet, it was too rapid-fire so increased its warmup time.
- The inferno cannon has been tweaked to be an incendiary weapon so it is no longer as dangerous as it used to be, lowered its warmup time to reflect that.
- Did the same adjustments for the variants of these weapons as well.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
