### PR TITLE
Mechanite apparel rebalanced

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Apparel_Mechanite.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Apparel_Mechanite.xml
@@ -12,28 +12,28 @@
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-				<ArmorRating_Sharp>7</ArmorRating_Sharp>
+				<ArmorRating_Sharp>2</ArmorRating_Sharp>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				<ArmorRating_Blunt>3</ArmorRating_Blunt>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
-				<ArmorRating_Sharp>7</ArmorRating_Sharp>
+				<ArmorRating_Sharp>2</ArmorRating_Sharp>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
 			<xpath>/Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
-				<ArmorRating_Blunt>10</ArmorRating_Blunt>
+				<ArmorRating_Blunt>3</ArmorRating_Blunt>
 			</value>
 		</li>
 	


### PR DESCRIPTION
## Changes

- Rebalanced the mechanite apparel from VFE - Mechanoids.

## Reasoning

- In vanilla game, these two items provide almost 20% of the armor that a flak vest provides, which is 20% and 7% sharp and blunt armor respectively. Making the same comparison in CE while being generous and we come up with 2/3 sharp/blunt armor which is still more than 20% of a steel armor vest for a skin layer item that is made out of steel, cloth and advanced components. 2/3 keeps the apparel fairly strong in terms of armor relatively to the other skin layer option in the game.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
