### PR TITLE
Unarmed damage bonus stat uncapped

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -308,6 +308,13 @@
         <weight>1</weight>
       </li>
     </capacityFactors>
+    <postProcessCurve>
+      <points>
+        <li>(0, 0)</li>
+        <li>(10, 10)</li>
+        <li>(100, 15)</li>
+      </points>
+    </postProcessCurve>
   </StatDef>
 
   <!-- ================================== Body part armor =======================================-->


### PR DESCRIPTION
## Changes

- Added a `postProcessCurve` to the stat to increase the higher end of the cap.

## References

- Closes #1583 

## Reasoning

- So that apparel that might give a bonus damage in the future are not pegged by the cap.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Already tested, waited for the stat to be compatible with MVCF)
