### PR TITLE
Prevent shields stopping melee hits

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
@@ -24,13 +24,12 @@ namespace CombatExtended.HarmonyCE
     {
         internal static bool Prefix(ref bool __result, DamageInfo dinfo, ShieldBelt __instance)
         {
+	    __result = false;
 
 	    if (__instance.ShieldState != ShieldState.Active)
 	    {
-		__result = false;
 		return false;
 	    }
-	    __result = true;
 	    float bc = 1.0f;
 	    bool isEMP = dinfo.Def == DamageDefOf.EMP;
 	    if (dinfo.Weapon.projectile is ProjectilePropertiesCE pce)
@@ -42,10 +41,12 @@ namespace CombatExtended.HarmonyCE
 	    {
 		__instance.energy = 0f;
 		__instance.Break();
+		__result = true;
 		return false;
 	    }
 	    if (dinfo.Def.isRanged || dinfo.Def.isExplosive)
 	    {
+		__result = true;
 		__instance.energy -= dinfo.Amount * __instance.EnergyLossPerDamage * (isEMP ? (1+bc) : 1);
 		if (__instance.energy < 0f)
 		{


### PR DESCRIPTION
## Changes
Shield belts no longer stop melee hits.

## Reasoning

Fixes bug introduced by previous ion changes.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
