### PR TITLE
Adjustments to Time-Fuzed HE Grenades

### DIFF
--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
@@ -17,9 +17,9 @@
   
   <CombatExtended.AmmoCategoryDef>
     <defName>GrenadeHETF</defName>
-    <label>High-explosive Time-Fuzed</label>
-    <labelShort>HEDP</labelShort>
-    <description>Grenade with a timed fuze. Fuze is set at or before launch, and can detonate mid flight.</description>
+    <label>High-explosive airburst</label>
+    <labelShort>Airburst</labelShort>
+    <description>Grenade with a timed fuze designed to detonate mid-flight for maxiumum effectiveness.</description>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -281,7 +281,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_30x29mmGrenade_HE>100</Ammo_30x29mmGrenade_HE>
+      <Ammo_30x29mmGrenade_HE_TFuzed>100</Ammo_30x29mmGrenade_HE_TFuzed>
     </products>
     <workAmount>13400</workAmount>
   </RecipeDef>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -15,7 +15,7 @@
     <label>30x29mm Grenades</label>
     <ammoTypes>
       <Ammo_30x29mmGrenade_HE>Bullet_30x29mmGrenade_HE</Ammo_30x29mmGrenade_HE>
-	  <Ammo_30x29mmGrenade_HE_TFuzed>Bullet_30x29mmGrenade_HE_TFuzed</Ammo_30x29mmGrenade_HE_TFuzed>
+	    <Ammo_30x29mmGrenade_HE_TFuzed>Bullet_30x29mmGrenade_HE_TFuzed</Ammo_30x29mmGrenade_HE_TFuzed>
       <Ammo_30x29mmGrenade_EMP>Bullet_30x29mmGrenade_EMP</Ammo_30x29mmGrenade_EMP>
       <Ammo_30x29mmGrenade_Smoke>Bullet_30x29mmGrenade_Smoke</Ammo_30x29mmGrenade_Smoke>	         
     </ammoTypes>
@@ -283,7 +283,7 @@
     <products>
       <Ammo_30x29mmGrenade_HE>100</Ammo_30x29mmGrenade_HE>
     </products>
-    <workAmount>11400</workAmount>
+    <workAmount>13400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -15,7 +15,7 @@
     <label>40x46mm Grenades</label>
     <ammoTypes>
       <Ammo_40x46mmGrenade_HE>Bullet_40x46mmGrenade_HE</Ammo_40x46mmGrenade_HE>
-	  <Ammo_40x46mmGrenade_HE_TFuzed>Bullet_40x46mmGrenade_HE_TFuzed</Ammo_40x46mmGrenade_HE_TFuzed>
+	    <Ammo_40x46mmGrenade_HE_TFuzed>Bullet_40x46mmGrenade_HE_TFuzed</Ammo_40x46mmGrenade_HE_TFuzed>
       <Ammo_40x46mmGrenade_HEDP>Bullet_40x46mmGrenade_HEDP</Ammo_40x46mmGrenade_HEDP>	  
       <Ammo_40x46mmGrenade_EMP>Bullet_40x46mmGrenade_EMP</Ammo_40x46mmGrenade_EMP>
       <Ammo_40x46mmGrenade_Smoke>Bullet_40x46mmGrenade_Smoke</Ammo_40x46mmGrenade_Smoke>    
@@ -281,9 +281,10 @@
   
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_40x46mmGrenade_HE_TFuzed</defName>
-    <label>make 40x46mm HE Airburst grenades x100</label>
-    <description>Craft 100 40x46mm HE Airburst grenades.</description>
-    <jobString>Making 40x46mm HE Airburst grenades.</jobString>
+    <label>make 40x46mm HE airburst grenades x100</label>
+    <description>Craft 100 40x46mm HE airburst grenades.</description>
+    <jobString>Making 40x46mm HE airburst grenades.</jobString>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -287,6 +287,7 @@
     <label>make 40x53mm HE Airburst grenades x100</label>
     <description>Craft 100 40x53mm HE Airburst grenades.</description>
     <jobString>Making 40x53mm HE Airburst grenades.</jobString>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -240,7 +240,7 @@
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_40x53mmVOG25Grenade_Smoke</defName>
-    <label>make 40x53mmVOG25 smoke grenades x100</label>
+    <label>make 40x53mm VOG25 smoke grenades x100</label>
     <description>Craft 100 40x53mmVOG25 smoke grenades.</description>
     <jobString>Making 40x53mmVOG25 smoke grenades.</jobString>
     <ingredients>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_90mmCannonShell_HEAT>Bullet_90mmCannonShell_HEAT</Ammo_90mmCannonShell_HEAT>
       <Ammo_90mmCannonShell_HE>Bullet_90mmCannonShell_HE</Ammo_90mmCannonShell_HE>
-	  <Ammo_90mmCannonShell_HE_TFuzed>Bullet_90mmCannonShell_HE_TFuzed</Ammo_90mmCannonShell_HE_TFuzed>
+	    <Ammo_90mmCannonShell_HE_TFuzed>Bullet_90mmCannonShell_HE_TFuzed</Ammo_90mmCannonShell_HE_TFuzed>
       <Ammo_90mmCannonShell_EMP>Bullet_90mmCannonShell_EMP</Ammo_90mmCannonShell_EMP>
     </ammoTypes>
     <isMortarAmmoSet>true</isMortarAmmoSet>
@@ -357,10 +357,11 @@
   
     <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_90mmCannonShell_HE_TFuzed</defName>
-    <label>make 90mm HE Time Fuzed cannon shells x5</label>
-    <description>Craft 5 90mm HE cannon shells.</description>
-    <jobString>Making 90mm HE cannon shells.</jobString>
-    <workAmount>24400</workAmount>
+    <label>make 90mm HE airburst cannon shells x5</label>
+    <description>Craft 5 90mm HE airburst cannon shells.</description>
+    <jobString>Making 90mm HE airburst cannon shells.</jobString>
+    <workAmount>26400</workAmount>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_Tier4_Misc.xml
@@ -17,7 +17,7 @@
   <ResearchProjectDef>
     <defName>CE_AdvancedLaunchers</defName>
     <label>advanced launchers</label>
-    <description>Allows production of more advanced launchers like the incendiary, triple rocket or doomsday launcher.</description>
+    <description>Allows production of more advanced launchers and munitions like the incendiary, triple rocket, or doomsday launcher and time-fuzed explosives.</description>
     <baseCost>1000</baseCost>
     <techLevel>Spacer</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>


### PR DESCRIPTION
## Changes
- The projectiles are now gated behind Advanced Launchers (and added a note to the research project description).
- Increased crafting costs for some of the grenades.
- Revised ammo category labels.
- Some whitespace changes.

## Reasoning
- The projectiles have a marked increase in average effectiveness against targets, especially against those in cover, and any reasonable player would probably choose to use these instead of basic HE if given the option (barring the extra cost). Thus, putting it at a higher tech level seems reasonable.
- Some the grenades had an extra 2000 work to build, but some did not. I added the extra work to those that lacked the increase and added it to the 90mm flak shell.
- Revised for a bit of clarity, since both 'time-fuzed' and 'air-burst' are used, and I felt the latter was more clear as to the round's function.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
