### PR TITLE
RE Asari and Reapers 80mm cell hotfix

### DIFF
--- a/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Ammo_Projectile_Reapers.xml
@@ -392,7 +392,7 @@
 
 		<!-- ================== Collossus ================== -->
 
-		<ThingDef ParentName="Base80x256mmFuelThermobaricBullet">
+		<ThingDef ParentName="Base80x256mmFuelIncendiaryBullet">
 			<defName>Bullet_Collosus</defName>
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 			<label>colossus artillery shot</label>
@@ -434,7 +434,7 @@
 
 		<!-- ================== Reaper Missile Launcher ================== -->
 
-		<ThingDef ParentName="Base80x256mmFuelThermobaricBullet">
+		<ThingDef ParentName="Base80x256mmFuelIncendiaryBullet">
 			<defName>Bullet_ReaperMissile</defName>
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 			<label>reaper missile launcher rocket</label>


### PR DESCRIPTION
## Changes

- Fixed the ParentName of the ammo used in the patch from thermobaric to the correct incendiary.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
