### PR TITLE
Adjust Frag Count and Cost of Time-Fuzed Explosives

### DIFF
--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.85</MarketValue>
+      <MarketValue>3.71</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
 	<detonateProjectile>Bullet_30x29mmGrenade_HE</detonateProjectile>
@@ -168,9 +168,9 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Small>84</Fragment_Small>
+          <Fragment_Small>28</Fragment_Small>
         </fragments>
-		<fragAngleRange>-89~-5</fragAngleRange>
+		    <fragAngleRange>-89~-5</fragAngleRange>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.37</MarketValue>
+      <MarketValue>3.08</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
 	<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -180,9 +180,9 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Small>76</Fragment_Small>
+          <Fragment_Small>19</Fragment_Small>
         </fragments>
-		<fragAngleRange>-89~-5</fragAngleRange>
+		    <fragAngleRange>-89~-5</fragAngleRange>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -50,7 +50,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.89</MarketValue>
+      <MarketValue>3.75</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -166,8 +166,6 @@
 		</comps>
 	</ThingDef>
 	
-	
-  
   <ThingDef ParentName="Base40x53mmGrenadeBullet">
     <defName>Bullet_40x53mmGrenade_HE_TFuzed</defName>
     <thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
@@ -183,9 +181,9 @@
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Small>105</Fragment_Small>
+          <Fragment_Small>35</Fragment_Small>
         </fragments>
-		<fragAngleRange>-89~-5</fragAngleRange>
+		    <fragAngleRange>-89~-5</fragAngleRange>
       </li>
     </comps>
   </ThingDef>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -102,7 +102,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>109.83</MarketValue>
+      <MarketValue>139.83</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <comps>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -240,8 +240,8 @@
     <comps>
 	  <li Class="CombatExtended.CompProperties_Fragments">
 		<fragments>
-			<Fragment_Large>159</Fragment_Large>
-			<Fragment_Small>288</Fragment_Small>
+			<Fragment_Large>53</Fragment_Large>
+			<Fragment_Small>96</Fragment_Small>
 		</fragments>
 		<fragAngleRange>-89~-10</fragAngleRange>
 	  </li>


### PR DESCRIPTION
## Changes
- Reduces frag count of time-fuzed rounds to match their normal HE counterparts.
- Increased cost of fuzed rounds by about 30% over normal HE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
