### PR TITLE
Fix Alpha Animals projectile damageDefs

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -161,7 +161,7 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>AA_ToxicSting</damageDef>
+							<damageDef>AA_ToxicBolt</damageDef>
 							<damageAmountBase>7</damageAmountBase>
 							<speed>31</speed>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
@@ -175,10 +175,10 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>AA_ToxicSting</damageDef>
+							<damageDef>AA_ToxicBolt</damageDef>
 							<damageAmountBase>12</damageAmountBase>
 							<speed>27</speed>
-							<armorPenetrationSharp>5</armorPenetrationSharp>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
 						</projectile>
 					</value>
@@ -189,10 +189,10 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>AA_ToxicSting</damageDef>
+							<damageDef>AA_ToxicBolt</damageDef>
 							<damageAmountBase>12</damageAmountBase>
 							<speed>27</speed>
-							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 						</projectile>
 					</value>
@@ -217,10 +217,10 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>AA_ToxicSting</damageDef>
+							<damageDef>AA_ToxicBolt</damageDef>
 							<damageAmountBase>18</damageAmountBase>
 							<speed>19</speed>
-							<armorPenetrationSharp>2.5</armorPenetrationSharp>
+							<armorPenetrationSharp>1.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>3</armorPenetrationBlunt>
 						</projectile>
 					</value>
@@ -231,7 +231,7 @@
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
-							<damageDef>AA_ToxicSting</damageDef>
+							<damageDef>AA_ToxicBolt</damageDef>
 							<damageAmountBase>7</damageAmountBase>
 							<speed>27</speed>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>


### PR DESCRIPTION
## Changes

- Fixed some wrong AA projectile damageDefs.

## References

- Closes #928

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
