### PR TITLE
Fix shooting at down pawns.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -797,7 +797,6 @@ namespace CombatExtended
 	    }
 	    if (currentTarget.Pawn?.Downed ?? true)
 	    {
-
 		Pawn newTarget = null;
 		Thing caster = Caster;
 		
@@ -824,6 +823,7 @@ namespace CombatExtended
 		    }
 		    return true;
 		}
+		shootingAtDowned = true;
 		return false;
 	    }
 	    return true;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -269,6 +269,7 @@ namespace CombatExtended
         /// </summary>
         public override void WarmupComplete()
         {
+	    lastTarget = null;
             if (ShooterPawn != null && ShooterPawn.pather == null)
             {
                 return; //Pawn has started a jump pack animation, or otherwise became despawned temporarily

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -782,7 +782,7 @@ namespace CombatExtended
             return true;
         }
 
-	private bool Retarget()
+	protected bool Retarget()
 	{
 	    if (currentTarget != lastTarget)
 	    {
@@ -835,10 +835,6 @@ namespace CombatExtended
         /// <returns>True for successful shot, false otherwise</returns>
         public override bool TryCastShot()
         {
-	    if (!Retarget()) {
-		return false;
-	    }
-	    
             if (!TryFindCEShootLineFromTo(caster.Position, currentTarget, out var shootLine))
             {
                 return false;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -278,6 +278,10 @@ namespace CombatExtended
 
         public override bool TryCastShot()
         {
+	    if (!Retarget())
+	    {
+		return false;
+	    }
             //Reduce ammunition
             if (CompAmmo != null)
             {


### PR DESCRIPTION

## Changes

Ordering a pawn to continue shooting at a downed pawn works.

## Reasoning

When a target pawn goes down and no valid retargets are available, the shooter stops shooting.  If the player then orders the pawn to continue shooting, the pawn needs to start shooting again.  



## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (minutes)
