### PR TITLE
add null checking to shield belts

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
+++ b/Source/CombatExtended/Harmony/Harmony_ShieldBelt.cs
@@ -32,7 +32,7 @@ namespace CombatExtended.HarmonyCE
 	    }
 	    float bc = 1.0f;
 	    bool isEMP = dinfo.Def == DamageDefOf.EMP;
-	    if (dinfo.Weapon.projectile is ProjectilePropertiesCE pce)
+	    if (dinfo.Weapon?.projectile is ProjectilePropertiesCE pce)
 	    {
 		bc = pce.empShieldBreakChance;
 		isEMP = isEMP || pce.secondaryDamage?.FirstOrDefault(sd => sd.def == DamageDefOf.EMP) != null;


### PR DESCRIPTION

## Reasoning

VFE looks like it might make traps try to do damage with a null weapon, so check for that.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
