### PR TITLE
Add null check to SelfConsume

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
@@ -44,7 +44,7 @@ namespace CombatExtended
             }
             if (inventory != null && ShooterPawn?.jobs.curJob.def != CE_JobDefOf.OpportunisticAttack)
             {
-                var newGun = inventory.rangedWeaponList.FirstOrDefault(t => t.def == EquipmentSource.def);
+                var newGun = inventory.rangedWeaponList.FirstOrDefault(t => t.def == EquipmentSource?.def);
                 if (newGun != null)
                 {
                     inventory.TrySwitchToWeapon(newGun);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCEOneUse.cs
@@ -38,13 +38,13 @@ namespace CombatExtended
         private void SelfConsume()
         {
             var inventory = ShooterPawn?.TryGetComp<CompInventory>();
-            if (this.EquipmentSource != null && !this.EquipmentSource.Destroyed)
+            if (!this.EquipmentSource?.Destroyed ?? false)
             {
                 this.EquipmentSource.Destroy(DestroyMode.Vanish);
             }
-            if (inventory != null && ShooterPawn?.jobs.curJob.def != CE_JobDefOf.OpportunisticAttack)
+            if (inventory != null && ShooterPawn?.jobs.curJob?.def != CE_JobDefOf.OpportunisticAttack)
             {
-                var newGun = inventory.rangedWeaponList.FirstOrDefault(t => t.def == EquipmentSource?.def);
+                var newGun = inventory.rangedWeaponList?.FirstOrDefault(t => t.def == EquipmentSource?.def);
                 if (newGun != null)
                 {
                     inventory.TrySwitchToWeapon(newGun);


### PR DESCRIPTION

## Reasoning

If EquipmentSource is null and inventory isn't, SelfConsume would NPE, now it just switches to the next available weapon.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
