### PR TITLE
Fix .338 Norma Mag's bullet speed

### DIFF
--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>243</speed>
+      <speed>162</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -184,7 +184,7 @@
       <damageAmountBase>13</damageAmountBase>
       <armorPenetrationSharp>39</armorPenetrationSharp>
       <armorPenetrationBlunt>162.46</armorPenetrationBlunt>
-     <speed>273</speed>	  
+      <speed>243</speed>	  
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- What it says on the tin, the cartridge had wrong bullet speed in XML which is fixed based on the spreadsheet.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
