### PR TITLE
Add more mechanoid ammo recipes to the ammo foundry

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -144,7 +144,7 @@
 							<li>2</li>
 						</amount>
 						<outputLimitControlled>true</outputLimitControlled>
-						<maxTotalOutput>100</maxTotalOutput>
+						<maxTotalOutput>25</maxTotalOutput>
 						<result>Ammo_80x256mmFuel_Incendiary</result>	
 						<yield>5</yield>		
 						<useQualityIncreasing>false</useQualityIncreasing>
@@ -195,6 +195,54 @@
 						<maxTotalOutput>2000</maxTotalOutput>
 						<result>Ammo_5x35mmCharged</result>	
 						<yield>500</yield>		
+						<useQualityIncreasing>false</useQualityIncreasing>
+						<singleTimeIfNotQualityIncreasing>0.1</singleTimeIfNotQualityIncreasing>
+					</ItemProcessor.CombinationDef>
+					<ItemProcessor.CombinationDef>
+						<defName>VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry_Ammo_6x22mmCharged</defName>
+						<building>VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry</building>
+						<items>
+							<li>Plasteel</li>
+						</items>	
+						<secondItems>
+							<li>Steel</li>
+						</secondItems>
+						<thirdItems>
+							<li>ComponentIndustrial</li>
+						</thirdItems>
+						<amount>
+							<li>8</li>
+							<li>6</li>
+							<li>8</li>
+						</amount>
+						<outputLimitControlled>true</outputLimitControlled>
+						<maxTotalOutput>2000</maxTotalOutput>
+						<result>Ammo_6x22mmCharged</result>	
+						<yield>500</yield>		
+						<useQualityIncreasing>false</useQualityIncreasing>
+						<singleTimeIfNotQualityIncreasing>0.1</singleTimeIfNotQualityIncreasing>
+					</ItemProcessor.CombinationDef>
+					<ItemProcessor.CombinationDef>
+						<defName>VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry_Ammo_164x284mmDemo</defName>
+						<building>VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry</building>
+						<items>
+							<li>Plasteel</li>
+						</items>	
+						<secondItems>
+							<li>FSX</li>
+						</secondItems>
+						<thirdItems>
+							<li>ComponentIndustrial</li>
+						</thirdItems>
+						<amount>
+							<li>6</li>
+							<li>50</li>
+							<li>4</li>
+						</amount>
+						<outputLimitControlled>true</outputLimitControlled>
+						<maxTotalOutput>25</maxTotalOutput>
+						<result>Ammo_164x284mmDemo</result>	
+						<yield>5</yield>		
 						<useQualityIncreasing>false</useQualityIncreasing>
 						<singleTimeIfNotQualityIncreasing>0.1</singleTimeIfNotQualityIncreasing>
 					</ItemProcessor.CombinationDef>


### PR DESCRIPTION
## Additions

- What is says on the tin, added the 6x22mm and the Thump cannon demo shell recipes to the ammo foundry from VFE - Mechs.

## Reasoning

- Now that we can give ammo to mechs, being able to manufacture these ammo types and giving them to colony mechs as kind of a necessity.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
