### PR TITLE
Royalty medieval melee weapons adjusted and housekeeping

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1447,7 +1447,7 @@
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
+    <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
   </Operation>
 
   <!-- ========== Remove Needle Gun ========== -->
@@ -1458,7 +1458,7 @@
 
   <!-- Increase Orbital Bombardment Range -->
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
+    <xpath>Defs/ThingDef[defName="OrbitalTargeterBombardment" or defName="OrbitalTargeterPowerBeam"]/verbs/li/range</xpath>
     <value>
       <range>60</range>
     </value>
@@ -1466,11 +1466,11 @@
 
   <!-- Remove Smoke and EMP Launchers -->
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
+    <xpath>Defs/ThingDef[defName="Gun_SmokeLauncher"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
+    <xpath>Defs/ThingDef[defName="Gun_EmpLauncher"]</xpath>
   </Operation>
 
 </Patch>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -34,11 +34,18 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Axe"]/statBases/Mass</xpath>
+		<value>
+			<Mass>5</Mass>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Axe"]/statBases</xpath>
 		<value>
-      		<Bulk>4</Bulk>
-      		<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+			<Bulk>4</Bulk>
+			<MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -58,6 +65,10 @@
 		<value>
 			<li>CE_OneHandedWeapon</li>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Axe"]/stuffCategories/li[contains(.,"Woody")]</xpath>
 	</Operation>
 
 	<!-- ========== Warhammer ========== -->
@@ -95,8 +106,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/statBases</xpath>
 		<value>
-      		<Bulk>8</Bulk>
-      		<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
+			<Bulk>8</Bulk>
+			<MeleeCounterParryBonus>0.24</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -135,8 +146,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_PsyfocusStaff"]/statBases</xpath>
 		<value>
-      		<Bulk>6</Bulk>
-      		<MeleeCounterParryBonus>0.93</MeleeCounterParryBonus>
+			<Bulk>6</Bulk>
+			<MeleeCounterParryBonus>0.93</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -195,9 +206,9 @@
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
-		<value>
-			<statBases />
-		</value>
+			<value>
+				<statBases />
+			</value>
 		</nomatch>
 	</Operation>
 
@@ -224,9 +235,9 @@
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
-		<value>
-			<weaponTags />
-		</value>
+			<value>
+				<weaponTags />
+			</value>
 		</nomatch>
 	</Operation>
 
@@ -279,17 +290,17 @@
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]</xpath>
-		<value>
-			<statBases />
-		</value>
+			<value>
+				<statBases />
+			</value>
 		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Zeushammer"]/statBases</xpath>
 		<value>
-      		<Bulk>8</Bulk>
-      		<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+			<Bulk>8</Bulk>
+			<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -365,17 +376,17 @@
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
 		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]</xpath>
-		<value>
-			<statBases />
-		</value>
+			<value>
+				<statBases />
+			</value>
 		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_PlasmaSword"]/statBases</xpath>
 		<value>
-      		<Bulk>8.5</Bulk>
-      		<MeleeCounterParryBonus>0.80</MeleeCounterParryBonus>
+			<Bulk>8.5</Bulk>
+			<MeleeCounterParryBonus>0.80</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -34,13 +34,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="MeleeWeapon_Axe"]/statBases/Mass</xpath>
-		<value>
-			<Mass>5</Mass>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Axe"]/statBases</xpath>
 		<value>
@@ -100,6 +93,13 @@
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/statBases/Mass</xpath>
+		<value>
+			<Mass>2.5</Mass>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Decreased the Royalty warhammer's mass from 5kg to 2.5kg based on the spreadsheet with the base mass increased to 2.5 and speed increase to 30 to replicate the current stats in the patch and also to avoid nerfing the weapon.
- Removed "Woody" materials from the Royalty axes' stuffCategories.

## Reasoning

- The closest thing to a warhammer weighs no more than 2.5kg.
- Axe heads are not commonly made from wood.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
