### PR TITLE
Magical Menagerie patch fixes

### DIFF
--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -179,7 +179,7 @@
 						<MeleeDodgeChance>0.19</MeleeDodgeChance>
 						<MeleeCritChance>0.18</MeleeCritChance>
 						<MeleeParryChance>0.17</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<AimingAccuracy>1.0</AimingAccuracy>
 					</value>
 				</li>
@@ -251,7 +251,7 @@
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.35</MeleeCritChance>
 						<MeleeParryChance>0.19</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<AimingAccuracy>1.0</AimingAccuracy>
 					</value>
 				</li>
@@ -477,7 +477,7 @@
 						<MeleeDodgeChance>0.09</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
 						<MeleeParryChance>0.27</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<AimingAccuracy>0.9</AimingAccuracy>
 					</value>
 				</li>
@@ -832,7 +832,8 @@
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.06</MeleeCritChance>
 						<MeleeParryChance>0.08</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<AimingAccuracy>0.9</AimingAccuracy>
 					</value>
 				</li>
 
@@ -1091,7 +1092,7 @@
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.22</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<AimingAccuracy>0.8</AimingAccuracy>
 					</value>
 				</li>
@@ -1252,7 +1253,8 @@
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.31</MeleeCritChance>
 						<MeleeParryChance>0.22</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<AimingAccuracy>1.0</AimingAccuracy>
 					</value>
 				</li>
 
@@ -1689,7 +1691,7 @@
 						<MeleeDodgeChance>0.23</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
 						<MeleeParryChance>0.15</MeleeParryChance>
-						<SightsEfficiency>1</SightsEfficiency>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 						<AimingAccuracy>1.0</AimingAccuracy>
 					</value>
 				</li>

--- a/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
+++ b/Patches/Magical Menagerie/MagicalMenagerie_CE_Patch_Races.xml
@@ -477,7 +477,7 @@
 						<MeleeDodgeChance>0.09</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
 						<MeleeParryChance>0.27</MeleeParryChance>
-						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>1.4</ShootingAccuracyPawn>
 						<AimingAccuracy>0.9</AimingAccuracy>
 					</value>
 				</li>
@@ -832,7 +832,7 @@
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.06</MeleeCritChance>
 						<MeleeParryChance>0.08</MeleeParryChance>
-						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>1.4</ShootingAccuracyPawn>
 						<AimingAccuracy>0.9</AimingAccuracy>
 					</value>
 				</li>
@@ -1092,7 +1092,7 @@
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.22</MeleeCritChance>
 						<MeleeParryChance>0.57</MeleeParryChance>
-						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
+						<ShootingAccuracyPawn>1.3</ShootingAccuracyPawn>
 						<AimingAccuracy>0.8</AimingAccuracy>
 					</value>
 				</li>


### PR DESCRIPTION
## Changes

- Animals are not guns to have `SightsEfficiency` nodes in their statBases, instead added a `ShootingAccuracyPawn` node to them.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) 
- [x] Playtested a colony
