### PR TITLE
Minigun readjusted

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -4,14 +4,14 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]</xpath>
     <value>
-	    <relicChance>0</relicChance>
+      <relicChance>0</relicChance>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[@Name="BaseWeaponTurret"]</xpath>
     <value>
-	    <relicChance>0</relicChance>
+      <relicChance>0</relicChance>
     </value>
   </Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -838,7 +838,6 @@
 
   <!-- ========== Minigun ========== -->
 
-  
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName ="Gun_Minigun"]/weaponTags</xpath>
     <value>
@@ -848,15 +847,14 @@
     </value>
   </Operation>
 
-
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
     <defName>Gun_Minigun</defName>
     <statBases>
-      <Mass>30.00</Mass>
+      <Mass>20.00</Mass>
       <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.06</ShotSpread>
-      <SwayFactor>5.41</SwayFactor>
+      <SwayFactor>3.22</SwayFactor>
       <Bulk>10</Bulk>
     </statBases>
     <Properties>
@@ -864,8 +862,8 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
-      <warmupTime>2.3</warmupTime>
-      <range>56</range>
+      <warmupTime>2.1</warmupTime>
+      <range>62</range>
       <burstShotCount>100</burstShotCount>
       <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
       <soundCast>Shot_Minigun</soundCast>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -865,7 +865,7 @@
       <warmupTime>2.1</warmupTime>
       <range>62</range>
       <burstShotCount>50</burstShotCount>
-      <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+      <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
       <soundCast>Shot_Minigun</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -902,13 +902,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/statBases</xpath>
-    <value>
-      <MarketValue>1700</MarketValue>
-    </value>
-  </Operation>
-
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/Steel</xpath>
     <value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -864,7 +864,7 @@
       <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
       <warmupTime>2.1</warmupTime>
       <range>62</range>
-      <burstShotCount>100</burstShotCount>
+      <burstShotCount>50</burstShotCount>
       <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
       <soundCast>Shot_Minigun</soundCast>
       <soundCastTail>GunTail_Medium</soundCastTail>
@@ -877,7 +877,7 @@
     </AmmoUser>
     <FireModes>
       <aiAimMode>SuppressFire</aiAimMode>
-      <aimedBurstShotCount>50</aimedBurstShotCount>
+      <aimedBurstShotCount>25</aimedBurstShotCount>
     </FireModes>
     <weaponTags>
       <li>CE_AI_Suppressive</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -871,7 +871,7 @@
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <AmmoUser>
-      <magazineSize>500</magazineSize>
+      <magazineSize>250</magazineSize>
       <reloadTime>9.2</reloadTime>
       <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
     </AmmoUser>


### PR DESCRIPTION
## Changes

- Readjusted the minigun based on the findings linked below and the newly inserted mass value into the spreadsheet.

## References

- http://www.navweaps.com/Weapons/WNUS_30-cal_GAU17.php

## Reasoning

- Pawn can't properly spawn with 30kg miniguns and carry enough ammo for it.
- Assuming that the minigun itself weighs around 16kg based on the M134D Gatling gun, a battery pack that weighs around 4kg makes sense resulting in a package that weighs 20kg. The result is still a fully loaded minigun not being a viable weapon for an unaugmented pawn or a pawn that is wearing some armor which also wants to carry extra ammo for the gun, armored pawns still won't be able to carry a minigun around.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
