### PR TITLE
Axe Rimthreaded from Compatibility List

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -22,6 +22,7 @@
 		<li>XeoNovaDan.ProperShotguns</li>
 		<li>swedishmask.ProperShotgunsPatch</li>
 		<li>me.samboycoding.betterloading</li>
+		<li>majorhoff.rimthreaded</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>


### PR DESCRIPTION
## Reasoning

Why did you choose to implement things this way, e.g.
- since the current Rimthreaded state is questionable with their performance stability, it's better to stay on the safe side for now.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
