### PR TITLE
VGE Archotech Centipede buffed

### DIFF
--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
@@ -21,7 +21,7 @@
 				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>3</AimingAccuracy>
-					<ShootingAccuracyPawn>3</ShootingAccuracyPawn> 
+					<ShootingAccuracyPawn>5</ShootingAccuracyPawn> 
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
 					<MeleeParryChance>0.25</MeleeParryChance>

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
@@ -20,24 +20,26 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases</xpath>
 				<value>
-				<AimingAccuracy>3</AimingAccuracy>
-				<ShootingAccuracyPawn>3</ShootingAccuracyPawn> 
-				<MeleeDodgeChance>0.01</MeleeDodgeChance>
-				<MeleeCritChance>1</MeleeCritChance>
-				<MeleeParryChance>0.25</MeleeParryChance>
+					<AimingAccuracy>3</AimingAccuracy>
+					<ShootingAccuracyPawn>3</ShootingAccuracyPawn> 
+					<MeleeDodgeChance>0.01</MeleeDodgeChance>
+					<MeleeCritChance>1</MeleeCritChance>
+					<MeleeParryChance>0.25</MeleeParryChance>
+					<ArmorRating_Heat>2.00</ArmorRating_Heat>
+					<ArmorRating_Electric>1.00</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>220</ArmorRating_Blunt>
+					<ArmorRating_Blunt>500</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>44</ArmorRating_Sharp>
+					<ArmorRating_Sharp>50</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -46,7 +48,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-				                                                <label>head</label>
+							<label>head</label>
 							<capacities><li>Blunt</li></capacities>
 							<power>160</power>
 							<cooldownTime>2</cooldownTime>


### PR DESCRIPTION
## Changes

- Buffed the Archotech Centipede from VGE as it is a ultimate weapon and the end-game win condition.

## Reasoning

- A nigh unkillable pawn should resemble as such.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
