### PR TITLE
Vanilla Skills Expanded patch

### DIFF
--- a/Patches/Vanilla Skills Expanded/Expertise.xml
+++ b/Patches/Vanilla Skills Expanded/Expertise.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Skills Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Aiming expertise -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="CloseQuarters"]/statOffsets</xpath>
+					<value>
+						<statOffsets>
+							<AimingDelayFactor>-0.025</AimingDelayFactor>
+						</statOffsets>
+					</value>
+				</li>
+
+				<!-- Reloading expertise -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="Gunner"]/statOffsets</xpath>
+					<value>
+						<statOffsets>
+							<ReloadSpeed>0.025</ReloadSpeed>
+						</statOffsets>
+					</value>
+				</li>
+
+				<!-- Piercing expertise -->
+				<!-- <li Class="PatchOperationReplace">
+					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="Sharp"]/statOffsets</xpath>
+					<value>
+						<statOffsets>
+							<MeleePenetrationFactor>0.025</MeleePenetrationFactor>
+						</statOffsets>
+					</value>
+				</li> -->
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Skills Expanded/Expertise.xml
+++ b/Patches/Vanilla Skills Expanded/Expertise.xml
@@ -8,6 +8,17 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
+				<!-- Sharpshooting expertise -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="Precision"]/statOffsets</xpath>
+					<value>
+						<statOffsets>
+							<ShootingAccuracyPawn>0.075</ShootingAccuracyPawn>
+							<AimingAccuracy>0.025</AimingAccuracy>
+						</statOffsets>
+					</value>
+				</li>
+
 				<!-- Aiming expertise -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="CloseQuarters"]/statOffsets</xpath>
@@ -29,14 +40,14 @@
 				</li>
 
 				<!-- Piercing expertise -->
-				<!-- <li Class="PatchOperationReplace">
+				<li Class="PatchOperationReplace">
 					<xpath>Defs/VSE.Expertise.ExpertiseDef[defName="Sharp"]/statOffsets</xpath>
 					<value>
 						<statOffsets>
-							<MeleePenetrationFactor>0.025</MeleePenetrationFactor>
+							<MeleeCritChance>0.05</MeleeCritChance>
 						</statOffsets>
 					</value>
-				</li> -->
+				</li>
 
 			</operations>
 		</match>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -427,6 +427,7 @@ Vanilla Ideology Expanded - Hats and Rags |
 Vanilla Ideology Expanded - Memes and Structures    |
 Vanilla Genetics Expanded   |
 Vanilla Psycasts Expanded   |
+Vanilla Skills Expanded  |
 Vanilla Vehicles Expanded	|
 Vanilla Weapons Expanded |
 Vanilla Weapons Expanded - Coilguns |


### PR DESCRIPTION
## Additions

- Added the patch for Vanilla Skills Expanded's combat-related expertise

## Reasoning

- Adjusted the aiming time expertise for better balance in CE's ecosystem.
- Changed the Reloading expertise t actually impact reload speed in CE.
- The melee weapon armor penetration expertise looks to not be working in CE with the original VSE modifier, the `MeleePenetrationFactor` does not impact melee weapons either when given to pawns. So instead I opted to go for a crit chance bonus to resemble the armor penetration aspect of the expertise since crits with sharp weapons have double armor penetration.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
