### PR TITLE
Increase animal bodies' HP

### DIFF
--- a/Patches/Core/Bodies/BodyParts_Animal.xml
+++ b/Patches/Core/Bodies/BodyParts_Animal.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="Body"]/hitPoints</xpath>
+    <value>
+      <hitPoints>50</hitPoints>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="SnakeBody"]/hitPoints</xpath>
+    <value>
+      <hitPoints>40</hitPoints>
+    </value>
+  </Operation>
+
   <!-- ========== Modify bleed rates ========== -->
 
   <Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Changes

- Increased the "Body" and "SnakeBody" bodyparts' HP by 10 respectively.

## Reasoning

- Same as humanoid and mechanoid torso's and thoraxes that have had their HPs increased, animal bodies need the increase to prevent the "Body destroyed" situation happening to them to some extent.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
