### PR TITLE
Fix VFE - Medieval plate helmets' stat offsets

### DIFF
--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
@@ -24,6 +24,10 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationRemove">
+					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/equippedStatOffsets</xpath>
+				</li>
+
 				<!-- ========== Heavy Helmet =========== -->
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases</xpath>
@@ -37,6 +41,13 @@
 					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<value>
+						<AimingAccuracy>-0.5</AimingAccuracy>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes

- What it says on the tin, the `equippedStatOffsets` were unpatched...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
