### PR TITLE
Higher caliber ammo readjusted

### DIFF
--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -123,7 +123,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>170</speed>
+      <speed>172</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -132,9 +132,9 @@
     <defName>Bullet_127x108mm_FMJ</defName>
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>40</damageAmountBase>
+      <damageAmountBase>42</damageAmountBase>
       <armorPenetrationSharp>15</armorPenetrationSharp>
-      <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
+      <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -144,7 +144,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
+      <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -154,7 +154,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>348.24</armorPenetrationBlunt>
+      <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
@@ -168,9 +168,9 @@
     <defName>Bullet_127x108mm_HE</defName>
     <label>12.7x108mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>39</damageAmountBase>
+      <damageAmountBase>42</damageAmountBase>
       <armorPenetrationSharp>15</armorPenetrationSharp>
-      <armorPenetrationBlunt>296.22</armorPenetrationBlunt>
+      <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
@@ -185,9 +185,9 @@
     <label>12.7x108mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>234</speed>
-	    <damageAmountBase>20</damageAmountBase>
-	    <armorPenetrationSharp>53</armorPenetrationSharp>
-	    <armorPenetrationBlunt>339.48</armorPenetrationBlunt>
+	    <damageAmountBase>21</damageAmountBase>
+	    <armorPenetrationSharp>52.5</armorPenetrationSharp>
+	    <armorPenetrationBlunt>377.82</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -131,7 +131,7 @@
     <label>14.5x114mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>53</damageAmountBase>
-      <armorPenetrationSharp>18</armorPenetrationSharp>
+      <armorPenetrationSharp>19</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -141,7 +141,7 @@
     <label>14.5x114mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>33</damageAmountBase>
-      <armorPenetrationSharp>36</armorPenetrationSharp>
+      <armorPenetrationSharp>38</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -151,7 +151,7 @@
     <label>14.5x114mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>33</damageAmountBase>
-      <armorPenetrationSharp>36</armorPenetrationSharp>
+      <armorPenetrationSharp>38</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -167,7 +167,7 @@
     <label>14.5x114mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>53</damageAmountBase>
-      <armorPenetrationSharp>18</armorPenetrationSharp>
+      <armorPenetrationSharp>19</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -184,7 +184,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	  <speed>300</speed>
       <damageAmountBase>27</damageAmountBase>
-      <armorPenetrationSharp>63</armorPenetrationSharp>
+      <armorPenetrationSharp>66.5</armorPenetrationSharp>
       <armorPenetrationBlunt>820.360</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -14,10 +14,6 @@
     <defName>AmmoSet_152x169mm</defName>
     <label>15.2x169mm</label>
     <ammoTypes>
-      <Ammo_152x169mm_FMJ>Bullet_152x169mm_FMJ</Ammo_152x169mm_FMJ>
-      <Ammo_152x169mm_AP>Bullet_152x169mm_AP</Ammo_152x169mm_AP>
-      <Ammo_152x169mm_Incendiary>Bullet_152x169mm_Incendiary</Ammo_152x169mm_Incendiary>
-      <Ammo_152x169mm_HE>Bullet_152x169mm_HE</Ammo_152x169mm_HE>
       <Ammo_152x169mm_Sabot>Bullet_152x169mm_Sabot</Ammo_152x169mm_Sabot>	       
     </ammoTypes>
     <similarTo>AmmoSet_AntiMateriel</similarTo>
@@ -40,62 +36,6 @@
     </thingCategories>
 	<stackLimit>2000</stackLimit>
   </ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
-		<defName>Ammo_152x169mm_FMJ</defName>
-		<label>15.2x169mm cartridge (FMJ)</label>
-		<graphicData>
-			<texPath>Things/Ammo/HighCaliber/FMJ</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.6</MarketValue>
-		</statBases>
-		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_152x169mm_FMJ</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
-		<defName>Ammo_152x169mm_AP</defName>
-		<label>15.2x169mm cartridge (AP)</label>
-		<graphicData>
-			<texPath>Things/Ammo/HighCaliber/AP</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.6</MarketValue>
-		</statBases>
-		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_152x169mm_AP</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
-		<defName>Ammo_152x169mm_Incendiary</defName>
-		<label>15.2x169mm cartridge (AP-I)</label>
-		<graphicData>
-			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>0.73</MarketValue>
-		</statBases>
-		<ammoClass>IncendiaryAP</ammoClass>
-		<cookOffProjectile>Bullet_152x169mm_Incendiary</cookOffProjectile>
-	</ThingDef>
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
-		<defName>Ammo_152x169mm_HE</defName>
-		<label>15.2x169mm cartridge (HE)</label>
-		<graphicData>
-			<texPath>Things/Ammo/HighCaliber/HE</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<MarketValue>1.01</MarketValue>
-		</statBases>
-		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_152x169mm_HE</cookOffProjectile>
-	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo152x169mmBase">
 		<defName>Ammo_152x169mm_Sabot</defName>
@@ -121,59 +61,6 @@
       </graphicData>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <damageDef>Bullet</damageDef>
-        <speed>290</speed>
-      </projectile>
-    </ThingDef>
-    
-    <ThingDef ParentName="Base152x169mmBullet">
-      <defName>Bullet_152x169mm_FMJ</defName>
-      <label>15.2x169mm bullet (FMJ)</label>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <damageAmountBase>56</damageAmountBase>
-        <armorPenetrationSharp>17</armorPenetrationSharp>
-        <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-      </projectile>
-    </ThingDef>
-
-    <ThingDef ParentName="Base152x169mmBullet">
-      <defName>Bullet_152x169mm_AP</defName>
-      <label>15.2x169mm bullet (AP)</label>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <damageAmountBase>36</damageAmountBase>
-        <armorPenetrationSharp>35</armorPenetrationSharp>
-        <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-      </projectile>
-    </ThingDef>
-
-    <ThingDef ParentName="Base152x169mmBullet">
-      <defName>Bullet_152x169mm_Incendiary</defName>
-      <label>15.2x169mm bullet (AP-I)</label>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>36</damageAmountBase>
-		  <armorPenetrationSharp>35</armorPenetrationSharp>
-		  <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-		  <secondaryDamage>
-			<li>
-			<def>Flame_Secondary</def>
-			<amount>22</amount>
-			</li>
-		  </secondaryDamage>
-      </projectile>
-    </ThingDef>
-    
-    <ThingDef ParentName="Base152x169mmBullet">
-      <defName>Bullet_152x169mm_HE</defName>
-      <label>15.2x169mm bullet (HE)</label>
-      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>56</damageAmountBase>
-		  <armorPenetrationSharp>17</armorPenetrationSharp>
-		  <armorPenetrationBlunt>735.88</armorPenetrationBlunt>
-		  <secondaryDamage>
-			<li>
-			<def>Bomb_Secondary</def>
-			<amount>34</amount>
-			</li>
-		  </secondaryDamage>
       </projectile>
     </ThingDef>
 
@@ -182,135 +69,13 @@
       <label>15.2x169mm bullet (Sabot)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <speed>435</speed>
-	    <damageAmountBase>30</damageAmountBase>
+	    <damageAmountBase>26</damageAmountBase>
 	    <armorPenetrationSharp>60</armorPenetrationSharp>
-	    <armorPenetrationBlunt>943.76</armorPenetrationBlunt>
+	    <armorPenetrationBlunt>420.5</armorPenetrationBlunt>
       </projectile>
     </ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
-
-    <RecipeDef ParentName="AmmoRecipeBase">
-      <defName>MakeAmmo_152x169mm_FMJ</defName>
-      <label>make 15.2x169mm (FMJ) cartridge x200</label>
-      <description>Craft 200 15.2x169mm (FMJ) cartridges.</description>
-      <jobString>Making 15.2x169mm (FMJ) cartridges.</jobString>
-      <ingredients>
-        <li>
-          <filter>
-            <thingDefs>
-              <li>Steel</li>
-            </thingDefs>
-          </filter>
-          <count>60</count>
-        </li>
-      </ingredients>
-      <fixedIngredientFilter>
-        <thingDefs>
-          <li>Steel</li>
-        </thingDefs>
-      </fixedIngredientFilter>
-      <products>
-        <Ammo_152x169mm_FMJ>200</Ammo_152x169mm_FMJ>
-      </products>
-      <workAmount>6000</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AmmoRecipeBase">
-      <defName>MakeAmmo_152x169mm_AP</defName>
-      <label>make 15.2x169mm (AP) cartridge x200</label>
-      <description>Craft 200 15.2x169mm (AP) cartridges.</description>
-      <jobString>Making 15.2x169mm (AP) cartridges.</jobString>
-      <ingredients>
-        <li>
-          <filter>
-            <thingDefs>
-              <li>Steel</li>
-            </thingDefs>
-          </filter>
-          <count>60</count>
-        </li>
-      </ingredients>
-      <fixedIngredientFilter>
-        <thingDefs>
-          <li>Steel</li>
-        </thingDefs>
-      </fixedIngredientFilter>
-      <products>
-        <Ammo_152x169mm_AP>200</Ammo_152x169mm_AP>
-      </products>
-      <workAmount>6000</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-      <defName>MakeAmmo_152x169mm_Incendiary</defName>
-      <label>make 15.2x169mm (AP-I) cartridge x200</label>
-      <description>Craft 200 15.2x169mm (AP-I) cartridges.</description>
-      <jobString>Making 15.2x169mm (AP-I) cartridges.</jobString>
-      <ingredients>
-      <li>
-        <filter>
-        <thingDefs>
-          <li>Steel</li>
-        </thingDefs>
-        </filter>
-        <count>60</count>
-      </li>
-      <li>
-        <filter>
-        <thingDefs>
-          <li>Prometheum</li>
-        </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-      </ingredients>
-      <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-      </fixedIngredientFilter>
-      <products>
-      <Ammo_152x169mm_Incendiary>200</Ammo_152x169mm_Incendiary>
-      </products>
-      <workAmount>7600</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-      <defName>MakeAmmo_152x169mm_HE</defName>
-      <label>make 15.2x169mm (HE) cartridge x200</label>
-      <description>Craft 200 15.2x169mm (HE) cartridges.</description>
-      <jobString>Making 15.2x169mm (HE) cartridges.</jobString>
-      <ingredients>
-      <li>
-        <filter>
-        <thingDefs>
-          <li>Steel</li>
-        </thingDefs>
-        </filter>
-        <count>60</count>
-      </li>
-      <li>
-        <filter>
-        <thingDefs>
-          <li>FSX</li>
-        </thingDefs>
-        </filter>
-        <count>8</count>
-      </li>
-      </ingredients>
-      <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-      </fixedIngredientFilter>
-      <products>
-      <Ammo_152x169mm_HE>200</Ammo_152x169mm_HE>
-      </products>
-      <workAmount>9200</workAmount>
-    </RecipeDef>
 
     <RecipeDef ParentName="AdvancedAmmoRecipeBase">
       <defName>MakeAmmo_152x169mm_Sabot</defName>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -131,9 +131,9 @@
     <defName>Bullet_50BMG_FMJ</defName>
     <label>.50 BMG bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>14</armorPenetrationSharp>
-      <armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+      <damageAmountBase>42</damageAmountBase>
+      <armorPenetrationSharp>15.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -141,9 +141,9 @@
     <defName>Bullet_50BMG_AP</defName>
     <label>.50 BMG bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>25</damageAmountBase>
-      <armorPenetrationSharp>28</armorPenetrationSharp>
-      <armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+      <damageAmountBase>26</damageAmountBase>
+      <armorPenetrationSharp>31</armorPenetrationSharp>
+      <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -151,9 +151,9 @@
     <defName>Bullet_50BMG_Incendiary</defName>
     <label>.50 BMG bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>25</damageAmountBase>
-      <armorPenetrationSharp>28</armorPenetrationSharp>
-      <armorPenetrationBlunt>314.7</armorPenetrationBlunt>
+      <damageAmountBase>26</damageAmountBase>
+      <armorPenetrationSharp>31</armorPenetrationSharp>
+      <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
@@ -167,9 +167,9 @@
     <defName>Bullet_50BMG_HE</defName>
     <label>.50 BMG bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>41</damageAmountBase>
-      <armorPenetrationSharp>14</armorPenetrationSharp>
-      <armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+      <damageAmountBase>42</damageAmountBase>
+      <armorPenetrationSharp>15.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
@@ -183,9 +183,9 @@
     <defName>Bullet_50BMG_Sabot</defName>
     <label>.50 BMG bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>19</damageAmountBase>	
-      <armorPenetrationSharp>49</armorPenetrationSharp>
-      <armorPenetrationBlunt>341.780</armorPenetrationBlunt>
+      <damageAmountBase>21</damageAmountBase>	
+      <armorPenetrationSharp>54</armorPenetrationSharp>
+      <armorPenetrationBlunt>388.88</armorPenetrationBlunt>
       <speed>244</speed>
     </projectile>
   </ThingDef>


### PR DESCRIPTION
## Changes

- Made adjustments to certain high caliber ammo based on some sources.

## References

- The new values with the sources used are all entered here:
https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

* The new AP values for 20mm rounds are included here as well

## Reasoning

- We use uniform bullet mass values for different ammo types, made this the case for .50 BMG and .50 Soviet withc adjustments to bullet velocity and mass.
- 14.5mm rounds penetrate 40mm RHA based on the sources on the internet, 38mm at 100 meters is a good estimation for in-game values of an AP round.
- 15.2x169mm is a APFSDS round and the cartridge does not have any other ammo types.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
