### PR TITLE
Added missing bodyparts groups for Mechadroids

### DIFF
--- a/Patches/O21 Mechadroids/Bodies_Mechadroids.xml
+++ b/Patches/O21 Mechadroids/Bodies_Mechadroids.xml
@@ -90,6 +90,36 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="O21_Mechadroid"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+				<value>
+					<li>LeftShoulder</li>
+					<li>Shoulders</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="O21_Mechadroid"]/corePart/parts/li[customLabel="right mechanical shoulder"]/groups</xpath>
+				<value>
+					<li>RightShoulder</li>
+					<li>Shoulders</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="O21_Mechadroid"]/corePart/parts/li[customLabel="left shoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
+				<value>
+					<li>LeftArm</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/BodyDef[defName="O21_Mechadroid"]/corePart/parts/li[customLabel="right mechanical shoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
+				<value>
+					<li>RightArm</li>
+				</value>
+			</li>
+				
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

Add missing body part groups for Mechadroids
Fixes a bug where mechadroids would wear an infinite number of backpacks.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
 XML Only
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
 Just checked if the backpack bug is gone
