### PR TITLE
VFE Pirates' patch fix

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/AbilityDefs/Abilities.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/AbilityDefs/Abilities.xml
@@ -10,14 +10,14 @@
 
 		<!-- Firing Frenzy -->
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/AbilityDef[@Name="VFEP_RoleAuraBuffBase"]/verbProperties/range</xpath>
 			<value>
 				<range>14.9</range>
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/AbilityDef[@Name="VFEP_RoleAuraBuffBase"]/statBases/Ability_EffectRadius</xpath>
 			<value>
 				<Ability_EffectRadius>14.9</Ability_EffectRadius>

--- a/Patches/Vanilla Factions Expanded - Pirates/Misc/Hediffs_Casts.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Misc/Hediffs_Casts.xml
@@ -10,14 +10,14 @@
 
 		<!-- Firing Frenzy -->
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzy"]/comps/li[@Class="HediffCompProperties_GiveHediffsInRange"]/range</xpath>
 			<value>
 				<range>14.9</range>
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzyBuff"]/stages/li/statOffsets</xpath>
 			<value>
 				<statOffsets>
@@ -26,7 +26,7 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationAdd">
+		<li Class="PatchOperationAdd" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/HediffDef[defName="VFEP_FiringFrenzyBuff"]/stages/li</xpath>
 			<value>
 				<statFactors>

--- a/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Misc/Precepts_Role.xml
@@ -10,14 +10,14 @@
 
 		<!-- Pirate Captain -->
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="ShootingAccuracyPawn"]/modifier</xpath>
 			<value>
 				<modifier>3</modifier>
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
+		<li Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Ideology">
 			<xpath>/Defs/PreceptDef[defName="VFEP_IdeoRole_Captain"]/roleEffects/li[./statDef="AimingDelayFactor"]</xpath>
 			<value>
 				<li Class="RoleEffect_PawnStatOffset">


### PR DESCRIPTION
## Changes

- Added the MayRequire condition to Ideology-related stuff from the mod's patches since they were throwing errors if Ideology was not enabled in the modlist.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors (Tested with and without Ideology)
