### PR TITLE
Large fragments adjusted

### DIFF
--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -10,10 +10,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>37</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<speed>60</speed>
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>178.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>62.5</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- Rebalanced the large fragments.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1198674278
- Closes https://github.com/CombatExtended-Continued/CombatExtended/issues/1811

## Reasoning

- According to the holy spreadsheet, large fragments are apparently 11 cubic millimeters of material, which even when made out of Tungsten, that'd amount to 25 grams per fragment and 10 grams for steel fragments. This PR fixes the wrong math by giving large frags less mass resulting in them being not so overkill...

## Alternatives

- Leave large frags as is and add medium frags which would require much more work and rebalancing, large frags are just wrong value-wise.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
