### PR TITLE
Remove the name and description patch of the Marine Armor

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -488,20 +488,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_PowerArmor"]/label</xpath>
-		<value>
-			<label>power armor</label>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_PowerArmor"]/description</xpath>
-		<value>
-			<description>A suit of powered armor. Layered plasteel-weave plates are very effective at stopping attacks, with few vulnerable joint sections. Neuro-memetic assistors allow a human to wear the armor and still move easily.\n\nArmor like this is often used by imperial janissaries and rapid-incursion space marines. \n\nWhile bulky and heavy, the advanced servo-motors greatly increase the wearer's load bearing capacity and assist in weapon-handling.</description>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>500</MaxHitPoints>


### PR DESCRIPTION
## Changes

- Removed a redundant Marine Armor name and description patch which was only confusing and created inconsistencies.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
