### PR TITLE
Tweaked the 12mm charge ammo

### DIFF
--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -60,16 +60,16 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>38</damageAmountBase>
+      <damageAmountBase>39</damageAmountBase>
       <speed>180</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>11</amount>
+          <amount>12</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>291.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -88,7 +88,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>180</speed>
+      <speed>200</speed>
     </projectile>
   </ThingDef>
 
@@ -97,15 +97,15 @@
     <defName>Bullet_12x72mmCharged</defName>
     <label>12x72mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>38</damageAmountBase>
+      <damageAmountBase>42</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>11</amount>
+          <amount>13</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>291.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>400</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -114,15 +114,15 @@
     <defName>Bullet_12x72mmCharged_AP</defName>
     <label>12x72mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>33</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>4</amount>
+          <amount>5</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>60</armorPenetrationSharp>
-      <armorPenetrationBlunt>291.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>400</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -131,15 +131,15 @@
     <defName>Bullet_12x72mmCharged_Ion</defName>
     <label>12x72mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>33</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>EMP</def>
-          <amount>16</amount>
+          <amount>20</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>45</armorPenetrationSharp>
-      <armorPenetrationBlunt>291.6</armorPenetrationBlunt>
+      <armorPenetrationBlunt>400</armorPenetrationBlunt>
       <empShieldBreakChance>1</empShieldBreakChance>
     </projectile>
   </ThingDef>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1149,7 +1149,7 @@
       <Bulk>13.00</Bulk>
     </statBases>
     <Properties>
-      <recoilAmount>1.28</recoilAmount>
+      <recoilAmount>1.38</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
@@ -1167,7 +1167,7 @@
       <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
     </AmmoUser>
     <FireModes>
-      <aimedBurstShotCount>5</aimedBurstShotCount>
+      <aimedBurstShotCount>10</aimedBurstShotCount>
       <aiAimMode>AimedShot</aiAimMode>
     </FireModes>
     <weaponTags>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -82,7 +82,7 @@
 				  <Bulk>13.00</Bulk>
 				</statBases>
 				<Properties>
-				  <recoilAmount>1.28</recoilAmount>
+				  <recoilAmount>1.38</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -574,7 +574,7 @@
 		  <Bulk>13.00</Bulk>
 		</statBases>
 		<Properties>
-		  <recoilAmount>1.02</recoilAmount>
+		  <recoilAmount>1.1</recoilAmount>
 		  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		  <hasStandardCommand>true</hasStandardCommand>
 		  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
@@ -592,7 +592,7 @@
 		  <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
 		</AmmoUser>
 		<FireModes>
-		  <aimedBurstShotCount>5</aimedBurstShotCount>
+		  <aimedBurstShotCount>15</aimedBurstShotCount>
 		  <aiAimMode>AimedShot</aiAimMode>
 		</FireModes>
 		<weaponTags>


### PR DESCRIPTION
## Changes

- What it says on the tin, tweaked and fixed some values based on the spreadsheet. 12mm charged ammo is 40 grams because it is loosely based on .50 BMG.
- 12x72mm as mentioned in the name has a longer "case" than 12x64mm charged ammo, so made it a bit faster to resemble that.
- Tweaked the HCB based on the spreadsheet.

## References

- https://docs.google.com/spreadsheets/d/11ZcgItLsGnegNDy08xCMxbO3jHv2YNwmmbwabRKzkwg/edit#gid=1573763037
- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
