### PR TITLE
Mech Ammo/Human makeable mech ammo

### DIFF
--- a/Defs/Ammo/Advanced/12x65mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x65mmCharged.xml
@@ -1,0 +1,281 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingCategoryDef>
+    <defName>Ammo12x65mmCharged</defName>
+    <label>12x72mm Charged</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_12x65mmCharged</defName>
+    <label>12x72mm Charged</label>
+    <ammoTypes>
+      <Ammo_12x65mmCharged>Bullet_12x65mmCharged</Ammo_12x65mmCharged>
+      <Ammo_12x65mmCharged_AP>Bullet_12x65mmCharged_AP</Ammo_12x65mmCharged_AP>
+      <Ammo_12x65mmCharged_Ion>Bullet_12x65mmCharged_Ion</Ammo_12x65mmCharged_Ion>
+    </ammoTypes>
+    <similarTo>AmmoSet_ChargedHeavy</similarTo>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="12x65mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>High-caliber charged shot ammo used by advanced heavy machine guns and anti-materiel rifles.</description>
+    <statBases>
+      <Mass>0.058</Mass>
+      <Bulk>0.04</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo12x65mmCharged</li>
+    </thingCategories>
+    <stackLimit>5000</stackLimit>	
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="12x65mmChargedBase">
+    <defName>Ammo_12x65mmCharged</defName>
+    <label>12x72mm Charged cartridge</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Regular</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>6.78</MarketValue>
+    </statBases>
+    <ammoClass>Charged</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="12x65mmChargedBase">
+    <defName>Ammo_12x65mmCharged_AP</defName>
+    <label>12x72mm Charged cartridge (Conc.)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Concentrated</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>6.78</MarketValue>
+    </statBases>
+    <ammoClass>ChargedAP</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="12x65mmChargedBase">
+    <defName>Ammo_12x65mmCharged_Ion</defName>
+    <label>12x72mm Charged cartridge (Ion)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Ion</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>6.78</MarketValue>
+    </statBases>
+    <ammoClass>Ionized</ammoClass>
+    <generateAllowChance>0.25</generateAllowChance>
+  </ThingDef>
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef Name="Base12x65mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Charge_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>180</speed>
+    </projectile>
+  </ThingDef>
+
+  <!-- normal charged bullets -->
+  <ThingDef ParentName="Base12x65mmChargedBullet">
+    <defName>Bullet_12x65mmCharged</defName>
+    <label>12x72mm Charged bullet</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>39</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>12</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- concentrated bullets -->
+  <ThingDef ParentName="Base12x65mmChargedBullet">
+    <defName>Bullet_12x65mmCharged_AP</defName>
+    <label>12x72mm Charged bullet (Conc.)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>31</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>5</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>60</armorPenetrationSharp>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- ion bullets -->
+  <ThingDef ParentName="Base12x65mmChargedBullet">
+    <defName>Bullet_12x65mmCharged_Ion</defName>
+    <label>12x72mm Charged bullet (Ion)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>31</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>EMP</def>
+          <amount>18</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>45</armorPenetrationSharp>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
+      <empShieldBreakChance>1</empShieldBreakChance>
+    </projectile>
+  </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_12x65mmCharged</defName>
+    <label>make 12x72mm Charged cartridge x500</label>
+    <description>Craft 500 12x72mm Charged cartridges.</description>
+    <jobString>Making 12x72mm Charged cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_12x65mmCharged>200</Ammo_12x65mmCharged>
+    </products>
+    <workAmount>32800</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_12x65mmCharged_AP</defName>
+    <label>make 12x72mm Charged (Conc.) cartridge x500</label>
+    <description>Craft 500 12x72mm Charged (Conc.) cartridges.</description>
+    <jobString>Making 12x72mm Charged (Conc.) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_12x65mmCharged_AP>200</Ammo_12x65mmCharged_AP>
+    </products>
+    <workAmount>32800</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_12x65mmCharged_Ion</defName>
+    <label>make 12x72mm Charged (Ion) cartridge x200</label>
+    <description>Craft 200 12x72mm Charged (Ion) cartridges.</description>
+    <jobString>Making 12x72mm Charged (Ion) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_12x65mmCharged_Ion>200</Ammo_12x65mmCharged_Ion>
+    </products>
+    <workAmount>32800</workAmount>	
+  </RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef ParentName="BaseBullet">
+  <ThingDef Name="Base6x22mmChargedBullet" ParentName="BaseBullet">
     <defName>Bullet_6x22mmCharged</defName>
     <label>6x22mm Charged bullet</label>
     <graphicData>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -50,7 +50,7 @@
 
   <!-- ================== Projectiles ================== -->
 
-  <ThingDef Name="Base6x22mmChargedBullet" ParentName="BaseBullet">
+  <ThingDef ParentName="BaseBullet">
     <defName>Bullet_6x22mmCharged</defName>
     <label>6x22mm Charged bullet</label>
     <graphicData>
@@ -59,12 +59,12 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>11</damageAmountBase>
+      <damageAmountBase>13</damageAmountBase>
       <speed>200</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>2</amount>
+          <amount>4</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>15</armorPenetrationSharp>


### PR DESCRIPTION
## Additions

12x65 turned into 12x72 which turned into its own caliber, eliminating the original purpose of the damn thing, so it's back again.

## Changes

Fix 6x22 damage, as it is a carbon copy of 6x24 regular ammo for mechanoid use.

## Reasoning

12x65 round purpose is to be a hard equivalent of 12x64, not a rough equivalent. It's not like we don't have 50 different rifles anyway so adding one more charge should not be a significant problem for situations where it's not supposed to be a up-gunned shot like 12x72

## Alternatives

Revert 12x72 changes

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
