### PR TITLE
Redo of #1829

### DIFF
--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -97,15 +97,15 @@
     <defName>Bullet_12x72mmCharged</defName>
     <label>12x72mm Charged bullet</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>42</damageAmountBase>
+      <damageAmountBase>39</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>13</amount>
+          <amount>12</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>30</armorPenetrationSharp>
-      <armorPenetrationBlunt>400</armorPenetrationBlunt>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -114,7 +114,7 @@
     <defName>Bullet_12x72mmCharged_AP</defName>
     <label>12x72mm Charged bullet (Conc.)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>33</damageAmountBase>
+      <damageAmountBase>31</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
@@ -122,7 +122,7 @@
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>60</armorPenetrationSharp>
-      <armorPenetrationBlunt>400</armorPenetrationBlunt>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -131,15 +131,15 @@
     <defName>Bullet_12x72mmCharged_Ion</defName>
     <label>12x72mm Charged bullet (Ion)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>33</damageAmountBase>
+      <damageAmountBase>31</damageAmountBase>
       <secondaryDamage>
         <li>
           <def>EMP</def>
-          <amount>20</amount>
+          <amount>18</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>45</armorPenetrationSharp>
-      <armorPenetrationBlunt>400</armorPenetrationBlunt>
+      <armorPenetrationBlunt>324</armorPenetrationBlunt>
       <empShieldBreakChance>1</empShieldBreakChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -59,12 +59,12 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>11</damageAmountBase>
+      <damageAmountBase>13</damageAmountBase>
       <speed>200</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>2</amount>
+          <amount>4</amount>
         </li>
       </secondaryDamage>
       <armorPenetrationSharp>15</armorPenetrationSharp>


### PR DESCRIPTION
## Changes

- Redid the #1829 PR while keeping the 12x72mm ammo intact and as the 12x64mm equivalent as it's supposed to be the carbon-copy of the aforementioned ammo.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
