### PR TITLE
Shot ammo mass value fix

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -26,7 +26,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeChargedBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
     <statBases>
-	  <Mass>0.034</Mass>
+	  <Mass>0.047</Mass>
 	  <Bulk>0.07</Bulk>
     </statBases>
     <tradeTags>
@@ -46,8 +46,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.8</MarketValue>
-	    <Mass>0.028</Mass>      
+      <MarketValue>2.8</MarketValue>    
     </statBases>
     <ammoClass>BuckShot</ammoClass>
   </ThingDef>
@@ -60,7 +59,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.8</MarketValue>       
+      <MarketValue>2.8</MarketValue> 
+	  <Mass>0.043</Mass>  
     </statBases>
     <ammoClass>Slug</ammoClass>
   </ThingDef>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -23,7 +23,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="15x65mmDiffusingChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
     <description>Mechanoid-built cartridge designed to split upon firing.</description>
     <statBases>
-	  <Mass>0.05</Mass>
+	  <Mass>0.11</Mass>
 	  <Bulk>0.04</Bulk>
     </statBases>
     <thingCategories>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -20,7 +20,7 @@
       <Ammo_12Gauge_Beanbag>Bullet_12Gauge_Beanbag</Ammo_12Gauge_Beanbag>
       <Ammo_12Gauge_ElectroSlug>Bullet_12Gauge_ElectroSlug</Ammo_12Gauge_ElectroSlug>
     </ammoTypes>
-		<similarTo>AmmoSet_Shotgun</similarTo>
+    <similarTo>AmmoSet_Shotgun</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->
@@ -28,7 +28,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Extremely common shotgun caliber used in almost every application, from hunting over riot control to military firearms.</description>
     <statBases>
-      <Mass>0.023</Mass>
+      <Mass>0.051</Mass>
       <Bulk>0.06</Bulk>
     </statBases>
     <tradeTags>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -20,7 +20,7 @@
       <Ammo_20Gauge_Beanbag>Bullet_20Gauge_Beanbag</Ammo_20Gauge_Beanbag>
       <Ammo_20Gauge_ElectroSlug>Bullet_20Gauge_ElectroSlug</Ammo_20Gauge_ElectroSlug>
     </ammoTypes>
-		<similarTo>AmmoSet_Shotgun</similarTo>
+    <similarTo>AmmoSet_Shotgun</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->
@@ -28,7 +28,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="20GaugeBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Very common shotgun caliber used mostly for hunting.</description>
     <statBases>
-	  <Mass>0.017</Mass>
+	  <Mass>0.044</Mass>
 	  <Bulk>0.05</Bulk>
     </statBases>
 	<tradeTags>
@@ -77,7 +77,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.08</Mass>
+      <Mass>0.033</Mass>
       <MarketValue>0.14</MarketValue>
     </statBases>
     <ammoClass>Slug</ammoClass>
@@ -93,6 +93,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
+      <Mass>0.042</Mass>
       <MarketValue>0.19</MarketValue>
     </statBases>
     <ammoClass>Beanbag</ammoClass>
@@ -107,6 +108,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
+      <Mass>0.037</Mass>
       <MarketValue>0.49</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -19,7 +19,7 @@
       <Ammo_23x75mmR_Beanbag>Bullet_23x75mmR_Beanbag</Ammo_23x75mmR_Beanbag>
       <Ammo_23x75mmR_ElectroSlug>Bullet_23x75mmR_ElectroSlug</Ammo_23x75mmR_ElectroSlug>
     </ammoTypes>
-		<similarTo>AmmoSet_Shotgun</similarTo>
+    <similarTo>AmmoSet_Shotgun</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -27,7 +27,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large 6.27 gauge shotgun caliber designed to be fired by the KS-23 shotgun.</description>
     <statBases>
-	  <Mass>0.023</Mass>
+	  <Mass>0.063</Mass>
 	  <Bulk>0.1</Bulk>
     </statBases>
 	<tradeTags>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -27,7 +27,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large 6.27 gauge shotgun caliber designed to be fired by the KS-23 shotgun.</description>
     <statBases>
-	  <Mass>0.063</Mass>
+	  <Mass>0.077</Mass>
 	  <Bulk>0.1</Bulk>
     </statBases>
 	<tradeTags>
@@ -119,10 +119,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<pelletCount>16</pelletCount>
-      <armorPenetrationSharp>5</armorPenetrationSharp>
-      <armorPenetrationBlunt>3.98</armorPenetrationBlunt>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.3</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
 	</ThingDef>
@@ -135,10 +135,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>114</speed>
+			<speed>114</speed>
 			<damageAmountBase>57</damageAmountBase>
-      <armorPenetrationSharp>9</armorPenetrationSharp>
-      <armorPenetrationBlunt>526.34</armorPenetrationBlunt>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>526.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -150,7 +150,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
+			<speed>18</speed>
 			<damageDef>Beanbag</damageDef>
 			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBlunt>13.78</armorPenetrationBlunt>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -15,7 +15,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="410BoreBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Low caliber shotgun shell. Its small diameter allows it to be fired from many of the same firearms as the .45 Colt cartridge.</description>
     <statBases>
-      <Mass>0.009</Mass>
+      <Mass>0.027</Mass>
       <Bulk>0.03</Bulk>
     </statBases>
     <tradeTags>


### PR DESCRIPTION
## Changes

- Fixed the shot ammo mass value formula which was incorrectly calculated in the spreadsheet due to it not taking pellet counts into account when calculating cartridge mass. The new formula is included in the linked spreadsheet which correctly calculates cartridge mass based on pellet counts.
- Changed the 23x75mm shot shells from firing # 1 shots to 00 buck.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1198674278

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
