### PR TITLE
Pikeman mech combat power increase

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -17,6 +17,13 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="Mech_Pikeman"]/combatPower</xpath>
+    <value>
+      <combatPower>180</combatPower>
+    </value>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
     <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
     <value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -382,6 +382,10 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Mech_Pikeman"]/race/baseHealthScale</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Pikeman"]/tools</xpath>
 		<value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -252,9 +252,9 @@
 						<li>Cut</li>
 					</capacities>
 					<power>43</power>
-					<cooldownTime>1.65</cooldownTime>
+					<cooldownTime>2.07</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>2.07</armorPenetrationSharp>
+					<armorPenetrationSharp>2.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -15,7 +15,14 @@
 				<combatPower>580</combatPower>
 			</value>
 		  </li>
-		  
+
+		  <li Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[defName="VFE_Mech_Pikeman" or defName="VFE_Mech_AdvancedPikeman"]/combatPower</xpath>
+			<value>
+				<combatPower>180</combatPower>
+			</value>
+		  </li>
+
 		  <li Class="PatchOperationAddModExtension">
 			<xpath>Defs/PawnKindDef[
 			defName="VFE_Mech_Centipede" or

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -164,9 +164,9 @@
               <li>Cut</li>
             </capacities>
             <power>43</power>
-            <cooldownTime>1.65</cooldownTime>
+            <cooldownTime>2.07</cooldownTime>
             <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-            <armorPenetrationSharp>2.07</armorPenetrationSharp>
+            <armorPenetrationSharp>2.16</armorPenetrationSharp>
             <armorPenetrationBlunt>5.4</armorPenetrationBlunt>
             <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
           </li>
@@ -292,6 +292,10 @@
 			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
+	</li>
+
+	<li Class="PatchOperationRemove">
+		<xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/race/baseHealthScale</xpath>
 	</li>
 
 	<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -165,9 +165,9 @@
               <li>Cut</li>
             </capacities>
             <power>43</power>
-            <cooldownTime>1.65</cooldownTime>
+            <cooldownTime>2.07</cooldownTime>
             <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-            <armorPenetrationSharp>2.07</armorPenetrationSharp>
+            <armorPenetrationSharp>2.16</armorPenetrationSharp>
             <armorPenetrationBlunt>5.4</armorPenetrationBlunt>
             <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
           </li>
@@ -293,6 +293,10 @@
 			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
+	</li>
+
+	<li Class="PatchOperationRemove">
+		<xpath>/Defs/ThingDef[defName="VFE_Mech_Pikeman"]/race/baseHealthScale</xpath>
 	</li>
 
 	<li Class="PatchOperationReplace">


### PR DESCRIPTION
## Additions

- Added a patch that increase the Pikeman mech and its variants' combat power from 110 to 180.
- Increased their health scale to 1.0 to make them more durable than their current paper-weak status.

## Reasoning

- Pikeman mechs in CE are tougher than Lancers and Scythers with more dangerous guns, 110 Combat Power for them is too low which results in them being spammed in raids which is not appropriate for a relatively tougher pawn.
- Pikeman mechs are easier to hit than other walker mechs which their 0.85 health scale is a disadvantage on top of that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors