### PR TITLE
Alpha Animals patch update

### DIFF
--- a/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Alpha Animals</li>
+        </mods>
+
+			<match Class="PatchOperationFindMod">
+				<mods>
+					<li>Vanilla Psycasts Expanded</li>
+				</mods>
+
+					<match Class="PatchOperationSequence">
+						<operations>
+
+							<!-- ======= Ability Range Adjustment ======= -->
+
+							<!-- ===== Herald Path ===== -->
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_VenomSpit"]/range</xpath>
+								<value>
+									<range>19.9</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationAdd"> <!-- ===== The patched projectile does not work ===== -->
+								<xpath>Defs</xpath>
+								<value>
+									<ThingDef ParentName="BaseBullet">
+										<defName>AA_PoisonBolt_V</defName>
+										<label>venomous spit</label>
+										<graphicData>
+											<texPath>Things/Projectiles/AA_PoisonBolt</texPath>
+											<graphicClass>Graphic_Single</graphicClass>
+										</graphicData>
+										<projectile>
+											<flyOverhead>false</flyOverhead>
+											<damageDef>AA_ToxicBolt</damageDef>
+											<damageAmountBase>12</damageAmountBase>
+											<speed>50</speed>
+										</projectile>
+									</ThingDef>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_VenomSpit"]/modExtensions/li[@Class="VFECore.Abilities.AbilityExtension_Projectile"]/projectile</xpath>
+								<value>
+									<projectile>AA_PoisonBolt_V</projectile>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_SummonBlackScarab" or defName="AAVPE_SummonBlackSpelopede" or  defName="AAVPE_SummonBlackSpider" or defName="AAVPE_SummonMammothWorm" or defName="AAVPE_SummonBlackQueen"]/range</xpath>
+								<value>
+									<range>24</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_StrengthenInsect"]/range</xpath>
+								<value>
+									<range>11.9</range>
+								</value>
+							</li>
+
+							<!-- ===== Ocultist Path ===== -->
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_SummonEyeling" or defName="AAVPE_SummonOcularOriginator" or AAVPE_SummonEyelingHorde]/range</xpath>
+								<value>
+									<range>24</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_StrikeEyes" or defName="AAVPE_EyeEruption"]/range</xpath>
+								<value>
+									<range>11.9</range>
+								</value>
+							</li>
+
+							<!-- ===== Ravager Path ===== -->
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Slice"]/range</xpath>
+								<value>
+									<range>6</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Slice"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>6.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_ClawFrenzy"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>3.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_DisablingStrike"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>1.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Skewer"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>9.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Charge"]/range</xpath>
+								<value>
+									<range>12</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Charge"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>1.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_ChargeAndSkewer"]/range</xpath>
+								<value>
+									<range>19</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_ChargeAndSkewer"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>9.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_EmpBlow"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>10.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_SpinCut"]/range</xpath>
+								<value>
+									<range>10</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_SpinCut"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>4.0</armourPen>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_LegSkip"]/range</xpath>
+								<value>
+									<range>6</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_LegSkip"]/modExtensions/li[@Class="AlphaBehavioursAndEvents.Ability_Damage_Extension"]/armourPen</xpath>
+								<value>
+									<armourPen>10000</armourPen>
+								</value>
+							</li>
+
+							<!-- ===== Xenoseer Path ===== -->
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_ChemfuelNodules"]/range</xpath>
+								<value>
+									<range>29</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Hover" or defName="AAVPE_Hover"]/range</xpath>
+								<value>
+									<range>24</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_WebSlinging"]/range</xpath>
+								<value>
+									<range>19.9</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_AcidSpit"]/range</xpath>
+								<value>
+									<range>12</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Laser"]/range</xpath>
+								<value>
+									<range>18</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Electrify"]/range</xpath>
+								<value>
+									<range>29</range>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Regeneration"]/range</xpath>
+								<value>
+									<range>12</range>
+								</value>
+							</li>
+
+						</operations>
+					</match>
+			</match>
+    </Operation>
+
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
@@ -188,7 +188,7 @@
 							</li>
 
 							<li Class="PatchOperationReplace">
-								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Hover" or defName="AAVPE_Hover"]/range</xpath>
+								<xpath>Defs/VFECore.Abilities.AbilityDef[defName="AAVPE_Hover" or defName="AAVPE_FungalSkin"]/range</xpath>
 								<value>
 									<range>24</range>
 								</value>

--- a/Patches/Alpha Animals/AA_VPE/HediffDefs/Hediffs_Patch.xml
+++ b/Patches/Alpha Animals/AA_VPE/HediffDefs/Hediffs_Patch.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Alpha Animals</li>
+        </mods>
+
+			<match Class="PatchOperationFindMod">
+				<mods>
+					<li>Vanilla Psycasts Expanded</li>
+				</mods>
+
+					<match Class="PatchOperationSequence">
+						<operations>
+
+							<!-- ======= Ability Range Adjustment ======= -->
+
+							<!-- ===== Herald Path ===== -->
+							<li Class="PatchOperationReplace">
+							   <xpath>Defs/HediffDef[defName="AAVPE_StrengthenBlackHive"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+							   <value>
+								  <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+							   </value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+							   <xpath>Defs/HediffDef[defName="AAVPE_StrengthenBlackHive"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+							   <value>
+								  <ArmorRating_Sharp>1.0</ArmorRating_Sharp>
+							   </value>
+							</li>
+
+							<!-- ===== Xenoseer Path ===== -->
+							<li Class="PatchOperationReplace">
+							   <xpath>Defs/HediffDef[defName="AAVPE_FungalSkin"]/stages/li/statOffsets/ArmorRating_Blunt</xpath>
+							   <value>
+								  <ArmorRating_Blunt>3.75</ArmorRating_Blunt>
+							   </value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+							   <xpath>Defs/HediffDef[defName="AAVPE_FungalSkin"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
+							   <value>
+								  <ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+							   </value>
+							</li>
+
+						</operations>
+					</match>
+			</match>
+    </Operation>
+
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Psycasts Expanded</li>
+			</mods>
+
+				<match Class="PatchOperationSequence">
+					<operations>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>QuadrupedLow</bodyShape>
+								</li>
+							</value>
+						</li>
+							
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/PawnKindDef[defName="AA_BlackScarab_Temporary"]/combatPower</xpath>
+							<value>
+								<combatPower>60</combatPower>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>2.55</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/MoveSpeed</xpath>
+							<value>
+								<MoveSpeed>4.9</MoveSpeed>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases</xpath>
+							<value>
+								<MeleeDodgeChance>0.15</MeleeDodgeChance>
+								<MeleeCritChance>0.01</MeleeCritChance>
+								<MeleeParryChance>0</MeleeParryChance>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>mandibles</label>
+										<capacities>
+											<li>Bite</li>
+										</capacities>
+										<power>9</power>
+										<cooldownTime>1.33</cooldownTime>
+										<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+										<armorPenetrationSharp>0.5</armorPenetrationSharp>
+										<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head</label>
+										<capacities>
+											<li>Blunt</li>
+										</capacities>
+										<power>1</power>
+										<cooldownTime>1.26</cooldownTime>
+										<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+										<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+										<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+										<chanceFactor>0.1</chanceFactor>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>QuadrupedLow</bodyShape>
+								</li>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>6</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>3</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/MoveSpeed</xpath>
+							<value>
+								<MoveSpeed>4.7</MoveSpeed>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases</xpath>
+							<value>
+								<AimingAccuracy>0.75</AimingAccuracy>
+								<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
+								<MeleeDodgeChance>0.08</MeleeDodgeChance>
+								<MeleeCritChance>0.18</MeleeCritChance>
+								<MeleeParryChance>0.15</MeleeParryChance>
+								<Suppressability>0.25</Suppressability>
+							</value>
+						</li>
+							
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/PawnKindDef[defName="AA_BlackSpelopede_Temporary"]/combatPower</xpath>
+							<value>
+								<combatPower>100</combatPower>
+							</value>
+						</li>
+							
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/race/baseHealthScale</xpath>
+							<value>
+								<baseHealthScale>1.4</baseHealthScale>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>head claw</label>
+										<capacities>
+											<li>Cut</li>
+										</capacities>
+										<power>22</power>
+										<cooldownTime>1.68</cooldownTime>
+										<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+										<armorPenetrationSharp>0.75</armorPenetrationSharp>
+										<armorPenetrationBlunt>3.75</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head claw</label>
+										<capacities>
+											<li>Stab</li>
+										</capacities>
+										<power>15</power>
+										<cooldownTime>1.48</cooldownTime>
+										<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+										<armorPenetrationSharp>6</armorPenetrationSharp>
+										<armorPenetrationBlunt>3</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head</label>
+										<capacities>
+											<li>Blunt</li>
+										</capacities>
+										<power>2</power>
+										<cooldownTime>1.5</cooldownTime>
+										<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+										<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+										<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+										<chanceFactor>0.2</chanceFactor>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>Quadruped</bodyShape>
+								</li>
+							</value>
+						</li>
+							
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/race/baseHealthScale</xpath>
+							<value>
+								<baseHealthScale>2.1</baseHealthScale>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>12</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>5</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/MoveSpeed</xpath>
+							<value>
+								<MoveSpeed>4.6</MoveSpeed>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases</xpath>
+							<value>
+								<AimingAccuracy>0.65</AimingAccuracy>
+								<ShootingAccuracyPawn>0.65</ShootingAccuracyPawn>
+								<MeleeDodgeChance>0.09</MeleeDodgeChance>
+								<MeleeCritChance>0.45</MeleeCritChance>
+								<MeleeParryChance>0.25</MeleeParryChance>
+									<Suppressability>0.2</Suppressability>
+							</value>
+						</li>
+							
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/PawnKindDef[defName="AA_BlackSpider_Temporary"]/combatPower</xpath>
+							<value>
+								<combatPower>200</combatPower>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>head claw</label>
+										<capacities>
+											<li>Cut</li>
+										</capacities>
+										<power>44</power>
+										<cooldownTime>2.0</cooldownTime>
+										<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+										<armorPenetrationSharp>2.0</armorPenetrationSharp>
+										<armorPenetrationBlunt>10</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head claw</label>
+										<capacities>
+											<li>Stab</li>
+										</capacities>
+										<power>26</power>
+										<cooldownTime>1.33</cooldownTime>
+										<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+										<armorPenetrationSharp>44</armorPenetrationSharp>
+										<armorPenetrationBlunt>22</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<label>head</label>
+										<capacities>
+											<li>Blunt</li>
+										</capacities>
+										<power>25</power>
+										<cooldownTime>1.33</cooldownTime>
+										<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+										<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+										<armorPenetrationBlunt>8.5</armorPenetrationBlunt>
+										<chanceFactor>0.2</chanceFactor>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>Quadruped</bodyShape>
+								</li>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/PawnKindDef[defName="AA_MammothWorm_Temporary"]/combatPower</xpath>
+							<value>
+								<combatPower>250</combatPower>
+							</value>
+						</li>
+						
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<value>
+								<ArmorRating_Blunt>24</ArmorRating_Blunt>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<value>
+								<ArmorRating_Sharp>10</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/MoveSpeed</xpath>
+							<value>
+								<MoveSpeed>2.7</MoveSpeed>
+								<MeleeDodgeChance>0.08</MeleeDodgeChance>
+								<MeleeCritChance>0.8</MeleeCritChance>
+								<MeleeParryChance>0.23</MeleeParryChance>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>body</label>
+										<capacities>
+											<li>AA_SiegeBlunt</li>
+										</capacities>
+										<power>43</power>
+										<cooldownTime>2.48</cooldownTime>
+										<surpriseAttack>
+											<extraMeleeDamages>
+												<li>
+													<def>Stun</def>
+													<amount>21</amount>
+												</li>
+											</extraMeleeDamages>
+										</surpriseAttack>
+										<armorPenetrationBlunt>50</armorPenetrationBlunt>
+									</li>
+									<li Class="CombatExtended.ToolCE">
+										<capacities>
+											<li>Stab</li>
+										</capacities>
+										<power>48</power>
+										<cooldownTime>2.68</cooldownTime>
+										<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+										<armorPenetrationSharp>20</armorPenetrationSharp>
+										<armorPenetrationBlunt>50</armorPenetrationBlunt>
+									</li>
+								</tools>
+							</value>
+						</li>
+
+					</operations>
+				</match>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -188,6 +188,28 @@
 							</value>
 						</li>
 
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/verbs</xpath>
+							<value>
+								<verbs>
+									<li Class="CombatExtended.VerbPropertiesCE">
+										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+										<hasStandardCommand>true</hasStandardCommand>
+										<defaultProjectile>AA_PoisonBolt</defaultProjectile>
+										<warmupTime>2.4</warmupTime>
+										<burstShotCount>1</burstShotCount>
+										<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+										<minRange>2</minRange>
+										<range>20</range>
+										<soundCast>AA_PoisonBolt</soundCast>
+										<muzzleFlashScale>0</muzzleFlashScale>
+										<label>venomous spit</label>
+										<commonality>0.8</commonality>
+									</li>
+								</verbs>
+							</value>
+						</li>
+
 						<li Class="PatchOperationAddModExtension">
 							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]</xpath>
 							<value>
@@ -285,6 +307,28 @@
 								</tools>
 							</value>
 						</li>
+
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/verbs</xpath>
+						<value>
+							<verbs>
+								<li Class="CombatExtended.VerbPropertiesCE">
+									<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+									<hasStandardCommand>true</hasStandardCommand>
+									<defaultProjectile>AA_PoisonBolt</defaultProjectile>
+									<warmupTime>1.6</warmupTime>
+									<burstShotCount>1</burstShotCount>
+									<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+									<minRange>1.9</minRange>
+									<range>32</range>
+									<soundCast>AA_PoisonBolt</soundCast>
+									<muzzleFlashScale>0</muzzleFlashScale>
+									<label>venomous spit</label>
+									<commonality>0.8</commonality>
+								</li>
+							</verbs>
+						</value>
+					</li>
 
 						<li Class="PatchOperationAddModExtension">
 							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]</xpath>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -255,7 +255,7 @@
 								<MeleeDodgeChance>0.09</MeleeDodgeChance>
 								<MeleeCritChance>0.45</MeleeCritChance>
 								<MeleeParryChance>0.25</MeleeParryChance>
-									<Suppressability>0.2</Suppressability>
+								<Suppressability>0.2</Suppressability>
 							</value>
 						</li>
 							

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackLarva.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackLarva.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Psycasts Expanded</li>
+			</mods>
+
+				<match Class="PatchOperationSequence">
+					<operations>
+
+						<li Class="PatchOperationAdd">
+						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/statBases</xpath>
+						  <value>
+							<MeleeDodgeChance>0.06</MeleeDodgeChance>
+							<MeleeCritChance>0.02</MeleeCritChance>
+							<MeleeParryChance>0.04</MeleeParryChance>
+						  </value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/race/baseHealthScale</xpath>
+						  <value>
+							<baseHealthScale>0.2</baseHealthScale>
+						  </value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/tools</xpath>
+						  <value>
+							<tools>
+							  <li Class="CombatExtended.ToolCE">
+								<label>mandibles</label>
+								<capacities>
+								  <li>Bite</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>2.12</cooldownTime>
+								<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.01</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.031</armorPenetrationBlunt>
+							  </li>
+							  <li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+								  <li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>2.12</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.031</armorPenetrationBlunt>
+							  </li>
+							</tools>
+						  </value>
+						</li>
+
+					</operations>
+				</match>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Psycasts Expanded</li>
+			</mods>
+
+				<match Class="PatchOperationSequence">
+					<operations>
+
+						<li Class="PatchOperationAdd">
+						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases</xpath>
+						  <value>
+							<MeleeDodgeChance>0.03</MeleeDodgeChance>
+							<MeleeCritChance>0.30</MeleeCritChance>
+							<MeleeParryChance>0.57</MeleeParryChance>
+						  </value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Blunt</xpath>
+						  <value>
+							<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						  </value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Sharp</xpath>
+						  <value>
+							<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						  </value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/tools</xpath>
+						  <value>
+							<tools>
+							  <li Class="CombatExtended.ToolCE">
+								<label>head claw</label>
+								<capacities>
+								  <li>Stab</li>
+								</capacities>
+								<power>37</power>
+								<cooldownTime>1.48</cooldownTime>
+								<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+								<armorPenetrationSharp>50</armorPenetrationSharp>
+								<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							  </li>
+							  <li Class="CombatExtended.ToolCE">
+								<label>AAVPE_InfectedMandibles</label>
+								<capacities>
+								  <li>Cut</li>
+								</capacities>
+								<power>65</power>
+								<cooldownTime>1.65</cooldownTime>
+								<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
+								<armorPenetrationSharp>3.38</armorPenetrationSharp>
+								<armorPenetrationBlunt>8.438</armorPenetrationBlunt>
+							  </li>
+							  <li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+								  <li>Blunt</li>
+								</capacities>
+								<power>34</power>
+								<cooldownTime>2.64</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+							  </li>
+							</tools>
+						  </value>
+						</li>
+
+					</operations>
+				</match>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_OcularOriginator.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_OcularOriginator.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
+		<match Class="PatchOperationFindMod">
+			<mods>
+				<li>Vanilla Psycasts Expanded</li>
+			</mods>
+
+				<match Class="PatchOperationSequence">
+					<operations>
+
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>Birdlike</bodyShape>
+								</li>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]/statBases</xpath>
+							<value>
+								<MeleeDodgeChance>0.3</MeleeDodgeChance>
+								<MeleeCritChance>0.04</MeleeCritChance>
+								<MeleeParryChance>0.3</MeleeParryChance>
+							</value>
+						</li>
+
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>tentacles</label>
+										<capacities>
+											<li>Blunt</li>
+										</capacities>
+										<power>5</power>
+										<cooldownTime>0.35</cooldownTime>
+										<linkedBodyPartsGroup>Arms</linkedBodyPartsGroup>
+										<armorPenetrationBlunt>0.7</armorPenetrationBlunt>
+									</li>
+								</tools>
+							</value>
+						</li>
+					</operations>
+				</match>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_Summoned_Eyeling.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_Summoned_Eyeling.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+			<mods>
+				<li>Alpha Animals</li>
+			</mods>
+			<match Class="PatchOperationFindMod">
+				<mods>
+					<li>Vanilla Psycasts Expanded</li>
+				</mods>
+				<match Class="PatchOperationFindMod">
+					<mods>
+						<li>Ideology</li>
+					</mods>
+
+					<match Class="PatchOperationSequence">
+						<operations>
+
+							<li Class="PatchOperationAddModExtension">
+								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]</xpath>
+								<value>
+									<li Class="CombatExtended.RacePropertiesExtensionCE">
+										<bodyShape>Quadruped</bodyShape>
+									</li>
+								</value>
+							</li>
+
+							<li Class="PatchOperationAdd">
+								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]/statBases</xpath>
+								<value>
+									<MeleeDodgeChance>0.1</MeleeDodgeChance>
+									<MeleeCritChance>0.1</MeleeCritChance>
+									<MeleeParryChance>0.1</MeleeParryChance>
+								</value>
+							</li>
+
+							<li Class="PatchOperationReplace">
+								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]/tools</xpath>
+								<value>
+									<tools>
+										<li Class="CombatExtended.ToolCE">
+											<capacities>
+												<li>AA_ToxicBite</li>
+											</capacities>
+											<power>12</power>
+											<cooldownTime>1.65</cooldownTime>
+											<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+											<surpriseAttack>
+												<extraMeleeDamages>
+													<li>
+														<def>Stun</def>
+														<amount>10</amount>
+													</li>
+												</extraMeleeDamages>
+											</surpriseAttack>
+											<armorPenetrationSharp>1.0</armorPenetrationSharp>
+											<armorPenetrationBlunt>0.544</armorPenetrationBlunt>
+										</li>
+									</tools>
+								</value>
+							</li>
+
+						</operations>
+					</match>
+				</match>
+			</match>
+	</Operation>
+
+</Patch>
+


### PR DESCRIPTION
## Additions

- Added the patch files for the new additions to the Alpha Animals mod, including the new animals and Psycasts.

## Reasoning

- The new temporary pawns that are spawned via psycasts are the exact same as the already existing ones in the mod, so the patches are the same as well.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (All the new things are tested in-game)
