### PR TITLE
.303 British tweaks

### DIFF
--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>149</speed>
+			<speed>154</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -144,9 +144,9 @@
 		<defName>Bullet_303British_FMJ</defName>
 		<label>.303 British bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
+			<armorPenetrationBlunt>67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -156,7 +156,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
+			<armorPenetrationBlunt>67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -164,9 +164,9 @@
 		<defName>Bullet_303British_HP</defName>
 		<label>.303 British bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>24</damageAmountBase>
+			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
+			<armorPenetrationBlunt>67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -176,7 +176,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
 		  <armorPenetrationSharp>14</armorPenetrationSharp>
-		  <armorPenetrationBlunt>62.540</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>67</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
 			  <def>Flame_Secondary</def>
@@ -190,9 +190,9 @@
 		<defName>Bullet_303British_HE</defName>
 		<label>.303 British bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>19</damageAmountBase>
+		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
-		  <armorPenetrationBlunt>62.540</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>67</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -208,7 +208,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
-		  <armorPenetrationBlunt>80.960</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>86.72</armorPenetrationBlunt>
 		  <speed>224</speed>
 		</projectile>
 	  </ThingDef>


### PR DESCRIPTION
## Changes

- Tweaked the .303 ammo based on the Mark VIIIz rounds.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The data used for the ammo was based on the old designs of the cartridge which were not so good, used the latest version as the base in the spreadsheet which resulted in a slight buff to the ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
