### PR TITLE
VWE Laser and Coilgun adjustments

### DIFF
--- a/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
@@ -108,7 +108,7 @@
           <Mass>1.45</Mass>
           <Bulk>2.50</Bulk>
           <SwayFactor>1.32</SwayFactor>
-          <ShotSpread>0.17</ShotSpread>
+          <ShotSpread>0.08</ShotSpread>
           <SightsEfficiency>0.8</SightsEfficiency>
           <RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
         </statBases>
@@ -143,7 +143,7 @@
           <Mass>4.0</Mass>
           <Bulk>9.0</Bulk>
           <SwayFactor>1.30</SwayFactor>
-          <ShotSpread>0.07</ShotSpread>
+          <ShotSpread>0.03</ShotSpread>
           <SightsEfficiency>1.10</SightsEfficiency>
           <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
         </statBases>
@@ -183,7 +183,7 @@
           <Mass>12.0</Mass>
           <Bulk>12.0</Bulk>
           <SwayFactor>2.40</SwayFactor>
-          <ShotSpread>0.66</ShotSpread>
+          <ShotSpread>0.06</ShotSpread>
           <SightsEfficiency>1</SightsEfficiency>
           <RangedWeapon_Cooldown>0.86</RangedWeapon_Cooldown>
         </statBases>

--- a/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
@@ -137,7 +137,7 @@
           <Mass>1.20</Mass>
           <Bulk>2.30</Bulk>
           <SwayFactor>1.17</SwayFactor>
-          <ShotSpread>0.06</ShotSpread>
+          <ShotSpread>0.04</ShotSpread>
           <SightsEfficiency>0.8</SightsEfficiency>
           <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
         </statBases>
@@ -208,8 +208,8 @@
           <Mass>2.25</Mass>
           <Bulk>6.90</Bulk>
           <SwayFactor>0.92</SwayFactor>
-          <ShotSpread>0.06</ShotSpread>
-          <SightsEfficiency>0.8</SightsEfficiency>
+          <ShotSpread>0.04</ShotSpread>
+          <SightsEfficiency>1.10</SightsEfficiency>
           <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
         </statBases>
         <Properties>
@@ -242,7 +242,7 @@
           <Mass>3.50</Mass>
           <Bulk>10.00</Bulk>
           <SwayFactor>1.35</SwayFactor>
-          <ShotSpread>0.06</ShotSpread>
+          <ShotSpread>0.04</ShotSpread>
           <SightsEfficiency>1.10</SightsEfficiency>
           <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
         </statBases>
@@ -314,7 +314,7 @@
           <Mass>3.40</Mass>
           <Bulk>9.00</Bulk>
           <SwayFactor>1.24</SwayFactor>
-          <ShotSpread>0.06</ShotSpread>
+          <ShotSpread>0.04</ShotSpread>
           <SightsEfficiency>1.10</SightsEfficiency>
           <RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
         </statBases>
@@ -380,7 +380,7 @@
           <Mass>4.20</Mass>
           <Bulk>13.00</Bulk>
           <SwayFactor>1.19</SwayFactor>
-          <ShotSpread>0.04</ShotSpread>
+          <ShotSpread>0.02</ShotSpread>
           <SightsEfficiency>2.48</SightsEfficiency>
           <RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
           <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
@@ -450,7 +450,7 @@
           <Mass>16.00</Mass>
           <Bulk>10.40</Bulk>
           <SwayFactor>2.64</SwayFactor>
-          <ShotSpread>0.06</ShotSpread>
+          <ShotSpread>0.04</ShotSpread>
           <SightsEfficiency>1</SightsEfficiency>
           <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
         </statBases>


### PR DESCRIPTION
## Changes

- Lowered the shot spread of the laser and coilgun weapons from aforementioned mods.

## Reasoning

- The guns in question are supposed to be very accurate but in-game the very opposite is true, made some tweaks to make them a bit more accurate.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
