### PR TITLE
Fix the Exoframe's unfinished item

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -273,10 +273,13 @@
       <CarryWeight>50</CarryWeight>
     </equippedStatOffsets>
     <recipeMaker>
-    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>		
+      <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>		
+      <effectWorking>Smith</effectWorking>
+      <soundWorking>Recipe_Machining</soundWorking>
       <recipeUsers>
-		    <li>TableMachining</li>
+		<li>TableMachining</li>
       </recipeUsers>
+	  <unfinishedThingDef>UnfinishedTechArmor</unfinishedThingDef>
     </recipeMaker>
     <costList>
       <Plasteel>80</Plasteel>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -131,7 +131,7 @@
           <hulk><offset>(0,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
           <male><offset>(0.125,0)</offset></male>
-		      <female><offset>(0.125,0)</offset></female>	
+          <female><offset>(0.125,0)</offset></female>	
         </east>
         <west>
           <offset>(0,-0.05)</offset>
@@ -139,7 +139,7 @@
           <hulk><offset>(0,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
           <male><offset>(-0.125,0)</offset></male>
-		      <female><offset>(-0.125,0)</offset></female>		  
+          <female><offset>(-0.125,0)</offset></female>		  
         </west>
         <north>
           <offset>(0,-0.1)</offset> 
@@ -209,7 +209,7 @@
           <hulk><offset>(0.05,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
           <male><offset>(0.2,0)</offset></male>
-		      <female><offset>(0.2,0)</offset></female>	
+          <female><offset>(0.2,0)</offset></female>	
         </east>
         <west>
           <offset>(0,-0.05)</offset>
@@ -217,7 +217,7 @@
           <hulk><offset>(-0.05,0)</offset></hulk>
           <fat><offset>(0,0)</offset></fat>
           <male><offset>(-0.2,0)</offset></male>
-		      <female><offset>(-0.2,0)</offset></female>		  
+          <female><offset>(-0.2,0)</offset></female>		  
         </west>
         <north>
           <offset>(0,-0.1)</offset> 
@@ -277,9 +277,9 @@
       <effectWorking>Smith</effectWorking>
       <soundWorking>Recipe_Machining</soundWorking>
       <recipeUsers>
-		<li>TableMachining</li>
+        <li>TableMachining</li>
       </recipeUsers>
-	  <unfinishedThingDef>UnfinishedTechArmor</unfinishedThingDef>
+      <unfinishedThingDef>UnfinishedTechArmor</unfinishedThingDef>
     </recipeMaker>
     <costList>
       <Plasteel>80</Plasteel>


### PR DESCRIPTION
## Changes

- What it says on the tin, the item was inheriting wrong recipe stuff from its parent def causing stuff like stuffed unfinished Exoframes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
