### PR TITLE
Adjuested 20 Gauge ammo

### DIFF
--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -136,7 +136,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
 			<pelletCount>20</pelletCount>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.92</armorPenetrationBlunt>
 			<spreadMult>21.8</spreadMult>
 		</projectile>
@@ -167,7 +167,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>97</speed>
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.14</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, based on sources on the net and number comparisons, the 20ga shells had too much sharp penetration which this PR fixes.

## References

- https://www.youtube.com/watch?v=-VeeqLX0CZA
- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
