### PR TITLE
Heavy weapon tweaks and housekeeping

### DIFF
--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
@@ -12,6 +12,15 @@
                     <value>
 
                         <!-- ===== Ammo Sets ===== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_5x35mmHV</defName>
+							<label>5x35mm Hyper</label>
+							<ammoTypes>
+								<Ammo_5x35mmCharged>Bullet_5x35mmHV</Ammo_5x35mmCharged>
+							</ammoTypes>
+						</CombatExtended.AmmoSetDef>
+
                         <CombatExtended.AmmoSetDef>
                             <defName>AmmoSet_RM_CoilPistolGun</defName>
                             <label>coil charge</label>
@@ -35,6 +44,31 @@
                                 <Ammo_LaserChargePack>RM_Bullet_TeslaCoil</Ammo_LaserChargePack>
                             </ammoTypes>
                         </CombatExtended.AmmoSetDef>
+
+                        <!-- ===== High velocity 5x35mm Projectile ===== -->
+						<ThingDef ParentName="Base5x35mmChargedBullet">
+							<defName>Bullet_5x35mmHV</defName>
+							<label>5x35mm high-velocity bullet</label>
+							<graphicData>
+								<texPath>Things/Projectile/ChargeLanceShot</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+								<shaderType>TransparentPostLight</shaderType>
+								<drawSize>(3,3)</drawSize>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bullet</damageDef>
+								<damageAmountBase>14</damageAmountBase>
+								<speed>280</speed>
+								<secondaryDamage>
+									<li>
+										<def>Bomb_Secondary</def>
+										<amount>2</amount>
+									</li>
+								</secondaryDamage>
+								<armorPenetrationSharp>36</armorPenetrationSharp>
+								<armorPenetrationBlunt>78.4</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>	
 
                         <!-- ===== Reinforced Tesla/Coil Projectiles ===== -->
                         <ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletWhite">

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_SpacerWeapons_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_SpacerWeapons_Mech.xml
@@ -236,17 +236,16 @@
                         <Mass>7</Mass>
                         <Bulk>12</Bulk>
                         <SwayFactor>1</SwayFactor>
-                        <ShotSpread>0.03</ShotSpread>
+                        <ShotSpread>0.02</ShotSpread>
                         <SightsEfficiency>1.15</SightsEfficiency>
                         <RangedWeapon_Cooldown>0.45</RangedWeapon_Cooldown>
                     </statBases>
                     <Properties>
-                        <recoilAmount>1.16</recoilAmount>
                         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                         <hasStandardCommand>true</hasStandardCommand>
-                        <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+                        <defaultProjectile>Bullet_5x35mmHV</defaultProjectile>
                         <warmupTime>1.2</warmupTime>
-                        <range>59</range>
+                        <range>65</range>
                         <burstShotCount>1</burstShotCount>
                         <soundCast>ChargeLance_Fire</soundCast>
                         <soundCastTail>GunTail_Heavy</soundCastTail>
@@ -255,7 +254,7 @@
                     <AmmoUser>
                         <magazineSize>15</magazineSize>
                         <reloadTime>4</reloadTime>
-                        <ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+                        <ammoSet>AmmoSet_5x35mmHV</ammoSet>
                     </AmmoUser>
                     <FireModes>
                         <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEVRangedWarcasket.xml
@@ -33,7 +33,6 @@
       <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
         <defName>VFEP_WarcasketGun_CryptoCannon</defName>
         <statBases>
-          <Mass>35</Mass>
           <Bulk>20</Bulk>
           <SwayFactor>2.10</SwayFactor>
           <ShotSpread>3.00</ShotSpread>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWECRangedWarcasket.xml
@@ -34,7 +34,6 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VFEP_WarcasketGun_Railgun</defName>
           <statBases>
-            <Mass>45.0</Mass>
             <Bulk>55.0</Bulk>
             <SwayFactor>2.40</SwayFactor>
             <ShotSpread>0.66</ShotSpread>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWELRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWELRangedWarcasket.xml
@@ -39,7 +39,7 @@
           <defName>VFEP_WarcasketGun_SalvagedLaserEradicator</defName>
           <statBases>
             <Mass>30</Mass>
-            <Bulk>25</Bulk>
+            <Bulk>40</Bulk>
             <SwayFactor>2.85</SwayFactor>
             <ShotSpread>0.08</ShotSpread>
             <SightsEfficiency>2.20</SightsEfficiency>
@@ -70,8 +70,8 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VFEP_WarcasketGun_LaserBlaster</defName>
           <statBases>
-            <Mass>30</Mass>
-            <Bulk>40</Bulk>
+            <Mass>20</Mass>
+            <Bulk>25</Bulk>
             <SwayFactor>2.64</SwayFactor>
             <ShotSpread>0.06</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWENLRangedWarcasket.xml
@@ -33,7 +33,6 @@
 		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>VFEP_WarcasketGun_TearGasGrenadeLauncher</defName>
 			<statBases>
-				<Mass>25</Mass>
 				<Bulk>25</Bulk>
 				<SwayFactor>1.31</SwayFactor>
 				<ShotSpread>0.18</ShotSpread>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VWEQRangedWarcasket.xml
@@ -37,8 +37,7 @@
             <SightsEfficiency>0.85</SightsEfficiency>
             <ShotSpread>0.10</ShotSpread>
             <SwayFactor>2.32</SwayFactor>
-            <Bulk>25</Bulk>
-            <Mass>25</Mass>
+            <Bulk>15</Bulk>
           </statBases>
           <Properties>
             <recoilAmount>0.6</recoilAmount>
@@ -47,7 +46,7 @@
             <defaultProjectile>Bullet_338Norma_FMJ</defaultProjectile>
             <warmupTime>0.5</warmupTime>
             <range>57</range>
-            <burstShotCount>20</burstShotCount>
+            <burstShotCount>10</burstShotCount>
             <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
             <soundCast>VFEP_Shot_Minigun</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -70,7 +70,7 @@
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
             <warmupTime>1.3</warmupTime>
-            <range>52</range>
+            <range>60</range>
             <soundCast>Shot_Autocannon</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>12</muzzleFlashScale>
@@ -191,7 +191,7 @@
           <statBases>
             <RangedWeapon_Cooldown>0.6</RangedWeapon_Cooldown>
             <SightsEfficiency>0.9</SightsEfficiency>
-            <ShotSpread>0.10</ShotSpread>
+            <ShotSpread>0.08</ShotSpread>
             <SwayFactor>2.32</SwayFactor>
             <Bulk>25</Bulk>
           </statBases>
@@ -270,7 +270,6 @@
             <ShotSpread>0.01</ShotSpread>
             <SwayFactor>2.08</SwayFactor>
             <Bulk>45.00</Bulk>
-            <Mass>45.00</Mass>
             <RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
           </statBases>
           <Properties>				
@@ -340,7 +339,6 @@
             <ShotSpread>0.06</ShotSpread>
             <SwayFactor>1.18</SwayFactor>
             <Bulk>31.00</Bulk>
-            <Mass>55</Mass>
             <RangedWeapon_Cooldown>1.56</RangedWeapon_Cooldown>
           </statBases>
           <Properties>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -123,7 +123,6 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_HandheldMortar</defName>
           <statBases>
-            <Mass>30</Mass>
             <Bulk>20</Bulk>
             <SwayFactor>1.24</SwayFactor>
             <ShotSpread>0.10</ShotSpread>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -68,7 +68,7 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_Autocannon</defName>
           <statBases>
-            <Mass>65</Mass>
+            <Mass>55</Mass>
             <Bulk>22</Bulk>
             <SwayFactor>8.80</SwayFactor>
             <ShotSpread>0.01</ShotSpread>
@@ -123,7 +123,7 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_HandheldMortar</defName>
           <statBases>
-            <Mass>42</Mass>
+            <Mass>30</Mass>
             <Bulk>20</Bulk>
             <SwayFactor>1.24</SwayFactor>
             <ShotSpread>0.10</ShotSpread>
@@ -182,7 +182,7 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_UraniumSlugRifle</defName>
           <statBases>
-            <Mass>75</Mass>
+            <Mass>60</Mass>
             <Bulk>22.5</Bulk>
             <SwayFactor>9.85</SwayFactor>
             <ShotSpread>0.01</ShotSpread>
@@ -233,7 +233,6 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_HeavyFlamer</defName>
           <statBases>
-            <Mass>45</Mass>
             <Bulk>18</Bulk>
             <SwayFactor>7.10</SwayFactor>
             <ShotSpread>0.5</ShotSpread>
@@ -285,7 +284,7 @@
         <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
           <defName>VWE_Gun_SwarmMissileLauncher</defName>
           <statBases>
-            <Mass>45</Mass>
+            <Mass>40</Mass>
             <Bulk>22</Bulk>
             <SwayFactor>3.54</SwayFactor>
             <ShotSpread>0.10</ShotSpread>
@@ -304,7 +303,7 @@
             <soundCast>InfernoCannon_Fire</soundCast>
             <soundCastTail>GunTail_Heavy</soundCastTail>
             <onlyManualCast>true</onlyManualCast>
-				    <stopBurstWithoutLos>false</stopBurstWithoutLos>
+            <stopBurstWithoutLos>false</stopBurstWithoutLos>
             <muzzleFlashScale>12</muzzleFlashScale>
             <targetParams>
               <canTargetLocations>true</canTargetLocations>


### PR DESCRIPTION
## Changes

- Tweaked some heavy weapons from VWE Heavy to be consistent with their counterparts.
- .50 BMG out of even a short barrel goes farther than .338, made it so for the Pirate autorifle and consistent among other guns.
- Some housekeeping and duplicate/redundant values removal, the mass node removed were because the items themselves already had the same mass value making the replaced value redundant.
- Tweaked the Folding Gun from Pirates to be more accurate to its description.
- Changed the charge lance rifle from Reinforced Mechanoids to fire 5x35mm High-Velocity instead of 8x35mm.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
