### PR TITLE
Aura mechs rebalanced and housekeeping

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aura.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-		<li>Alpha Animals</li>
+			<li>Alpha Animals</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">
@@ -23,7 +23,7 @@
 				<xpath>/Defs/ThingDef[defName="AA_Aura"]</xpath>
 				<value>
 					<statBases> <!-- Ok this is pissing me off -->
-					        <MoveSpeed>5.5</MoveSpeed>
+						<MoveSpeed>5.5</MoveSpeed>
 						<ArmorRating_Blunt>6</ArmorRating_Blunt>
 						<ArmorRating_Sharp>4</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.5</MeleeDodgeChance>
@@ -43,12 +43,12 @@
 							<capacities>
 							  <li>Cut</li>
 							</capacities>
-							<power>24</power>
-							<cooldownTime>0.6</cooldownTime>
+							<power>37</power>
+							<cooldownTime>1.5</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>
-							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>wing blade</label>
@@ -56,10 +56,10 @@
 							  <li>Stab</li>
 							</capacities>
 							<power>18</power>
-							<cooldownTime>0.6</cooldownTime>
+							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
 							<armorPenetrationSharp>30</armorPenetrationSharp>
 						</li>
       						<li Class="CombatExtended.ToolCE">
@@ -77,7 +77,9 @@
 					</tools>
 				</value>
 			</li>
+
 			</operations>
 		</match>
 	</Operation>
+
 </Patch>

--- a/Patches/Alpha Animals/VFE_Mechs/AdvAura.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/AdvAura.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Alpha Animals</li>
-					</mods>
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
 		<match Class="PatchOperationFindMod">
-					<mods>
-						<li>Vanilla Factions Expanded - Mechanoids</li>
-					</mods>
+			<mods>
+				<li>Vanilla Factions Expanded - Mechanoids</li>
+			</mods>
 					
 			<match Class="PatchOperationSequence">
 				<operations>
@@ -20,13 +21,14 @@
 					</li>
 				</value>
 			</li>
-		<!-- Assign armor values, change replace and add depending on what exists or not -->
+
+			<!-- Assign armor values, change replace and add depending on what exists or not -->
 					
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Advanced_Aura"]</xpath>
 				<value>
 					<statBases> <!-- Ok this is pissing me off -->
-					        <MoveSpeed>5.5</MoveSpeed>
+						<MoveSpeed>5.5</MoveSpeed>
 						<ArmorRating_Blunt>10</ArmorRating_Blunt>
 						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.66</MeleeDodgeChance>
@@ -46,23 +48,23 @@
 							<capacities>
 							  <li>Cut</li>
 							</capacities>
-							<power>28</power>
-							<cooldownTime>0.66</cooldownTime>
+							<power>44</power>
+							<cooldownTime>1.65</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>30</armorPenetrationBlunt>
-							<armorPenetrationSharp>15</armorPenetrationSharp>
+							<armorPenetrationBlunt>9</armorPenetrationBlunt>
+							<armorPenetrationSharp>3.5</armorPenetrationSharp>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>wing blade</label>
 							<capacities>
 							  <li>Stab</li>
 							</capacities>
-							<power>21</power>
-							<cooldownTime>0.66</cooldownTime>
+							<power>18</power>
+							<cooldownTime>1.33</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							<armorPenetrationBlunt>20</armorPenetrationBlunt>
 							<armorPenetrationSharp>40</armorPenetrationSharp>
 						</li>
       						<li Class="CombatExtended.ToolCE">
@@ -80,6 +82,7 @@
 					</tools>
 				</value>
 			</li>
+
 				</operations>
 			</match>					
 		</match>			

--- a/Patches/Alpha Animals/VFE_Mechs/VFEAura.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFEAura.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Alpha Animals</li>
-					</mods>
+		<mods>
+			<li>Alpha Animals</li>
+		</mods>
+
 		<match Class="PatchOperationFindMod">
-					<mods>
-						<li>Vanilla Factions Expanded - Mechanoids</li>
-					</mods>
+			<mods>
+				<li>Vanilla Factions Expanded - Mechanoids</li>
+			</mods>
 
 		<match Class="PatchOperationSequence">
 			<operations>
@@ -21,13 +22,13 @@
 				</value>
 			</li>
 
-		<!-- Assign armor values, change replace and add depending on what exists or not -->
+			<!-- Assign armor values, change replace and add depending on what exists or not -->
 					
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Mech_Aura"]</xpath>
 				<value>
 					<statBases> <!-- Ok this is pissing me off -->
-					        <MoveSpeed>5.5</MoveSpeed>
+						<MoveSpeed>5.5</MoveSpeed>
 						<ArmorRating_Blunt>6</ArmorRating_Blunt>
 						<ArmorRating_Sharp>4</ArmorRating_Sharp>
 						<MeleeDodgeChance>0.5</MeleeDodgeChance>
@@ -47,12 +48,12 @@
 							<capacities>
 							  <li>Cut</li>
 							</capacities>
-							<power>24</power>
-							<cooldownTime>0.6</cooldownTime>
+							<power>37</power>
+							<cooldownTime>1.5</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>20</armorPenetrationBlunt>
-							<armorPenetrationSharp>10</armorPenetrationSharp>
+							<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							<armorPenetrationSharp>2.5</armorPenetrationSharp>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>wing blade</label>
@@ -60,10 +61,10 @@
 							  <li>Stab</li>
 							</capacities>
 							<power>18</power>
-							<cooldownTime>0.6</cooldownTime>
+							<cooldownTime>1.25</cooldownTime>
 							<linkedBodyPartsGroup>AA_WingBlades</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							<armorPenetrationBlunt>30</armorPenetrationBlunt>
+							<armorPenetrationBlunt>15</armorPenetrationBlunt>
 							<armorPenetrationSharp>30</armorPenetrationSharp>
 						</li>
       						<li Class="CombatExtended.ToolCE">

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -252,9 +252,9 @@
 						<li>Cut</li>
 					</capacities>
 					<power>43</power>
-					<cooldownTime>1.65</cooldownTime>
+					<cooldownTime>2.07</cooldownTime>
 					<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-					<armorPenetrationSharp>2.07</armorPenetrationSharp>
+					<armorPenetrationSharp>2.16</armorPenetrationSharp>
 					<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -164,9 +164,9 @@
               <li>Cut</li>
             </capacities>
             <power>43</power>
-            <cooldownTime>1.65</cooldownTime>
+            <cooldownTime>2.07</cooldownTime>
             <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-            <armorPenetrationSharp>2.07</armorPenetrationSharp>
+            <armorPenetrationSharp>2.16</armorPenetrationSharp>
             <armorPenetrationBlunt>5.4</armorPenetrationBlunt>
             <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
           </li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -165,9 +165,9 @@
               <li>Cut</li>
             </capacities>
             <power>43</power>
-            <cooldownTime>1.65</cooldownTime>
+            <cooldownTime>2.07</cooldownTime>
             <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
-            <armorPenetrationSharp>2.07</armorPenetrationSharp>
+            <armorPenetrationSharp>2.16</armorPenetrationSharp>
             <armorPenetrationBlunt>5.4</armorPenetrationBlunt>
             <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
           </li>


### PR DESCRIPTION
## Changes

- Rebalanced the Aura mechs from Alpha Animals based on the spreadsheet.
- Scythers had a faster left hook for some reason, fixed that as well.

## References

- https://docs.google.com/spreadsheets/d/1gJreRqm--zvrJlpSd1Jq6G3v4b7aHwhwtDotXcFB9mQ/edit#gid=647442519

## Reasoning

- Absurd and unrealistic values were used for the Aura mechs which made them even more OP than they are intended to be.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
