### PR TITLE
Added Carry Weight to implants and bionics of EPOE Forked

### DIFF
--- a/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/Patches/EPOE Forked/Bionics_Patch.xml
@@ -306,6 +306,37 @@
 					</tools>
 				</value>
 			</li>
+			<!-- Add Carry Weight to bionics that increase Carry Capacity -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="BionicSpine"]/stages/li/statOffsets</xpath>
+				<value>
+						<CarryWeight>+5</CarryWeight>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="AdvancedBionicSpine"]/stages/li/statOffsets</xpath>
+				<value>
+						<CarryWeight>+10</CarryWeight>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="ExoskeletonSuit"]/stages/li/statOffsets</xpath>
+				<value>
+						<CarryWeight>+20</CarryWeight>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="EPIA_ProtectiveExoskeleton"]/stages/li/statOffsets</xpath>
+				<value>
+						<CarryWeight>+20</CarryWeight>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="MuscleStimulatorArms"]/stages/li/statOffsets</xpath>
+				<value>
+						<CarryWeight>+10</CarryWeight>
+				</value>
+			</li>
 
 		</operations>
 	</match>

--- a/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/Patches/EPOE Forked/Bionics_Patch.xml
@@ -306,35 +306,24 @@
 					</tools>
 				</value>
 			</li>
+
 			<!-- Add Carry Weight to bionics that increase Carry Capacity -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/HediffDef[defName="BionicSpine"]/stages/li/statOffsets</xpath>
 				<value>
-						<CarryWeight>+5</CarryWeight>
+					<CarryWeight>5</CarryWeight>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/HediffDef[defName="AdvancedBionicSpine"]/stages/li/statOffsets</xpath>
 				<value>
-						<CarryWeight>+10</CarryWeight>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/HediffDef[defName="ExoskeletonSuit"]/stages/li/statOffsets</xpath>
-				<value>
-						<CarryWeight>+20</CarryWeight>
+					<CarryWeight>10</CarryWeight>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/HediffDef[defName="EPIA_ProtectiveExoskeleton"]/stages/li/statOffsets</xpath>
 				<value>
-						<CarryWeight>+20</CarryWeight>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/HediffDef[defName="MuscleStimulatorArms"]/stages/li/statOffsets</xpath>
-				<value>
-						<CarryWeight>+10</CarryWeight>
+					<CarryWeight>10</CarryWeight>
 				</value>
 			</li>
 


### PR DESCRIPTION
Added Carry Weight Bonus to the Bionic Spine, Advanced Bionic Spine and Protective Exoskeleton as these enhancements also add Carry Capacity bonus.

## Additions

Bionic Spine: +5
Advanced Bionic Spine: +10
Protective Exoskeletons: +10

## Reasoning
These bionics increase Carry Capacity, and the description always imply they allow the user's body to handle more weight. Since Carry Capacity in CE does not bring any benefit to pawns, while Carry Weight has much more impact. 
As these bionics also give a flat Carry Weight bonus, smaller alien races should become more viable combat wise.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony 
Tested also how it felt to unlock these bionics through normal game progression and if the added bonus felt overturned or not. As of now they feel right.
