### PR TITLE
8x35mm charged ammo rebalanced

### DIFF
--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -104,7 +104,7 @@
           <amount>6</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>16</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -121,7 +121,7 @@
           <amount>2</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>32</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -138,9 +138,9 @@
           <amount>9</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationSharp>22.5</armorPenetrationSharp>
+      <armorPenetrationSharp>24</armorPenetrationSharp>
       <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
-      <empShieldBreakChance>0.2</empShieldBreakChance>
+      <empShieldBreakChance>0.33</empShieldBreakChance>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- Increased the base sharp armor penetration of the 8x35mm charged ammo by 1.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- 8x35mm has always had more sharp AP than 6x24mm up until #652, which in the aforementioned PR, after increasing the AP values of both 8x35 and 6x24, they are given the same values which kinda does not make sense for a round that has more energy to have the same sharp AP as the smaller one. It's the exact same situation as 5.56 vs 7.62x51 which the latter has 1 more sharp AP value while having double the blunt AP. This should help with the gap between 6x24 and 8x50, also make 8x35mm a better cartridge to consider same as how 7.62NATO is worth switching over 5.56.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
