### PR TITLE
Adjusted 7.62x39mm AP data

### DIFF
--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -17,7 +17,7 @@
 			<Ammo_762x39mmSoviet_FMJ>Bullet_762x39mmSoviet_FMJ</Ammo_762x39mmSoviet_FMJ>
 			<Ammo_762x39mmSoviet_AP>Bullet_762x39mmSoviet_AP</Ammo_762x39mmSoviet_AP>
 			<Ammo_762x39mmSoviet_HP>Bullet_762x39mmSoviet_HP</Ammo_762x39mmSoviet_HP>
-		    <Ammo_762x39mmSoviet_Incendiary>Bullet_762x39mmSoviet_Incendiary</Ammo_762x39mmSoviet_Incendiary>
+			<Ammo_762x39mmSoviet_Incendiary>Bullet_762x39mmSoviet_Incendiary</Ammo_762x39mmSoviet_Incendiary>
 			<Ammo_762x39mmSoviet_HE>Bullet_762x39mmSoviet_HE</Ammo_762x39mmSoviet_HE>
 			<Ammo_762x39mmSoviet_Sabot>Bullet_762x39mmSoviet_Sabot</Ammo_762x39mmSoviet_Sabot>				
 		</ammoTypes>
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>17</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -163,7 +163,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -177,7 +177,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -187,7 +187,7 @@
 		<label>7.62mm Soviet bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>10</armorPenetrationSharp>
 		  <armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -203,13 +203,13 @@
 		<label>7.62mm Soviet bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>17</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		  <secondaryDamage>
-				<li>
-			  	<def>Bomb_Secondary</def>
-			  	<amount>10</amount>
-				</li>
+			<li>
+			  <def>Bomb_Secondary</def>
+			  <amount>10</amount>
+			</li>
 		  </secondaryDamage>
 		</projectile>
 	  </ThingDef>
@@ -219,7 +219,7 @@
 		<label>7.62mm Soviet bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		  <speed>216</speed>
 		</projectile>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070
- The HB hardness rating states that for a tungsten carbide penetrator moving at 700m/s, it can penetrate 10mm of AR500 steel which is level 3 armor and 12mm of AR400 steel which is roughly RHA, our AP rounds are not exactly tungsten carbide so yea...

## Reasoning

- Slow and big boolet penetrates less armor than faster and smaller ones, 7.62x39 should and does not do so vs 5.56.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
