### PR TITLE
Tweaked base CE turrets

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -110,11 +110,11 @@
     <uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>48000</WorkToBuild>
-      <MaxHitPoints>140</MaxHitPoints>
+      <MaxHitPoints>250</MaxHitPoints>
       <Mass>20</Mass>
       <Bulk>25</Bulk>
-      <AimingAccuracy>0.5</AimingAccuracy>
-      <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+      <AimingAccuracy>0.75</AimingAccuracy>
+      <ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
     </statBases>
     <techLevel>Spacer</techLevel>
     <comps>
@@ -162,8 +162,8 @@
       <MarketValue>2150</MarketValue>
       <MaxHitPoints>550</MaxHitPoints>
       <Flammability>0.05</Flammability>
-      <Mass>80</Mass>
-      <Bulk>100</Bulk>
+      <Mass>60</Mass>
+      <Bulk>80</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
       <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
     </statBases>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -47,18 +47,18 @@
     <statBases>
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.08</ShotSpread>
-      <SwayFactor>0.72</SwayFactor>
+      <ShotSpread>0.06</ShotSpread>
+      <SwayFactor>0.86</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
       <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
-      <Mass>5</Mass>
+      <Mass>10</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.1</recoilAmount>
+        <recoilAmount>1.14</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+        <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
         <warmupTime>1.3</warmupTime>
         <range>55</range>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -73,7 +73,7 @@
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>100</magazineSize>
         <reloadTime>7.8</reloadTime>
-        <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+        <ammoSet>AmmoSet_8x35mmCharged</ammoSet>
       </li>
     </comps>
   </ThingDef>
@@ -92,13 +92,13 @@
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>0.98</SwayFactor>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SwayFactor>1.31</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
       <Mass>30</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.43</recoilAmount>
+        <recoilAmount>2.02</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -134,14 +134,14 @@
     <statBases>
       <MarketValue>500</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.03</ShotSpread>
-      <SwayFactor>0.86</SwayFactor>
+      <ShotSpread>0.05</ShotSpread>
+      <SwayFactor>0.94</SwayFactor>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-      <Mass>10</Mass>
+      <Mass>15</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.0</recoilAmount>
+        <recoilAmount>0.95</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -177,20 +177,20 @@
     <statBases>
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.1</ShotSpread>
-      <SwayFactor>1.42</SwayFactor>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.61</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
       <Mass>50</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.61</recoilAmount>
+        <recoilAmount>1.96</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
         <warmupTime>4.3</warmupTime>
         <range>78</range>
-        <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+        <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
         <soundCast>HeavyMG</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
@@ -228,7 +228,7 @@
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>2.36</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>1.14</SwayFactor>
+      <SwayFactor>1.89</SwayFactor>
       <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
       <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
       <Mass>50</Mass>
@@ -274,13 +274,13 @@
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>1.6</SwayFactor>
-      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <SwayFactor>1.42</SwayFactor>
+      <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
       <Mass>35</Mass>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.52</recoilAmount>
+        <recoilAmount>1.86</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -327,7 +327,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.16</recoilAmount>
+        <recoilAmount>1.08</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -369,7 +369,7 @@
       <MarketValue>2000</MarketValue>
       <SightsEfficiency>2.3</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
-      <SwayFactor>1.14</SwayFactor>
+      <SwayFactor>1.41</SwayFactor>
       <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
       <Mass>500</Mass>
     </statBases>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -153,7 +153,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Turret_Sniper"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.25</AimingAccuracy>
+			<AimingAccuracy>0.75</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -170,7 +170,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Turret_Sniper"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>1.5</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
@@ -220,7 +220,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Turret_Autocannon"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.25</AimingAccuracy>
+			<AimingAccuracy>0.5</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -244,7 +244,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName = "Turret_Autocannon"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -805,14 +805,13 @@
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
     <defName>Gun_MiniTurret</defName>
     <statBases>
-      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.07</ShotSpread>
-      <SwayFactor>0.82</SwayFactor>
-      <Bulk>10.00</Bulk>
+      <SwayFactor>0.69</SwayFactor>
     </statBases>
     <Properties>
-      <recoilAmount>0.76</recoilAmount>
+      <recoilAmount>1.15</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>


### PR DESCRIPTION
## Changes

- Fixed the base CE and vanilla turrets based on the data from the gun spreadsheet.
- Rechambered the charge blaster turret from 6x24mm to 8x35mm charged.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- By the time that the charge blaster turret becomes available, it's pretty much obsolete and underpowered, let alone it consuming 950 watts of power as well. I am aware that it pretty much is the human-built version of the mech mini slugger turret tho but it has to have a good purpose to be built. To summarize, the current implementation is expensive for its performance, low firepower for the stage of the game it is unlocked at and high power consumption again for the general lackluster performance of it. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
