### PR TITLE
40mm grenade hotfix

### DIFF
--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -193,7 +193,7 @@
     <label>40x46mm grenade (HEDP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>112</damageAmountBase>
+      <damageAmountBase>19</damageAmountBase>
       <armorPenetrationSharp>63</armorPenetrationSharp>
       <armorPenetrationBlunt>7.302</armorPenetrationBlunt>
     </projectile>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -194,7 +194,7 @@
     <label>40x53mm grenade (HEDP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>50</damageAmountBase>
+      <damageAmountBase>22</damageAmountBase>
       <armorPenetrationSharp>76</armorPenetrationSharp>
       <armorPenetrationBlunt>8.348</armorPenetrationBlunt>
     </projectile>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -194,7 +194,7 @@
     <label>40x53mm grenade (HEDP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>123</damageAmountBase>
+      <damageAmountBase>50</damageAmountBase>
       <armorPenetrationSharp>76</armorPenetrationSharp>
       <armorPenetrationBlunt>8.348</armorPenetrationBlunt>
     </projectile>


### PR DESCRIPTION
## Changes

- Introduced a new ammo type in the projectile spreadsheet specifically for the HEDP grenades which balances them out damage-wise.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1198674278

## Reasoning

- HEAT projectiles are not the same as HEDP nades...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
