### PR TITLE
Custom modded mech ammo hotfix

### DIFF
--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
@@ -46,7 +46,7 @@
                         </CombatExtended.AmmoSetDef>
 
                         <!-- ===== High velocity 5x35mm Projectile ===== -->
-                        <ThingDef ParentName="Base5x35mmChargedBullet">
+                        <ThingDef ParentName="BaseBullet">
                             <defName>Bullet_5x35mmS</defName>
                             <label>5x35mm Super bullet</label>
                             <graphicData>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -25,7 +25,7 @@
 
         <!-- ================== Projectiles ================== -->
 
-		<ThingDef ParentName="Base5x35mmChargedBullet">
+		<ThingDef ParentName="BaseBullet">
 			<defName>Bullet_5x35mmHyper</defName>
 			<label>5x35mm Hyper bullet</label>
 			<graphicData>
@@ -49,7 +49,7 @@
 			</projectile>
 		</ThingDef>	
 
-		<ThingDef ParentName="Base12x64mmChargedBullet">
+		<ThingDef ParentName="BaseBullet">
 			<defName>Bullet_12x64mmHyper</defName>
 			<label>12x64mm Hyper bullet</label>
 			<graphicData>


### PR DESCRIPTION
## Changes

- Fixed the custom mech ammo's parent name added to patched mods causing duplicate secondary damage values inherited from the parent.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Loaded up the mods to test the applied changes)
