### PR TITLE
Charge projectile size adjustments and Ion rounds for AI pawns

### DIFF
--- a/Defs/Ammo/Advanced/10x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/10x18mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>1.71</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0.25</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->
@@ -85,6 +85,7 @@
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.2,1.2)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>2.8</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-	<generateAllowChance>0.25</generateAllowChance>
+	<generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->
@@ -113,6 +113,9 @@
   <ThingDef ParentName="Base12GaugeChargedBullet">
     <defName>Bullet_12GaugeCharged_Slug</defName>
     <label>charge shot (Slug)</label>
+    <graphicData>
+      <drawSize>(1.5,1.5)</drawSize>
+    </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>24</damageAmountBase>
       <secondaryDamage>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -57,6 +57,7 @@
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <shaderType>TransparentPostLight</shaderType>
+      <drawSize>(1.3,1.3)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>6.15</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0.25</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->
@@ -85,6 +85,7 @@
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.3,1.3)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -59,20 +59,20 @@
 		<defName>Bullet_15x65mmDiffusingCharged_Buck</defName>
 		<label>diffusing charged shot</label>
 		<graphicData>
-			<texPath>Things/Projectile/Charged/charge_regular</texPath>
+			<texPath>Things/Projectile/Charge_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>22</damageAmountBase>
 			<pelletCount>5</pelletCount>
-      <secondaryDamage>
-        <li>
-          <def>Bomb_Secondary</def>
-          <amount>7</amount>
-        </li>
-      </secondaryDamage>
-      <armorPenetrationSharp>8</armorPenetrationSharp>      
-      <armorPenetrationBlunt>50.46</armorPenetrationBlunt>
+				<secondaryDamage>
+					<li>
+						<def>Bomb_Secondary</def>
+						<amount>7</amount>
+					</li>
+				</secondaryDamage>
+			<armorPenetrationSharp>8</armorPenetrationSharp>      
+			<armorPenetrationBlunt>50.46</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -57,7 +57,7 @@
       <texPath>Things/Projectile/ChargeLanceShot</texPath>
       <graphicClass>Graphic_Single</graphicClass>
       <shaderType>TransparentPostLight</shaderType>
-      <drawSize>(3,3)</drawSize>
+      <drawSize>(2,2)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>0.69</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>0.7</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>1.55</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->
@@ -85,6 +85,7 @@
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.1,1.1)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -76,7 +76,7 @@
       <MarketValue>2.08</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
+    <generateAllowChance>0.5</generateAllowChance>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->
@@ -85,6 +85,7 @@
     <graphicData>
       <texPath>Things/Projectile/Charge_Small</texPath>
       <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.15,1.15)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>


### PR DESCRIPTION
## Changes

- Adjusted the projectile sizes for charge rounds so that bigger calibers look bigger in-game as well.
- Adjusted the `generateAllowChance` of Ion charge rounds so that they can spawn on AI pawns.

## Reasoning

- Ion rounds are kinda the best charge rounds, in a world filled with mechs, you'd assume the empire pawns would carry them as commonly as other rounds or mercs for that matter. 0.5 chance at least brings the effective round into the mix which is helpful for AI pawns to deal with mechs a bit better.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
