### PR TITLE
.44 Magnum high velocity ammo set bullet speed fix

### DIFF
--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -144,6 +144,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
+			<speed>110</speed>
 		</projectile>
 	</ThingDef>
 
@@ -154,6 +155,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
+			<speed>110</speed>
 		</projectile>
 	</ThingDef>
 
@@ -164,6 +166,7 @@
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
+			<speed>110</speed>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Additions

- Added proper speed nodes to the high velocity .44 magnum rounds which were missing due to an oversight.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
