### PR TITLE
.45-70 sharp armor penetration adjusted and some ammo housekeeping and corrections

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -46,7 +46,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.8</MarketValue>    
+      <MarketValue>4.29</MarketValue>    
     </statBases>
     <ammoClass>BuckShot</ammoClass>
   </ThingDef>
@@ -59,7 +59,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.8</MarketValue> 
+      <MarketValue>4.27</MarketValue> 
 	  <Mass>0.043</Mass>  
     </statBases>
     <ammoClass>Slug</ammoClass>
@@ -73,7 +73,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.8</MarketValue>
+      <MarketValue>4.29</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
 	<generateAllowChance>0.5</generateAllowChance>
@@ -170,7 +170,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>10</count>
       </li>	      
       <li>
         <filter>
@@ -191,7 +191,7 @@
     <products>
       <Ammo_12GaugeCharged>200</Ammo_12GaugeCharged>
     </products>
-    <workAmount>20800</workAmount>
+    <workAmount>21000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
@@ -258,7 +258,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>10</count>
       </li>	      
       <li>
         <filter>
@@ -279,7 +279,7 @@
     <products>
       <Ammo_12GaugeCharged_Ion>200</Ammo_12GaugeCharged_Ion>
     </products>
-    <workAmount>20800</workAmount>	    
+    <workAmount>21000</workAmount>	    
   </RecipeDef>
 	
 </Defs>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -23,7 +23,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="12x64mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
     <description>Mechanoid-built high-caliber charged shot ammo used in heavy weapons.</description>
     <statBases>
-      <Mass>0.054</Mass>
+      <Mass>0.058</Mass>
       <Bulk>0.04</Bulk>
     </statBases>
     <thingCategories>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -26,7 +26,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="12x72mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
     <description>High-caliber charged shot ammo used by advanced heavy machine guns and anti-materiel rifles.</description>
     <statBases>
-      <Mass>0.054</Mass>
+      <Mass>0.058</Mass>
       <Bulk>0.04</Bulk>
     </statBases>
     <tradeTags>
@@ -47,7 +47,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>6.15</MarketValue>
+      <MarketValue>6.78</MarketValue>
     </statBases>
     <ammoClass>Charged</ammoClass>
   </ThingDef>
@@ -60,7 +60,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>6.15</MarketValue>
+      <MarketValue>6.78</MarketValue>
     </statBases>
     <ammoClass>ChargedAP</ammoClass>
   </ThingDef>
@@ -73,7 +73,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>6.15</MarketValue>
+      <MarketValue>6.78</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>200</speed>
+      <speed>180</speed>
     </projectile>
   </ThingDef>
 
@@ -188,7 +188,7 @@
     <products>
       <Ammo_12x72mmCharged>200</Ammo_12x72mmCharged>
     </products>
-    <workAmount>29800</workAmount>		
+    <workAmount>32800</workAmount>		
   </RecipeDef>
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
@@ -232,7 +232,7 @@
     <products>
       <Ammo_12x72mmCharged_AP>200</Ammo_12x72mmCharged_AP>
     </products>
-    <workAmount>29800</workAmount>		
+    <workAmount>32800</workAmount>		
   </RecipeDef>
 
   <RecipeDef ParentName="ChargeAmmoRecipeBase">
@@ -276,7 +276,7 @@
     <products>
       <Ammo_12x72mmCharged_Ion>200</Ammo_12x72mmCharged_Ion>
     </products>
-    <workAmount>29800</workAmount>	
+    <workAmount>32800</workAmount>	
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -39,7 +39,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.65</MarketValue>
+      <MarketValue>0.2</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
     </statBases>
     <ammoClass>BuckShot</ammoClass>
     <cookOffProjectile>Bullet_15x65mmDiffusingCharged_Buck</cookOffProjectile>

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -60,7 +60,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <damageAmountBase>13</damageAmountBase>
-      <speed>200</speed>
+      <speed>160</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -28,7 +28,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo127x108mmBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large caliber bullet used by many heavy machine guns and anti-materiel rifles.</description>
     <statBases>
-    <Mass>0.128</Mass>
+    <Mass>0.133</Mass>
     <Bulk>0.17</Bulk>
     </statBases>
     <tradeTags>
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.52</MarketValue>
+      <MarketValue>0.54</MarketValue>
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_FMJ</cookOffProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.52</MarketValue>
+      <MarketValue>0.54</MarketValue>
     </statBases>
     <ammoClass>ArmorPiercing</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_AP</cookOffProjectile>
@@ -77,8 +77,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.7</MarketValue>
-      <Mass>0.133</Mass>      
+      <MarketValue>0.7</MarketValue>    
     </statBases>
     <ammoClass>IncendiaryAP</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_Incendiary</cookOffProjectile>
@@ -92,8 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.93</MarketValue>
-      <Mass>0.125</Mass>
+      <MarketValue>1.06</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_HE</cookOffProjectile>
@@ -107,8 +105,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.56</MarketValue>
-	    <Mass>0.109</Mass>
+      <MarketValue>0.61</MarketValue>
+	    <Mass>0.112</Mass>
     </statBases>
     <ammoClass>Sabot</ammoClass>
     <cookOffProjectile>Bullet_127x108mm_Sabot</cookOffProjectile>
@@ -205,7 +203,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>52</count>
+        <count>54</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -216,7 +214,7 @@
     <products>
       <Ammo_127x108mm_FMJ>200</Ammo_127x108mm_FMJ>
     </products>
-    <workAmount>5200</workAmount>
+    <workAmount>5400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -231,7 +229,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>52</count>
+        <count>54</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -242,7 +240,7 @@
     <products>
       <Ammo_127x108mm_AP>200</Ammo_127x108mm_AP>
     </products>
-    <workAmount>5200</workAmount>
+    <workAmount>5400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -292,7 +290,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>52</count>
+        <count>54</count>
       </li>
       <li>
         <filter>
@@ -300,7 +298,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>10</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -312,7 +310,7 @@
     <products>
       <Ammo_127x108mm_HE>200</Ammo_127x108mm_HE>
     </products>
-    <workAmount>8400</workAmount>
+    <workAmount>9400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -335,7 +333,7 @@
             <li>Uranium</li>
           </thingDefs>
         </filter>
-        <count>5</count>
+        <count>6</count>
       </li>
       <li>
         <filter>
@@ -343,20 +341,20 @@
             <li>Chemfuel</li>
           </thingDefs>
         </filter>
-        <count>5</count>
+        <count>6</count>
       </li>	  
     </ingredients>
     <fixedIngredientFilter>
       <thingDefs>
 		    <li>Chemfuel</li>	  
-        <li>Steel</li>
+		    <li>Steel</li>
 		    <li>Uranium</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
       <Ammo_127x108mm_Sabot>200</Ammo_127x108mm_Sabot>
     </products>
-    <workAmount>6400</workAmount>
+    <workAmount>7000</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -28,7 +28,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo50BMGBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large caliber bullet used by many heavy machine guns and anti-materiel rifles.</description>
     <statBases>
-      <Mass>0.115</Mass>
+      <Mass>0.118</Mass>
       <Bulk>0.14</Bulk>
     </statBases>
     <tradeTags>
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.48</MarketValue>
+      <MarketValue>0.5</MarketValue>
     </statBases>
     <ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_50BMG_FMJ</cookOffProjectile>
@@ -63,7 +63,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.48</MarketValue>
+      <MarketValue>0.5</MarketValue>
     </statBases>
     <ammoClass>ArmorPiercing</ammoClass>
     <cookOffProjectile>Bullet_50BMG_AP</cookOffProjectile>
@@ -77,8 +77,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.59</MarketValue>
-	  <Mass>0.112</Mass>
+      <MarketValue>0.66</MarketValue>
     </statBases>
     <ammoClass>IncendiaryAP</ammoClass>
     <cookOffProjectile>Bullet_50BMG_Incendiary</cookOffProjectile>
@@ -92,7 +91,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1</MarketValue>
+      <MarketValue>1.02</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>
@@ -106,8 +105,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.52</MarketValue>
-	  <Mass>0.095</Mass>
+      <MarketValue>0.57</MarketValue>
+	  <Mass>0.099</Mass>
     </statBases>
     <ammoClass>Sabot</ammoClass>
     <cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
@@ -204,7 +203,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -215,7 +214,7 @@
     <products>
       <Ammo_50BMG_FMJ>200</Ammo_50BMG_FMJ>
     </products>
-    <workAmount>4800</workAmount>
+    <workAmount>5000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -230,7 +229,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -241,7 +240,7 @@
     <products>
       <Ammo_50BMG_AP>200</Ammo_50BMG_AP>
     </products>
-    <workAmount>4800</workAmount>
+    <workAmount>5000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -256,7 +255,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>46</count>
+        <count>50</count>
       </li>
       <li>
         <filter>
@@ -264,7 +263,7 @@
             <li>Prometheum</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -276,7 +275,7 @@
     <products>
       <Ammo_50BMG_Incendiary>200</Ammo_50BMG_Incendiary>
     </products>
-    <workAmount>6200</workAmount>
+    <workAmount>7000</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -291,7 +290,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>48</count>
+        <count>50</count>
       </li>
       <li>
         <filter>
@@ -311,7 +310,7 @@
     <products>
       <Ammo_50BMG_HE>200</Ammo_50BMG_HE>
     </products>
-    <workAmount>8800</workAmount>
+    <workAmount>9000</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -334,7 +333,7 @@
             <li>Uranium</li>
           </thingDefs>
         </filter>
-        <count>5</count>
+        <count>6</count>
       </li>
       <li>
         <filter>
@@ -342,7 +341,7 @@
             <li>Chemfuel</li>
           </thingDefs>
         </filter>
-        <count>5</count>
+        <count>6</count>
       </li>		  
     </ingredients>
     <fixedIngredientFilter>
@@ -355,7 +354,7 @@
     <products>
       <Ammo_50BMG_Sabot>200</Ammo_50BMG_Sabot>
     </products>
-    <workAmount>6000</workAmount>
+    <workAmount>6600</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -29,8 +29,8 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="4570GovBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Rather large and bulky rifle cartridge propelled by a charge of 'black powder'. Good for making people imitate sacks when they are hit.</description>
 		<statBases>
-		<Mass>0.03</Mass>
-		<Bulk>0.044</Bulk>
+		<Mass>0.037</Mass>
+		<Bulk>0.03</Bulk>
 		</statBases>
 	<tradeTags>
 		<li>CE_AutoEnableTrade</li>
@@ -49,7 +49,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.19</MarketValue>
+			<MarketValue>0.16</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_FMJ</cookOffProjectile>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.19</MarketValue>
+			<MarketValue>0.16</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_AP</cookOffProjectile>
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.19</MarketValue>
+			<MarketValue>0.16</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_HP</cookOffProjectile>
@@ -91,7 +91,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.28</MarketValue>
+			<MarketValue>0.22</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_Incendiary</cookOffProjectile>
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.46</MarketValue>
+			<MarketValue>0.36</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_HE</cookOffProjectile>
@@ -119,8 +119,8 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.22</MarketValue>
-			<Mass>0.033</Mass>
+			<MarketValue>0.18</MarketValue>
+			<Mass>0.029</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
 		<cookOffProjectile>Bullet_4570Gov_Sabot</cookOffProjectile>
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>85</speed>
+			<speed>127</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -144,9 +144,9 @@
 		<defName>Bullet_4570Gov_FMJ</defName>
 		<label>.45-70 Government cartridge (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -154,9 +154,9 @@
 		<defName>Bullet_4570Gov_AP</defName>
 		<label>.45-70 Government cartridge (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -164,9 +164,9 @@
 		<defName>Bullet_4570Gov_HP</defName>
 		<label>.45-70 Government cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>30</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -174,13 +174,13 @@
 		<defName>Bullet_4570Gov_Incendiary</defName>
 		<label>.45-70 bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>13</damageAmountBase>
+		  <damageAmountBase>15</damageAmountBase>
 		  <armorPenetrationSharp>14</armorPenetrationSharp>
-		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
-			  	<amount>8</amount>
+			  	<amount>9</amount>
 				</li>
 		  </secondaryDamage>
 		</projectile>
@@ -190,13 +190,13 @@
 		<defName>Bullet_4570Gov_HE</defName>
 		<label>.45-70 bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>20</damageAmountBase>
+		  <damageAmountBase>24</damageAmountBase>
 		  <armorPenetrationSharp>7</armorPenetrationSharp>
-		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
-			  	<amount>12</amount>
+			  	<amount>14</amount>
 				</li>
 		  </secondaryDamage>
 		</projectile>
@@ -206,10 +206,10 @@
 		<defName>Bullet_4570Gov_Sabot</defName>
 		<label>.45-70 bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>11</damageAmountBase>
+		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>24.5</armorPenetrationSharp>
-		  <armorPenetrationBlunt>60.68</armorPenetrationBlunt>
-		  <speed>128</speed>
+		  <armorPenetrationBlunt>99.54</armorPenetrationBlunt>
+		  <speed>190</speed>
 		</projectile>
 	  </ThingDef>
   
@@ -227,7 +227,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>38</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -238,7 +238,7 @@
 		<products>
 			<Ammo_4570Gov_FMJ>500</Ammo_4570Gov_FMJ>
 		</products>
-	    <workAmount>4600</workAmount>			
+	    <workAmount>3800</workAmount>			
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -253,7 +253,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>38</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_4570Gov_AP>500</Ammo_4570Gov_AP>
 		</products>
-	    <workAmount>4600</workAmount>			
+	    <workAmount>3800</workAmount>			
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -279,7 +279,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>46</count>
+				<count>38</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -290,7 +290,7 @@
 		<products>
 			<Ammo_4570Gov_HP>500</Ammo_4570Gov_HP>
 		</products>
-	    <workAmount>4600</workAmount>	
+	    <workAmount>3800</workAmount>	
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -305,7 +305,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>46</count>
+        <count>38</count>
       </li>
       <li>
         <filter>
@@ -313,7 +313,7 @@
             <li>Prometheum</li>
           </thingDefs>
         </filter>
-        <count>7</count>
+        <count>5</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -325,7 +325,7 @@
     <products>
       <Ammo_4570Gov_Incendiary>500</Ammo_4570Gov_Incendiary>
     </products>
-    <workAmount>7400</workAmount>
+    <workAmount>5800</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -340,7 +340,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>46</count>
+        <count>38</count>
       </li>
       <li>
         <filter>
@@ -348,7 +348,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>13</count>
+        <count>10</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -360,7 +360,7 @@
     <products>
       <Ammo_4570Gov_HE>500</Ammo_4570Gov_HE>
     </products>
-    <workAmount>9800</workAmount>
+    <workAmount>7800</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -383,7 +383,7 @@
             <li>Uranium</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>6</count>
       </li>
       <li>
         <filter>
@@ -391,7 +391,7 @@
             <li>Chemfuel</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>6</count>
       </li>		  
     </ingredients>
     <fixedIngredientFilter>
@@ -404,7 +404,7 @@
     <products>
       <Ammo_4570Gov_Sabot>500</Ammo_4570Gov_Sabot>
     </products>
-    <workAmount>6600</workAmount>
+    <workAmount>5400</workAmount>
   </RecipeDef>
 	
 </Defs>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -145,7 +145,7 @@
 		<label>.45-70 Government cartridge (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>.45-70 Government cartridge (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>.45-70 Government cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>.45-70 bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>18</armorPenetrationSharp>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
 		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -191,7 +191,7 @@
 		<label>.45-70 bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
-		  <armorPenetrationSharp>9</armorPenetrationSharp>
+		  <armorPenetrationSharp>7</armorPenetrationSharp>
 		  <armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>.45-70 bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>11</damageAmountBase>
-		  <armorPenetrationSharp>31.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>24.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>60.68</armorPenetrationBlunt>
 		  <speed>128</speed>
 		</projectile>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.1</MarketValue>
+      <MarketValue>0.22</MarketValue>
     </statBases>
     <ammoClass>BuckShot</ammoClass>
     <cookOffProjectile>Bullet_12Gauge_Buck</cookOffProjectile>
@@ -220,7 +220,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>22</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -231,7 +231,7 @@
     <products>
       <Ammo_12Gauge_Buck>200</Ammo_12Gauge_Buck>
     </products>
-    <workAmount>1000</workAmount>
+    <workAmount>2200</workAmount>
   </RecipeDef>
 
   <!-- <RecipeDef ParentName="AmmoRecipeBase"> -->

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.08</MarketValue>
+      <MarketValue>0.18</MarketValue>
     </statBases>
     <ammoClass>BuckShot</ammoClass>
     <cookOffProjectile>Bullet_20Gauge_Buck</cookOffProjectile>
@@ -219,7 +219,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>15</count>
+        <count>18</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -230,7 +230,7 @@
     <products>
       <Ammo_20Gauge_Buck>200</Ammo_20Gauge_Buck>
     </products>
-    <workAmount>3250</workAmount>
+    <workAmount>1800</workAmount>
   </RecipeDef>
 
   <!-- <RecipeDef ParentName="AmmoRecipeBase">
@@ -282,7 +282,7 @@
     <products>
       <Ammo_20Gauge_Slug>200</Ammo_20Gauge_Slug>
     </products>
-    <workAmount>3750</workAmount>
+    <workAmount>1400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -297,7 +297,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>14</count>
+        <count>18</count>
       </li>
       <li>
         <filter>
@@ -305,7 +305,7 @@
             <li>Cloth</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>1</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -317,7 +317,7 @@
     <products>
       <Ammo_20Gauge_Beanbag>200</Ammo_20Gauge_Beanbag>
     </products>
-    <workAmount>2500</workAmount>
+    <workAmount>1900</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -332,7 +332,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>14</count>
+        <count>16</count>
       </li>
       <li>
         <filter>
@@ -340,7 +340,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>3</count>
+        <count>2</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -352,7 +352,7 @@
     <products>
       <Ammo_20Gauge_ElectroSlug>200</Ammo_20Gauge_ElectroSlug>
     </products>
-    <workAmount>5750</workAmount>
+    <workAmount>2800</workAmount>
   </RecipeDef>
 	
 </Defs>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.12</MarketValue>
+      <MarketValue>0.34</MarketValue>
     </statBases>
     <ammoClass>BuckShot</ammoClass>
     <cookOffProjectile>Bullet_23x75mmR_Buck</cookOffProjectile>
@@ -185,7 +185,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>12</count>
+        <count>34</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -196,7 +196,7 @@
     <products>
       <Ammo_23x75mmR_Buck>200</Ammo_23x75mmR_Buck>
     </products>
-    <workAmount>1200</workAmount>
+    <workAmount>3400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -36,7 +36,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.04</MarketValue>
+      <MarketValue>0.12</MarketValue>
     </statBases>
     <ammoClass>BuckShot</ammoClass>
     <cookOffProjectile>Bullet_410Bore_Buck</cookOffProjectile>
@@ -100,7 +100,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>12</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -111,7 +111,7 @@
     <products>
       <Ammo_410Bore_Buck>200</Ammo_410Bore_Buck>
     </products>
-    <workAmount>400</workAmount>
+    <workAmount>1200</workAmount>
   </RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Changes

- Adjusted the aforementioned round's sharp and blunt armor penetration based on the spreadsheet.
- Corrected some values based on the spreadsheet.
- Adjusted some formulas in the spreadsheet so that it calculates recipes for shot shells correctly based on the number of pellets in the shell.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The current stats used for the cartridge is based on the slower trapdoor versions of the round and not the standard ones which is adjusted as well.
- A slow and fat round should not have the same RHA penetration of .30-06 which is very fast and has a lot of energy behind it, gel data is not as reliable for pistol rounds and fat rifle rounds that have a lot of inertia. .45-70 has even less blunt pen than 7.62 NATO, 7/14/4 sharp armor penetration should be a good compromise if not even a bit forgiving.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
