### PR TITLE
Adjust flare gun's warmup time

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -406,7 +406,7 @@
         <forceNormalTimeSpeed>false</forceNormalTimeSpeed>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_Flare</defaultProjectile>
-        <warmupTime>3</warmupTime>
+        <warmupTime>1.1</warmupTime>
         <range>45</range>
         <soundCast>InfernoCannon_Fire</soundCast>
         <muzzleFlashScale>16</muzzleFlashScale>


### PR DESCRIPTION
## Changes

- Decreased the flare gun's warmup time in an attempt to make it more viable since it does not require proper aiming, it's only a point at the sky and shoot type of gun.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
