### PR TITLE
Paniel Equipment Update

### DIFF
--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -34,6 +34,31 @@
 						</ammoTypes>
 						<isMortarAmmoSet>true</isMortarAmmoSet>		
 					</CombatExtended.AmmoSetDef>
+					
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_PanielLSWMulti</defName>
+						<label>Paniel Multi-Launcher munitions</label>
+						<ammoTypes>
+						  <Ammo_40x53mmGrenade_HE>Bullet_40x53mmGrenade_HE</Ammo_40x53mmGrenade_HE>
+						  <Ammo_40x53mmGrenade_HE_TFuzed>Bullet_40x53mmGrenade_HE_TFuzed</Ammo_40x53mmGrenade_HE_TFuzed>
+						  <Ammo_40x53mmGrenade_HEDP>Bullet_40x53mmGrenade_HEDP</Ammo_40x53mmGrenade_HEDP>
+						  <Ammo_40x53mmGrenade_EMP>Bullet_40x53mmGrenade_EMP</Ammo_40x53mmGrenade_EMP>
+						  <Ammo_40x53mmGrenade_Smoke>Bullet_40x53mmGrenade_Smoke</Ammo_40x53mmGrenade_Smoke>	
+						  <Ammo_30x64mmFuel_Incendiary>Bullet_30x64mmFuel_Incendiary</Ammo_30x64mmFuel_Incendiary>
+						  <Ammo_30x64mmFuel_Thermobaric>Bullet_30x64mmFuel_Thermobaric</Ammo_30x64mmFuel_Thermobaric>
+						  <Ammo_30x64mmFuel_Foam>Bullet_30x64mmFuel_Foam</Ammo_30x64mmFuel_Foam>
+						</ammoTypes>
+						<isMortarAmmoSet>false</isMortarAmmoSet>		
+					</CombatExtended.AmmoSetDef>
+					
+					<CombatExtended.AmmoSetDef>
+						<defName>AmmoSet_PanielRailShell</defName>
+						<label>Paniel Railgun shells</label>
+						<ammoTypes>
+							<Ammo_PanielRailShell>Bullet_PanielRail</Ammo_PanielRailShell>
+						</ammoTypes>	
+						<isMortarAmmoSet>false</isMortarAmmoSet>	
+					</CombatExtended.AmmoSetDef>
 
 					<!-- ==================== Ammo ========================== -->
 
@@ -168,6 +193,25 @@
 						</statBases>
 						<ammoClass>Antigrain</ammoClass>
 						<detonateProjectile>Bullet_PanielHowitzerShell_Anti</detonateProjectile>
+					</ThingDef>
+					
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="105mmHowitzerShellBase">
+						<defName>Ammo_PanielRailShell</defName>
+						<label>Paniel Railgun shell</label>
+						<graphicData>
+							<texPath>Things/Item/PNShell/PNShellAP</texPath>
+							<graphicClass>Graphic_StackCount</graphicClass>
+							<drawSize>0.90</drawSize>
+						</graphicData>
+						<tradeTags inherit="false">
+						  <li>CE_HeavyAmmo</li>
+						  <li>CE_AutoEnableTrade</li>
+						</tradeTags>
+						<statBases>
+							<MarketValue>225</MarketValue>
+						</statBases>
+						<ammoClass>Antigrain</ammoClass>
+						<detonateProjectile>Bullet_PanielRail</detonateProjectile>
 					</ThingDef>
 
 					<!-- ================== Projectiles ================== -->
@@ -730,6 +774,45 @@
 					</RecipeDef>
 					
 					<RecipeDef ParentName="AmmoRecipeBase">
+						<defName>MakeAmmo_PanielHowitzerShell_Anti</defName>
+						<label>make Paniel Antigrain Howitzer shell</label>
+						<description>Craft Paniel antigrain Howitzer shell.</description>
+						<jobString>Making Paniel antigrain Howitzer shell.</jobString>
+						<workAmount>1200</workAmount>
+						<recipeUsers inherit="false">
+							<li>PN_AutomatonBench</li>
+						</recipeUsers>
+						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<ingredients>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Steel</li>
+									</thingDefs>
+								</filter>
+								<count>10</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>Shell_AntigrainWarhead</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
+							</li>
+						</ingredients>
+						<fixedIngredientFilter>
+							<thingDefs>
+								<li>Steel</li>
+								<li>Shell_AntigrainWarhead</li>
+							</thingDefs>
+						</fixedIngredientFilter>
+						<products>
+							<Ammo_PanielHowitzerShell_Anti>1</Ammo_PanielHowitzerShell_Anti>
+						</products>
+					</RecipeDef>
+					
+					<RecipeDef ParentName="AmmoRecipeBase">
 						<defName>MakeAmmo_PanielHowitzerShell_AP</defName>
 						<label>make Paniel AP Howitzer shells x2</label>
 						<description>Craft 2 Paniel ap Howitzer shells.</description>
@@ -778,15 +861,15 @@
 					</RecipeDef>
 					
 					<RecipeDef ParentName="AmmoRecipeBase">
-						<defName>MakeAmmo_PanielHowitzerShell_Anti</defName>
-						<label>make Paniel Antigrain Howitzer shell</label>
-						<description>Craft Paniel antigrain Howitzer shell.</description>
-						<jobString>Making Paniel antigrain Howitzer shell.</jobString>
-						<workAmount>1200</workAmount>
+						<defName>MakeAmmo_PanielRailShell</defName>
+						<label>make Paniel Railgun Shell</label>
+						<description>Craft Paniel Railgun Shell.</description>
+						<jobString>Making Paniel Railgun Shell.</jobString>
+						<workAmount>16000</workAmount>
 						<recipeUsers inherit="false">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
-						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
+						<researchPrerequisite Inherit="false">PNRP_Railgun</researchPrerequisite>
 						<ingredients>
 							<li>
 								<filter>
@@ -794,25 +877,34 @@
 										<li>Steel</li>
 									</thingDefs>
 								</filter>
-								<count>10</count>
+								<count>50</count>
 							</li>
 							<li>
 								<filter>
 									<thingDefs>
-										<li>Shell_AntigrainWarhead</li>
+										<li>Uranium</li>
 									</thingDefs>
 								</filter>
-								<count>16</count>
+								<count>30</count>
+							</li>
+							<li>
+								<filter>
+									<thingDefs>
+										<li>ComponentSpacer</li>
+									</thingDefs>
+								</filter>
+								<count>1</count>
 							</li>
 						</ingredients>
 						<fixedIngredientFilter>
 							<thingDefs>
 								<li>Steel</li>
-								<li>Shell_AntigrainWarhead</li>
+								<li>Uranium</li>
+								<li>ComponentSpacer</li>
 							</thingDefs>
 						</fixedIngredientFilter>
 						<products>
-							<Ammo_PanielHowitzerShell_Anti>1</Ammo_PanielHowitzerShell_Anti>
+							<Ammo_PanielRailShell>1</Ammo_PanielRailShell>
 						</products>
 					</RecipeDef>
 				</value>

--- a/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -111,11 +111,94 @@
 				</value>
 			</li>
 			 
-			 
-				<!--<FireModes>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Base_Core"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Base_Core"]/statBases</xpath>
+				<value>
+					<AimingAccuracy>0.25</AimingAccuracy>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Base_Core"]/statBases/Mass</xpath>
+				<value>
+					<Mass>1000</Mass>
+				</value>
+			</li>
+			<!--
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[@Name="PN_BaseArtilleryBuilding" ]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+			</li>
+			-->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Base_Core"]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Base_Core"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<!-- ==========  Paniel Cannon  =========== -->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>PN_Railgun_Turret</defName>
+				<statBases>
+					<SightsEfficiency>1.0</SightsEfficiency>
+					<ShotSpread>0.01</ShotSpread>
+					<SwayFactor>0.80</SwayFactor>
+					<Bulk>22.00</Bulk>
+					<Mass>18.50</Mass>
+					<RangedWeapon_Cooldown>1.55</RangedWeapon_Cooldown>
+				</statBases>
+				<Properties>
+					<recoilAmount>1.12</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_PanielRail</defaultProjectile>
+					<warmupTime>4</warmupTime>
+					<minRange>5</minRange>
+					<range>86</range>
+					<soundAiming>PN_PrototypeRailGun_Warmup_Sound</soundAiming>
+					<soundCast>PN_PrototypeRailGun_Fire_Sound</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>16</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+				  <magazineSize>1</magazineSize>
+				  <reloadTime>7.8</reloadTime>
+				  <reloadOneAtATime>true</reloadOneAtATime>
+				  <ammoSet>AmmoSet_PanielRailShell</ammoSet>
+				</AmmoUser>
+				<FireModes>
 				  <aiAimMode>AimedShot</aiAimMode>
-				  <noSnapshot>true</noSnapshot>
-				</FireModes>-->
+				</FireModes>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Turret"]/building/fixedStorageSettings</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Turret"]/building/defaultStorageSettings</xpath>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="PN_Railgun_Turret" ]/comps/li[@Class="CompProperties_ChangeableProjectile"]</xpath>
+			</li>
 			
 		</operations>
 		</match>	

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -127,6 +127,71 @@
 			</value>
 		</li>
 		
+		<!-- Security -->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityUniform"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>16</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityUniform"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>40</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityUniform"]/statBases/Mass</xpath>
+			<value>
+				<Mass>12</Mass>
+				<Bulk>28</Bulk>
+				<WornBulk>18</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityUniform"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			<value>
+				<MeleeDodgeChance>0.3</MeleeDodgeChance>
+				<CarryBulk>25</CarryBulk>
+				<CarryWeight>10</CarryWeight>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityHat"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityHat"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>35</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityHat"]/statBases/Mass</xpath>
+			<value>
+				<Mass>3</Mass>
+				<Bulk>2.5</Bulk>
+				<WornBulk>1</WornBulk>
+				<NightVisionEfficiency_Apparel>0.70</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_EliteSecurityHat"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<AimingAccuracy>0.3</AimingAccuracy>
+			</value>
+		</li>
+		
 		<!-- Advanced -->
 		
 		<li Class="PatchOperationReplace">
@@ -181,14 +246,17 @@
 		<!-- Advanced -->
 		
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid" or
+			defName="PN_ApparelRoyalmeister"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>8.5</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid"]/statBases/Mass</xpath>
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaid" or
+			defName="PN_ApparelRoyalmeister"]/statBases/Mass</xpath>
 			<value>
 				<Mass>8</Mass>
 				<Bulk>25</Bulk>
@@ -197,14 +265,20 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat" or
+			defName="PN_ApparelRoyalmeisterHat" or
+			defName="PN_ApparelRoyalmeisterHatWithMonocle" or
+			defName="PN_ApparelRoyalmeisterMonocle"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat"]/statBases/Mass</xpath>
+			<xpath>Defs/ThingDef[defName="PN_ApparelRoyalmaidHat" or
+			defName="PN_ApparelRoyalmeisterHat" or
+			defName="PN_ApparelRoyalmeisterHatWithMonocle" or
+			defName="PN_ApparelRoyalmeisterMonocle"]/statBases/Mass</xpath>
 			<value>
 				<Mass>2</Mass>
 				<Bulk>0.5</Bulk>

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
@@ -214,7 +214,13 @@
 				<Bulk>10.25</Bulk>
 				<Mass>3.19</Mass>
 				<RangedWeapon_Cooldown>0.78</RangedWeapon_Cooldown>
+				<WorkToMake>10000</WorkToMake>
 			</statBases>
+			<costList>
+			  <Steel>50</Steel>
+			  <ComponentIndustrial>1</ComponentIndustrial>
+			  <WoodLog>10</WoodLog>
+			</costList>
 			
 			<Properties>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -253,7 +259,13 @@
 				<Bulk>3.25</Bulk>
 				<Mass>1.40</Mass>
 				<RangedWeapon_Cooldown>0.49</RangedWeapon_Cooldown>
+				<WorkToMake>10000</WorkToMake>
 			</statBases>
+			<costList>
+			  <Steel>25</Steel>
+			  <ComponentIndustrial>4</ComponentIndustrial>
+			  <WoodLog>5</WoodLog>
+			</costList>
 			
 			<Properties>
 				<recoilAmount>3.71</recoilAmount>
@@ -292,7 +304,13 @@
 				<Bulk>12.35</Bulk>
 				<Mass>10.00</Mass>
 				<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+				<WorkToMake>31000</WorkToMake>
 			</statBases>
+			<costList>
+			  <Steel>75</Steel>
+			  <ComponentIndustrial>5</ComponentIndustrial>
+			  <WoodLog>15</WoodLog>
+			</costList>
 			
 			<Properties>
 				<recoilAmount>1.24</recoilAmount>
@@ -304,7 +322,7 @@
 				<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
 				<range>59</range>
 				<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
-				<soundCast>Shot_Minigun</soundCast>
+				<soundCast>Shot_AssaultRifle</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>
@@ -317,8 +335,15 @@
 			<FireModes>
 				<aimedBurstShotCount>5</aimedBurstShotCount>
 				<aiUseBurstMode>FALSE</aiUseBurstMode>
-				<aiAimMode>AimedShot</aiAimMode>
+				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Machinegun"]/weaponTags</xpath>
+			<value>
+				<li>Bipod_LMG</li>
+			</value>
 		</li>
 		
 		<!-- ========== Portable Cannon =========== -->
@@ -332,7 +357,13 @@
 				<Bulk>19.85</Bulk>
 				<Mass>18.00</Mass>
 				<RangedWeapon_Cooldown>1.38</RangedWeapon_Cooldown>
+				<WorkToMake>19500</WorkToMake>
 			</statBases>
+			<costList>
+			  <Steel>120</Steel>
+			  <ComponentIndustrial>3</ComponentIndustrial>
+			  <WoodLog>25</WoodLog>
+			</costList>
 			
 			<Properties>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -353,6 +384,13 @@
 			<FireModes>
 				<aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_Cannon"]/weaponTags</xpath>
+			<value>
+				<li>Bipod_ATR</li>
+			</value>
 		</li>
 		
 		<!-- ========== Dual Royal Pistol =========== -->
@@ -411,10 +449,10 @@
 			</statBases>
 			
 			<Properties>
-				<recoilAmount>1.89</recoilAmount>
+				<recoilAmount>2.28</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+				<defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
 				<warmupTime>1.1</warmupTime>
 				<burstShotCount>3</burstShotCount>
 				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
@@ -425,13 +463,96 @@
 			</Properties>
 			
 			<AmmoUser>
-				<magazineSize>36</magazineSize>
-				<reloadTime>5</reloadTime>
-				<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+				<magazineSize>12</magazineSize>
+				<reloadTime>0.65</reloadTime>
+				<ammoSet>AmmoSet_8x50mmCharged</ammoSet>
+				<reloadOneAtATime>true</reloadOneAtATime>
 			</AmmoUser>
 			<FireModes>
 				<aimedBurstShotCount>2</aimedBurstShotCount>
 				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<!-- ========== Royal Machinegun =========== -->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_RoyalMachinegun</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.06</ShotSpread>
+				<SwayFactor>1.49</SwayFactor>
+				<Bulk>12.35</Bulk>
+				<Mass>10.00</Mass>
+				<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<recoilAmount>0.96</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+				<warmupTime>1.3</warmupTime>
+				<burstShotCount>10</burstShotCount>
+				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+				<range>59</range>
+				<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+				<soundCast>PNRoyalMachinegunSound</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>120</magazineSize>
+				<reloadTime>7.8</reloadTime>
+				<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>5</aimedBurstShotCount>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_RoyalMachinegun"]/weaponTags</xpath>
+			<value>
+				<li>Bipod_LMG</li>
+			</value>
+		</li>
+		
+		<!-- ========== Royal Cannon =========== -->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>PN_RoyalHeavySlug</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.05</ShotSpread>
+				<SwayFactor>1.85</SwayFactor>
+				<Bulk>12.00</Bulk>
+				<Mass>4.6</Mass>
+				<RangedWeapon_Cooldown>0.83</RangedWeapon_Cooldown>
+			</statBases>
+			
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>
+				<warmupTime>1.1</warmupTime>
+				<range>31</range>
+				<soundCast>PNRoyalHCSound</soundCast>
+				<soundCastTail>GunTail_Medium</soundCastTail>
+				<muzzleFlashScale>14</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>5</magazineSize>
+				<reloadTime>0.95</reloadTime>
+				<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+				<reloadOneAtATime>true</reloadOneAtATime>
+			</AmmoUser>
+			<FireModes>
 				<aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
 		</li>
@@ -457,10 +578,10 @@
 				<recoilAmount>1.89</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+				<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
 				<warmupTime>1.1</warmupTime>
 				<range>55</range>
-				<soundCast>PNRoyalRifleSound</soundCast>
+				<soundCast>Shot_IncendiaryLauncher</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</Properties>
@@ -468,7 +589,7 @@
 			<AmmoUser>
 				<magazineSize>6</magazineSize>
 				<reloadTime>5.5</reloadTime>
-				<ammoSet>AmmoSet_25x59mmGrenade</ammoSet>
+				<ammoSet>AmmoSet_PanielLSWMulti</ammoSet>
 			</AmmoUser>
 			<FireModes>
 				<aiAimMode>AimedShot</aiAimMode>
@@ -531,7 +652,9 @@
 			<xpath>Defs/ThingDef[defName="PN_Rifle" or 
 			defName="PN_Machinegun" or 
 			defName="PN_Cannon" or 
-			defName="PN_RoyalRifle" or 
+			defName="PN_RoyalRifle" or
+			defName="PN_RoyalHeavySlug" or
+			defName="PN_RoyalMachinegun" or
 			defName="PN_RoyalLSW"
 			]/tools</xpath>
 			<value>
@@ -600,6 +723,59 @@
 				</tools>
 			</value>
 		</li> 
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_TwinPistol"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>grip</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.54</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>kick</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>2.36</cooldownTime>
+						<armorPenetrationBlunt>11.75</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>Close Shot</label>
+						<capacities>
+						<li>Poke</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>0.36</cooldownTime>
+						<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_TwinPistol"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>1.10</MeleeCritChance>
+					<MeleeParryChance>0.70</MeleeParryChance>
+					<MeleeDodgeChance>0.50</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<!-- ========== Cost Adjustments =========== -->
+		
+		
 		
 		<!-- ========== Royalty Equipment =========== -->
 		
@@ -746,6 +922,131 @@
 							<MeleeCritChance>1.10</MeleeCritChance>
 							<MeleeParryChance>0.50</MeleeParryChance>
 							<MeleeDodgeChance>0.37</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="PN_RoyalHammer_Bladelink"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1.62</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>1.21</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+								<li>PN_ElectricalBluntTool</li>
+								</capacities>
+								<power>49</power>
+								<extraMeleeDamages>
+								<li>
+									<def>EMP</def>
+									<amount>8</amount>
+								</li>
+								</extraMeleeDamages>					
+								<cooldownTime>2.24</cooldownTime>
+								<armorPenetrationBlunt>190.575</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+								<chanceFactor>0.30</chanceFactor>
+							</li>
+						</tools>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_RoyalHammer_Bladelink"]/statBases</xpath>
+					<value>
+						<Bulk>5.5</Bulk>
+						<MeleeCounterParryBonus>0.50</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_RoyalHammer_Bladelink"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>1.60</MeleeCritChance>
+							<MeleeParryChance>0.40</MeleeParryChance>
+							<MeleeDodgeChance>0.40</MeleeDodgeChance>	
+						</equippedStatOffsets>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="PN_StormLance_Bladelink"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>1.53</cooldownTime>
+								<chanceFactor>0.10</chanceFactor>
+								<armorPenetrationBlunt>0.968</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>side</label>
+								<capacities>
+									<li>PN_ElectricalBluntTool</li>
+								</capacities>
+								<power>28</power>
+								<extraMeleeDamages>
+								<li>
+									<def>EMP</def>
+									<amount>8</amount>
+								</li>
+								</extraMeleeDamages>					
+								<cooldownTime>1.03</cooldownTime>
+								<chanceFactor>0.66</chanceFactor>
+								<armorPenetrationBlunt>111.6</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+								<li>PN_ElectricalStabTool</li>
+								</capacities>
+								<power>26</power>
+								<extraMeleeDamages>
+								<li>
+									<def>EMP</def>
+									<amount>8</amount>
+								</li>
+								</extraMeleeDamages>					
+								<cooldownTime>0.96</cooldownTime>
+								<armorPenetrationBlunt>2.478</armorPenetrationBlunt>
+								<armorPenetrationSharp>38.72</armorPenetrationSharp>
+							</li>	
+						</tools>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_StormLance_Bladelink"]/statBases</xpath>
+					<value>
+						<Bulk>5.5</Bulk>
+						<MeleeCounterParryBonus>0.50</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PN_StormLance_Bladelink"]</xpath>
+					<value>
+						<equippedStatOffsets>
+							<MeleeCritChance>1.60</MeleeCritChance>
+							<MeleeParryChance>0.40</MeleeParryChance>
+							<MeleeDodgeChance>0.40</MeleeDodgeChance>	
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Weapons.xml
@@ -199,6 +199,56 @@
 			</value>
 		</li>
 		
+		<!-- ==========  Hammer  =========== -->
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_WarHammer"]/statBases</xpath>
+			<value>
+				<MeleeCounterParryBonus>0.28</MeleeCounterParryBonus>
+				<Bulk>14.5</Bulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="PN_WarHammer"]</xpath>
+			<value>
+				<equippedStatOffsets>
+				  <MeleeCritChance>1.6</MeleeCritChance>
+				  <MeleeParryChance>0.38</MeleeParryChance>
+				  <MeleeDodgeChance>0.3</MeleeDodgeChance>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_WarHammer"]/tools</xpath>
+			<value>
+			  <tools>
+				  <li Class="CombatExtended.ToolCE">
+					<label>handle</label>
+					<capacities>
+					  <li>Poke</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>1.8</cooldownTime>
+					<chanceFactor>0.10</chanceFactor>
+					<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+				  </li>
+				  <li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+					  <li>Blunt</li>
+					</capacities>
+					<power>36</power>
+					<cooldownTime>2.67</cooldownTime>
+					<armorPenetrationBlunt>15.75</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+				  </li>
+			  </tools>
+			</value>
+		</li>
+		
 		<!-- ========== Rifle =========== -->
 		
 		<li Class="PatchOperationRemove">


### PR DESCRIPTION
## Additions

Added patches for new equipment

## Changes

Redid costs for the conventional weapons.
Charge rifle has been changed to fire 8x50 but higher recoil and smaller magazine with one by one reload, to differentiate more from LMG.
Launcher now, as per description, has a special hybrid launcher setup which allows it to fire both HV grenades and incendiary calibers.

## Reasoning

Conventional weapons have had their costs equalized with regular equipment from other mods. Advanced weapons retain their other differences. This is to make up for the disparity with some of the equipment compared to other weapons, and the fact that they lose their alternate fire modes etc. that are present in vanilla


## Testing

Check tests you have performed:
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
