### PR TITLE
Patch Makeshift Melee Weapons

### DIFF
--- a/Patches/Makeshift Melee Weapons/DetVisor_MakeshiftMelee.xml
+++ b/Patches/Makeshift Melee Weapons/DetVisor_MakeshiftMelee.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>[DV] Makeshift Melee Weapons</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>			
+
+        <!-- === Makeshift Hammer === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]/statBases</xpath>
+          <value>
+            <Bulk>5</Bulk>
+            <MeleeCounterParryBonus>1.52</MeleeCounterParryBonus>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]/equippedStatOffsets</xpath>
+          <value>
+            <MeleeCritChance>0.9</MeleeCritChance>
+            <MeleeParryChance>1.11</MeleeParryChance>
+            <MeleeDodgeChance>0.65</MeleeDodgeChance>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]/weaponTags</xpath>
+          <value>
+            <li>CE_OneHandedWeapon</li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>19</power>
+                <cooldownTime>2.42</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetrationBlunt>7.6</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>17</power>
+                <cooldownTime>2.22</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetrationBlunt>7.4</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>15</power>
+                <cooldownTime>2.02</cooldownTime>
+                <chanceFactor>1.33</chanceFactor>
+                <armorPenetrationBlunt>7.05</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+              </li>					  		  
+            </tools>
+          </value>
+        </li>
+
+		<!-- ========== Makeshift Mace ========== -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.59</cooldownTime>
+						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>14</power>
+						<cooldownTime>2.15</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>5.605</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>2</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>5.45</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>2.1</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>5.55</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
+					</li>											
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/statBases</xpath>
+			<value>
+				<Bulk>4</Bulk>
+				<MeleeCounterParryBonus>0.26</MeleeCounterParryBonus>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.42</MeleeCritChance>
+					<MeleeParryChance>0.24</MeleeParryChance>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+
+		<!-- ========== Makeshift Scythe ========== -->
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>1.44</cooldownTime>
+						<armorPenetrationBlunt>0.425</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>20</power>
+						<cooldownTime>1.54</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>0.976</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.44</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>16</power>
+						<cooldownTime>1.44</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>0.916</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.40</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>12</power>
+						<cooldownTime>1.24</cooldownTime>
+						<chanceFactor>1.33</chanceFactor>
+						<armorPenetrationBlunt>0.81</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.34</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>											
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/statBases</xpath>
+			<value>
+				<Bulk>3.85</Bulk>
+				<MeleeCounterParryBonus>0.30</MeleeCounterParryBonus>				
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.2</MeleeCritChance>
+					<MeleeParryChance>0.35</MeleeParryChance>
+					<MeleeDodgeChance>0.2</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/weaponTags</xpath>
+			<value>
+				<li>CE_OneHandedWeapon</li>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Makeshift Melee Weapons/DetVisor_MakeshiftMelee.xml
+++ b/Patches/Makeshift Melee Weapons/DetVisor_MakeshiftMelee.xml
@@ -17,11 +17,13 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]/equippedStatOffsets</xpath>
+          <xpath>/Defs/ThingDef[defName="DV_MakeshiftHammer"]</xpath>
           <value>
-            <MeleeCritChance>0.9</MeleeCritChance>
-            <MeleeParryChance>1.11</MeleeParryChance>
-            <MeleeDodgeChance>0.65</MeleeDodgeChance>
+		  	<equippedStatOffsets>
+				<MeleeCritChance>0.9</MeleeCritChance>
+				<MeleeParryChance>1.11</MeleeParryChance>
+				<MeleeDodgeChance>0.65</MeleeDodgeChance>
+			</equippedStatOffsets>		
           </value>
         </li>
 
@@ -76,7 +78,7 @@
 		<!-- ========== Makeshift Mace ========== -->
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/tools</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftMace"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -86,7 +88,7 @@
 						</capacities>
 						<power>2</power>
 						<cooldownTime>1.59</cooldownTime>
-						<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+						<armorPenetrationBlunt>0.675</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 					</li>
 					<li Class="CombatExtended.ToolCE">
@@ -94,10 +96,10 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>14</power>
-						<cooldownTime>2.15</cooldownTime>
+						<power>12</power>
+						<cooldownTime>3.05</cooldownTime>
 						<chanceFactor>1.33</chanceFactor>
-						<armorPenetrationBlunt>5.605</armorPenetrationBlunt>
+						<armorPenetrationBlunt>3.15</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>
 					<li Class="CombatExtended.ToolCE">
@@ -106,9 +108,9 @@
 							<li>Blunt</li>
 						</capacities>
 						<power>10</power>
-						<cooldownTime>2</cooldownTime>
+						<cooldownTime>2.97</cooldownTime>
 						<chanceFactor>1.33</chanceFactor>
-						<armorPenetrationBlunt>5.45</armorPenetrationBlunt>
+						<armorPenetrationBlunt>2.92</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 					</li>
 					<li Class="CombatExtended.ToolCE">
@@ -116,18 +118,18 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>12</power>
-						<cooldownTime>2.1</cooldownTime>
+						<power>8</power>
+						<cooldownTime>2.79</cooldownTime>
 						<chanceFactor>1.33</chanceFactor>
-						<armorPenetrationBlunt>5.55</armorPenetrationBlunt>
+						<armorPenetrationBlunt>2.7</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
-					</li>											
+					</li>																				
 				</tools>
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/statBases</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftMace"]/statBases</xpath>
 			<value>
 				<Bulk>4</Bulk>
 				<MeleeCounterParryBonus>0.26</MeleeCounterParryBonus>
@@ -135,7 +137,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftMace"]</xpath>
 			<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.42</MeleeCritChance>
@@ -146,7 +148,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftMace"]/weaponTags</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftMace"]/weaponTags</xpath>
 			<value>
 				<li>CE_OneHandedWeapon</li>
 			</value>
@@ -155,7 +157,7 @@
 		<!-- ========== Makeshift Scythe ========== -->
 
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/tools</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftScythe"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -209,7 +211,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/statBases</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftScythe"]/statBases</xpath>
 			<value>
 				<Bulk>3.85</Bulk>
 				<MeleeCounterParryBonus>0.30</MeleeCounterParryBonus>				
@@ -217,7 +219,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftScythe"]</xpath>
 			<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.2</MeleeCritChance>
@@ -228,7 +230,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="DV_MakeshiftScythe"]/weaponTags</xpath>
+			<xpath>/Defs/ThingDef[defName="DV_MakeshiftScythe"]/weaponTags</xpath>
 			<value>
 				<li>CE_OneHandedWeapon</li>
 			</value>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -249,6 +249,7 @@ Littluna Race |
 Logann Race	|
 Magical Menagerie	|
 Magic Wands |
+Makeshift Melee Weapons |
 Marilyn the Mincho Worshipper Witch |
 Mass Effect - Playable Geth |
 Martens - Nature's Most Adorable Assassins  |


### PR DESCRIPTION
## Additions
Patches the three melee weapons from the Makeshift Melee Weapons mod, based on patches for existing weapons.

The makeshift hammer is based on the VWE hammer, makeshift mace based on the mace, and the makeshift gladius based (somewhat) on the gladius, sans stab attack. Similar to base mod, the weapons have multiple iterations of the same attack, with varying damage, pen, and cooldown, to simulate imperfect and inconsistent strikes due to the poor balance and construction of the weapons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
