### PR TITLE
Add the AMR bipods tag, stat rebalances and housekeeping

### DIFF
--- a/Defs/BipodCategoryDefs/BipodCategories.xml
+++ b/Defs/BipodCategoryDefs/BipodCategories.xml
@@ -3,60 +3,29 @@
 
     <CombatExtended.BipodCategoryDef>
         <!--Same as in other defs -->
-        <defName>bipodLMG</defName>
+        <defName>bipodRifle</defName>
         <!--Same as in other defs -->
-        <label>LMG</label>
+        <label>Rifle</label>
         <!--The tag that is required for this bipod -->
-        <bipod_id>Bipod_LMG</bipod_id>
+        <bipod_id>Bipod_Rifle</bipod_id>
         <!--additional range with bipod set up -->
-        <ad_Range>7</ad_Range>
+        <ad_Range>3</ad_Range>
          <!--ticks to set up -->
-        <setuptime>360</setuptime>
+        <setuptime>150</setuptime>
          <!--recoil mult with bipod set up-->
-        <recoil_mult_setup>0.9</recoil_mult_setup>
+        <recoil_mult_setup>0.8</recoil_mult_setup>
          <!-- recoil mult without the bipod set up -->
-        <recoil_mult_NOT_setup>1.5</recoil_mult_NOT_setup>
+        <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
          <!--warmup mult with the bipod set up -->
         <warmup_mult_setup>0.85</warmup_mult_setup>
          <!--warmup mult without the bipod set up -->
-        <warmup_mult_NOT_setup>1.5</warmup_mult_NOT_setup>
-        <swayMult>0.9</swayMult>
-        <swayPenalty>1.4</swayPenalty>
-        <useAutoSetMode>false</useAutoSetMode>
-    </CombatExtended.BipodCategoryDef>
-
-    <CombatExtended.BipodCategoryDef>
-        <defName>bipodDMR</defName>
-        <label>DMR</label>
-        <bipod_id>Bipod_DMR</bipod_id>
-        <ad_Range>15</ad_Range>
-        <setuptime>180</setuptime>
-        <recoil_mult_setup>0.7</recoil_mult_setup>
-        <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
-        <warmup_mult_setup>0.75</warmup_mult_setup>
         <warmup_mult_NOT_setup>1</warmup_mult_NOT_setup>
          <!--when not specified just goes with blue, I just like making colorful logs tbh -->
-        <logColor>(255, 0, 0)</logColor>
-        <swayMult>0.5</swayMult>
+        <logColor>(0, 0, 255)</logColor>
+         <!--sway mult with the bipod set up -->
+        <swayMult>0.75</swayMult>
+         <!--sway mult without the bipod set up -->
         <swayPenalty>1</swayPenalty>
-        <autosetMode>AimedShot</autosetMode>
-        <useAutoSetMode>true</useAutoSetMode>
-    </CombatExtended.BipodCategoryDef>
-
-    <CombatExtended.BipodCategoryDef>
-        <defName>bipodATR</defName>
-        <label>ATR</label>
-        <bipod_id>Bipod_ATR</bipod_id>
-        <ad_Range>5</ad_Range>
-        <setuptime>480</setuptime>
-        <recoil_mult_setup>1</recoil_mult_setup>
-        <recoil_mult_NOT_setup>2.5</recoil_mult_NOT_setup>
-        <warmup_mult_setup>0.85</warmup_mult_setup>
-        <warmup_mult_NOT_setup>2.1</warmup_mult_NOT_setup>
-        <logColor>(0, 255, 0)</logColor>
-        <swayMult>1</swayMult>
-        <swayPenalty>1.85</swayPenalty>
-        <autosetMode>AimedShot</autosetMode>
         <useAutoSetMode>false</useAutoSetMode>
     </CombatExtended.BipodCategoryDef>
 
@@ -77,18 +46,68 @@
     </CombatExtended.BipodCategoryDef>
 
     <CombatExtended.BipodCategoryDef>
-        <defName>bipodRifle</defName>
-        <label>Rifle</label>
-        <bipod_id>Bipod_Rifle</bipod_id>
-        <ad_Range>3</ad_Range>
-        <setuptime>150</setuptime>
-        <recoil_mult_setup>0.8</recoil_mult_setup>
-        <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
+        <defName>bipodLMG</defName>
+        <label>LMG</label>
+        <bipod_id>Bipod_LMG</bipod_id>
+        <ad_Range>7</ad_Range>
+        <setuptime>300</setuptime>
+        <recoil_mult_setup>0.9</recoil_mult_setup>
+        <recoil_mult_NOT_setup>1.5</recoil_mult_NOT_setup>
         <warmup_mult_setup>0.85</warmup_mult_setup>
+        <warmup_mult_NOT_setup>1.5</warmup_mult_NOT_setup>
+        <swayMult>0.9</swayMult>
+        <swayPenalty>1.4</swayPenalty>
+        <useAutoSetMode>false</useAutoSetMode>
+    </CombatExtended.BipodCategoryDef>
+
+    <CombatExtended.BipodCategoryDef>
+        <defName>bipodDMR</defName>
+        <label>DMR</label>
+        <bipod_id>Bipod_DMR</bipod_id>
+        <ad_Range>15</ad_Range>
+        <setuptime>180</setuptime>
+        <recoil_mult_setup>0.7</recoil_mult_setup>
+        <recoil_mult_NOT_setup>1</recoil_mult_NOT_setup>
+        <warmup_mult_setup>0.75</warmup_mult_setup>
         <warmup_mult_NOT_setup>1</warmup_mult_NOT_setup>
-        <logColor>(0, 0, 255)</logColor>
-        <swayMult>0.75</swayMult>
+        <logColor>(255, 0, 0)</logColor>
+        <swayMult>0.5</swayMult>
         <swayPenalty>1</swayPenalty>
+        <autosetMode>AimedShot</autosetMode>
+        <useAutoSetMode>true</useAutoSetMode>
+    </CombatExtended.BipodCategoryDef>
+
+    <CombatExtended.BipodCategoryDef>
+        <defName>bipodAMR</defName>
+        <label>AMR</label>
+        <bipod_id>Bipod_AMR</bipod_id>
+        <ad_Range>10</ad_Range>
+        <setuptime>240</setuptime>
+        <recoil_mult_setup>1.0</recoil_mult_setup>
+        <recoil_mult_NOT_setup>1.5</recoil_mult_NOT_setup>
+        <warmup_mult_setup>0.75</warmup_mult_setup>
+        <warmup_mult_NOT_setup>1.5</warmup_mult_NOT_setup>
+        <logColor>(255, 255, 0)</logColor>
+        <swayMult>0.5</swayMult>
+        <swayPenalty>1.25</swayPenalty>
+        <autosetMode>AimedShot</autosetMode>
+        <useAutoSetMode>true</useAutoSetMode>
+    </CombatExtended.BipodCategoryDef>
+
+    <CombatExtended.BipodCategoryDef>
+        <defName>bipodATR</defName>
+        <label>ATR</label>
+        <bipod_id>Bipod_ATR</bipod_id>
+        <ad_Range>5</ad_Range>
+        <setuptime>420</setuptime>
+        <recoil_mult_setup>1</recoil_mult_setup>
+        <recoil_mult_NOT_setup>2.5</recoil_mult_NOT_setup>
+        <warmup_mult_setup>0.85</warmup_mult_setup>
+        <warmup_mult_NOT_setup>2.1</warmup_mult_NOT_setup>
+        <logColor>(0, 255, 0)</logColor>
+        <swayMult>0.66</swayMult>
+        <swayPenalty>1.85</swayPenalty>
+        <autosetMode>AimedShot</autosetMode>
         <useAutoSetMode>false</useAutoSetMode>
     </CombatExtended.BipodCategoryDef>
 

--- a/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
+++ b/Patches/Combat Enthusiast's Collection/ThingDefs_Weapons.xml
@@ -795,7 +795,7 @@
       <li>CE_AI_Rifle</li>
       <li>SniperRifle</li>
       <li>IndustrialGunAdvanced</li>  
-	    <li>Bipod_DMR</li>
+	    <li>Bipod_AMR</li>
     </weaponTags>
     <researchPrerequisite>PrecisionRifling</researchPrerequisite>
   </li>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
@@ -509,7 +509,7 @@
 				</FireModes>
 
 				<weaponTags>
-					<li>Bipod_DMR</li>
+					<li>Bipod_AMR</li>
 					<li>CE_AI_SR</li>
 				</weaponTags>
 

--- a/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
@@ -285,7 +285,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="JI_Gramr"]/weaponTags</xpath>
 				<value>
-				    <li>Bipod_DMR</li>
+				    <li>Bipod_AMR</li>
 				</value>
 			</li>				
 

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Charge_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Charge_CE.xml
@@ -203,6 +203,7 @@
 					<li>CE_AI_Rifle</li>
 					<li>SniperRifle</li>
 					<li>AdvancedGun</li>
+					<li>Bipod_AMR</li>
 				</weaponTags>
 			</li>
 			  

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_RSGuns_CE.xml
@@ -246,7 +246,7 @@
 				</FireModes>
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
-					<li>Bipod_DMR</li>
+					<li>Bipod_AMR</li>
 				</weaponTags>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
@@ -378,7 +378,7 @@
             </FireModes>
             <weaponTags>
 				<li>FeralSniperRifle</li>
-				<li>Bipod_DMR</li>
+				<li>Bipod_AMR</li>
             </weaponTags>
         </li>
 

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -657,7 +657,7 @@
 					</FireModes>
 					<weaponTags>
 						<li>SniperRifle</li>
-						<li>Bipod_DMR</li>
+						<li>Bipod_AMR</li>
 					</weaponTags>
 					<!-- Required Research Rework -->
 					<researchPrerequisite>PrecisionRifling</researchPrerequisite>


### PR DESCRIPTION
## Additions

- Add the AMR bipods tag

## Changes

- Made slight balance tweaks to some of the existing bipod tags

## Reasoning

- AMRs are not DMRs so they should not receive the same benefits from the DMR bipods tag, they in-between DMRs and ATRs and the new tag resembles that

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
