### PR TITLE
Add the NoRack shotgun fire SoundDef

### DIFF
--- a/Defs/SoundDefs/Shot_Weapons.xml
+++ b/Defs/SoundDefs/Shot_Weapons.xml
@@ -5,8 +5,8 @@
     <defName>HeavyMG</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -30,8 +30,8 @@
     <defName>MediumMG</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -55,8 +55,8 @@
     <defName>AGS</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -80,8 +80,8 @@
     <defName>120mm</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -105,8 +105,8 @@
     <defName>Explosion</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -130,7 +130,8 @@
     <defName>50Cal_Browning</defName>  
     <context>MapOnly</context>
     <eventNames />  
- <maxVoices>4</maxVoices>   <maxSimultaneous>1</maxSimultaneous>  
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>  
     <subSounds>
       <li>
         <grains>
@@ -152,8 +153,8 @@
     <defName>autocannon_slow</defName>
     <context>MapOnly</context>
     <eventNames />
-           <maxVoices>4</maxVoices>
-           <maxSimultaneous>1</maxSimultaneous>
+    <maxVoices>4</maxVoices>
+    <maxSimultaneous>1</maxSimultaneous>
     <subSounds>
       <li>
         <grains>
@@ -172,5 +173,22 @@
       </li>
     </subSounds>
   </SoundDef>
-  
+
+  <SoundDef>
+    <defName>Shot_Shotgun_NoRack</defName>  
+    <context>MapOnly</context>  
+    <maxSimultaneous>1</maxSimultaneous>  
+    <subSounds>
+      <li>
+        <grains>
+          <li Class="AudioGrain_Folder">
+            <clipFolderPath>Weapon/Shotgun/Shot</clipFolderPath>
+          </li>
+        </grains>      
+        <volumeRange>94.70588~94.70588</volumeRange>      
+        <distRange>39.11765~70</distRange>
+      </li>    
+    </subSounds>
+  </SoundDef>
+
 </Defs>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_Shotguns.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_Shotguns.xml
@@ -186,7 +186,7 @@
             <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
             <warmupTime>1.2</warmupTime>
             <range>16</range>
-            <soundCast>Shot_Shotgun</soundCast>
+            <soundCast>Shot_Shotgun_NoRack</soundCast>
             <soundCastTail>GunTail_Heavy</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -308,7 +308,7 @@
       <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
       <warmupTime>0.6</warmupTime>
       <range>16</range>
-      <soundCast>Shot_Shotgun</soundCast>
+      <soundCast>Shot_Shotgun_NoRack</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
       <ticksBetweenBurstShots>15</ticksBetweenBurstShots>

--- a/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
+++ b/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Guns.xml
@@ -167,7 +167,7 @@
             <defaultProjectile>Bullet_BlunderShot_Ball</defaultProjectile>
             <warmupTime>1.1</warmupTime>
             <range>16</range>
-			<soundCast>Shot_Shotgun</soundCast>
+			<soundCast>Shot_Shotgun_NoRack</soundCast>
 			<soundCastTail>GunTail_Light</soundCastTail>
             <muzzleFlashScale>12</muzzleFlashScale>
 			<ammoConsumedPerShotCount>7</ammoConsumedPerShotCount>

--- a/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Ranged.xml
@@ -236,7 +236,7 @@
                 <defaultProjectile>Bullet_FastMusketBall</defaultProjectile>
                 <warmupTime>1.66</warmupTime>
                 <range>12</range>
-                <soundCast>Shot_Shotgun</soundCast>
+                <soundCast>Shot_Shotgun_NoRack</soundCast>
                 <soundCastTail>GunTail_Heavy</soundCastTail>
                 <muzzleFlashScale>9</muzzleFlashScale>
             </Properties>

--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
@@ -208,7 +208,7 @@
 					<range>20</range>
 					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 					<burstShotCount>5</burstShotCount>
-					<soundCast>Shot_Shotgun</soundCast>
+					<soundCast>Shot_Shotgun_NoRack</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<muzzleFlashScale>18</muzzleFlashScale>
 					<recoilPattern>Mounted</recoilPattern>
@@ -258,7 +258,7 @@
 					<range>20</range>
 					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 					<burstShotCount>5</burstShotCount>
-					<soundCast>Shot_Shotgun</soundCast>
+					<soundCast>Shot_Shotgun_NoRack</soundCast>
 					<soundCastTail>GunTail_Medium</soundCastTail>
 					<muzzleFlashScale>18</muzzleFlashScale>
 					<recoilPattern>Mounted</recoilPattern>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrial.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrial.xml
@@ -166,7 +166,7 @@
             <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
             <warmupTime>0.6</warmupTime>
             <range>16</range>
-            <soundCast>Shot_Shotgun</soundCast>
+            <soundCast>Shot_Shotgun_NoRack</soundCast>
             <soundCastTail>GunTail_Heavy</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -380,7 +380,7 @@
 						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
 						<warmupTime>0.6</warmupTime>
 						<range>14</range>
-						<soundCast>Shot_Shotgun</soundCast>
+						<soundCast>Shot_Shotgun_NoRack</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
 					</Properties>


### PR DESCRIPTION
## Additions

- Added a shotgun fire SoundDef that lacks the cocking clip for non-pump action shotguns. It's the same vanilla sound without the cocking bit.

## Changes

- Some minor housekeeping
- Changed the auto and semi-auto shotgun fire sounds to the NoRack version

## Reasoning

- Only pump-action shotguns should have the cocking sound, immersion stuff

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
