### PR TITLE
Remove the shadow from manned turrets

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -267,7 +267,6 @@
       <Steel>125</Steel>
       <ComponentIndustrial>4</ComponentIndustrial>
     </costList>
-    <castEdgeShadows>true</castEdgeShadows>
     <building>
       <turretGunDef>Gun_M240B</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
@@ -308,7 +307,6 @@
       <turretGunDef>Gun_KPV</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
     </building>
-    <castEdgeShadows>true</castEdgeShadows>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>
       <li>PlaceWorker_ShowTurretRadius</li>
@@ -342,7 +340,6 @@
       <Steel>115</Steel>
       <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
-    <castEdgeShadows>true</castEdgeShadows>
     <building>
       <turretGunDef>Gun_AGSThirty</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>


### PR DESCRIPTION
## Changes

- What is says on the tin.

## Reasoning

- Vanilla turrets don't have a `castEdgeShadows` node.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Tested in-game and no more shadows were casted by the turrets)
