### PR TITLE
VFE-Security hotfix

### DIFF
--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -110,8 +110,8 @@
 	  	</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-	  	<xpath>Defs/ThingDef[defName = "VFES_Turret_TriRocket"]/statBases/ShootingAccuracyTurret</xpath>
+		<li Class="PatchOperationAdd">
+	  	<xpath>Defs/ThingDef[defName = "VFES_Turret_TriRocket"]/statBases</xpath>
 	  	<value>
 	  		<ShootingAccuracyTurret>1</ShootingAccuracyTurret>
 	  	</value>


### PR DESCRIPTION
## Changes

- Fixed the `ShootingAccuracyTurret` patch of the Triple Rocket turret from VFE-Security

## Reasoning

- The turret does not have a `ShootingAccuracyTurret` in the original mod making the replace patch fail, it had gone unnoticed because because of the "or" patches...

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (The patch fires correctly now)
