### PR TITLE
Adjust Molotov Cocktails and housekeeping

### DIFF
--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -29,12 +29,15 @@
     <comps>
       <li Class="CompProperties_Explosive">
         <damageAmountBase>2</damageAmountBase>
-        <explosiveRadius>1.9</explosiveRadius>
+        <explosiveRadius>0.9</explosiveRadius>
         <explosiveDamageType>PrometheumFlame</explosiveDamageType>
-        <explosiveExpandPerStackcount>0.02</explosiveExpandPerStackcount>
+        <explosiveExpandPerStackcount>0.027</explosiveExpandPerStackcount>
+        <startWickOnDamageTaken>
+          <li>Flame</li>
+        </startWickOnDamageTaken>
         <startWickHitPointsPercent>0.5</startWickHitPointsPercent>
         <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-        <preExplosionSpawnChance>0.5</preExplosionSpawnChance>
+        <preExplosionSpawnChance>1.0</preExplosionSpawnChance>
         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
         <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>60~90</wickTicks>
@@ -70,6 +73,9 @@
         <explosiveRadius>0.9</explosiveRadius>
         <explosiveDamageType>Bomb</explosiveDamageType>
         <explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
+        <startWickOnDamageTaken>
+          <li>Flame</li>
+        </startWickOnDamageTaken>
         <startWickHitPointsPercent>0.5</startWickHitPointsPercent>
         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
         <explodeOnKilled>True</explodeOnKilled>

--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -74,6 +74,7 @@
         <explosiveDamageType>Bomb</explosiveDamageType>
         <explosiveExpandPerStackcount>0.033</explosiveExpandPerStackcount>
         <startWickOnDamageTaken>
+          <li>Bomb</li>
           <li>Flame</li>
         </startWickOnDamageTaken>
         <startWickHitPointsPercent>0.5</startWickHitPointsPercent>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -232,7 +232,7 @@
 		<xpath>Defs/ThingDef[defName="Proj_GrenadeMolotov"]</xpath>
 		<value>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<explosionRadius>0.5</explosionRadius>
+				<explosionRadius>0.9</explosionRadius>
 				<damageDef>PrometheumFlame</damageDef>
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -302,7 +302,7 @@
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 			<damageAmountBase>1</damageAmountBase>
 			<explosiveDamageType>Flame</explosiveDamageType>
-			<explosiveRadius>0.5</explosiveRadius>
+			<explosiveRadius>0.9</explosiveRadius>
 			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>1</preExplosionSpawnChance>
 		  </li>
@@ -323,7 +323,7 @@
 			<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<range>10</range>
-			<minRange>2</minRange>
+			<minRange>1.9</minRange>
 			<warmupTime>0.8</warmupTime>
 			<noiseRadius>4</noiseRadius>
 			<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
@@ -334,7 +334,7 @@
 			<defaultProjectile>Proj_GrenadeMolotov</defaultProjectile>
 			<onlyManualCast>true</onlyManualCast>
 			<ignorePartialLoSBlocker>true</ignorePartialLoSBlocker>
-			<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
+			<ai_AvoidFriendlyFireRadius>2</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
 			<li>CE_AI_AOE</li>

--- a/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
+++ b/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
@@ -9,7 +9,7 @@
 		<match Class="PatchOperationSequence">
 		<operations>		
 
-		    <li Class="PatchOperationReplace" MayRequire="argon.vmeu">
+		    <li Class="PatchOperationReplace">
 			<xpath>/Defs/RecipeDef[
 			    defName="MakeAmmo_127x55mmAR_Sabot" or
 			    defName="MakeAmmo_3006Springfield_Sabot" or
@@ -52,7 +52,7 @@
 			</value>
 		    </li>
 
-		    <li Class="PatchOperationReplace" MayRequire="argon.vmeu">
+		    <li Class="PatchOperationReplace">
 			<xpath>/Defs/RecipeDef[
 			    defName="MakeAmmo_127x55mmAR_Sabot" or
 			    defName="MakeAmmo_3006Springfield_Sabot" or
@@ -86,7 +86,7 @@
 			    defName="MakeAmmo_40x311mmR_Sabot"]/fixedIngredientFilter
 			</xpath>
 			<value>
-					<fixedIngredientFilter>
+			    <fixedIngredientFilter>
 				<thingDefs>
 				    <li>VMEu_Bronze</li>
 				    <li>Steel</li>

--- a/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
+++ b/Patches/Expanded Materials - Metals/Ammo/Sabot.xml
@@ -1,92 +1,104 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-    <Operation Class="PatchOperationReplace" MayRequire="argon.vmeu">
-        <xpath>/Defs/RecipeDef[
-            defName="MakeAmmo_127x55mmAR_Sabot" or
-            defName="MakeAmmo_3006Springfield_Sabot" or
-            defName="MakeAmmo_300AACBlackout_Sabot" or
-            defName="MakeAmmo_303British_Sabot" or
-            defName="MakeAmmo_30Carbine_Sabot" or
-            defName="MakeAmmo_545x39mmSoviet_Sabot" or
-            defName="MakeAmmo_556x45mmNATO_Sabot" or
-            defName="MakeAmmo_58x42mmDBP10_Sabot" or
-            defName="MakeAmmo_65x52mmCarcano_Sabot" or
-            defName="MakeAmmo_75x54mmFrench_Sabot" or
-            defName="MakeAmmo_762x51mmNATO_Sabot" or
-            defName="MakeAmmo_762x39mmSoviet_Sabot" or
-            defName="MakeAmmo_762x54mmR_Sabot" or
-            defName="MakeAmmo_77x58mmArisaka_Sabot" or
-            defName="MakeAmmo_792x33mmKurz_Sabot" or
-            defName="MakeAmmo_792x57mmMauser_Sabot" or
-            defName="MakeAmmo_8x50mmRLebel_Sabot" or
-            defName="MakeAmmo_9x39mmSoviet_Sabot" or
-            defName="MakeAmmo_300WinchesterMagnum_Sabot" or
-            defName="MakeAmmo_338Lapua_Sabot" or
-            defName="MakeAmmo_338Norma_Sabot" or
-            defName="MakeAmmo_408CheyenneTactical_Sabot" or
-            defName="MakeAmmo_50BMG_Sabot" or
-            defName="MakeAmmo_127x108mm_Sabot" or
-            defName="MakeAmmo_145x114mm_Sabot" or
-            defName="MakeAmmo_20x102mmNATO_Sabot" or
-            defName="MakeAmmo_20x110mmHispano_Sabot" or
-            defName="MakeAmmo_25x137mmNATO_Sabot" or
-            defName="MakeAmmo_30x173mmNATO_Sabot" or
-            defName="MakeAmmo_40x311mmR_Sabot"]/ingredients/li[3]/filter
-        </xpath>
-        <value>
-            <filter>
-                <thingDefs>
-                    <li>VMEu_Tungsten</li>
-                    <li>Uranium</li>
-                </thingDefs>
-            </filter>
-        </value>
-    </Operation>
+	<Operation Class="PatchOperationFindMod">
+	    <mods>
+		<li>Expanded Materials - Metals</li>
+		<li>[LITE]Expanded Materials - Metals</li>
+	    </mods>
+		<match Class="PatchOperationSequence">
+		<operations>		
 
-    <Operation Class="PatchOperationReplace" MayRequire="argon.vmeu">
-        <xpath>/Defs/RecipeDef[
-            defName="MakeAmmo_127x55mmAR_Sabot" or
-            defName="MakeAmmo_3006Springfield_Sabot" or
-            defName="MakeAmmo_300AACBlackout_Sabot" or
-            defName="MakeAmmo_303British_Sabot" or
-            defName="MakeAmmo_30Carbine_Sabot" or
-            defName="MakeAmmo_545x39mmSoviet_Sabot" or
-            defName="MakeAmmo_556x45mmNATO_Sabot" or
-            defName="MakeAmmo_58x42mmDBP10_Sabot" or
-            defName="MakeAmmo_65x52mmCarcano_Sabot" or
-            defName="MakeAmmo_75x54mmFrench_Sabot" or
-            defName="MakeAmmo_762x51mmNATO_Sabot" or
-            defName="MakeAmmo_762x39mmSoviet_Sabot" or
-            defName="MakeAmmo_762x54mmR_Sabot" or
-            defName="MakeAmmo_77x58mmArisaka_Sabot" or
-            defName="MakeAmmo_792x33mmKurz_Sabot" or
-            defName="MakeAmmo_792x57mmMauser_Sabot" or
-            defName="MakeAmmo_8x50mmRLebel_Sabot" or
-            defName="MakeAmmo_9x39mmSoviet_Sabot" or
-            defName="MakeAmmo_300WinchesterMagnum_Sabot" or
-            defName="MakeAmmo_338Lapua_Sabot" or
-            defName="MakeAmmo_338Norma_Sabot" or
-            defName="MakeAmmo_408CheyenneTactical_Sabot" or
-            defName="MakeAmmo_50BMG_Sabot" or
-            defName="MakeAmmo_127x108mm_Sabot" or
-            defName="MakeAmmo_145x114mm_Sabot" or
-            defName="MakeAmmo_20x102mmNATO_Sabot" or
-            defName="MakeAmmo_20x110mmHispano_Sabot" or
-            defName="MakeAmmo_25x137mmNATO_Sabot" or
-            defName="MakeAmmo_30x173mmNATO_Sabot" or
-            defName="MakeAmmo_40x311mmR_Sabot"]/fixedIngredientFilter
-        </xpath>
-        <value>
-			<fixedIngredientFilter>
-                <thingDefs>
-                    <li>VMEu_Bronze</li>
-                    <li>Steel</li>
-                    <li>VMEu_Tungsten</li>
-                    <li>Uranium</li>
-                </thingDefs>
-            </fixedIngredientFilter>
-        </value>
-    </Operation>
+		    <li Class="PatchOperationReplace" MayRequire="argon.vmeu">
+			<xpath>/Defs/RecipeDef[
+			    defName="MakeAmmo_127x55mmAR_Sabot" or
+			    defName="MakeAmmo_3006Springfield_Sabot" or
+			    defName="MakeAmmo_300AACBlackout_Sabot" or
+			    defName="MakeAmmo_303British_Sabot" or
+			    defName="MakeAmmo_30Carbine_Sabot" or
+			    defName="MakeAmmo_545x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_556x45mmNATO_Sabot" or
+			    defName="MakeAmmo_58x42mmDBP10_Sabot" or
+			    defName="MakeAmmo_65x52mmCarcano_Sabot" or
+			    defName="MakeAmmo_75x54mmFrench_Sabot" or
+			    defName="MakeAmmo_762x51mmNATO_Sabot" or
+			    defName="MakeAmmo_762x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_762x54mmR_Sabot" or
+			    defName="MakeAmmo_77x58mmArisaka_Sabot" or
+			    defName="MakeAmmo_792x33mmKurz_Sabot" or
+			    defName="MakeAmmo_792x57mmMauser_Sabot" or
+			    defName="MakeAmmo_8x50mmRLebel_Sabot" or
+			    defName="MakeAmmo_9x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_300WinchesterMagnum_Sabot" or
+			    defName="MakeAmmo_338Lapua_Sabot" or
+			    defName="MakeAmmo_338Norma_Sabot" or
+			    defName="MakeAmmo_408CheyenneTactical_Sabot" or
+			    defName="MakeAmmo_50BMG_Sabot" or
+			    defName="MakeAmmo_127x108mm_Sabot" or
+			    defName="MakeAmmo_145x114mm_Sabot" or
+			    defName="MakeAmmo_20x102mmNATO_Sabot" or
+			    defName="MakeAmmo_20x110mmHispano_Sabot" or
+			    defName="MakeAmmo_25x137mmNATO_Sabot" or
+			    defName="MakeAmmo_30x173mmNATO_Sabot" or
+			    defName="MakeAmmo_40x311mmR_Sabot"]/ingredients/li[3]/filter
+			</xpath>
+			<value>
+			    <filter>
+				<thingDefs>
+				    <li>VMEu_Tungsten</li>
+				    <li>Uranium</li>
+				</thingDefs>
+			    </filter>
+			</value>
+		    </li>
 
+		    <li Class="PatchOperationReplace" MayRequire="argon.vmeu">
+			<xpath>/Defs/RecipeDef[
+			    defName="MakeAmmo_127x55mmAR_Sabot" or
+			    defName="MakeAmmo_3006Springfield_Sabot" or
+			    defName="MakeAmmo_300AACBlackout_Sabot" or
+			    defName="MakeAmmo_303British_Sabot" or
+			    defName="MakeAmmo_30Carbine_Sabot" or
+			    defName="MakeAmmo_545x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_556x45mmNATO_Sabot" or
+			    defName="MakeAmmo_58x42mmDBP10_Sabot" or
+			    defName="MakeAmmo_65x52mmCarcano_Sabot" or
+			    defName="MakeAmmo_75x54mmFrench_Sabot" or
+			    defName="MakeAmmo_762x51mmNATO_Sabot" or
+			    defName="MakeAmmo_762x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_762x54mmR_Sabot" or
+			    defName="MakeAmmo_77x58mmArisaka_Sabot" or
+			    defName="MakeAmmo_792x33mmKurz_Sabot" or
+			    defName="MakeAmmo_792x57mmMauser_Sabot" or
+			    defName="MakeAmmo_8x50mmRLebel_Sabot" or
+			    defName="MakeAmmo_9x39mmSoviet_Sabot" or
+			    defName="MakeAmmo_300WinchesterMagnum_Sabot" or
+			    defName="MakeAmmo_338Lapua_Sabot" or
+			    defName="MakeAmmo_338Norma_Sabot" or
+			    defName="MakeAmmo_408CheyenneTactical_Sabot" or
+			    defName="MakeAmmo_50BMG_Sabot" or
+			    defName="MakeAmmo_127x108mm_Sabot" or
+			    defName="MakeAmmo_145x114mm_Sabot" or
+			    defName="MakeAmmo_20x102mmNATO_Sabot" or
+			    defName="MakeAmmo_20x110mmHispano_Sabot" or
+			    defName="MakeAmmo_25x137mmNATO_Sabot" or
+			    defName="MakeAmmo_30x173mmNATO_Sabot" or
+			    defName="MakeAmmo_40x311mmR_Sabot"]/fixedIngredientFilter
+			</xpath>
+			<value>
+					<fixedIngredientFilter>
+				<thingDefs>
+				    <li>VMEu_Bronze</li>
+				    <li>Steel</li>
+				    <li>VMEu_Tungsten</li>
+				    <li>Uranium</li>
+				</thingDefs>
+			    </fixedIngredientFilter>
+			</value>
+		    </li>
+
+
+		</operations>
+		</match>
+	</Operation>
 </Patch>


### PR DESCRIPTION
## Changes

- Made slight adjustments to the Molotovs.
- Fixed the error caused by the problematic patch for Expanded Materials - Metals mods.
- Brought Prometheum's cook-off properties more in line with Chemfuel.

## Reasoning

- Both 0.5 and 0.9 explosion radius are the same, change the radius to 0.9 for consistency's sake.
- Molotovs having a 1x1 explosion do not need a 2 radius minimum range, a 3x3 box is big enough.
- Prometheum is volatile but a thicker and stickier substance in comparison with Chemfuel, similar to Molotovs which explode in a single tile radius and are a single Prometheum bottle with a rag, made Prometheum explode in a slightly smaller radius.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
