### PR TITLE
Increase bomb damage sources' blunt AP factor

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -9,7 +9,7 @@ namespace CombatExtended
         /// <summary>
         /// Multiplier used to scale the armor penetration of a given projectile's explosion
         /// </summary>
-        private const float ExplosiveArmorPenetrationMultiplier = 0.25f;
+        private const float ExplosiveArmorPenetrationMultiplier = 0.33f;
 
         /// <summary>
         ///     Generates a readout text for a projectile with the damage amount, type, secondary explosion and other CE stats for

--- a/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
+++ b/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
@@ -10,7 +10,7 @@ namespace CombatExtended
 {
     public class SecondaryDamage
     {
-        private const float SecExplosionPenPerDmg = 2;
+        private const float SecExplosionPenPerDmg = 2.5;
 
         public DamageDef def;
         public int amount;

--- a/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
+++ b/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
@@ -10,7 +10,7 @@ namespace CombatExtended
 {
     public class SecondaryDamage
     {
-        private const float SecExplosionPenPerDmg = 2.5;
+        private const float SecExplosionPenPerDmg = 2.5f;
 
         public DamageDef def;
         public int amount;


### PR DESCRIPTION
## Changes

- Increased secondary bomb damage's blunt AP factor from x2 to x2.5
- Increased normal bomb damage's blunt AP factor from x0.25 to x0.33

## Reasoning

- Since blunt damage with lower than 50% armor penetration vs what the target's armor provides does no damage to armor, letting alone natural armor taking no damage from bomb damage sources, normal bomb damage and secondary bomb damage currently fall flat against anything resembling armor. Barring big explosion sources like something with 150 or so bomb damage that has enough blunt pen to do anything meaningful.
- Things relatively have higher blunt armor vs the bomb damage sources' blunt penetration than sharp pen vs sharp armor which results in bomb damage sources underperforming in comparison.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
