### PR TITLE
Recoil value Adjustments

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -38,6 +38,7 @@
     </weaponTags>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>3.28</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -55,7 +55,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.14</recoilAmount>
+        <recoilAmount>0.90</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
@@ -98,7 +98,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>2.02</recoilAmount>
+        <recoilAmount>1.54</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -141,7 +141,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>0.95</recoilAmount>
+        <recoilAmount>0.77</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -184,7 +184,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.96</recoilAmount>
+        <recoilAmount>1.50</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
@@ -235,6 +235,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>4.15</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_40x311mmR_AP</defaultProjectile>
@@ -280,7 +281,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.86</recoilAmount>
+        <recoilAmount>1.43</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -327,7 +328,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>1.08</recoilAmount>
+        <recoilAmount>0.86</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -375,6 +376,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>3.27</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_90mmCannonShell_HEAT</defaultProjectile>
@@ -423,7 +425,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>3.15</recoilAmount>
+        <recoilAmount>2.38</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_30x29mmGrenade_HE</defaultProjectile>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -414,7 +414,7 @@
       <Chemfuel>10</Chemfuel>
     </costList>
     <Properties>
-      <recoilAmount>1.53</recoilAmount>
+      <recoilAmount>1.50</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -134,6 +134,7 @@
       <ComponentIndustrial>2</ComponentIndustrial>
     </costList>
     <Properties>
+      <recoilAmount>2.96</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
@@ -188,6 +189,7 @@
       <ComponentIndustrial>3</ComponentIndustrial>
     </costList>
     <Properties>
+      <recoilAmount>2.72</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
@@ -243,6 +245,7 @@
       <ComponentIndustrial>1</ComponentIndustrial>
     </costList>
     <Properties>
+      <recoilAmount>3.15</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
@@ -303,6 +306,7 @@
       <Chemfuel>10</Chemfuel>
     </costList>
     <Properties>
+      <recoilAmount>2.92</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
@@ -356,6 +360,7 @@
       <ComponentIndustrial>1</ComponentIndustrial>
     </costList>
     <Properties>
+      <recoilAmount>2.0</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
@@ -466,6 +471,7 @@
       <Chemfuel>15</Chemfuel>
     </costList>
     <Properties>
+      <recoilAmount>1.50</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -519,7 +525,7 @@
       <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
     <Properties>
-      <recoilAmount>1.75</recoilAmount>
+      <recoilAmount>1.71</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
@@ -578,7 +584,7 @@
       <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
     <Properties>
-      <recoilAmount>2.08</recoilAmount>
+      <recoilAmount>1.79</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
@@ -637,6 +643,7 @@
       <Chemfuel>10</Chemfuel>
     </costList>
     <Properties>
+      <recoilAmount>1.0</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
@@ -696,7 +703,7 @@
       <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
     <Properties>
-      <recoilAmount>1.32</recoilAmount>
+      <recoilAmount>1.30</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
@@ -811,7 +818,7 @@
       <SwayFactor>0.69</SwayFactor>
     </statBases>
     <Properties>
-      <recoilAmount>1.15</recoilAmount>
+      <recoilAmount>0.91</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
@@ -858,7 +865,7 @@
       <Bulk>10</Bulk>
     </statBases>
     <Properties>
-      <recoilAmount>0.75</recoilAmount>
+      <recoilAmount>0.97</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -1148,7 +1155,7 @@
       <Bulk>13.00</Bulk>
     </statBases>
     <Properties>
-      <recoilAmount>1.38</recoilAmount>
+      <recoilAmount>1.08</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
@@ -1216,6 +1223,7 @@
       <Bulk>20.00</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>0.08</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
@@ -1284,6 +1292,7 @@
       <Bulk>20.00</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>0.1</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_164x284mmDemo</defaultProjectile>
@@ -1352,6 +1361,7 @@
       <Bulk>13.00</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>0.75</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>


### PR DESCRIPTION
## Changes

- Adjusted the recoil value of the Fixed guns according to the new formula in the spreadsheet. The Fixed guns receive a x0.75 recoil multiplier instead of a flat -0.15 reduction.
- Added recoil values back to non-automatic guns for later use.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=884124215

## Reasoning

- The -0.15 recoil value bonus that fixed guns get is too low taking into account the recoil is not mitigated as much as sway via weapon handling stat and high recoil vales in return make turrets very inaccurate, it also makes sense that a properly mounted gun has much lower recoil than a handheld one.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
