### PR TITLE
Marine helmet name patch removal

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -144,19 +144,12 @@
     <xpath>Defs/ThingDef[defName="Apparel_AdvancedHelmet"]/stuffCategories</xpath>
   </Operation>
   
-  <!-- ========== Power Armor Helmet ========== -->
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmet"]/label</xpath>
-    <value>
-      <label>power armor helmet</label>
-    </value>
-  </Operation>
+  <!-- ========== Marine Helmet ========== -->
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmet"]/description</xpath>
     <value>
-      <description>A part of power armor set, mostly used by heavy infantry.\n\nIntegrated servo-motors assist the wearer's muscles in holding the weight of the helmet while the integrated combat HUD improves weapon accuracy.</description>
+      <description>A part of the marine armor set, mostly used by heavy infantry.\n\nIntegrated servo-motors assist the wearer's muscles in holding the weight of the helmet while the integrated combat HUD improves weapon accuracy.</description>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes

- Removed the marine helmet's name patch which was left out in the previous marine armor PR.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
