### PR TITLE
Make aiming time affected by skill and health stats

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -10,34 +10,34 @@
     <category>PawnCombat</category>
     <displayPriorityInCategory>4049</displayPriorityInCategory>
     <defaultBaseValue>1</defaultBaseValue>
-    <minValue>0.25</minValue>
+    <minValue>0.5</minValue>
     <toStringStyle>PercentZero</toStringStyle>
     <showOnAnimals>false</showOnAnimals>
 	<skillNeedFactors>
       <li Class="SkillNeed_Direct">
         <skill>Shooting</skill>
         <valuesPerLevel>
-          <li>1.5</li>
-          <li>1.35</li>
-          <li>1.3</li>
           <li>1.25</li>
           <li>1.2</li>
+          <li>1.17</li>
           <li>1.15</li>
-          <li>1.1</li>
-          <li>1.05</li>
+          <li>1.12</li>
+          <li>1.09</li>
+          <li>1.06</li>
+          <li>1.03</li>
           <li>1.0</li>
-          <li>0.95</li>
-          <li>0.9</li>
-          <li>0.85</li>
-          <li>0.8</li>
+          <li>0.98</li>
+          <li>0.96</li>
+          <li>0.94</li>
+          <li>0.92</li>
+          <li>0.90</li>
+          <li>0.88</li> 
+          <li>0.86</li>
+          <li>0.84</li>
+          <li>0.82</li>
+          <li>0.80</li> 
+          <li>0.78</li> 
           <li>0.75</li>
-          <li>0.7</li> 
-          <li>0.65</li>
-          <li>0.6</li>
-          <li>0.57</li>
-          <li>0.54</li> 
-          <li>0.52</li> 
-          <li>0.5</li>
         </valuesPerLevel>
       </li>
     </skillNeedFactors>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -54,7 +54,7 @@
       </li>
       <li>
         <capacity>Manipulation</capacity>
-        <weight>0.1</weight>
+        <weight>0.25</weight>
         <useReciprocal>true</useReciprocal>
       </li>
     </capacityFactors>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -4,6 +4,63 @@
   <!-- ================================== Shooting =======================================-->
 
   <StatDef>
+    <defName>AimingDelayFactor</defName>
+    <label>aiming time</label>
+    <description>How long it takes to shoot after choosing a target.</description>
+    <category>PawnCombat</category>
+    <displayPriorityInCategory>4049</displayPriorityInCategory>
+    <defaultBaseValue>1</defaultBaseValue>
+    <minValue>0.25</minValue>
+    <toStringStyle>PercentZero</toStringStyle>
+    <showOnAnimals>false</showOnAnimals>
+	<skillNeedFactors>
+      <li Class="SkillNeed_Direct">
+        <skill>Shooting</skill>
+        <valuesPerLevel>
+          <li>1.5</li>
+          <li>1.35</li>
+          <li>1.3</li>
+          <li>1.25</li>
+          <li>1.2</li>
+          <li>1.15</li>
+          <li>1.1</li>
+          <li>1.05</li>
+          <li>1.0</li>
+          <li>0.95</li>
+          <li>0.9</li>
+          <li>0.85</li>
+          <li>0.8</li>
+          <li>0.75</li>
+          <li>0.7</li> 
+          <li>0.65</li>
+          <li>0.6</li>
+          <li>0.57</li>
+          <li>0.54</li> 
+          <li>0.52</li> 
+          <li>0.5</li>
+        </valuesPerLevel>
+      </li>
+    </skillNeedFactors>
+    <capacityFactors>
+      <li>
+        <capacity>Consciousness</capacity>
+        <weight>1</weight>
+		<useReciprocal>true</useReciprocal>
+      </li>
+      <li>
+        <capacity>Sight</capacity>
+        <weight>0.5</weight>
+		<useReciprocal>true</useReciprocal>
+      </li>
+      <li>
+        <capacity>Manipulation</capacity>
+        <weight>0.1</weight>
+		<useReciprocal>true</useReciprocal>
+      </li>
+    </capacityFactors>
+  </StatDef>
+
+  <StatDef>
     <defName>AimingAccuracy</defName>
     <label>aiming accuracy</label>
     <description>How well a shooter can lead moving targets and estimate range in combination with the weapon's aiming efficiency.\n\nThe final modifier is calculated via this formula:\n(1.5 - aiming accuracy) / aiming efficiency\n\nLead error is calculated by multiplying this factor against total lead distance in cells. Range error is calculated by multiplying it against the total distance to the target divided by 4.\n\nAiming accuracy influences the the sway reduction during aimed shots. For example, at 75% aiming accuracy sway will be reduced to 25%.</description>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -4,58 +4,6 @@
   <!-- ================================== Shooting =======================================-->
 
   <StatDef>
-    <defName>AimingDelayFactor</defName>
-    <label>aiming time</label>
-    <description>How long it takes to shoot after choosing a target.</description>
-    <category>PawnCombat</category>
-    <displayPriorityInCategory>4049</displayPriorityInCategory>
-    <defaultBaseValue>1</defaultBaseValue>
-    <minValue>0.5</minValue>
-    <toStringStyle>PercentZero</toStringStyle>
-    <showOnAnimals>false</showOnAnimals>
-    <skillNeedFactors>
-      <li Class="SkillNeed_Direct">
-        <skill>Shooting</skill>
-        <valuesPerLevel>
-          <li>1.25</li>
-          <li>1.2</li>
-          <li>1.17</li>
-          <li>1.15</li>
-          <li>1.12</li>
-          <li>1.09</li>
-          <li>1.06</li>
-          <li>1.03</li>
-          <li>1.0</li>
-          <li>0.98</li>
-          <li>0.96</li>
-          <li>0.94</li>
-          <li>0.92</li>
-          <li>0.90</li>
-          <li>0.88</li> 
-          <li>0.86</li>
-          <li>0.84</li>
-          <li>0.82</li>
-          <li>0.80</li> 
-          <li>0.78</li> 
-          <li>0.75</li>
-        </valuesPerLevel>
-      </li>
-    </skillNeedFactors>
-    <capacityFactors>
-      <li>
-        <capacity>Manipulation</capacity>
-        <weight>1</weight>
-        <useReciprocal>true</useReciprocal>
-      </li>
-      <li>
-        <capacity>Sight</capacity>
-        <weight>0.7</weight>
-        <useReciprocal>true</useReciprocal>
-      </li>
-    </capacityFactors>
-  </StatDef>
-
-  <StatDef>
     <defName>AimingAccuracy</defName>
     <label>aiming accuracy</label>
     <description>How well a shooter can lead moving targets and estimate range in combination with the weapon's aiming efficiency.\n\nThe final modifier is calculated via this formula:\n(1.5 - aiming accuracy) / aiming efficiency\n\nLead error is calculated by multiplying this factor against total lead distance in cells. Range error is calculated by multiplying it against the total distance to the target divided by 4.\n\nAiming accuracy influences the the sway reduction during aimed shots. For example, at 75% aiming accuracy sway will be reduced to 25%.</description>
@@ -230,48 +178,6 @@
       <li>
         <capacity>Manipulation</capacity>
         <weight>1</weight>
-      </li>
-    </capacityFactors>
-    <postProcessCurve>
-      <points>
-        <li>(0.0, 0.0)</li>
-        <li>(0.3, 0.3)</li>
-        <li>(0.6, 0.45)</li>
-        <li>(1.2, 0.6)</li>
-        <li>(2.4, 0.75)</li>
-        <li>(3.2, 0.8)</li>
-      </points>
-    </postProcessCurve>
-  </StatDef>
-
-  <StatDef>
-    <defName>MeleeDodgeChance</defName>
-    <label>melee dodge chance</label>
-    <description>Chance to dodge a melee attack that would've otherwise hit. Characters will not dodge while aiming or firing a ranged weapon.</description>
-    <category>PawnCombat</category>
-    <workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
-    <displayPriorityInCategory>99</displayPriorityInCategory>
-    <defaultBaseValue>1</defaultBaseValue>
-    <minValue>0</minValue>
-    <maxValue>3.2</maxValue>
-    <toStringStyle>PercentZero</toStringStyle>
-    <neverDisabled>true</neverDisabled>
-    <skillNeedFactors>
-      <li Class="SkillNeed_BaseBonus">
-        <skill>Melee</skill>
-        <baseValue>0.05</baseValue>
-        <bonusPerLevel>0.0175</bonusPerLevel>
-      </li>
-    </skillNeedFactors>
-    <capacityFactors>
-      <li>
-        <capacity>Moving</capacity>
-        <weight>1</weight>
-      </li>
-      <li>
-        <capacity>Sight</capacity>
-        <weight>0.7</weight>
-        <max>1</max>
       </li>
     </capacityFactors>
     <postProcessCurve>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -13,7 +13,7 @@
     <minValue>0.5</minValue>
     <toStringStyle>PercentZero</toStringStyle>
     <showOnAnimals>false</showOnAnimals>
-	<skillNeedFactors>
+    <skillNeedFactors>
       <li Class="SkillNeed_Direct">
         <skill>Shooting</skill>
         <valuesPerLevel>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -45,17 +45,17 @@
       <li>
         <capacity>Consciousness</capacity>
         <weight>1</weight>
-		<useReciprocal>true</useReciprocal>
+        <useReciprocal>true</useReciprocal>
       </li>
       <li>
         <capacity>Sight</capacity>
         <weight>0.5</weight>
-		<useReciprocal>true</useReciprocal>
+        <useReciprocal>true</useReciprocal>
       </li>
       <li>
         <capacity>Manipulation</capacity>
         <weight>0.1</weight>
-		<useReciprocal>true</useReciprocal>
+        <useReciprocal>true</useReciprocal>
       </li>
     </capacityFactors>
   </StatDef>

--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -43,18 +43,13 @@
     </skillNeedFactors>
     <capacityFactors>
       <li>
-        <capacity>Consciousness</capacity>
+        <capacity>Manipulation</capacity>
         <weight>1</weight>
         <useReciprocal>true</useReciprocal>
       </li>
       <li>
         <capacity>Sight</capacity>
-        <weight>0.5</weight>
-        <useReciprocal>true</useReciprocal>
-      </li>
-      <li>
-        <capacity>Manipulation</capacity>
-        <weight>0.25</weight>
+        <weight>0.7</weight>
         <useReciprocal>true</useReciprocal>
       </li>
     </capacityFactors>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -157,6 +157,70 @@
 		</value>
 	</Operation>
 
+	<!-- Melee Dodge Chance -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
+		<value>
+			<workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
+			<displayPriorityInCategory>99</displayPriorityInCategory>
+			<maxValue>3.2</maxValue>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/defaultBaseValue</xpath>
+		<value>
+			<defaultBaseValue>1</defaultBaseValue>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/skillNeedFactors</xpath>
+		<value>
+		    <skillNeedFactors>
+		      <li Class="SkillNeed_BaseBonus">
+			<skill>Melee</skill>
+			<baseValue>0.05</baseValue>
+			<bonusPerLevel>0.0175</bonusPerLevel>
+		      </li>
+		    </skillNeedFactors>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/capacityFactors</xpath>
+		<value>
+		    <capacityFactors>
+		      <li>
+			<capacity>Moving</capacity>
+			<weight>1</weight>
+		      </li>
+		      <li>
+			<capacity>Sight</capacity>
+			<weight>0.7</weight>
+			<max>1</max>
+		      </li>
+		    </capacityFactors>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/postProcessCurve</xpath>
+		<value>
+		    <postProcessCurve>
+		      <points>
+			<li>(0.0, 0.0)</li>
+			<li>(0.3, 0.3)</li>
+			<li>(0.6, 0.45)</li>
+			<li>(1.2, 0.6)</li>
+			<li>(2.4, 0.75)</li>
+			<li>(3.2, 0.8)</li>
+		      </points>
+		    </postProcessCurve>
+		</value>
+	</Operation>
+
 	<!-- Shooting Accuracy -->
 
 	<Operation Class="PatchOperationReplace">
@@ -252,6 +316,70 @@
 		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/noSkillOffset</xpath>
 		<value>
 			<noSkillFactor>2.6</noSkillFactor>
+		</value>
+	</Operation>
+
+	<!-- Aiming Delay Factor -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
+		<value>
+			<maxValue>2.0</maxValue>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
+		<value>
+		    <skillNeedFactors>
+		      <li Class="SkillNeed_Direct">
+			<skill>Shooting</skill>
+			<valuesPerLevel>
+			  <li>1.25</li>
+			  <li>1.2</li>
+			  <li>1.17</li>
+			  <li>1.15</li>
+			  <li>1.12</li>
+			  <li>1.09</li>
+			  <li>1.06</li>
+			  <li>1.03</li>
+			  <li>1.0</li>
+			  <li>0.98</li>
+			  <li>0.96</li>
+			  <li>0.94</li>
+			  <li>0.92</li>
+			  <li>0.90</li>
+			  <li>0.88</li>
+			  <li>0.86</li>
+			  <li>0.84</li>
+			  <li>0.82</li>
+			  <li>0.80</li>
+			  <li>0.78</li>
+			  <li>0.75</li>
+			</valuesPerLevel>
+		      </li>
+		    </skillNeedFactors>
+		    <capacityFactors>
+		      <li>
+			<capacity>Manipulation</capacity>
+			<weight>1</weight>
+			<useReciprocal>true</useReciprocal>
+		      </li>
+		      <li>
+			<capacity>Sight</capacity>
+			<weight>0.7</weight>
+			<useReciprocal>true</useReciprocal>
+		      </li>
+		    </capacityFactors>
+		    <postProcessCurve>
+		      <points>
+			<li>(0.25, 0.5)</li>
+			<li>(0.75, 0.75)</li>
+			<li>(1.0, 1.0)</li>
+			<li>(1.25, 1.25)</li>
+			<li>(2.0, 1.5/li>
+		      </points>
+		    </postProcessCurve>
 		</value>
 	</Operation>
 

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -163,7 +163,6 @@
 		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
 		<value>
 			<workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
-			<displayPriorityInCategory>99</displayPriorityInCategory>
 			<maxValue>3.2</maxValue>
 		</value>
 	</Operation>
@@ -175,31 +174,31 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/skillNeedFactors</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
 		<value>
 		    <skillNeedFactors>
 		      <li Class="SkillNeed_BaseBonus">
-			<skill>Melee</skill>
-			<baseValue>0.05</baseValue>
-			<bonusPerLevel>0.0175</bonusPerLevel>
+				<skill>Melee</skill>
+				<baseValue>0.05</baseValue>
+				<bonusPerLevel>0.0175</bonusPerLevel>
 		      </li>
 		    </skillNeedFactors>
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/capacityFactors</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
 		<value>
 		    <capacityFactors>
 		      <li>
-			<capacity>Moving</capacity>
-			<weight>1</weight>
-		      </li>
-		      <li>
-			<capacity>Sight</capacity>
-			<weight>0.7</weight>
-			<max>1</max>
+				<capacity>Moving</capacity>
+				<weight>1</weight>
+				</li>
+				<li>
+				<capacity>Sight</capacity>
+				<weight>0.7</weight>
+				<max>1</max>
 		      </li>
 		    </capacityFactors>
 		</value>
@@ -210,12 +209,12 @@
 		<value>
 		    <postProcessCurve>
 		      <points>
-			<li>(0.0, 0.0)</li>
-			<li>(0.3, 0.3)</li>
-			<li>(0.6, 0.45)</li>
-			<li>(1.2, 0.6)</li>
-			<li>(2.4, 0.75)</li>
-			<li>(3.2, 0.8)</li>
+				<li>(0.0, 0.0)</li>
+				<li>(0.3, 0.3)</li>
+				<li>(0.6, 0.45)</li>
+				<li>(1.2, 0.6)</li>
+				<li>(2.4, 0.75)</li>
+				<li>(3.2, 0.8)</li>
 		      </points>
 		    </postProcessCurve>
 		</value>
@@ -325,12 +324,6 @@
 		<xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
 		<value>
 			<maxValue>2.0</maxValue>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
-		<value>
 		    <skillNeedFactors>
 		      <li Class="SkillNeed_Direct">
 			<skill>Shooting</skill>
@@ -377,7 +370,7 @@
 			<li>(0.75, 0.75)</li>
 			<li>(1.0, 1.0)</li>
 			<li>(1.25, 1.25)</li>
-			<li>(2.0, 1.5/li>
+			<li>(2.0, 1.5)</li>
 		      </points>
 		    </postProcessCurve>
 		</value>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -373,7 +373,7 @@
 		    </capacityFactors>
 		    <postProcessCurve>
 		      <points>
-			<li>(0.25, 0.5)</li>
+			<li>(0.01, 0.5)</li>
 			<li>(0.75, 0.75)</li>
 			<li>(1.0, 1.0)</li>
 			<li>(1.25, 1.25)</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, aiming time is impacted by skill and health stats and ranges from x1.25 at zero skill with no higher cap to x0.75 (via skills) and x0.5 at the minimum after stacking health stat bonuses. Trigger-happy and Careful shooter pawns are still balanced even at higher and lower end of shooting skill as well.

## Reasoning

- Skilled and enhanced pawns should aim faster.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (The changes work in-game)
