### PR TITLE
Modded turret recoil adjustments

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -376,7 +376,7 @@
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>3.27</recoilAmount>
+        <recoilAmount>4.74</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_90mmCannonShell_HEAT</defaultProjectile>

--- a/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
+++ b/Patches/More Vanilla Turrets/MVT_CE_Patch_Buildings_Security.xml
@@ -20,7 +20,7 @@
 					<Bulk>18.54</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.08</recoilAmount>
+					<recoilAmount>0.83</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
@@ -115,7 +115,7 @@
 					<Bulk>37.08</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.09</recoilAmount>
+					<recoilAmount>0.84</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -154,7 +154,7 @@
 					<Bulk>37.08</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.09</recoilAmount>
+					<recoilAmount>0.84</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -299,7 +299,7 @@
 					<Bulk>28.72</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.80</recoilAmount>
+					<recoilAmount>1.38</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -342,7 +342,7 @@
 					<Bulk>28.72</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.80</recoilAmount>
+					<recoilAmount>1.38</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
@@ -385,7 +385,7 @@
 					<Bulk>12.9</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.58</recoilAmount>
+					<recoilAmount>1.21</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>
@@ -431,7 +431,7 @@
 					<Bulk>12.9</Bulk>
 				</statBases>
 				<Properties>
-					<recoilAmount>1.58</recoilAmount>
+					<recoilAmount>1.21</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
 					<defaultProjectile>Bullet_40x53mmGrenade_HE</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -82,7 +82,7 @@
 				  <Bulk>13.00</Bulk>
 				</statBases>
 				<Properties>
-				  <recoilAmount>1.38</recoilAmount>
+				  <recoilAmount>1.08</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
@@ -165,6 +165,7 @@
 				  <Bulk>13.00</Bulk>
 				</statBases>
 				<Properties>
+				  <recoilAmount>0.75</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
@@ -269,6 +270,7 @@
 				  <Bulk>20.00</Bulk>
 				</statBases>
 				<Properties>
+				  <recoilAmount>0.08</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -208,9 +208,10 @@
       <li Class="PatchOperationAdd">
         <xpath>/Defs/ThingDef[defName="VFEP_Turret_Cannon"]</xpath>
         <value>
-        <statBases>
-          <Mass>250</Mass>
-        </statBases>
+          <statBases>
+            <Bulk>150</Bulk>
+            <Mass>250</Mass>
+          </statBases>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Artillery.xml
@@ -27,21 +27,21 @@
       <!-- Field Gun -->
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Turret_FieldGun"]</xpath>
         <value>
             <fillPercent>0.85</fillPercent>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]/building/turretBurstWarmupTime</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Turret_FieldGun"]/building/turretBurstWarmupTime</xpath>
         <value>
             <turretBurstWarmupTime>4.0</turretBurstWarmupTime>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]/building/turretBurstCooldownTime</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Turret_FieldGun"]/building/turretBurstCooldownTime</xpath>
         <value>
             <turretBurstCooldownTime>2.0</turretBurstCooldownTime>
         </value>
@@ -58,7 +58,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Turret_FieldGun"]</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Turret_FieldGun"]</xpath>
         <value>
           <placeWorkers Inherit="False">
             <li>PlaceWorker_TurretTop</li>
@@ -67,22 +67,29 @@
         </value>
       </li>
 
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/statBases</xpath>
+        <value>
+            <Mass>250</Mass>
+        </value>
+      </li>
+
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/statBases/RangedWeapon_Cooldown</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/statBases/RangedWeapon_Cooldown</xpath>
         <value>
             <RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
         </value>
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/statBases</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/statBases</xpath>
         <value>
             <SightsEfficiency>0.5</SightsEfficiency>
         </value>
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/comps</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/comps</xpath>
         <value>
             <li Class="CombatExtended.CompProperties_AmmoUser">
               <magazineSize>1</magazineSize>
@@ -93,17 +100,18 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/weaponTags</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/weaponTags</xpath>
         <value>
           <li>TurretGun</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_FieldGun"]/verbs</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_FieldGun"]/verbs</xpath>
         <value>
           <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
+              <recoilAmount>4.36</recoilAmount>
               <verbClass>CombatExtended.Verb_ShootCE</verbClass>
               <forceNormalTimeSpeed>false</forceNormalTimeSpeed>
               <hasStandardCommand>true</hasStandardCommand>
@@ -126,28 +134,28 @@
       <!-- Cannon - Based on the M1897 12-pounder -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/fillPercent</xpath>
+        <xpath>/Defs/ThingDef[@Name="VFEP_BaseCannonBuilding"]/fillPercent</xpath>
         <value>
             <fillPercent>0.85</fillPercent>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/building/turretBurstWarmupTime</xpath>
+        <xpath>/Defs/ThingDef[@Name="VFEP_BaseCannonBuilding"]/building/turretBurstWarmupTime</xpath>
         <value>
             <turretBurstWarmupTime>3.3</turretBurstWarmupTime>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/building/turretBurstCooldownTime</xpath>
+        <xpath>/Defs/ThingDef[@Name="VFEP_BaseCannonBuilding"]/building/turretBurstCooldownTime</xpath>
         <value>
             <turretBurstCooldownTime>2.7</turretBurstCooldownTime>
         </value>
       </li>
 
       <li Class="PatchOperationRemove">
-        <xpath>/Defs/ThingDef[@Name = "VFEP_BaseCannonBuilding"]/placeWorkers/li[.="PlaceWorker_NotUnderRoof"]</xpath>
+        <xpath>/Defs/ThingDef[@Name="VFEP_BaseCannonBuilding"]/placeWorkers/li[.="PlaceWorker_NotUnderRoof"]</xpath>
       </li>
 
       <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
@@ -157,6 +165,7 @@
             <SightsEfficiency>0.80</SightsEfficiency>
             <ShotSpread>0.15</ShotSpread>
             <SwayFactor>0.81</SwayFactor>
+            <Mass>125</Mass>
           </statBases>
           <AmmoUser>
             <magazineSize>1</magazineSize>
@@ -173,10 +182,11 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEP_Artillery_Cannon"]/verbs</xpath>
+        <xpath>/Defs/ThingDef[defName="VFEP_Artillery_Cannon"]/verbs</xpath>
         <value>
           <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
+              <recoilAmount>2.40</recoilAmount>
               <verbClass>CombatExtended.Verb_ShootCE</verbClass>
               <hasStandardCommand>true</hasStandardCommand>
               <defaultProjectile>Bullet_CannonBall_Round</defaultProjectile>
@@ -199,9 +209,6 @@
         <xpath>/Defs/ThingDef[defName="VFEP_Turret_Cannon"]</xpath>
         <value>
         <statBases>
-          <ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
-          <AimingAccuracy>1.0</AimingAccuracy>
-          <Bulk>150</Bulk>
           <Mass>250</Mass>
         </statBases>
         </value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -67,6 +67,7 @@
           <SwayFactor>0.26</SwayFactor>
         </statBases>
         <Properties>
+          <recoilAmount>1.08</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
@@ -19,7 +19,7 @@
             <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
-            <recoilAmount>1.52</recoilAmount>
+            <recoilAmount>1.17</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_4570Gov_FMJ</defaultProjectile>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -89,6 +89,7 @@
 		    <SwayFactor>0.82</SwayFactor>
 		  </statBases>
 		  <Properties>
+		    <recoilAmount>0.96</recoilAmount>
 		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		    <hasStandardCommand>True</hasStandardCommand>
 		    <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
@@ -126,9 +127,9 @@
 		    <SightsEfficiency>1</SightsEfficiency>
 		    <ShotSpread>0.04</ShotSpread>
 		    <SwayFactor>1.16</SwayFactor>
-		    <Bulk>15.54</Bulk>
 		  </statBases>
 		  <Properties>
+		    <recoilAmount>0.81</recoilAmount>
 		    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		    <hasStandardCommand>True</hasStandardCommand>
 		    <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -181,7 +181,7 @@
 			  <SwayFactor>1.59</SwayFactor>
 			</statBases>
 			<Properties>
-			  <recoilAmount>0.85</recoilAmount>
+			  <recoilAmount>0.65</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_Flamethrower_Napalm</defaultProjectile>
@@ -219,7 +219,7 @@
 			  <SwayFactor>0.82</SwayFactor>
 			</statBases>
 			<Properties>
-			  <recoilAmount>1.1</recoilAmount>
+			  <recoilAmount>0.85</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
@@ -254,7 +254,7 @@
 			  <SwayFactor>0.82</SwayFactor>
 			</statBases>
 			<Properties>
-			  <recoilAmount>0.76</recoilAmount>
+			  <recoilAmount>0.91</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
@@ -290,7 +290,7 @@
 			  <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
 			</statBases>
 			<Properties>
-			  <recoilAmount>1.1</recoilAmount>
+			  <recoilAmount>0.85</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
@@ -328,7 +328,7 @@
 			  <SwayFactor>1.72</SwayFactor>
 			</statBases>
 			<Properties>
-			  <recoilAmount>2.03</recoilAmount>
+			  <recoilAmount>1.56</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
@@ -494,6 +494,7 @@
 			  <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
 			</statBases>
 			<Properties>
+			  <recoilAmount>2.0</recoilAmount>
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_12mmRailgun_Sabot</defaultProjectile>


### PR DESCRIPTION
## Changes

- The continuation of #1888 for modded turrets.
- Fixed the 90mm Flak cannon's recoil values since it it was using a wrong velocity value for its 90mm shell.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
