### PR TITLE
Add the sway reduction stat for apparel

### DIFF
--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -101,8 +101,25 @@
     <parts>
       <li Class="CombatExtended.StatPart_Attachments" />
       <li Class="CombatExtended.Bipod_Sway_StatPart" />
+      <li Class="CombatExtended.StatPart_StatMaxima">           
+        <apparelStat>SwayReduction_Apparel</apparelStat>
+        <sumApparelsStat>false</sumApparelsStat>  
+      </li>
     </parts>    
   </StatDef>
+
+  <StatDef Name="ApparelSwayReduction">    
+    <defName>SwayReduction_Apparel</defName>	  
+    <label>sway reduction</label>    
+    <description>The effect of apparel items on a pawn's ability to overcome the effects of weapon sway.</description>
+    <category>Apparel</category>  
+    <minValue>-1</minValue>
+    <maxValue>0</maxValue>    
+    <hideAtValue>0</hideAtValue>    
+    <defaultBaseValue>0</defaultBaseValue>
+    <toStringStyle>PercentZero</toStringStyle>
+    <showIfUndefined>false</showIfUndefined>    
+  </StatDef>  
 
   <!-- ========== Don't do anything, only display information to the player ========== -->
 


### PR DESCRIPTION
## Additions

- An attempt at making a new sway reduction stat to be given to apparel like power armor and such instead of weapon handling bonuses.

_Currently does not work as intended, apparel show the value correctly but weapons don't get reduced sway values. A new StartPart Class is needed for the stat to work as intended from the looks of it._

## Reasoning

- Cuz weapon handling stat is too broad and powered armor pieces deserve a higher sway reduction bonus.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
