### PR TITLE
Patch Erin's Chocobos

### DIFF
--- a/Patches/Erin's Chocobos/Erin_Chocobos.xml
+++ b/Patches/Erin's Chocobos/Erin_Chocobos.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Erin's Chocobos</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/ThingDef[defName="ERN_Chocobo"]</xpath>
+        <value>
+          <li Class="CombatExtended.RacePropertiesExtensionCE">
+            <bodyShape>Birdlike</bodyShape>
+          </li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="ERN_Chocobo"]/statBases</xpath>
+        <value>
+          <MeleeDodgeChance>0.22</MeleeDodgeChance>
+          <MeleeCritChance>0.11</MeleeCritChance>
+          <MeleeParryChance>0.03</MeleeParryChance>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="ERN_Chocobo"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>claws</label>
+              <capacities>
+                <li>Cut</li>
+              </capacities>
+              <power>11</power>
+              <cooldownTime>1.52</cooldownTime>
+              <linkedBodyPartsGroup>Feet</linkedBodyPartsGroup>
+              <surpriseAttack>
+                <extraMeleeDamages>
+                  <li>
+                    <def>Stun</def>
+                    <amount>20</amount>
+                  </li>
+                </extraMeleeDamages>
+              </surpriseAttack>
+              <armorPenetrationSharp>0.12</armorPenetrationSharp>
+              <armorPenetrationBlunt>0.52</armorPenetrationBlunt>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <capacities>
+                <li>Bite</li>
+              </capacities>
+              <power>8.3</power>
+              <cooldownTime>1.93</cooldownTime>
+              <linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
+              <chanceFactor>0.5</chanceFactor>
+              <armorPenetrationSharp>0.03</armorPenetrationSharp>					
+              <armorPenetrationBlunt>1.350</armorPenetrationBlunt>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>head</label>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>4</power>
+              <cooldownTime>1.82</cooldownTime>
+              <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+              <chanceFactor>0.2</chanceFactor>
+              <armorPenetrationBlunt>1.05</armorPenetrationBlunt>
+            </li>
+          </tools>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -156,6 +156,7 @@ Epona The centaur race  |
 Equiums Horse Race	|
 Erin's Au Ra    |
 Erin's Azaphrae |
+Erin's Chocobos |
 Erin's Critter Collection |
 Erin's Forest Critters |
 Erin's Friendly Ferrets |


### PR DESCRIPTION
## Additions
Patch Erin's Chocobos. The mod has only a single animal. Vanilla stats are similar to a slightly stronger, faster emu, and the patch stats reflect that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
