### PR TITLE
4.9 adjustments

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -7,7 +7,7 @@
 		<li>1.3</li>
 	</supportedVersions>
 	<packageId>CETeam.CombatExtended</packageId>
-	<description>Version: 1.3.4.8.1\n\nExtends combat mechanics to make them deeper and more tactical.</description>
+	<description>Version: 1.3.4.9\n\nExtends combat mechanics to make them deeper and more tactical.</description>
 	<modDependencies>
 		<li>
 			<packageId>brrainz.harmony</packageId>

--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
   <identifier>CombatExtended</identifier>
-  <version>1.3.4.8</version> <!-- Don't add extra digits to this, or it breaks Fluffy's versioning.  -->
+  <version>1.3.4.9</version> <!-- Don't add extra digits to this, or it breaks Fluffy's versioning.  -->
   <dependencies>
     <li>2009463077</li> <!-- Harmony -->
   </dependencies>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -131,7 +131,7 @@
     <label>14.5x114mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>53</damageAmountBase>
-      <armorPenetrationSharp>19</armorPenetrationSharp>
+      <armorPenetrationSharp>18</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -141,7 +141,7 @@
     <label>14.5x114mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>33</damageAmountBase>
-      <armorPenetrationSharp>38</armorPenetrationSharp>
+      <armorPenetrationSharp>36</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -151,7 +151,7 @@
     <label>14.5x114mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>33</damageAmountBase>
-      <armorPenetrationSharp>38</armorPenetrationSharp>
+      <armorPenetrationSharp>36</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -167,7 +167,7 @@
     <label>14.5x114mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>53</damageAmountBase>
-      <armorPenetrationSharp>19</armorPenetrationSharp>
+      <armorPenetrationSharp>18</armorPenetrationSharp>
       <armorPenetrationBlunt>634</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -184,7 +184,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	  <speed>300</speed>
       <damageAmountBase>27</damageAmountBase>
-      <armorPenetrationSharp>66.5</armorPenetrationSharp>
+      <armorPenetrationSharp>63</armorPenetrationSharp>
       <armorPenetrationBlunt>820.360</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -174,7 +174,7 @@
 			<damageAmountBase>0</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>1.5</explosionRadius>
+			<explosionRadius>1.0</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -147,18 +147,18 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>91</speed>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>102</damageAmountBase>
+			<damageAmountBase>142</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>2</explosionRadius>
+			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 		<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-				<Fragment_Large>19</Fragment_Large>
-				<Fragment_Small>13</Fragment_Small>
+				<Fragment_Large>17</Fragment_Large>
+				<Fragment_Small>22</Fragment_Small>
 			</fragments>
 		</li>
 		</comps>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -174,9 +174,9 @@
 			<damageAmountBase>0</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>1.0</explosionRadius>
+			<explosionRadius>4.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.85</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -147,7 +147,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>91</speed>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>82</damageAmountBase>
+			<damageAmountBase>102</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>2</explosionRadius>
@@ -158,7 +158,7 @@
 		<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
 				<Fragment_Large>19</Fragment_Large>
-				<Fragment_Small>9</Fragment_Small>
+				<Fragment_Small>13</Fragment_Small>
 			</fragments>
 		</li>
 		</comps>
@@ -176,7 +176,7 @@
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>1.0</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.85</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -64,7 +64,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>375.44</MarketValue>
+			<MarketValue>427.1</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_155mmHowitzerShell_HE</detonateProjectile>
@@ -140,8 +140,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>452</damageAmountBase>
-			<explosionRadius>5</explosionRadius>
+			<damageAmountBase>546</damageAmountBase>
+			<explosionRadius>5.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
@@ -249,8 +249,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>452</damageAmountBase>
-			<explosionRadius>5</explosionRadius>
+			<damageAmountBase>546</damageAmountBase>
+			<explosionRadius>5.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
@@ -362,7 +362,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>12</count>
+				<count>17</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -312,8 +312,8 @@
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Weapon_GrenadeMolotov</defName>
 		<statBases>
-			<Mass>0.6</Mass>
-			<Bulk>2.55</Bulk>
+			<Mass>0.7</Mass>
+			<Bulk>1.96</Bulk>
 			<MarketValue>7.05</MarketValue>
 			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.65</SightsEfficiency>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -232,11 +232,11 @@
 		<xpath>Defs/ThingDef[defName="Proj_GrenadeMolotov"]</xpath>
 		<value>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<explosionRadius>0.9</explosionRadius>
+				<explosionRadius>1</explosionRadius>
 				<damageDef>PrometheumFlame</damageDef>
 				<damageAmountBase>10</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-				<preExplosionSpawnChance>1</preExplosionSpawnChance>
+				<preExplosionSpawnChance>0.8</preExplosionSpawnChance>
 				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 				<gravityFactor>2</gravityFactor>
@@ -302,9 +302,9 @@
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 			<damageAmountBase>1</damageAmountBase>
 			<explosiveDamageType>Flame</explosiveDamageType>
-			<explosiveRadius>0.9</explosiveRadius>
+			<explosiveRadius>1</explosiveRadius>
 			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>1</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.8</preExplosionSpawnChance>
 		  </li>
 		</value>
 	</Operation>

--- a/Patches/Kurin Deluxe Patch/Ammo/Ammo_Kurin.xml
+++ b/Patches/Kurin Deluxe Patch/Ammo/Ammo_Kurin.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	  <Operation Class="PatchOperationFindMod">
+		<mods>
+		  <li>Kurin, The Three Tailed Fox [Deluxe Edition]</li>
+		</mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<!-- 8x35mmChargedkurin -->
+		<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+		
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_8x35mmChargedK</defName>
+    <label>8x35mm Charged K</label>
+    <ammoTypes>
+      <Ammo_8x35mmCharged>Bullet_8x35mmChargedK</Ammo_8x35mmCharged>
+      <Ammo_8x35mmCharged_AP>Bullet_8x35mmChargedK_AP</Ammo_8x35mmCharged_AP>
+      <Ammo_8x35mmCharged_Ion>Bullet_8x35mmChargedK_Ion</Ammo_8x35mmCharged_Ion>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+
+  <!-- normal charged bullets -->
+  <ThingDef Name="Bullet_8x35mmChargedK" ParentName="Base8x35mmChargedBullet">
+    <defName>Bullet_8x35mmChargedK</defName>
+    <label>8x35mm Charged bullet K</label>
+    <graphicData>
+      <texPath>Kurin/Projectile/Charge_Rifle_Bullet/Texture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+	
+      <damageDef>Bullet</damageDef>
+      <speed>150</speed>
+      <damageAmountBase>18</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>8</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- concentrated bullets -->
+  <ThingDef Name="Bullet_8x35mmChargedK_AP" ParentName="Base8x35mmChargedBullet">
+    <defName>Bullet_8x35mmChargedK_AP</defName>
+    <label>8x35mm Charged bullet K (Conc.)</label>
+    <graphicData>
+      <texPath>Kurin/Projectile/Charge_Rifle_Bullet/Texture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>150</speed>
+      <damageAmountBase>14</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>4</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- ion bullets -->
+  <ThingDef Name="Bullet_8x35mmChargedK_Ion" ParentName="Base8x35mmChargedBullet">
+    <defName>Bullet_8x35mmChargedK_Ion</defName>
+    <label>8x35mm Charged bullet K (Ion)</label>
+    <graphicData>
+      <texPath>Kurin/Projectile/Charge_Rifle_Bullet/Texture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>150</speed>
+      <damageAmountBase>14</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>EMP</def>
+          <amount>12</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>22.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>57.6</armorPenetrationBlunt>
+      <empShieldBreakChance>0.2</empShieldBreakChance>
+    </projectile>
+  </ThingDef>
+		
+		</value>
+		</li>
+		
+		<!-- 12mmRailgunkurin -->
+		<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+		
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_12mmRailgunK</defName>
+		<label>12mm Railgun K</label>
+		<ammoTypes>
+			<Ammo_12mmRailgun_Sabot>Bullet_12mmRailgun_K_Sabot</Ammo_12mmRailgun_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef ParentName="BaseBullet">
+		<defName>Bullet_12mmRailgun_K_Sabot</defName>
+		<label>12mm Railgun bullet K (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Projectile/ChargeLanceShot</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>40</damageAmountBase>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
+			<armorPenetrationBlunt>500</armorPenetrationBlunt>
+			<speed>150</speed>
+		</projectile>
+	</ThingDef>
+		
+		</value>
+		</li>
+		
+		<!-- Surigum -->
+		<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+		
+  <ThingDef ParentName="BaseBullet">
+    <defName>Bullet_Kurin_Surigum_CE</defName>
+	<thingClass>CombatExtended.BulletCE</thingClass>
+    <label>Surigum</label>
+    <graphicData>
+      <texPath>Kurin/Projectile/Surigum_Bullet/Texture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+        <damageDef>RangedStab</damageDef>
+		<damageAmountBase>15</damageAmountBase>
+		<speed>20</speed>
+		<armorPenetrationBlunt>2.22</armorPenetrationBlunt>
+		<armorPenetrationSharp>1</armorPenetrationSharp>
+    </projectile>
+  </ThingDef>
+		
+		</value>
+		</li>
+		
+		<!-- Unmaker -->
+		<li Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+		
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_PlasmaCellHeavy_K</defName>
+		<label>Plasma Heavy Power Cell</label>
+		<ammoTypes>
+			<Ammo_PlasmaCellHeavy>Bullet_Unmakerblast_Standard</Ammo_PlasmaCellHeavy>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+	<ThingDef ParentName="BaseBullet">
+		<defName>Bullet_Unmakerblast_Standard</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
+		<label>Unmaker blast shell</label>
+    <graphicData>
+      <texPath>Kurin/Projectile/Unmaker_Bullet/Texture</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+		<damageDef>Kurin_Damage_Unmaker</damageDef>
+		<damageAmountBase>175</damageAmountBase>
+		<speed>90</speed>
+		<flyOverhead>false</flyOverhead>
+		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+		<explosionRadius>3.9</explosionRadius>
+    </projectile>
+	<comps>
+	<li Class="CombatExtended.CompProperties_ExplosiveCE">
+		<damageAmountBase>200</damageAmountBase>
+		<explosiveDamageType>EMP</explosiveDamageType>
+		<explosiveRadius>3.9</explosiveRadius>
+	  </li>
+	  </comps>
+  </ThingDef>
+		
+		</value>
+		</li>
+		
+		</operations>
+		</match>
+  </Operation>
+</Patch>

--- a/Patches/Kurin Deluxe Patch/ScenarioDef/Scenarios_DRNTF.xml
+++ b/Patches/Kurin Deluxe Patch/ScenarioDef/Scenarios_DRNTF.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+			<li>Kurin, The Three Tailed Fox [Deluxe Edition]</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- === Add ammo to scenario === -->
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/ScenarioDef[defName="Kurin_Scenario"]/scenario/parts</xpath>
+          <value>
+            <li Class="ScenPart_StartingThing_Defined">
+              <def>StartingThing_Defined</def>
+              <thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
+              <count>200</count>
+            </li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>
+

--- a/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Apparel.xml
+++ b/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Apparel.xml
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	  <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kurin, The Three Tailed Fox [Deluxe Edition]</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+		
+		<!--========= Underwear/On Skin =========-->
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Kurin_UnderwearBase" or @Name="Kurin_StockingBase"]/statBases</xpath>
+			<value>
+				<Bulk>0.5</Bulk>
+				<WornBulk>0.25</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Kurin_UnderwearBase" or @Name="Kurin_StockingBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="Kurin_ApparelBase"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Shirt" or 
+			defName="Kurin_OnSkin_T_Shirt" or
+			defName="Kurin_Legs_Shorts" or
+			defName="Kurin_Legs_Pants" or
+			defName="Kurin_OnSkin_Hot_Pants" or
+			defName="Kurin_OnSkin_Pajama_A" or
+			defName="Kurin_OnSkin_Pajama_B" or
+			defName="Kurin_OnSkin_Pajama_C" or
+			defName="Kurin_OnSkin_One_Piece_Dress" or
+			defName="Kurin_OnSkin_Open_Back_Knit" or
+			defName="Kurin_OnSkin_Open_Front_Knit" or
+			defName="Kurin_OnSkin_Open_Shoulder_Knit" or
+			defName="Kurin_OnSkin_Casual_Wear" or
+			defName="Kurin_Legs_Long_Skirt" or
+			defName="Kurin_Legs_Skirt" or
+			defName="Kurin_OnSkin_Hoodie"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Gothic_Dress" or 
+			defName="Kurin_OnSkin_Nun_Dress" or
+			defName="Kurin_OnSkin_Work_Jumpsuit" or
+			defName="Kurin_OnSkin_Traditional_Simple_Dress" or
+			defName="Kurin_OnSkin_Traditional_Fancy_Dress" or
+			defName="Kurin_OnSkin_Traditional_Luxury_Dress" or
+			defName="Kurin_OnSkin_Cute_Dress" or
+			defName="Kurin_OnSkin_Seductive_White_Dress" or
+			defName="Kurin_OnSkin_Seductive_Black_Dress"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kimiri_OnSkin_Short_Jumpsuit" or
+			defName="Kimiri_OnSkin_Swimsuit_Armor"
+			]/statBases</xpath>
+			<value>
+				<Bulk>10</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kimiri_OnSkin_Short_Jumpsuit" or
+			defName="Kimiri_OnSkin_Swimsuit_Armor"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<!--========= Onskin Armor =========-->
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress" or
+			defName="Kurin_OnSkin_Military_Uniform"
+			]/statBases</xpath>
+			<value>
+				<Bulk>20</Bulk>
+				<WornBulk>10</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress" or
+			defName="Kurin_OnSkin_Military_Uniform"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform" or
+			defName="Kurin_OnSkin_Spaceship_Crew_Suit"
+			]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>1.75</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Armored_Gothic_Dress"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>2.30</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform" or
+			defName="Kurin_OnSkin_Spaceship_Crew_Suit"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Military_Uniform" or
+			defName="Kurin_OnSkin_Spaceship_Crew_Suit"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>3.05</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"
+			]/statBases</xpath>
+			<value>
+				<Bulk>100</Bulk>
+				<WornBulk>15</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_OnSkin_Bikini_Armor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+			<value>
+				<MeleeDodgeChance>0.6</MeleeDodgeChance>
+			</value>
+		</li>
+
+		
+		<!--========= Hats =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Winter_Hat" or 
+			defName="Kurin_Overhead_Summer_Hat" or
+			defName="Kurin_Overhead_Cap" or
+			defName="Kurin_Overhead_Sunglasses" or
+			defName="Kurin_Overhead_Goggles" or
+			defName="Kurin_Overhead_Casual_Hair_Pin"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Gothic_Hair_Pin" or 
+			defName="Kurin_Overhead_Traditional_Hair_Pin" or
+			defName="Kurin_Overhead_Cute_Hair_Pin"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<!--========= Overhead Armor =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>4</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Goggles"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>6</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Bikini_Armor_Headgear" or
+			defName="Kurin_OnSkin_Spaceship_Crew_Suit"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>3</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet_A" or
+			defName="Kurin_Overhead_Military_Helmet_B"]/statBases</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>3</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet_A" or 
+			defName="Kurin_Overhead_Military_Helmet_B"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Overhead_Military_Helmet_A" or 
+			defName="Kurin_Overhead_Military_Helmet_B"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<AimingDelayFactor>-0.1</AimingDelayFactor>
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Middle_Scarf"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Middle_Scarf"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Power_Armor_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>20.4</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Power_Armor_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>50</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Heavy_Power_Armor_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>25</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Heavy_Power_Armor_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>60</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Power_Armor_Helmet" or
+			defName="Kurin_Heavy_Power_Armor_Helmet"]/statBases</xpath>
+			<value>
+				<Bulk>6</Bulk>
+				<WornBulk>2</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Power_Armor_Helmet" or
+			defName="Kurin_Heavy_Power_Armor_Helmet"]/statBases</xpath>
+			<value>
+				<NightVisionEfficiency_Apparel>0.8</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Power_Armor_Helmet" or
+			defName="Kurin_Heavy_Power_Armor_Helmet"]/equippedStatOffsets</xpath>
+			<value>
+				<AimingDelayFactor>-0.15</AimingDelayFactor>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Backpack_Civil"]/equippedStatOffsets/CarryingCapacity</xpath>
+			<value>
+				<CarryBulk>40</CarryBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Backpack_Military"]/equippedStatOffsets/CarryingCapacity</xpath>
+			<value>
+				<CarryBulk>60</CarryBulk>
+			</value>
+		</li>
+		
+
+		<!--========= Middle Apparel =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Middle_Body_Armor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+
+		<!--========= Middle_Heavy =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Middle_Heavy_Body_Armor"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<!--========= Shell Apparel =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
+			defName="Kurin_Shell_Duster" or
+			defName="Kurin_Shell_Winter_Padding"
+			]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Shell_Cardigan" or
+			defName="Kurin_Shell_Duster" or
+			defName="Kurin_Shell_Winter_Padding"
+			]/statBases</xpath>
+			<value>
+				<Bulk>7.5</Bulk>
+				<WornBulk>1</WornBulk>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Shell_Traditional_Coat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>6.25</StuffEffectMultiplierArmor>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Shell_Traditional_Coat"]/statBases</xpath>
+			<value>
+				<Bulk>7.5</Bulk>				
+				<WornBulk>1.5</WornBulk>
+			</value>
+		</li>
+		
+		<!--========= Power Armor =========-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>26</ArmorRating_Sharp>
+			</value>
+		</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Heavy_Power_Armor"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>30</ArmorRating_Sharp>
+			</value>
+		</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>64</ArmorRating_Blunt>
+			</value>
+		</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Heavy_Power_Armor"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>76</ArmorRating_Blunt>
+			</value>
+		</li>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor" or "Kurin_Heavy_Power_Armor"]/statBases</xpath>
+			<value>
+				<Bulk>45.5</Bulk>
+				<WornBulk>6.5</WornBulk>
+			</value>
+		</li>
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/KurinDeluxeEdition.PowerArmor.KurinPowerArmorThingDef[defName="Kurin_Power_Armor"
+			or "Kurin_Heavy_Power_Armor"
+			]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>120</CarryWeight>
+				<CarryBulk>20</CarryBulk>
+			</value>
+		</li>
+		
+		</operations>
+		</match>	
+  </Operation>
+</Patch>

--- a/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Weapon.xml
+++ b/Patches/Kurin Deluxe Patch/ThingDefs_Misc/DRNTF_Weapon.xml
@@ -1,0 +1,1015 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	  <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kurin, The Three Tailed Fox [Deluxe Edition]</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!--========= Rifle : K2 as a Basis =========-->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Assault_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.08</ShotSpread>
+				<SwayFactor>1.31</SwayFactor>
+				<Bulk>7.30</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+				<warmupTime>1.0</warmupTime>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+				<range>60</range>
+				<soundCast>Kurin_Sound_Assault_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>30</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_Rifle</li>
+			</weaponTags>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Heavy_Assault_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.07</ShotSpread>
+				<SwayFactor>1.60</SwayFactor>
+				<Bulk>8.30</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+				<range>58</range>
+				<soundCast>Kurin_Sound_Heavy_Assault_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>20</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_Rifle</li>
+			</weaponTags>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Sniper_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>2.0</SightsEfficiency>
+				<ShotSpread>0.04</ShotSpread>
+				<SwayFactor>1.60</SwayFactor>
+				<Bulk>8.30</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.53</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+				<warmupTime>1.4</warmupTime>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+				<range>75</range>
+				<soundCast>Kurin_Sound_Sniper_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			
+			<AmmoUser>
+				<magazineSize>20</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Auto_Shotgun</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+				<SightsEfficiency>1</SightsEfficiency>
+				<ShotSpread>0.14</ShotSpread>
+				<SwayFactor>1.49</SwayFactor>
+				<Bulk>10.66</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>2.26</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<range>18</range>
+				<soundCast>Kurin_Sound_Auto_Shotgun</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>10</magazineSize>
+				<reloadTime>4.9</reloadTime>
+				<ammoSet>AmmoSet_12Gauge</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Heavy_Sniper_Rifle</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.80</RangedWeapon_Cooldown>
+				<SightsEfficiency>2.5</SightsEfficiency>
+				<ShotSpread>0.02</ShotSpread>
+				<SwayFactor>1.92</SwayFactor>
+				<Bulk>13.00</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>2.00</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+				<warmupTime>3.2</warmupTime>
+				<range>86</range>
+				<soundCast>Kurin_Sound_Heavy_Sniper_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>10</magazineSize>
+				<reloadTime>4.3</reloadTime>
+				<ammoSet>AmmoSet_50BMG</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Heavy_Sniper_Rifle_HE</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.80</RangedWeapon_Cooldown>
+				<SightsEfficiency>2.5</SightsEfficiency>
+				<ShotSpread>0.02</ShotSpread>
+				<SwayFactor>1.92</SwayFactor>
+				<Bulk>13.00</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.60</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_127x108mm_FMJ</defaultProjectile>
+				<warmupTime>3.2</warmupTime>
+				<range>86</range>
+				<soundCast>Kurin_Sound_Heavy_Sniper_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>10</magazineSize>
+				<reloadTime>4.3</reloadTime>
+				<ammoSet>AmmoSet_127x108mm</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Hunting_Shotgun</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				<SightsEfficiency>1</SightsEfficiency>
+				<ShotSpread>0.10</ShotSpread>
+				<SwayFactor>1.36</SwayFactor>
+				<Bulk>8.25</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.80</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+				<warmupTime>0.6</warmupTime>
+				<range>16</range>
+				<soundCast>Kurin_Sound_Hunting_Shotgun</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>2</magazineSize>
+				<reloadOneAtATime>true</reloadOneAtATime>
+					<reloadTime>1</reloadTime>
+				<ammoSet>AmmoSet_12Gauge</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Heavy_SMG</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.17</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>4.90</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>0.90</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_545x39mmSoviet_AP</defaultProjectile>
+				<warmupTime>0.8</warmupTime>
+				<range>32</range>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+				<soundCast>Kurin_Sound_Heavy_SMG</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>30</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+			</FireModes>
+			<weaponTags>
+				<li>CE_SMG</li>
+			</weaponTags>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Pistol</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+				<SightsEfficiency>0.70</SightsEfficiency>
+				<ShotSpread>0.17</ShotSpread>
+				<SwayFactor>0.90</SwayFactor>
+				<Bulk>2.08</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>0.60</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+				<warmupTime>0.5</warmupTime>
+				<range>12</range>
+				<soundCast>Kurin_Sound_Pistol</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>20</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+			</weaponTags>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Charge_LMG</defName>
+			<statBases>
+				<SightsEfficiency>1.1</SightsEfficiency>
+				<ShotSpread>0.08</ShotSpread>
+				<SwayFactor>1.50</SwayFactor>
+				<Bulk>11.00</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.2</recoilAmount>					
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>70</range>
+				<burstShotCount>10</burstShotCount>
+				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+				<soundCast>Kurin_Sound_Charge_LMG</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>200</magazineSize>
+				<reloadTime>6</reloadTime>
+				<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>5</aimedBurstShotCount>
+				<aiUseBurstMode>True</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_MachineGun</li>
+				<li>CE_AI_Suppressive</li>
+				<li>AdvancedGun</li>
+			</weaponTags>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Charge_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>1.2</SightsEfficiency>
+				<ShotSpread>0.06</ShotSpread>
+				<SwayFactor>1.30</SwayFactor>
+				<Bulk>9.60</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.3</recoilAmount>					
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_8x35mmChargedK</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>62</range>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+				<soundCast>Kurin_Sound_Charge_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>36</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_8x35mmChargedK</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aimedBurstShotCount>3</aimedBurstShotCount>
+				<aiUseBurstMode>True</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_AssaultWeapon</li>
+				<li>AdvancedGun</li>
+			</weaponTags>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Sniper_Charge_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>3.0</SightsEfficiency>
+				<ShotSpread>0.01</ShotSpread>
+				<SwayFactor>2.08</SwayFactor>
+				<Bulk>12.00</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.3</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>86</range>
+				<soundCast>Kurin_Sound_Sniper_Charge_Rifle</soundCast>
+				<muzzleFlashScale>9</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>15</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_12x72mmCharged</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_Rifle</li>
+				<li>SniperRifle</li>
+				<li>AdvancedGun</li>
+			</weaponTags>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Flamethrower</defName>
+		<statBases>
+			<SwayFactor>2.10</SwayFactor>
+			<ShotSpread>3.00</ShotSpread>
+			<SightsEfficiency>0.65</SightsEfficiency>
+			<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+		</statBases>
+		<Properties>
+			<recoilAmount>0.55</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
+			<burstShotCount>10</burstShotCount>
+			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+			<warmupTime>1.3</warmupTime>
+			<range>25</range>
+			<minRange>3</minRange>
+			<soundCast>Kurin_Sound_Flamethrower</soundCast>
+			<muzzleFlashScale>12</muzzleFlashScale>
+			<targetParams>
+			<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>200</magazineSize>
+			<reloadTime>6.6</reloadTime>
+			<ammoSet>AmmoSet_Flamethrower</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiAimMode>SuppressFire</aiAimMode>
+			<aimedBurstShotCount>5</aimedBurstShotCount>
+			<noSingleShot>True</noSingleShot>
+		</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Gauss_Rifle</defName>
+			<statBases>
+				<SightsEfficiency>3.5</SightsEfficiency>
+				<ShotSpread>0.01</ShotSpread>
+				<SwayFactor>1.95</SwayFactor>
+				<Bulk>12.00</Bulk>
+				<RangedWeapon_Cooldown>1.10</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>2.00</recoilAmount>			
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_12mmRailgun_K_Sabot</defaultProjectile>
+				<warmupTime>1.5</warmupTime>
+				<range>86</range>
+				<soundCast>Kurin_Sound_Gauss_Rifle</soundCast>
+				<muzzleFlashScale>15</muzzleFlashScale>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>5</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_12mmRailgunK</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_AI_Rifle</li>
+				<li>SniperRifle</li>
+				<li>AdvancedGun</li>
+			</weaponTags>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Special_Rocket_Launcher</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+				<SightsEfficiency>2.16</SightsEfficiency>
+				<ShotSpread>0.2</ShotSpread>
+				<SwayFactor>1.68</SwayFactor>
+				<Bulk>10.50</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>2.0</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_RPG32Rocket_HEAT</defaultProjectile>
+				<warmupTime>2.5</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Rocket_Launcher</soundCast>
+				<muzzleFlashScale>15</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>1</magazineSize>
+				<reloadTime>8.4</reloadTime>
+				<ammoSet>AmmoSet_RPG32Rocket</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Special_Rocket_Launcher_Typhoon</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.5</SightsEfficiency>
+				<ShotSpread>0.2</ShotSpread>
+				<SwayFactor>1.68</SwayFactor>
+				<Bulk>10.50</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>2.0</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_RPG32Rocket_HEAT</defaultProjectile>
+				<warmupTime>2.5</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Rocket_Launcher_Various</soundCast>
+				<muzzleFlashScale>15</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>4</magazineSize>
+				<reloadTime>12.6</reloadTime>
+				<ammoSet>AmmoSet_RPG32Rocket</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Unmaker</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.50</RangedWeapon_Cooldown>
+				<SightsEfficiency>2.5</SightsEfficiency>
+				<ShotSpread>0.01</ShotSpread>
+				<SwayFactor>1.0</SwayFactor>
+				<Bulk>10.50</Bulk>
+			</statBases>
+			<Properties>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_Unmakerblast_Standard</defaultProjectile>
+				<warmupTime>1.3</warmupTime>
+				<ammoConsumedPerShotCount>2</ammoConsumedPerShotCount>
+				<range>86</range>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Unmaker</soundCast>
+				<muzzleFlashScale>15</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>8</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_PlasmaCellHeavy_K</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>SuppressFire</aiAimMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Grenade_Launcher</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.10</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>7.31</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>42</range>
+						<minRange>3</minRange>
+				<burstShotCount>6</burstShotCount>
+				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+				<onlyManualCast>true</onlyManualCast>
+				<stopBurstWithoutLos>false</stopBurstWithoutLos>
+				<soundCast>Kurin_Sound_Grenade_Launcher</soundCast>
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<AmmoUser>
+				<magazineSize>12</magazineSize>
+				<reloadTime>4</reloadTime>
+				<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>SuppressFire</aiAimMode>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Grenade_Launcher_IM</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.16</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>7.31</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_30x64mmFuel_Incendiary</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Grenade_Launcher</soundCast>
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<FireModes>
+				<aiAimMode>SuppressFire</aiAimMode>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Grenade_Launcher_EMPM</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.16</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>7.31</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_40x46mmGrenade_EMP</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Grenade_Launcher</soundCast>
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<FireModes>
+				<aiAimMode>SuppressFire</aiAimMode>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Grenade_Launcher_FEM</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.16</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>7.31</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_30x64mmFuel_Foam</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Grenade_Launcher</soundCast>
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<FireModes>
+				<aiAimMode>SuppressFire</aiAimMode>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Grenade_Launcher_SM</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+				<SightsEfficiency>1.00</SightsEfficiency>
+				<ShotSpread>0.16</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>7.31</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_40x46mmGrenade_Smoke</defaultProjectile>
+				<warmupTime>1.2</warmupTime>
+				<range>40</range>
+				<minRange>3</minRange>
+				<onlyManualCast>true</onlyManualCast>
+				<soundCast>Kurin_Sound_Grenade_Launcher</soundCast>
+				<muzzleFlashScale>14</muzzleFlashScale>
+				<targetParams>
+					<canTargetLocations>true</canTargetLocations>
+				</targetParams>
+			</Properties>
+			<FireModes>
+				<aiAimMode>SuppressFire</aiAimMode>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+			</FireModes>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Gun_Assault_Rifle" or 
+			defName="Kurin_Gun_Heavy_Assault_Rifle" or
+			defName="Kurin_Gun_Auto_Shotgun" or
+			defName="Kurin_Gun_Heavy_Sniper_Rifle" or
+			defName="Kurin_Gun_Heavy_Sniper_Rifle_HE" or
+			defName="Kurin_Gun_Hunting_Shotgun" or
+			defName="Kurin_Gun_Heavy_SMG" or
+			defName="Kurin_Gun_Pistol" or
+			defName="Kurin_Gun_Charge_LMG" or
+			defName="Kurin_Gun_Charge_Rifle" or
+			defName="Kurin_Gun_Sniper_Charge_Rifle" or
+			defName="Kurin_Gun_Flamethrower" or
+			defName="Kurin_Gun_Gauss_Rifle" or
+			defName="Kurin_Special_Rocket_Launcher" or
+			defName="Kurin_Special_Rocket_Launcher_Typhoon" or
+			defName="Kurin_Gun_Unmaker" or
+			defName="Kurin_Gun_Sniper_Rifle"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+					<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>barrel</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Kurin_GrenadeLauncherBase"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+					<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>barrel</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.02</cooldownTime>
+						<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Katana" or defName="Kimiri_MeleeWeapon_Katana"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>handle</label>
+						<capacities>
+							<li>Poke</li>
+						</capacities>
+						<power>3</power>
+						<cooldownTime>0.80</cooldownTime>
+						<chanceFactor>0.10</chanceFactor>
+						<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>point</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>15</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.50</chanceFactor>
+						<armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.4</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>edge</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>31</power>
+						<cooldownTime>1.5</cooldownTime>
+						<chanceFactor>0.50</chanceFactor>
+						<armorPenetrationBlunt>3.8</armorPenetrationBlunt>
+						<armorPenetrationSharp>0.8</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/tools</xpath>
+			<value>
+				<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>edge</label>
+							<capacities>
+							<li>Cut</li>
+							</capacities>
+							<power>47</power>
+							<cooldownTime>2.5</cooldownTime>
+							<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
+							<armorPenetrationSharp>0.4</armorPenetrationSharp>
+							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+						</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Katana" or defName="Kimiri_MeleeWeapon_Katana"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>1.5</MeleeCritChance>
+					<MeleeParryChance>0.45</MeleeParryChance>
+					<MeleeDodgeChance>0.45</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/equippedStatOffsets</xpath>
+			<value>
+				<MeleeCritChance>0.08</MeleeCritChance>
+				<MeleeParryChance>0.5</MeleeParryChance>
+				<MeleeDodgeChance>0.5</MeleeDodgeChance>
+			</value>
+		</li>
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Kurin_Gun_Surigum</defName>
+			<statBases>
+				<SightsEfficiency>0.50</SightsEfficiency>
+				<ShotSpread>0.15</ShotSpread>
+				<SwayFactor>1.0</SwayFactor>
+				<Bulk>2.00</Bulk>
+				<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.50</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_Kurin_Surigum_CE</defaultProjectile>
+				<warmupTime>0.3</warmupTime>
+				<range>15</range>
+				<soundCast>ThrowGrenade</soundCast>
+				<muzzleFlashScale>0</muzzleFlashScale>
+			</Properties>
+			<FireModes>
+				<aiUseBurstMode>TRUE</aiUseBurstMode>
+				<aiAimMode>Snapshot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>CE_OneHandedWeapon</li>
+			</weaponTags>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<MeleeCritChance>0.5</MeleeCritChance>
+					<MeleeParryChance>0.15</MeleeParryChance>
+					<MeleeDodgeChance>0.05</MeleeDodgeChance>	
+				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Kurin_Gun_Surigum"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>blade</label>
+						<capacities>
+							<li>Cut</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>0.5</cooldownTime>
+						<armorPenetrationBlunt>4.44</armorPenetrationBlunt>
+						<armorPenetrationSharp>1</armorPenetrationSharp>
+						<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Ceremonial_Sword"]/statBases</xpath>
+			<value>
+				<Bulk>20.00</Bulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Kurin_MeleeWeapon_Katana" or defName="Kimiri_MeleeWeapon_Katana"]/statBases</xpath>
+			<value>
+				<Bulk>5.00</Bulk>
+			</value>
+		</li>
+		
+		<!--========= Turret =========-->
+		
+		<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>Gun_Kurin_Ship_Turret</defName>
+			<statBases>
+				<RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
+				<SightsEfficiency>1</SightsEfficiency>
+				<ShotSpread>0.01</ShotSpread>
+				<SwayFactor>1.00</SwayFactor>
+				<Bulk>40.00</Bulk>
+			</statBases>
+			<Properties>
+				<recoilAmount>1.00</recoilAmount>
+				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<defaultProjectile>Bullet_Unmakerblast_Standard</defaultProjectile>
+				<warmupTime>1.5</warmupTime>
+				<range>86</range>
+				<soundCast>Kurin_Sound_Unmaker</soundCast>
+				<soundCastTail>GunTail_Heavy</soundCastTail>
+				<muzzleFlashScale>12</muzzleFlashScale>
+				<recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<FireModes>
+				<aiUseBurstMode>FALSE</aiUseBurstMode>
+				<aiAimMode>AimedShot</aiAimMode>
+			</FireModes>
+			<weaponTags>
+				<li>TurretGun</li>
+			</weaponTags>
+		</li>
+			
+		</operations>
+		</match>	
+  </Operation>
+</Patch>

--- a/Patches/Kurin Deluxe Patch/ThingDefs_Races/Race_DRNTF.xml
+++ b/Patches/Kurin Deluxe Patch/ThingDefs_Races/Race_DRNTF.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Kurin, The Three Tailed Fox [Deluxe Edition]</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]</xpath>
+				<value>
+					<comps/>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]</xpath>
+				<value>
+				</value>
+			</match>
+		</li>
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]/comps</xpath>
+			<value>
+				<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+				</li>
+				<li Class="CombatExtended.CompProperties_Suppressable" />
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin" or defName="Kimiri"]/statBases</xpath>
+			<value>
+				<MeleeDodgeChance>1</MeleeDodgeChance>
+				<MeleeCritChance>1</MeleeCritChance>
+				<MeleeParryChance>1</MeleeParryChance>
+				<Suppressability>1</Suppressability>
+				<SmokeSensitivity>1</SmokeSensitivity>
+			</value>
+		</li>
+	
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kurin"]/tools</xpath> 
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>0.5</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>0.5</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>2.14</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationSharp>0.01</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.245</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>2</power>
+						<cooldownTime>2.49</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationBlunt>1.625</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Kimiri"]/tools</xpath> 
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>0.5</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>1</power>
+						<cooldownTime>0.5</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>teeth</label>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>2.14</cooldownTime>
+						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+						<chanceFactor>0.2</chanceFactor>
+						<armorPenetrationSharp>0.01</armorPenetrationSharp>
+						<armorPenetrationBlunt>0.245</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>tail</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>3</cooldownTime>
+						<linkedBodyPartsGroup>Kimiri_Tail</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationBlunt>2.625</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>left horn</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>2</cooldownTime>
+						<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationSharp>2.01</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.245</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right horn</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>2</cooldownTime>
+						<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
+						<chanceFactor>0.5</chanceFactor>
+						<armorPenetrationSharp>2.01</armorPenetrationSharp>
+						<armorPenetrationBlunt>2.245</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+			
+		</operations>
+		</match>
+  </Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -243,6 +243,7 @@ Kit's Roman Weapons |
 Kit's VFE Weapons |
 Kobolds of the Rim  |
 Kurin, The Three Tailed Fox	|
+Kurin, The Three Tailed Fox [Deluxe Edition]    |
 Leeani Playable Race	|
 Lemolim Race    |
 Let's Have a Cat!	|


### PR DESCRIPTION
Some assorted tweaks and adjustments for the 4.9 release.
- Adjust the mass and bulk of the molotov to be appropriate for a 12 oz glass bottle. Also adjust the radius based on an appropriate amount of filler.
- Add patch for Kurin Deluxe edition. Patch originally from #1820, plus a few adjustments and fixes that PR needed. Since it was on the patch author's fork, it was more expedient to move over to work on here.
- Increment version number from 4.8 to 4.9.
- Increase Cannon Ball bursting shell damage and frag count; I had miscalculated the filler volume on the sheet the first time.
- Adjusted the 155mm HE shells according to the sheet as well.