### PR TITLE
Magazine stats display and 20/25mm airburst grenades

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -15,6 +15,7 @@
     <label>20x42mm Grenades</label>
     <ammoTypes>
     	<Ammo_20x42mmGrenade_HE>Bullet_20x42mmGrenade_HE</Ammo_20x42mmGrenade_HE>
+		<Ammo_20x42mmGrenade_HEAB>Bullet_20x42mmGrenade_HEAB</Ammo_20x42mmGrenade_HEAB>
     	<Ammo_20x42mmGrenade_EMP>Bullet_20x42mmGrenade_EMP</Ammo_20x42mmGrenade_EMP>
 		<Ammo_20x42mmGrenade_Smoke>Bullet_20x42mmGrenade_Smoke</Ammo_20x42mmGrenade_Smoke>	      
     </ammoTypes>
@@ -51,6 +52,20 @@
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_20x42mmGrenade_HE</detonateProjectile>
+  </ThingDef>  
+  
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
+    <defName>Ammo_20x42mmGrenade_HEAB</defName>
+    <label>20x42mm grenade (HEAB)</label>
+    <graphicData>
+      <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>2.31</MarketValue>
+    </statBases>
+    <ammoClass>GrenadeHETF</ammoClass>
+	<detonateProjectile>Bullet_20x42mmGrenade_HEAB</detonateProjectile>
   </ThingDef>  
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
@@ -134,6 +149,27 @@
 		  </li>
 		</comps>
 	</ThingDef>
+	
+	<ThingDef ParentName="Base20x42mmGrenadeBullet">
+		<defName>Bullet_20x42mmGrenade_HEAB</defName>
+		<label>20mm grenade (HEAB)</label>
+		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>15</damageAmountBase>
+			<explosionRadius>0.5</explosionRadius>
+			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			<aimHeightOffset>0.4</aimHeightOffset>
+			<armingDelay>2</armingDelay>
+		</projectile>
+		<comps>
+		  <li Class="CombatExtended.CompProperties_Fragments">
+			<fragments>
+			  <Fragment_Small>33</Fragment_Small>
+			</fragments>
+		  </li>
+		</comps>
+	</ThingDef>
 		
 	<ThingDef ParentName="Base20x42mmGrenadeBullet">
 		<defName>Bullet_20x42mmGrenade_EMP</defName>
@@ -201,6 +237,50 @@
       <Ammo_20x42mmGrenade_HE>100</Ammo_20x42mmGrenade_HE>
     </products>
     <workAmount>5800</workAmount>    
+  </RecipeDef>
+  
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
+    <defName>MakeAmmo_20x42mmGrenade_HEAB</defName>
+    <label>make 20x42mm HEAB grenades x100</label>
+    <description>Craft 100 20x42mm HEAB grenades.</description>
+    <jobString>Making 20x42mm HEAB grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>24</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_20x42mmGrenade_HEAB>100</Ammo_20x42mmGrenade_HEAB>
+    </products>
+    <workAmount>6800</workAmount>    
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -15,7 +15,7 @@
     <label>20x42mm Grenades</label>
     <ammoTypes>
     	<Ammo_20x42mmGrenade_HE>Bullet_20x42mmGrenade_HE</Ammo_20x42mmGrenade_HE>
-		<Ammo_20x42mmGrenade_HEAB>Bullet_20x42mmGrenade_HEAB</Ammo_20x42mmGrenade_HEAB>
+		<Ammo_20x42mmGrenade_HE_TFuzed>Bullet_20x42mmGrenade_HE_TFuzed</Ammo_20x42mmGrenade_HE_TFuzed>
     	<Ammo_20x42mmGrenade_EMP>Bullet_20x42mmGrenade_EMP</Ammo_20x42mmGrenade_EMP>
 		<Ammo_20x42mmGrenade_Smoke>Bullet_20x42mmGrenade_Smoke</Ammo_20x42mmGrenade_Smoke>	      
     </ammoTypes>
@@ -55,8 +55,8 @@
   </ThingDef>  
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
-    <defName>Ammo_20x42mmGrenade_HEAB</defName>
-    <label>20x42mm grenade (HEAB)</label>
+    <defName>Ammo_20x42mmGrenade_HE_TFuzed</defName>
+    <label>20x42mm grenade (HE-Airburst)</label>
     <graphicData>
       <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -65,7 +65,7 @@
       <MarketValue>2.31</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
-	<detonateProjectile>Bullet_20x42mmGrenade_HEAB</detonateProjectile>
+	<detonateProjectile>Bullet_20x42mmGrenade_HE</detonateProjectile>
   </ThingDef>  
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
@@ -151,8 +151,8 @@
 	</ThingDef>
 	
 	<ThingDef ParentName="Base20x42mmGrenadeBullet">
-		<defName>Bullet_20x42mmGrenade_HEAB</defName>
-		<label>20mm grenade (HEAB)</label>
+		<defName>Bullet_20x42mmGrenade_HE_TFuzed</defName>
+		<label>20mm grenade (HE-Airburst)</label>
 		<thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
@@ -240,10 +240,10 @@
   </RecipeDef>
   
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_20x42mmGrenade_HEAB</defName>
-    <label>make 20x42mm HEAB grenades x100</label>
-    <description>Craft 100 20x42mm HEAB grenades.</description>
-    <jobString>Making 20x42mm HEAB grenades.</jobString>
+    <defName>MakeAmmo_20x42mmGrenade_HE_TFuzed</defName>
+    <label>make 20x42mm HE-Airburst grenades x100</label>
+    <description>Craft 100 20x42mm HE-Airburst grenades.</description>
+    <jobString>Making 20x42mm HE-Airburst grenades.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -278,7 +278,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_20x42mmGrenade_HEAB>100</Ammo_20x42mmGrenade_HEAB>
+      <Ammo_20x42mmGrenade_HE_TFuzed>100</Ammo_20x42mmGrenade_HE_TFuzed>
     </products>
     <workAmount>6800</workAmount>    
   </RecipeDef>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -15,6 +15,7 @@
     <label>25x40mm Grenades</label>
     <ammoTypes>
       <Ammo_25x40mmGrenade_HE>Bullet_25x40mmGrenade_HE</Ammo_25x40mmGrenade_HE>
+	  <Ammo_25x40mmGrenade_HEAB>Bullet_25x40mmGrenade_HEAB</Ammo_25x40mmGrenade_HEAB>
       <Ammo_25x40mmGrenade_EMP>Bullet_25x40mmGrenade_EMP</Ammo_25x40mmGrenade_EMP>
 	  <Ammo_25x40mmGrenade_Smoke>Bullet_25x40mmGrenade_Smoke</Ammo_25x40mmGrenade_Smoke>	      
     </ammoTypes>
@@ -51,6 +52,20 @@
       <MarketValue>1.81</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
+	<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
+  </ThingDef>
+  
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="25x40mmGrenadeBase">
+    <defName>Ammo_25x40mmGrenade_HEAB</defName>
+    <label>25x40mm grenade (HEAB)</label>
+    <graphicData>
+      <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>2.88</MarketValue>
+    </statBases>
+    <ammoClass>GrenadeHETF</ammoClass>
 	<detonateProjectile>Bullet_25x40mmGrenade_HE</detonateProjectile>
   </ThingDef>
 
@@ -135,6 +150,27 @@
       </li>
     </comps>
   </ThingDef>
+  
+    <ThingDef ParentName="Base25x40mmGrenadeBullet">
+    <defName>Bullet_25x40mmGrenade_HEAB</defName>
+    <label>25mm grenade HEAB</label>
+    <thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bomb</damageDef>
+      <damageAmountBase>17</damageAmountBase>
+      <explosionRadius>1</explosionRadius>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+	  <aimHeightOffset>0.5</aimHeightOffset>
+	  <armingDelay>2</armingDelay>
+    </projectile>
+    <comps>
+      <li Class="CombatExtended.CompProperties_Fragments">
+        <fragments>
+          <Fragment_Small>39</Fragment_Small>
+        </fragments>
+      </li>
+    </comps>
+  </ThingDef>
 
   <ThingDef ParentName="Base25x40mmGrenadeBullet">
     <defName>Bullet_25x40mmGrenade_EMP</defName>
@@ -203,6 +239,51 @@
     </products>
 	<workAmount>6400</workAmount>
   </RecipeDef>
+  
+    <RecipeDef ParentName="LauncherAmmoRecipeBase">
+    <defName>MakeAmmo_25x40mmGrenade_HEAB</defName>
+    <label>make 25x40mm HEAB grenades x100</label>
+    <description>Craft 100 25x40mm HEAB grenades.</description>
+    <jobString>Making 25x40mm HEAB grenades.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>30</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_25x40mmGrenade_HEAB>100</Ammo_25x40mmGrenade_HEAB>
+    </products>
+	<workAmount>8000</workAmount>
+  </RecipeDef>
+
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_25x40mmGrenade_EMP</defName>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -15,7 +15,7 @@
     <label>25x40mm Grenades</label>
     <ammoTypes>
       <Ammo_25x40mmGrenade_HE>Bullet_25x40mmGrenade_HE</Ammo_25x40mmGrenade_HE>
-	  <Ammo_25x40mmGrenade_HEAB>Bullet_25x40mmGrenade_HEAB</Ammo_25x40mmGrenade_HEAB>
+	  <Ammo_25x40mmGrenade_HE_TFuzed>Bullet_25x40mmGrenade_HE_TFuzed</Ammo_25x40mmGrenade_HE_TFuzed>
       <Ammo_25x40mmGrenade_EMP>Bullet_25x40mmGrenade_EMP</Ammo_25x40mmGrenade_EMP>
 	  <Ammo_25x40mmGrenade_Smoke>Bullet_25x40mmGrenade_Smoke</Ammo_25x40mmGrenade_Smoke>	      
     </ammoTypes>
@@ -56,8 +56,8 @@
   </ThingDef>
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="25x40mmGrenadeBase">
-    <defName>Ammo_25x40mmGrenade_HEAB</defName>
-    <label>25x40mm grenade (HEAB)</label>
+    <defName>Ammo_25x40mmGrenade_HE_TFuzed</defName>
+    <label>25x40mm grenade (HE-Airburst)</label>
     <graphicData>
       <texPath>Things/Ammo/GrenadeLauncher/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -152,8 +152,8 @@
   </ThingDef>
   
     <ThingDef ParentName="Base25x40mmGrenadeBullet">
-    <defName>Bullet_25x40mmGrenade_HEAB</defName>
-    <label>25mm grenade HEAB</label>
+    <defName>Bullet_25x40mmGrenade_HE_TFuzed</defName>
+    <label>25mm grenade (HE-Airburst)</label>
     <thingClass>CombatExtended.ProjectileCE_Bursting</thingClass>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
@@ -241,10 +241,10 @@
   </RecipeDef>
   
     <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_25x40mmGrenade_HEAB</defName>
-    <label>make 25x40mm HEAB grenades x100</label>
-    <description>Craft 100 25x40mm HEAB grenades.</description>
-    <jobString>Making 25x40mm HEAB grenades.</jobString>
+    <defName>MakeAmmo_25x40mmGrenade_HE_TFuzed</defName>
+    <label>make 25x40mm HE-Airburst grenades x100</label>
+    <description>Craft 100 25x40mm HE-Airburst grenades.</description>
+    <jobString>Making 25x40mm HE-Airburst grenades.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -279,7 +279,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_25x40mmGrenade_HEAB>100</Ammo_25x40mmGrenade_HEAB>
+      <Ammo_25x40mmGrenade_HE_TFuzed>100</Ammo_25x40mmGrenade_HE_TFuzed>
     </products>
 	<workAmount>8000</workAmount>
   </RecipeDef>

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -185,7 +185,7 @@
   <StatDef>
     <defName>MagazineCapacity</defName>
     <workerClass>CombatExtended.StatWorker_Magazine</workerClass>
-    <label>magazine capacity</label>
+    <label>magazine capacity / reload time</label>
     <description>How many projectiles this weapon's magazine holds and how long it takes to reload it.</description>
     <category>Weapon</category>
     <showIfUndefined>true</showIfUndefined>
@@ -202,6 +202,7 @@
     <description>How long should this weapon take to reload.</description>
     <category>Weapon</category>
     <showIfUndefined>false</showIfUndefined>
+	<alwaysHide>true</alwaysHide>
     <displayPriorityInCategory>897</displayPriorityInCategory>
     <defaultBaseValue>1</defaultBaseValue>
     <parts>

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -185,7 +185,7 @@
   <StatDef>
     <defName>MagazineCapacity</defName>
     <workerClass>CombatExtended.StatWorker_Magazine</workerClass>
-    <label>magazine capacity / reload time</label>
+    <label>magazine capacity</label>
     <description>How many projectiles this weapon's magazine holds and how long it takes to reload it.</description>
     <category>Weapon</category>
     <showIfUndefined>true</showIfUndefined>

--- a/Defs/Stats/Stats_Weapons_Ranged.xml
+++ b/Defs/Stats/Stats_Weapons_Ranged.xml
@@ -202,7 +202,7 @@
     <description>How long should this weapon take to reload.</description>
     <category>Weapon</category>
     <showIfUndefined>false</showIfUndefined>
-	<alwaysHide>true</alwaysHide>
+    <alwaysHide>true</alwaysHide>
     <displayPriorityInCategory>897</displayPriorityInCategory>
     <defaultBaseValue>1</defaultBaseValue>
     <parts>
@@ -216,8 +216,8 @@
     <label>ammo consumed per shot</label>
     <description>How many units of ammunition this gun consumes for each individual shot.\n\nThis applies to guns with multiple barrels that fire simultaneously with each pull of the trigger, or exotic energy weapons that use up different amounts of energy from a power cell.</description>
     <category>Weapon</category>
-      <showIfUndefined>true</showIfUndefined>
-	  <displayPriorityInCategory>877</displayPriorityInCategory>
+    <showIfUndefined>true</showIfUndefined>
+    <displayPriorityInCategory>877</displayPriorityInCategory>
   </StatDef>
 
 </Defs>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -8,7 +8,5 @@
     <CE_MassEffect>Carried weight:</CE_MassEffect>
     <CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier: </CE_StatsReport_WeaponToughness_StuffEffect>
     <CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect: </CE_StatsReport_WeaponToughness_HolderEffect>
-	
-	<Rounds>rnds</Rounds>
 
 </LanguageData>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -9,6 +9,6 @@
     <CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier: </CE_StatsReport_WeaponToughness_StuffEffect>
     <CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect: </CE_StatsReport_WeaponToughness_HolderEffect>
 	
-	<Rounds>Rounds</Rounds>
+	<Rounds>rounds</Rounds>
 
 </LanguageData>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -9,6 +9,6 @@
     <CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier: </CE_StatsReport_WeaponToughness_StuffEffect>
     <CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect: </CE_StatsReport_WeaponToughness_HolderEffect>
 	
-	<Rounds>rounds</Rounds>
+	<Rounds>rnds</Rounds>
 
 </LanguageData>

--- a/Languages/English/Keyed/Stats.xml
+++ b/Languages/English/Keyed/Stats.xml
@@ -8,5 +8,7 @@
     <CE_MassEffect>Carried weight:</CE_MassEffect>
     <CE_StatsReport_WeaponToughness_StuffEffect>Additional material toughness multiplier: </CE_StatsReport_WeaponToughness_StuffEffect>
     <CE_StatsReport_WeaponToughness_HolderEffect>Wielder skill effect: </CE_StatsReport_WeaponToughness_HolderEffect>
+	
+	<Rounds>Rounds</Rounds>
 
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -55,7 +55,7 @@ namespace CombatExtended
             else
             {
                 var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return GetMagSize(optionalReq).ToString() + " " + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                return GetMagSize(optionalReq).ToString() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -50,7 +50,7 @@ namespace CombatExtended
             if (!optionalReq.HasThing)
             {
                 var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return ammoProps.magazineSize.ToString() + " " + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                return ammoProps.magazineSize.ToString() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
             else
             {

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -50,12 +50,12 @@ namespace CombatExtended
             if (!optionalReq.HasThing)
             {
                 var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return ammoProps.magazineSize.ToString() + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                return ammoProps.magazineSize.ToString() + " " + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
             else
             {
                 var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return GetMagSize(optionalReq).ToString() + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                return GetMagSize(optionalReq).ToString() + " " + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -50,14 +50,12 @@ namespace CombatExtended
             if (!optionalReq.HasThing)
             {
                 var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return ammoProps.magazineSize.ToString();
-                //+ " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                return ammoProps.magazineSize.ToString() + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
             else
             {
-                //var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
-                return GetMagSize(optionalReq).ToString();
-                //" / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
+                var ammoProps = GunDef(optionalReq)?.GetCompProperties<CompProperties_AmmoUser>();
+                return GetMagSize(optionalReq).ToString() + "Rounds".Translate() + " / " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate();
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -39,9 +39,9 @@ namespace CombatExtended
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
         {            
             StringBuilder stringBuilder = new StringBuilder();
-            //var ammoProps = GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>();
+            var ammoProps = GunDef(req)?.GetCompProperties<CompProperties_AmmoUser>();
             stringBuilder.AppendLine("CE_MagazineSize".Translate() + ": " + GenText.ToStringByStyle(GetMagSize(req), ToStringStyle.Integer));
-            //stringBuilder.AppendLine("CE_ReloadTime".Translate() + ": " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate());
+            stringBuilder.AppendLine("CE_ReloadTime".Translate() + ": " + GenText.ToStringByStyle((ammoProps.reloadTime), ToStringStyle.FloatTwo) + " " + "LetterSecond".Translate());
             return stringBuilder.ToString().TrimEndNewlines();
         }
 


### PR DESCRIPTION
## Additions

20x42mm and 25x40mm airburst grenades.

## Changes

Re-added single line magazine size / reload time stat display on weapons stats window

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #1843 


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
