### PR TITLE
Add .410 bore and .38/.357 Ammo Sets

### DIFF
--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -21,6 +21,20 @@
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_357Magnum_Revolver</defName>
+		<label>.357 Magnum</label>
+		<ammoTypes>
+			<Ammo_357Magnum_FMJ>Bullet_357Magnum_FMJ</Ammo_357Magnum_FMJ>
+			<Ammo_357Magnum_AP>Bullet_357Magnum_AP</Ammo_357Magnum_AP>
+			<Ammo_357Magnum_HP>Bullet_357Magnum_HP</Ammo_357Magnum_HP>
+			<Ammo_38Special_FMJ>Bullet_38Special_FMJ</Ammo_38Special_FMJ>
+			<Ammo_38Special_AP>Bullet_38Special_AP</Ammo_38Special_AP>
+			<Ammo_38Special_HP>Bullet_38Special_HP</Ammo_38Special_HP>
+			</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="357MagnumBase" ParentName="SmallAmmoBase" Abstract="True">

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -21,20 +21,6 @@
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_357Magnum_Revolver</defName>
-		<label>.357 Magnum</label>
-		<ammoTypes>
-			<Ammo_357Magnum_FMJ>Bullet_357Magnum_FMJ</Ammo_357Magnum_FMJ>
-			<Ammo_357Magnum_AP>Bullet_357Magnum_AP</Ammo_357Magnum_AP>
-			<Ammo_357Magnum_HP>Bullet_357Magnum_HP</Ammo_357Magnum_HP>
-			<Ammo_38Special_FMJ>Bullet_38Special_FMJ</Ammo_38Special_FMJ>
-			<Ammo_38Special_AP>Bullet_38Special_AP</Ammo_38Special_AP>
-			<Ammo_38Special_HP>Bullet_38Special_HP</Ammo_38Special_HP>
-			</ammoTypes>
-		<similarTo>AmmoSet_PistolMagnum</similarTo>
-	</CombatExtended.AmmoSetDef>
-
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="357MagnumBase" ParentName="SmallAmmoBase" Abstract="True">

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -10,6 +10,24 @@
 
   <!-- ==================== AmmoSet ========================== -->
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_410Bore</defName>
+		<label>.410 bore</label>
+		<ammoTypes>
+			<Ammo_410Bore_Buck>Bullet_410Bore_Buck</Ammo_410Bore_Buck>
+		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_410Bore_SB</defName>
+		<label>.410 bore</label>
+		<ammoTypes>
+		  <Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
+
   <!-- ==================== Ammo ========================== -->
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="410BoreBase" ParentName="SmallAmmoBase" Abstract="True">


### PR DESCRIPTION
## Additions
- Adds an ammoset for .410 shotgun shells. The ammo and projectile already exist and could conceivably be used in a .410 shotgun, so there's really no reason not to have it. Also includes a short barrel (lower velocity) version, since there's no reason not to.
- Adds an ammoset for .357/.38 special. Most .357 revolvers are capable of safely loading and firing both (though the opposite is not true). Shooters might use .38 special instead owing to the more manageable recoil and cheaper ammo cost. These aren't _really_ considerations that is a CE player is going to be concerned about, but it's still a nice option to include.

While the latter ammoset is functional in testing, the fact that the .38 spc and .357 mag ammo shares the same ammo types means that the ammo selector can't differentiate between the two when a pawn has both in their inventory. As such, the player can't switch between the two as desired but switching between them is currently possible with clicking on the ammo type twice to switch the ammo type from .357 FMJ to .38 FMJ as an example.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
