### PR TITLE
Mech ammo recycle recipe error fix

### DIFF
--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -160,7 +160,6 @@
 		  <li>
 			<filter>
 				<thingDefs>
-					<li>Ammo_66mmExplosiveBolt_HE-I</li>
 					<li>Ammo_80x256mmFuel_Incendiary</li>
 					<li>Ammo_164x284mmDemo</li>
 				</thingDefs>
@@ -170,7 +169,6 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Ammo_66mmExplosiveBolt_HE-I</li>
 				<li>Ammo_80x256mmFuel_Incendiary</li>
 				<li>Ammo_164x284mmDemo</li>
 			</thingDefs>		


### PR DESCRIPTION
## Changes

- A temporary change to mech ammo recycle recipe to fix the red error created by the 66mm thermal bolts not existing in dev

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
