### PR TITLE
Properly fix the tribal chief issues

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -796,22 +796,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName="Tribal_ChiefMelee"]</xpath>
-    <value>
-      <li Class="CombatExtended.LoadoutPropertiesExtension">
-        <shieldMoney>
-          <min>120</min>
-          <max>160</max>
-        </shieldMoney>
-        <shieldTags>
-          <li>TribalShield</li>
-        </shieldTags>
-        <shieldChance>0.9</shieldChance>
-      </li>
-    </value>
-  </Operation>
-
   <Operation Class="PatchOperationConditional">
    <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefMelee"]/skills</xpath>
    <nomatch Class="PatchOperationAdd">
@@ -827,8 +811,15 @@
    </nomatch>
   </Operation>
 
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[defName="Tribal_ChiefMelee"]/weaponTags</xpath>
+    <value>
+      <li>MedievalMeleeDecent</li>
+    </value>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName="Tribal_ChiefRanged"]</xpath>
+    <xpath>Defs/PawnKindDef[@Name="TribalChiefBase"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
@@ -842,7 +833,7 @@
         <shieldTags>
           <li>TribalShield</li>
         </shieldTags>
-        <shieldChance>0.9</shieldChance>
+        <shieldChance>0.5</shieldChance>
         <sidearms>
           <li>
             <sidearmMoney>


### PR DESCRIPTION
## Changes

- Fixed the tribal chiefs not spawning with ammo and shields
- Added one-handed melee weapons to melee chiefs so that they can spawn with melee shields, the one-handed to two-handed weapons they spawn with is generally around 2 to 1.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Spawned several pawns and the changes are working as intended)
