### PR TITLE
Add 30x113mmB autocannon ammo and other ammo tweaks

### DIFF
--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -14,7 +14,7 @@
 		<defName>AmmoSet_20x128mmOerlikon</defName>
 		<label>20x128mm Oerlikon</label>
 		<ammoTypes>
-      		<Ammo_20x128mmOerlikon_AP>Bullet_20x128mmOerlikon_AP</Ammo_20x128mmOerlikon_AP>		
+			<Ammo_20x128mmOerlikon_AP>Bullet_20x128mmOerlikon_AP</Ammo_20x128mmOerlikon_AP>		
 			<Ammo_20x128mmOerlikon_Incendiary>Bullet_20x128mmOerlikon_Incendiary</Ammo_20x128mmOerlikon_Incendiary>
 			<Ammo_20x128mmOerlikon_HE>Bullet_20x128mmOerlikon_HE</Ammo_20x128mmOerlikon_HE>
 			<Ammo_20x128mmOerlikon_Sabot>Bullet_20x128mmOerlikon_Sabot</Ammo_20x128mmOerlikon_Sabot>	   			
@@ -117,7 +117,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>47</damageAmountBase>
       <armorPenetrationSharp>36</armorPenetrationSharp>
-      <armorPenetrationBlunt>314.28</armorPenetrationBlunt>
+      <armorPenetrationBlunt>1280.120</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-
 <Defs>
 
 	<ThingCategoryDef>
@@ -15,7 +14,7 @@
 		<defName>AmmoSet_20x138mmB</defName>
 		<label>20x138mmB</label>
 		<ammoTypes>
-      		<Ammo_20x138mmB_AP>Bullet_20x138mmB_AP</Ammo_20x138mmB_AP>		
+			<Ammo_20x138mmB_AP>Bullet_20x138mmB_AP</Ammo_20x138mmB_AP>		
 			<Ammo_20x138mmB_Incendiary>Bullet_20x138mmB_Incendiary</Ammo_20x138mmB_Incendiary>
 			<Ammo_20x138mmB_HE>Bullet_20x138mmB_HE</Ammo_20x138mmB_HE>
 			<Ammo_20x138mmB_Sabot>Bullet_20x138mmB_Sabot</Ammo_20x138mmB_Sabot>	   			
@@ -105,7 +104,7 @@
 		<label>20x138mmB bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>43</damageAmountBase>
-		  <armorPenetrationSharp>40</armorPenetrationSharp>
+		  <armorPenetrationSharp>34</armorPenetrationSharp>
 		  <armorPenetrationBlunt>972</armorPenetrationBlunt>
 		  <speed>180</speed>
 		</projectile>
@@ -116,7 +115,7 @@
 		<label>20x138mmB bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>43</damageAmountBase>
-		  <armorPenetrationSharp>40</armorPenetrationSharp>
+		  <armorPenetrationSharp>34</armorPenetrationSharp>
 		  <armorPenetrationBlunt>972</armorPenetrationBlunt>
 		  <speed>180</speed>
 		  <secondaryDamage>
@@ -133,7 +132,7 @@
 		<label>20x138mmB bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>68</damageAmountBase>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationSharp>17</armorPenetrationSharp>
 			<armorPenetrationBlunt>972</armorPenetrationBlunt>
 			<speed>180</speed>
 			<secondaryDamage>
@@ -151,7 +150,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>270</speed>
 	    <damageAmountBase>36</damageAmountBase>
-	    <armorPenetrationSharp>70</armorPenetrationSharp>
+	    <armorPenetrationSharp>60</armorPenetrationSharp>
 	    <armorPenetrationBlunt>1257.52</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo30x113mmB</defName>
+		<label>30x113mmB</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_30x113mmB</defName>
+		<label>30x113mmB</label>
+		<ammoTypes>
+			<Ammo_30x113mmB_Incendiary>Bullet_30x113mmB_Incendiary</Ammo_30x113mmB_Incendiary>
+			<Ammo_30x113mmB_HE>Bullet_30x113mmB_HE</Ammo_30x113mmB_HE>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x113mmBBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.45</Mass>
+			<Bulk>0.55</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo30x113mmB</li>
+		</thingCategories>
+		<stackLimit>150</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
+		<defName>Ammo_30x113mmB_Incendiary</defName>
+		<label>30x113mmB cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.65</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_30x113mmB_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
+		<defName>Ammo_30x113mmB_HE</defName>
+		<label>30x113mmB cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>4.21</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_30x113mmB_HE</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base30x113mmBBullet" ParentName="BaseBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>161</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x113mmBBullet">
+		<defName>Bullet_30x113mmB_Incendiary</defName>
+		<label>30x113mmB bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>59</damageAmountBase>
+			<armorPenetrationSharp>60</armorPenetrationSharp>
+			<armorPenetrationBlunt>1587.66</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>37</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x113mmBBullet">
+		<defName>Bullet_30x113mmB_HE</defName>
+		<label>30x113mmB bullet (HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>93</damageAmountBase>
+			<armorPenetrationSharp>60</armorPenetrationSharp>
+			<armorPenetrationBlunt>1587.66</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>56</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x113mmB_Incendiary</defName>
+		<label>make 30x113mmB (AP-I) cartridge x100</label>
+		<description>Craft 100 .30x113mmB (AP-I) cartridges.</description>
+		<jobString>Making .30x113mmB (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>92</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>13</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x113mmB_Incendiary>100</Ammo_30x113mmB_Incendiary>
+		</products>
+		<workAmount>14400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x113mmB_HE</defName>
+		<label>make 30x113mmB (HE) cartridge x100</label>
+		<description>Craft 100 .30x113mmB (HE) cartridges.</description>
+		<jobString>Making .30x113mmB (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>92</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>23</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x113mmB_HE>100</Ammo_30x113mmB_HE>
+		</products>
+		<workAmount>18400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -14,8 +14,10 @@
 		<defName>AmmoSet_30x113mmB</defName>
 		<label>30x113mmB</label>
 		<ammoTypes>
+			<Ammo_30x113mmB_AP>Bullet_30x113mmB_AP</Ammo_30x113mmB_AP>	
 			<Ammo_30x113mmB_Incendiary>Bullet_30x113mmB_Incendiary</Ammo_30x113mmB_Incendiary>
 			<Ammo_30x113mmB_HE>Bullet_30x113mmB_HE</Ammo_30x113mmB_HE>
+			<Ammo_30x113mmB_Sabot>Bullet_30x113mmB_Sabot</Ammo_30x113mmB_Sabot>
 		</ammoTypes>
 		<similarTo>AmmoSet_Autocannon</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -25,8 +27,8 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x113mmBBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
-			<Mass>0.45</Mass>
-			<Bulk>0.55</Bulk>
+			<Mass>0.49</Mass>
+			<Bulk>0.49</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -35,7 +37,21 @@
 		<thingCategories>
 			<li>Ammo30x113mmB</li>
 		</thingCategories>
-		<stackLimit>150</stackLimit>
+		<stackLimit>750</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
+		<defName>Ammo_30x113mmB_AP</defName>
+		<label>30x113mmB cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.99</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_30x113mmB_AP</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
@@ -46,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.65</MarketValue>
+			<MarketValue>2.87</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_30x113mmB_Incendiary</cookOffProjectile>
@@ -60,10 +76,25 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.21</MarketValue>
+			<MarketValue>4.61</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_30x113mmB_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
+		<defName>Ammo_30x113mmB_Sabot</defName>
+		<label>30x113mmB cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.373</Mass>
+			<MarketValue>2.29</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_30x113mmB_Sabot</cookOffProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
@@ -75,8 +106,18 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>161</speed>
+			<speed>155</speed>
 			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x113mmBBullet">
+		<defName>Bullet_30x113mmB_AP</defName>
+		<label>30x113mmB bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>59</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>1651.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -85,8 +126,8 @@
 		<label>30x113mmB bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>59</damageAmountBase>
-			<armorPenetrationSharp>60</armorPenetrationSharp>
-			<armorPenetrationBlunt>1587.66</armorPenetrationBlunt>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>1651.72</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
@@ -100,19 +141,56 @@
 		<defName>Bullet_30x113mmB_HE</defName>
 		<label>30x113mmB bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>93</damageAmountBase>
-			<armorPenetrationSharp>60</armorPenetrationSharp>
-			<armorPenetrationBlunt>1587.66</armorPenetrationBlunt>
+			<damageAmountBase>94</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>1651.72</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>56</amount>
+					<amount>57</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 
+	<ThingDef ParentName="Base30x113mmBBullet">
+		<defName>Bullet_30x113mmB_Sabot</defName>
+		<label>30x113mmB bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>57</damageAmountBase>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
+			<armorPenetrationBlunt>2125.56</armorPenetrationBlunt>
+			<speed>233</speed>
+		</projectile>
+	</ThingDef>
+
 	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_30x113mmB_AP</defName>
+		<label>make 30x113mmB (AP) cartridge x100</label>
+		<description>Craft 100 .30x113mmB (AP) cartridges.</description>
+		<jobString>Making .30x113mmB (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>150</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x113mmB_AP>150</Ammo_30x113mmB_AP>
+		</products>
+		<workAmount>15000</workAmount>
+	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_Incendiary</defName>
@@ -126,7 +204,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>92</count>
+				<count>150</count>
 			</li>
 			<li>
 				<filter>
@@ -134,7 +212,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>13</count>
+				<count>21</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -144,9 +222,9 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_30x113mmB_Incendiary>100</Ammo_30x113mmB_Incendiary>
+			<Ammo_30x113mmB_Incendiary>150</Ammo_30x113mmB_Incendiary>
 		</products>
-		<workAmount>14400</workAmount>
+		<workAmount>23400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -161,7 +239,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>92</count>
+				<count>150</count>
 			</li>
 			<li>
 				<filter>
@@ -169,7 +247,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>23</count>
+				<count>38</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -179,9 +257,53 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_30x113mmB_HE>100</Ammo_30x113mmB_HE>
+			<Ammo_30x113mmB_HE>150</Ammo_30x113mmB_HE>
 		</products>
-		<workAmount>18400</workAmount>
+		<workAmount>30200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x113mmB_Sabot</defName>
+		<label>make 30x113mmB (Sabot) cartridge x100</label>
+		<description>Craft 100 .30x113mmB (Sabot) cartridges.</description>
+		<jobString>Making .30x113mmB (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>66</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x113mmB_Sabot>150</Ammo_30x113mmB_Sabot>
+		</products>
+		<workAmount>21000</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
     <defName>Ammo_50BMG_HE</defName>
-    <label>.50 BMG cartridge (AP-HE)</label>
+    <label>.50 BMG cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
   
   <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_HE</defName>
-    <label>.50 BMG bullet (AP-HE)</label>
+    <label>.50 BMG bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
       <armorPenetrationSharp>15.5</armorPenetrationSharp>
@@ -280,7 +280,7 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_50BMG_HE</defName>
-    <label>make .50 BMG (AP-HE) cartridge x200</label>
+    <label>make .50 BMG (HE) cartridge x200</label>
     <description>Craft 200 .50 BMG (HE) cartridges.</description>
     <jobString>Making .50 BMG (HE) cartridges.</jobString>
     <ingredients>


### PR DESCRIPTION
## Additions

- Added two new 30x113mmB autocannon ammo.

## Changes

- Adjusted armor penetration of the 20x138mmB rounds and fixed the blunt armor penetration of the 20x128mm Oerlikon AP round.
- Fixed the .50 BMG HE round labels.

https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (20 mins with Defensive Machine Gun Turret Pack making use of the new ammo)
