### PR TITLE
Fix parrying

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -76,9 +76,6 @@
   <CE_Settings_ShowExtraStats_Desc>Enables extra (internal, redundant, or confusing) stats in some info cards.</CE_Settings_ShowExtraStats_Desc>
   <CE_Settings_ShowExtraStats_Title>Show extra stats</CE_Settings_ShowExtraStats_Title>
 
-  <CE_Settings_UnlimitNewParryDamage_Desc>If false, limits damage done to parrying weapons to the lesser of the hardness-based or 10% of parried damage.</CE_Settings_UnlimitNewParryDamage_Desc>
-  <CE_Settings_UnlimitNewParryDamage_Title>Unlimit weapon parry damage</CE_Settings_UnlimitNewParryDamage_Title>
-
   <CE_Settings_FragmentsFromWalls_Desc>If true, damaging walls can generate fragments</CE_Settings_FragmentsFromWalls_Desc>
   <CE_Settings_FragmentsFromWalls_Title>Fragments From Walls</CE_Settings_FragmentsFromWalls_Title>
 

--- a/Languages/English/Keyed/TextMotes.xml
+++ b/Languages/English/Keyed/TextMotes.xml
@@ -2,6 +2,7 @@
 <LanguageData>
 
 	<CE_TextMote_Riposted>Riposted!</CE_TextMote_Riposted>
+	<CE_TextMote_Blocked>Blocked!</CE_TextMote_Blocked>
 	<CE_TextMote_Parried>Parried!</CE_TextMote_Parried>
 	<CE_TextMote_Knockdown>Knockdown!</CE_TextMote_Knockdown>
 	<CE_TextMote_CriticalHit>Critical hit!</CE_TextMote_CriticalHit>

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -230,12 +230,7 @@ namespace CombatExtended
         /// <param name="armor">The armor apparel</param>
         /// <param name="partDensity">When penetrating body parts, the body part density</param>
         /// <returns>False if the attack is deflected, true otherwise</returns>
-        private static bool TryPenetrateArmor(DamageDef def, float armorAmount, ref float penAmount, ref float dmgAmount, Thing armor = null, float partDensity = 0) {
-            float maxDamage = float.MaxValue;
-            return TryPenetrateArmor(def, armorAmount, ref penAmount, ref dmgAmount, ref maxDamage, armor, partDensity);
-        }
-    
-        private static bool TryPenetrateArmor(DamageDef def, float armorAmount, ref float penAmount, ref float dmgAmount, ref float maxDamage, Thing armor = null, float partDensity = 0)
+        private static bool TryPenetrateArmor(DamageDef def, float armorAmount, ref float penAmount, ref float dmgAmount, Thing armor = null, float partDensity = 0)
         {
             // Calculate deflection
             var isSharpDmg = def.armorCategory == DamageArmorCategoryDefOf.Sharp;
@@ -263,12 +258,6 @@ namespace CombatExtended
                     if (isSharpDmg)
                     {
                         armorDamage = Mathf.Max(dmgAmount * SoftArmorMinDamageFactor, dmgAmount - newDmgAmount);
-                        if (armorDamage > maxDamage) {
-                            armorDamage = maxDamage;
-                        }
-                        if (armorDamage > 0) {
-                            maxDamage -= armorDamage;
-                        }
                         TryDamageArmor(def, penAmount, armorAmount, ref armorDamage, armor);
                     }
                 }
@@ -287,13 +276,6 @@ namespace CombatExtended
                         armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
                     }
 
-                    if (armorDamage > maxDamage) {
-                        armorDamage = maxDamage;
-                        newDmgAmount = maxDamage;
-                    }
-                    if (armorDamage > 0) {
-                        maxDamage -= armorDamage;
-                    }
                     TryDamageArmor(def, penAmount, armorAmount, ref armorDamage, armor);
                 }
             }
@@ -393,12 +375,7 @@ namespace CombatExtended
         /// <param name="hitPart">The originally hit part</param>
         /// <param name="partialPen">Is this is supposed to be a partial penetration</param>
         /// <returns>DamageInfo copied from dinfo with Def and forceHitPart adjusted</returns>
-        private static DamageInfo GetDeflectDamageInfo(DamageInfo dinfo, BodyPartRecord hitPart, ref float dmgAmount, ref float penAmount, bool partialPen = false) {
-            float maxDamage = float.MaxValue;
-            return GetDeflectDamageInfo(dinfo, hitPart, ref dmgAmount, ref penAmount, ref maxDamage, partialPen);
-        }
-
-        private static DamageInfo GetDeflectDamageInfo(DamageInfo dinfo, BodyPartRecord hitPart, ref float dmgAmount, ref float penAmount, ref float maxDamage, bool partialPen = false)
+        private static DamageInfo GetDeflectDamageInfo(DamageInfo dinfo, BodyPartRecord hitPart, ref float dmgAmount, ref float penAmount, bool partialPen = false)
         {
             if (dinfo.Def.armorCategory != DamageArmorCategoryDefOf.Sharp)
             {
@@ -457,12 +434,6 @@ namespace CombatExtended
                 localDmgAmount *= dinfo.Amount / (float)dinfo.Weapon.projectile.damageAmountBase;
             }
 
-            if (localDmgAmount > maxDamage) {
-                localDmgAmount = maxDamage;
-            }
-            if (localDmgAmount > 0) {
-                maxDamage -= localDmgAmount;
-            }
         
             var newDinfo = new DamageInfo(DamageDefOf.Blunt,
                 localDmgAmount,
@@ -517,11 +488,7 @@ namespace CombatExtended
         /// </summary>
         /// <param name="dinfo">DamageInfo to apply to parryThing</param>
         /// <param name="parryThing">Thing taking the damage</param>
-        public static void ApplyParryDamage(DamageInfo dinfo, Thing parryThing) {
-            float maxDamage = float.MaxValue;
-            ApplyParryDamage(dinfo, parryThing, ref maxDamage);
-        }
-        public static void ApplyParryDamage(DamageInfo dinfo, Thing parryThing, ref float maxDamage)
+        public static void ApplyParryDamage(DamageInfo dinfo, Thing parryThing)
         {
             var pawn = parryThing as Pawn;
             if (pawn != null)
@@ -540,12 +507,6 @@ namespace CombatExtended
             {
                 float parryThingArmor;
                 var dmgAmount = dinfo.Amount * 0.5f;
-                if (maxDamage == float.MaxValue) {
-                    maxDamage = dinfo.Amount * 0.1f;
-                }
-                if (Controller.settings.UnlimitParryDamage) {
-                    maxDamage = float.MaxValue;
-                }
             
                 // For apparel
                 if (parryThing.def.IsApparel)
@@ -561,12 +522,12 @@ namespace CombatExtended
 
                 var penAmount = dinfo.ArmorPenetrationInt; //GetPenetrationValue(dinfo);
 
-                bool partialPen = TryPenetrateArmor(dinfo.Def, parryThingArmor, ref penAmount, ref dmgAmount, ref maxDamage, parryThing);
+                bool partialPen = TryPenetrateArmor(dinfo.Def, parryThingArmor, ref penAmount, ref dmgAmount, parryThing);
 
                 if (dinfo.Def.armorCategory == DamageArmorCategoryDefOf.Sharp && dmgAmount > 0) {
-                    var ndi = GetDeflectDamageInfo(dinfo, dinfo.HitPart, ref dmgAmount, ref penAmount, ref maxDamage, partialPen);
+                    var ndi = GetDeflectDamageInfo(dinfo, dinfo.HitPart, ref dmgAmount, ref penAmount, partialPen);
                     if (dmgAmount > 0) {
-                        ApplyParryDamage(ndi, parryThing, ref maxDamage);
+                        ApplyParryDamage(ndi, parryThing);
                     }
                 }
 

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -33,8 +33,6 @@ namespace CombatExtended
 
 	private bool showExtraStats = false;
 
-	private bool unlimitParryDamage = false;
-
 	private bool fragmentsFromWalls = false;
 
         public bool ShowCasings => showCasings;
@@ -55,7 +53,6 @@ namespace CombatExtended
 	public bool ShowExtraTooltips => showExtraTooltips;
 
 	public bool ShowExtraStats => showExtraStats;
-	public bool UnlimitParryDamage => unlimitParryDamage;
 
         public bool ShowTutorialPopup = true;
 
@@ -147,7 +144,6 @@ namespace CombatExtended
 	    Scribe_Values.Look(ref showExtraTooltips, "showExtraTooltips", false);
 
 	    Scribe_Values.Look(ref showExtraStats, "showExtraStats", false);
-	    Scribe_Values.Look(ref unlimitParryDamage, "unlimitParryDamage", false);
 	    
 
 #if DEBUG
@@ -212,8 +208,6 @@ namespace CombatExtended
             list.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
 	    list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
 	    list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
-
-	    list.CheckboxLabeled("CE_Settings_UnlimitNewParryDamage_Title".Translate(), ref unlimitParryDamage, "CE_Settings_UnlimitNewParryDamage_Desc".Translate());
 
 
             // Only Allow these settings to be changed in the main menu since doing while a


### PR DESCRIPTION
## Changes

- Removes the mod option to limit parry damage
- Pawns will sometimes deflect attacks without damaging their weapon or shield.  Same chance as a riposte.

## References

- Closes #1866 

## Reasoning

Skilled pawns in melee should be able to parry attacks without damaging their weapons.
Unskilled pawns who manage to stop an attack are likely to do so by making the attack strike their weapon.

## Alternatives

Leave the parry damage limited - makes some junk weapons too tough

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
