### PR TITLE
Patch/Update Animal Collab Project - Vanilla Style

### DIFF
--- a/Patches/AnimalCollabProj/AnimalCollabProj-VanillaStyle_CE_Patch_StuffRebalance.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj-VanillaStyle_CE_Patch_StuffRebalance.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Animal Collab Project Vanilla-Style</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<!-- Clear these out all at once so we can just replace them easily -->
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[
+					defName="Leather_ACP" or 
+					defName="ACPFerretSilk" or 
+					defName="ACPBDireWolfWool" or 
+					defName="ACPSpidersilk" or 
+					defName="ACPLlamaWool" or 
+					@Name="WoolBaseACP"
+				]/statBases/StuffPower_Armor_Sharp |
+				Defs/ThingDef[
+					defName="Leather_ACP" or 
+					defName="ACPFerretSilk" or 
+					defName="ACPBDireWolfWool" or 
+					defName="ACPSpidersilk" or 
+					defName="ACPLlamaWool" or 
+					@Name="WoolBaseACP"
+				]/statBases/StuffPower_Armor_Blunt</xpath>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Leather_ACP"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.33</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.165</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ACPFerretSilk"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.25</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.12</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ACPBDireWolfWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.35</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.17</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ACPSpidersilk"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.30</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ACPLlamaWool"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.20</StuffPower_Armor_Sharp>
+					<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="WoolBaseACP"]/statBases</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.044</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_AddClass.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_AddClass.xml
@@ -2,7 +2,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-				<li>AnimalCollabProj</li>
+			<li>AnimalCollabProj</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>
@@ -10,7 +10,6 @@
 			<li Class="PatchOperationAddModExtension">
 				<xpath>
 					Defs/ThingDef[
-						defName="ACPBison" or 
 						defName="ACPBlackRhinoceros" or 
 						defName="ACPBlackwolf" or 
 						defName="ACPDirewolf" or 
@@ -33,6 +32,7 @@
 					</li>
 				</value>
 			</li>
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>
 					Defs/ThingDef[
@@ -44,7 +44,6 @@
 						defName="ACPErmine" or 
 						defName="ACPFerret" or 
 						defName="ACPFishercat" or 
-						defName="ACPGuineaPig" or
 						defName="ACPHaulerAnt" or 
 						defName="ACPHedgehog" or 
 						defName="ACPHoneyBadger" or 
@@ -71,12 +70,11 @@
 					</li>
 				</value>
 			</li>
+
 			<li Class="PatchOperationAddModExtension">
 				<xpath>
 					Defs/ThingDef[
-						@Name="GooseThingBase" or
 						defName="ACPGiraffe" or 
-						defName="ACPDuck" or 
 						defName="ACPFlamingo" or 
 						defName="ACPGreatBustard" or 
 						defName="ACPKiwi" or 

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Damages.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Damages.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>			
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Hediffs.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Hediffs.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Misc.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Misc.xml
@@ -59,16 +59,3 @@
 		</match>
 	</Operation>
 </Patch>
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Misc.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Misc.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Animal Collab Project Vanilla-Style</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Walrus Tusk -->
+		<li Class="PatchOperationRemove">
+			<xpath>Defs/ThingDef[defName="ACPWalrusTusk"]/tools</xpath>
+		</li>
+
+		<li Class="PatchOperationAttributeSet">
+			<xpath>Defs/ThingDef[defName="ACPWalrusTusk"]</xpath>
+			<attribute>ParentName</attribute>
+			<value>ResourceBase</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="ACPWalrusTusk"]/statBases/Mass</xpath>
+			<value>
+				<Mass>5</Mass>
+				<Bulk>13</Bulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="ACPWalrusTusk"]/description</xpath>
+			<value>
+				<description>A walrus' tusk. Very durable and valuable.</description>
+			</value>
+		</li>
+
+		<!-- Carapace Helmet -->
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Apparel_ACPCarapaceHelmet"]/statBases</xpath>
+			<value>
+				<Bulk>4</Bulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Apparel_ACPCarapaceHelmet"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>2.25</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Apparel_ACPCarapaceHelmet"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>4.75</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Angora.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Angora.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_BRhino.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_BRhino.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Bison.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Bison.xml
@@ -7,6 +7,15 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ACPBison"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ACPBison"]/statBases</xpath>
 				<value>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Blackbear.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Blackbear.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Cats.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Cats.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Chipmunk.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Chipmunk.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DomesticCats.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DomesticCats.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DomesticRabbit.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DomesticRabbit.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Duck.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Duck.xml
@@ -7,6 +7,15 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ACPDuck"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Birdlike</bodyShape>
+					</li>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ACPDuck"]/statBases</xpath>
 				<value>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DuckBilledPlatypus.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_DuckBilledPlatypus.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Ferret.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Ferret.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Flamingo.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Flamingo.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Giraffe.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Giraffe.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Goat.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Goat.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Goose.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Goose.xml
@@ -7,6 +7,15 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[@Name="GooseThingBase"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Birdlike</bodyShape>
+					</li>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[@Name="GooseThingBase"]/statBases</xpath>
 				<value>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_GreatBustard.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_GreatBustard.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_GuineaPig.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_GuineaPig.xml
@@ -7,6 +7,15 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ACPGuineaPig"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ACPGuineaPig"]/statBases</xpath>
 				<value>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Hedgehog.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Hedgehog.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Hippo.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Hippo.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_HoneyBadger.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_HoneyBadger.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Horse.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Horse.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Insects.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Insects.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Jackalope.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Jackalope.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Kiwi.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Kiwi.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Komodo.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Komodo.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Lizard.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Lizard.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Llama.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Llama.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Martens.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Martens.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_MegaBadger.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_MegaBadger.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 		<li>AnimalCollabProj</li>
+		<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 
 		<match Class="PatchOperationSequence">

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_MegaFerret.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_MegaFerret.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Otter.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Otter.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Panda.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Panda.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Peccary.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Peccary.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Penguin.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Penguin.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Porcupine.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Porcupine.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Ptarmigan.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Ptarmigan.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Quail.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Quail.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_RedPanda.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_RedPanda.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Scorpions.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Scorpions.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Seal.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Seal.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Silkie.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Silkie.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Tapir.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Tapir.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_ThornyDevil.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_ThornyDevil.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Walrus.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Walrus.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_WildDog.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_WildDog.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Wolves.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Wolves.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Woolyrhino.xml
+++ b/Patches/AnimalCollabProj/AnimalCollabProj_CE_Patch_Races_Animal_Woolyrhino.xml
@@ -3,6 +3,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>AnimalCollabProj</li>
+			<li>Animal Collab Project Vanilla-Style</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -93,6 +93,7 @@ Anima Animals - Community Pack  |
 Anima Bionics   |
 Anima Gear  |
 AnimalCollabProj	|
+Animal Collab Project Vanilla-Style |
 Animal Armor: Vanilla	|
 Animal Equipment	|
 Anthro Race |


### PR DESCRIPTION
AnimalCollabProject - Vanilla Style (for 1.3) is virtually identical to the older AnimalCollabProject (for 1.1), except the Bison, Duck, Guinea Pig, and Goose were removed (since those animals are now in vanilla). It also renames "ACPWoolBase" to "WoolBaseACP".

I've updated the patch to accommodate these changes and patch a few other small items that either were overlooked or weren't in the older version of ACP.

## Additions
- The Walrus Tusk can no longer be used as a weapon, similar to the Thrumbo tusk.
- Patched the Carapace helmet, which offers around half the protection of a steel simple helmet.

## Changes
- Added the mod name updated version of ACP to the FindMod to the patch files (excluding those creatures that eventually became vanilla).
- Move around and split a few operations assigning bodyShape to prevent errors, since some of the creatures no longer exist within the new version of the mod. 

## Reasoning
Patch is largely intact, no reason not to fix it as needed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
