### PR TITLE
Update 12.7x55mm's naming convention

### DIFF
--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -2,8 +2,8 @@
 <Defs>
 
 	<ThingCategoryDef>
-		<defName>Ammo127x55mmAR</defName>
-		<label>12.7x55mm AR</label>
+		<defName>Ammo127x55mm</defName>
+		<label>12.7x55mm</label>
 		<parent>AmmoRifles</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
 	</ThingCategoryDef>
@@ -11,23 +11,22 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_127x55mmAR</defName>
-		<label>12.7x55mm AR</label>
+		<defName>AmmoSet_127x55mm</defName>
+		<label>12.7x55mm</label>
 		<ammoTypes>
-			<Ammo_127x55mmAR_FMJ>Bullet_127x55mmAR_FMJ</Ammo_127x55mmAR_FMJ>
-			<Ammo_127x55mmAR_AP>Bullet_127x55mmAR_AP</Ammo_127x55mmAR_AP>
-			<Ammo_127x55mmAR_HP>Bullet_127x55mmAR_HP</Ammo_127x55mmAR_HP>
-	<!-- new ammotypes added below -->
-			<Ammo_127x55mmAR_Incendiary>Bullet_127x55mmAR_Incendiary</Ammo_127x55mmAR_Incendiary>
-			<Ammo_127x55mmAR_HE>Bullet_127x55mmAR_HE</Ammo_127x55mmAR_HE>
-			<Ammo_127x55mmAR_Sabot>Bullet_127x55mmAR_Sabot</Ammo_127x55mmAR_Sabot>
+			<Ammo_127x55mm_FMJ>Bullet_127x55mm_FMJ</Ammo_127x55mm_FMJ>
+			<Ammo_127x55mm_AP>Bullet_127x55mm_AP</Ammo_127x55mm_AP>
+			<Ammo_127x55mm_HP>Bullet_127x55mm_HP</Ammo_127x55mm_HP>
+			<Ammo_127x55mm_Incendiary>Bullet_127x55mm_Incendiary</Ammo_127x55mm_Incendiary>
+			<Ammo_127x55mm_HE>Bullet_127x55mm_HE</Ammo_127x55mm_HE>
+			<Ammo_127x55mm_Sabot>Bullet_127x55mm_Sabot</Ammo_127x55mm_Sabot>
 		</ammoTypes>
 		<similarTo>AmmoSet_RifleMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="127x55mmARBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="127x55mmBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>High caliber subsonic assault rifle cartridge designed for suppressed fire.</description>
 		<statBases>
 			<Mass>0.08</Mass>
@@ -43,9 +42,9 @@
 		<stackLimit>5000</stackLimit>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_FMJ</defName>
-		<label>12.7x55mm AR cartridge (FMJ)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_FMJ</defName>
+		<label>12.7x55mm cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -54,12 +53,12 @@
 			<MarketValue>0.33</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_FMJ</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_FMJ</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_AP</defName>
-		<label>12.7x55mm AR cartridge (AP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_AP</defName>
+		<label>12.7x55mm cartridge (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -68,12 +67,12 @@
 			<MarketValue>0.33</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_AP</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_AP</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_HP</defName>
-		<label>12.7x55mm AR cartridge (HP)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_HP</defName>
+		<label>12.7x55mm cartridge (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -82,14 +81,12 @@
 			<MarketValue>0.33</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_HP</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_HP</cookOffProjectile>
 	</ThingDef>
 
-	<!-- New ammotypes added: HE, Incendiary, Sabot. Note that it lacks an unique cookOffProjectile for these new projectiles. -->
-
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_Incendiary</defName>
-		<label>12.7x55mm AR cartridge (AP-I)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_Incendiary</defName>
+		<label>12.7x55mm cartridge (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -98,12 +95,12 @@
 			<MarketValue>0.52</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_Incendiary</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_Incendiary</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_HE</defName>
-		<label>12.7x55mm AR cartridge (HE)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_HE</defName>
+		<label>12.7x55mm cartridge (HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -112,12 +109,12 @@
 			<MarketValue>0.91</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_HE</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_HE</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmARBase">
-		<defName>Ammo_127x55mmAR_Sabot</defName>
-		<label>12.7x55mm AR cartridge (Sabot)</label>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
+		<defName>Ammo_127x55mm_Sabot</defName>
+		<label>12.7x55mm cartridge (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -127,12 +124,12 @@
 			<Mass>0.054</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<cookOffProjectile>Bullet_127x55mmAR_Sabot</cookOffProjectile>
+		<cookOffProjectile>Bullet_127x55mm_Sabot</cookOffProjectile>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base127x55mmARBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base127x55mmBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -145,8 +142,8 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_FMJ</defName>
-		<label>12.7mm AR bullet (FMJ)</label>
+		<defName>Bullet_127x55mm_FMJ</defName>
+		<label>12.7mm bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationSharp>7.5</armorPenetrationSharp>
@@ -155,8 +152,8 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_AP</defName>
-		<label>12.7mm AR bullet (AP)</label>
+		<defName>Bullet_127x55mm_AP</defName>
+		<label>12.7mm bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
@@ -165,8 +162,8 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_HP</defName>
-		<label>12.7mm AR bullet (HP)</label>
+		<defName>Bullet_127x55mm_HP</defName>
+		<label>12.7mm bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
 			<armorPenetrationSharp>3.75</armorPenetrationSharp>
@@ -174,18 +171,16 @@
 		</projectile>
 	</ThingDef>
 
-	<!-- New ammotypes added: HE, Incendiary, Sabot. -->
-
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_Incendiary</defName>
-		<label>12.7mm AR bullet (AP-I)</label>
+		<defName>Bullet_127x55mm_Incendiary</defName>
+		<label>12.7mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
 			<secondaryDamage>
-			<li>
-			  <def>Flame_Secondary</def>
-			  <amount>8</amount>
-			</li>
+				<li>
+				  <def>Flame_Secondary</def>
+				  <amount>8</amount>
+				</li>
 			</secondaryDamage>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
@@ -193,15 +188,15 @@
 	</ThingDef>
 	
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_HE</defName>
-		<label>12.7mm AR bullet (HE)</label>
+		<defName>Bullet_127x55mm_HE</defName>
+		<label>12.7mm bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
 			<secondaryDamage>
-			<li>
-			  <def>Bomb_Secondary</def>
-			  <amount>13</amount>
-			</li>
+				<li>
+				  <def>Bomb_Secondary</def>
+				  <amount>13</amount>
+				</li>
 			</secondaryDamage>
 			<armorPenetrationSharp>7.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
@@ -209,8 +204,8 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
-		<defName>Bullet_127x55mmAR_Sabot</defName>
-		<label>12.7mm AR bullet (Sabot)</label>
+		<defName>Bullet_127x55mm_Sabot</defName>
+		<label>12.7mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>26.25</armorPenetrationSharp>
@@ -222,10 +217,10 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_FMJ</defName>
-		<label>make 12.7x55mm AR (FMJ) cartridge x500</label>
-		<description>Craft 500 12.7x55mm AR (FMJ) cartridges.</description>
-		<jobString>Making 12.7x55mm AR (FMJ) cartridges.</jobString>
+		<defName>MakeAmmo_127x55mm_FMJ</defName>
+		<label>make 12.7x55mm (FMJ) cartridge x500</label>
+		<description>Craft 500 12.7x55mm (FMJ) cartridges.</description>
+		<jobString>Making 12.7x55mm (FMJ) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -242,16 +237,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_FMJ>500</Ammo_127x55mmAR_FMJ>
+			<Ammo_127x55mm_FMJ>500</Ammo_127x55mm_FMJ>
 		</products>
 		<workAmount>8200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_AP</defName>
-		<label>make 12.7x55mm AR (AP) cartridge x500</label>
-		<description>Craft 500 12.7x55mm AR (AP) cartridges.</description>
-		<jobString>Making 12.7x55mm AR (AP) cartridges.</jobString>
+		<defName>MakeAmmo_127x55mm_AP</defName>
+		<label>make 12.7x55mm (AP) cartridge x500</label>
+		<description>Craft 500 12.7x55mm (AP) cartridges.</description>
+		<jobString>Making 12.7x55mm (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -268,16 +263,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_AP>500</Ammo_127x55mmAR_AP>
+			<Ammo_127x55mm_AP>500</Ammo_127x55mm_AP>
 		</products>
 		<workAmount>8200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_HP</defName>
-		<label>make 12.7x55mm AR (HP) cartridge x500</label>
-		<description>Craft 500 12.7x55mm AR (HP) cartridges.</description>
-		<jobString>Making 12.7x55mm AR (HP) cartridges.</jobString>
+		<defName>MakeAmmo_127x55mm_HP</defName>
+		<label>make 12.7x55mm (HP) cartridge x500</label>
+		<description>Craft 500 12.7x55mm (HP) cartridges.</description>
+		<jobString>Making 12.7x55mm (HP) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -294,18 +289,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_HP>500</Ammo_127x55mmAR_HP>
+			<Ammo_127x55mm_HP>500</Ammo_127x55mm_HP>
 		</products>
 		<workAmount>8200</workAmount>
 	</RecipeDef>
-
-	<!-- New ammotypes to be added: HE, Incendiary, Sabot.  -->
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_Incendiary</defName>
-		<label>make 12.7x55mm AR cartridge (AP-I) cartridge x500</label>
-		<description>Craft 500 12.7x55mm AR cartridge (AP-I) cartridge.</description>
-		<jobString>Making 12.7x55mm AR cartridge (AP-I) cartridges.</jobString>
+		<defName>MakeAmmo_127x55mm_Incendiary</defName>
+		<label>make 12.7x55mm cartridge (AP-I) cartridge x500</label>
+		<description>Craft 500 12.7x55mm cartridge (AP-I) cartridge.</description>
+		<jobString>Making 12.7x55mm cartridge (AP-I) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -331,16 +324,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_Incendiary>500</Ammo_127x55mmAR_Incendiary>
+			<Ammo_127x55mm_Incendiary>500</Ammo_127x55mm_Incendiary>
 		</products>
 		<workAmount>14200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_127x55mmAR_HE</defName>
-		<label>make 12.7x55mm AR cartridge (HE) cartridge x200</label>
-		<description>Craft 200 12.7x55mm AR cartridge (HE) cartridge.</description>
-		<jobString>Making 12.7x55mm AR cartridge (HE) cartridges.</jobString>
+		<label>make 12.7x55mm cartridge (HE) cartridge x200</label>
+		<description>Craft 200 12.7x55mm cartridge (HE) cartridge.</description>
+		<jobString>Making 12.7x55mm cartridge (HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -366,16 +359,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_HE>500</Ammo_127x55mmAR_HE>
+			<Ammo_127x55mm_HE>500</Ammo_127x55mm_HE>
 		</products>
 		<workAmount>19400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_Sabot</defName>
-		<label>make 12.7x55mm AR cartridge (Sabot) cartridge x500</label>
-		<description>Craft 500 12.7x55mm AR cartridge (Sabot) cartridge.</description>
-		<jobString>Making 12.7x55mm AR cartridge (Sabot) cartridges.</jobString>
+		<defName>MakeAmmo_127x55mm_Sabot</defName>
+		<label>make 12.7x55mm cartridge (Sabot) cartridge x500</label>
+		<description>Craft 500 12.7x55mm cartridge (Sabot) cartridge.</description>
+		<jobString>Making 12.7x55mm cartridge (Sabot) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -410,7 +403,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_127x55mmAR_Sabot>500</Ammo_127x55mmAR_Sabot>
+			<Ammo_127x55mm_Sabot>500</Ammo_127x55mm_Sabot>
 		</products>
 		<workAmount>12400</workAmount>
 	</RecipeDef>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -37,7 +37,7 @@
 			<li>CE_AutoEnableCrafting</li>
 		</tradeTags>
 		<thingCategories>
-			<li>Ammo127x55mmAR</li>
+			<li>Ammo127x55mm</li>
 		</thingCategories>
 		<stackLimit>5000</stackLimit>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -330,7 +330,7 @@
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
-		<defName>MakeAmmo_127x55mmAR_HE</defName>
+		<defName>MakeAmmo_127x55mm_HE</defName>
 		<label>make 12.7x55mm cartridge (HE) cartridge x200</label>
 		<description>Craft 200 12.7x55mm cartridge (HE) cartridge.</description>
 		<jobString>Making 12.7x55mm cartridge (HE) cartridges.</jobString>

--- a/Patches/Nearmare Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Nearmare Race/ThingDefs_Misc/Weapons.xml
@@ -381,7 +381,7 @@
 					<recoilAmount>3</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_127x55mmAR_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_127x55mm_FMJ</defaultProjectile>
 					<warmupTime>5</warmupTime>
 					<range>52</range>
 					<burstShotCount>10</burstShotCount>
@@ -394,7 +394,7 @@
 				<AmmoUser>
 					<magazineSize>30</magazineSize>
 					<reloadTime>5.2</reloadTime>
-					<ammoSet>AmmoSet_127x55mmAR</ammoSet>
+					<ammoSet>AmmoSet_127x55mm</ammoSet>
 				</AmmoUser>
 				
 				<FireModes>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_assaultrifles.xml
@@ -799,7 +799,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_127x55mmAR_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_127x55mm_FMJ</defaultProjectile>
             <recoilAmount>2.68</recoilAmount>
             <warmupTime>1.20</warmupTime>
             <range>22</range>
@@ -812,7 +812,7 @@
           <AmmoUser>
             <magazineSize>20</magazineSize>
             <reloadTime>4.5</reloadTime>
-            <ammoSet>AmmoSet_127x55mmAR</ammoSet>
+            <ammoSet>AmmoSet_127x55mm</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>AimedShot</aiAimMode>

--- a/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
+++ b/Patches/Rambo Weapons Pack/RamboWeaponsPack_sniperrifles.xml
@@ -570,7 +570,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_127x55mmAR_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_127x55mm_FMJ</defaultProjectile>
             <warmupTime>1.9</warmupTime>
             <range>62</range>
             <soundCast>ShotSuppressedSniper</soundCast>
@@ -579,7 +579,7 @@
           <AmmoUser>
             <magazineSize>5</magazineSize>
             <reloadTime>4.5</reloadTime>
-            <ammoSet>AmmoSet_127x55mmAR</ammoSet>
+            <ammoSet>AmmoSet_127x55mm</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiUseBurstMode>FALSE</aiUseBurstMode>


### PR DESCRIPTION
## Changes

- Updated 12.7x55mm's naming convention to prevent confusion, removed the AR bit to make the ammo type uniform

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
