### PR TITLE
RW 1.4 xml Fixes.

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -152,7 +152,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -153,7 +153,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -194,7 +194,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -191,7 +191,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -192,7 +192,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -228,7 +228,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -151,7 +151,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -229,7 +229,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -152,7 +152,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2.5</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -154,7 +154,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<explosionRadius>2</explosionRadius>
 		<damageDef>Smoke</damageDef>
-		<postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		<postExplosionGasType>BlindSmoke</postExplosionGasType>
 		<preExplosionSpawnChance>1</preExplosionSpawnChance>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -145,7 +145,7 @@
 				<explosionDamage>30</explosionDamage>
 				<explosionDamageDef>Bomb</explosionDamageDef>
 				<explosionRadius>2</explosionRadius>
-				<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+				<postExplosionGasType>BlindSmoke</postExplosionGasType>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 				<soundExplode>MortarBomb_Explode</soundExplode>
 			</li>

--- a/Defs/Ammo/Rocket/RPO.xml
+++ b/Defs/Ammo/Rocket/RPO.xml
@@ -56,7 +56,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Smoke</damageDef>
       <explosionRadius>8</explosionRadius>
-      <preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -239,7 +239,7 @@
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 		  <soundAmbient>MortarRound_Ambient</soundAmbient>
-		  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 		  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  <explosionEffect>ExtinguisherExplosion</explosionEffect>
@@ -376,7 +376,7 @@
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 		  <soundAmbient>MortarRound_Ambient</soundAmbient>
-		  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 		  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -218,7 +218,7 @@
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 		  <soundAmbient>MortarRound_Ambient</soundAmbient>
-		  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 		  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  <explosionEffect>ExtinguisherExplosion</explosionEffect>
@@ -324,7 +324,7 @@
 		  <soundExplode>Explosion_EMP</soundExplode>
 		  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 		  <soundAmbient>MortarRound_Ambient</soundAmbient>
-		  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+		  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 		  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		  <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -157,7 +157,7 @@
         <explosiveRadius>4.5</explosiveRadius>
         <explosiveDamageType>Smoke</explosiveDamageType>
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-        <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+        <postExplosionGasType>BlindSmoke</postExplosionGasType>
         <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		    <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
@@ -291,7 +291,7 @@
       <soundExplode>Explosion_EMP</soundExplode>
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -193,7 +193,7 @@
         <explosiveRadius>6</explosiveRadius>
         <explosiveDamageType>Smoke</explosiveDamageType>
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-        <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+        <postExplosionGasType>BlindSmoke</postExplosionGasType>
         <preExplosionSpawnChance>1</preExplosionSpawnChance>
         <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~60</wickTicks>
@@ -372,7 +372,7 @@
       <soundExplode>Explosion_EMP</soundExplode>
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -160,7 +160,6 @@
 		  <li>
 			<filter>
 				<thingDefs>
-					<li>Ammo_66mmExplosiveBolt_HE-I</li>
 					<li>Ammo_80x256mmFuel_Incendiary</li>
 					<li>Ammo_164x284mmDemo</li>
 				</thingDefs>
@@ -170,7 +169,6 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>Ammo_66mmExplosiveBolt_HE-I</li>
 				<li>Ammo_80x256mmFuel_Incendiary</li>
 				<li>Ammo_164x284mmDemo</li>
 			</thingDefs>		

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -101,7 +101,7 @@
             <EquipDelay>0.5</EquipDelay>
         </statBases>
         <equippedStatOffsets>
-            <ToxicSensitivity>-0.5</ToxicSensitivity>
+            <ToxicResistance>0.5</ToxicResistance>
             <SmokeSensitivity>-1</SmokeSensitivity>
         </equippedStatOffsets>
         <apparel>
@@ -168,7 +168,7 @@
             <EquipDelay>1</EquipDelay>
         </statBases>
         <equippedStatOffsets>
-            <ToxicSensitivity>-0.3</ToxicSensitivity>
+            <ToxicResistance>0.3</ToxicResistance>
             <SmokeSensitivity>-0.6</SmokeSensitivity>
         </equippedStatOffsets>
         <apparel>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -293,7 +293,7 @@
       <explosionDelay>30</explosionDelay>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>12</speed>
       <gravityFactor>2</gravityFactor>
@@ -347,7 +347,7 @@
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
         <damageAmountBase>4</damageAmountBase>
         <explosiveDamageType>Smoke</explosiveDamageType>
-        <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+        <postExplosionGasType>BlindSmoke</postExplosionGasType>
         <preExplosionSpawnChance>1</preExplosionSpawnChance>
       </li>
     </comps>

--- a/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
+++ b/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
@@ -173,7 +173,7 @@
           <value>
             <CarryWeight>60</CarryWeight>
             <CarryBulk>10</CarryBulk>
-            <ToxicSensitivity>-0.50</ToxicSensitivity>
+            <ToxicResistance>0.50</ToxicResistance>
           </value>
         </li>
 
@@ -219,7 +219,7 @@
           <xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]</xpath>
           <value>
             <equippedStatOffsets>
-              <ToxicSensitivity>-0.50</ToxicSensitivity>
+              <ToxicResistance>0.50</ToxicResistance>
               <SmokeSensitivity>-1</SmokeSensitivity>
             </equippedStatOffsets>
           </value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
@@ -36,7 +36,7 @@
 					<value>
 						<CarryWeight>60</CarryWeight>
 						<CarryBulk>10</CarryBulk>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 					</value>
 				</li>
 
@@ -118,7 +118,7 @@
 					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]</xpath>
 					<value>
 						<equippedStatOffsets>
-							<ToxicSensitivity>-0.50</ToxicSensitivity>
+							<ToxicResistance>0.50</ToxicResistance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
 						</equippedStatOffsets>
 					</value>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_Grenades.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_Weapons_Grenades.xml
@@ -80,7 +80,7 @@
               <damageAmountBase>10</damageAmountBase>
               <explosionDelay>60</explosionDelay>
               <dropsCasings>true</dropsCasings>
-              <preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+              <postExplosionGasType>BlindSmoke</postExplosionGasType>
               <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
             </projectile>
           </value>

--- a/Patches/Arachne/ApparelNew_Arachne.xml
+++ b/Patches/Arachne/ApparelNew_Arachne.xml
@@ -229,7 +229,7 @@
 					<CarryWeight>50</CarryWeight>
 					<CarryBulk>8</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>0.3</MoveSpeed>
 				</value>
 			</li>
@@ -358,7 +358,7 @@
 				<xpath>/Defs/ThingDef[defName="Arachne_Scout_Helmet"]/equippedStatOffsets</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/Arachne/Apparel_Arachne.xml
+++ b/Patches/Arachne/Apparel_Arachne.xml
@@ -212,7 +212,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 
@@ -328,7 +328,7 @@
 				<xpath>/Defs/ThingDef[defName="Arachne_Power_Helmet"]/equippedStatOffsets</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/Archotech PowerArmor/Apparel_JDS.xml
+++ b/Patches/Archotech PowerArmor/Apparel_JDS.xml
@@ -71,7 +71,7 @@
                     <xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/equippedStatOffsets</xpath>
                     <value>
                         <AimingAccuracy>0.20</AimingAccuracy>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <SmokeSensitivity>-1</SmokeSensitivity>
                         <NightVisionEfficiency_Apparel>1.0</NightVisionEfficiency_Apparel>
                     </value>

--- a/Patches/Censored Armory/30mm Rifle Grenade.xml
+++ b/Patches/Censored Armory/30mm Rifle Grenade.xml
@@ -162,7 +162,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <explosionRadius>1.5</explosionRadius>
             <damageDef>Smoke</damageDef>
-            <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+            <postExplosionGasType>BlindSmoke</postExplosionGasType>
             <preExplosionSpawnChance>1</preExplosionSpawnChance>
           </projectile>
         </ThingDef>

--- a/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
@@ -38,14 +38,14 @@
 	<!-- Burn -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Burn"]/injuryProps/painPerSeverity</xpath>
+		<xpath>Defs/HediffDef[@Name="BurnBase"]/injuryProps/painPerSeverity</xpath>
 		<value>
 			<painPerSeverity>0.025</painPerSeverity>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Burn"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[@Name="BurnBase"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.07</infectionChancePerHourUntended>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -11,7 +11,7 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName="Mech_Centipede"]/combatPower</xpath>
+    <xpath>Defs/PawnKindDef[@Name="MechCentipedeBase"]/combatPower</xpath>
     <value>
       <combatPower>580</combatPower>
     </value>
@@ -25,7 +25,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
+    <xpath>Defs/PawnKindDef[defName="Mech_Lancer" or @Name="MechCentipedeBase"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -149,11 +149,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="MeleeHitChance"]</xpath>
+		<xpath>Defs/StatDef[defName="MeleeHitChance"]/parts</xpath>
 		<value>
-			<parts>
-				<li Class="CombatExtended.StatPart_Bulk" />
-			</parts>
+			<li Class="CombatExtended.StatPart_Bulk" />
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -202,7 +202,7 @@
     <value>
       <PsychicSensitivity>-0.2</PsychicSensitivity>
       <AimingAccuracy>0.15</AimingAccuracy>
-      <ToxicSensitivity>-0.50</ToxicSensitivity>
+      <ToxicResistance>0.50</ToxicResistance>
       <SmokeSensitivity>-1</SmokeSensitivity>
     </value>
   </Operation>
@@ -316,7 +316,7 @@
       <equippedStatOffsets>
         <PsychicSensitivity>-0.2</PsychicSensitivity>
         <AimingAccuracy>0.15</AimingAccuracy>
-        <ToxicSensitivity>-0.50</ToxicSensitivity>
+        <ToxicResistance>0.50</ToxicResistance>
         <SmokeSensitivity>-1</SmokeSensitivity>
       </equippedStatOffsets>
     </value>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -546,7 +546,7 @@
 			<CarryWeight>80</CarryWeight>
 			<CarryBulk>10</CarryBulk>
 			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<ToxicResistance>0.50</ToxicResistance>
 		</value>
 	</Operation>
 
@@ -685,7 +685,7 @@
 		<equippedStatOffsets>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>8</CarryBulk>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<ToxicResistance>0.50</ToxicResistance>
 			<MoveSpeed>0.4</MoveSpeed>
 		</equippedStatOffsets>
 		</value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -428,10 +428,6 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]/smeltProducts</xpath>
-	</Operation>
-
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Weapon_GrenadeEMP</defName>
 		<statBases>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -43,7 +43,7 @@
 	<!-- ========== Centipede ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
@@ -52,7 +52,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/statBases</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases</xpath>
 		<value>
 			<CarryWeight>400</CarryWeight>
 			<CarryBulk>80</CarryBulk>
@@ -67,35 +67,35 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/statBases/ArmorRating_Blunt</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>45</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/statBases/ArmorRating_Sharp</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/race/baseHealthScale</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/race/baseHealthScale</xpath>
 		<value>
 			<baseHealthScale>2.5</baseHealthScale>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/race/baseBodySize</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>2.0</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]/tools</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -119,7 +119,7 @@
 		 CombatExtended.BodyPartExploderExt has only <triggerChance> and <allowedDamageDefs> (list node, example usage <allowedDamageDefs><li>Burn</li></allowedDamageDefs>) nodes
 	-->
 	<!--<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Centipede"]</xpath>
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]</xpath>
 		<value>
 			<comps>
 				<li>

--- a/Patches/Darkest Rim Core/Apparel_DarkestCE.xml
+++ b/Patches/Darkest Rim Core/Apparel_DarkestCE.xml
@@ -268,7 +268,7 @@
       <li Class="PatchOperationReplace">
         <xpath>/Defs/ThingDef[defName="Apparel_PlagueMask"]/equippedStatOffsets/ToxicSensitivity</xpath>
         <value>
-          <ToxicSensitivity>-0.33</ToxicSensitivity>
+          <ToxicResistance>0.33</ToxicResistance>
           <SmokeSensitivity>-0.60</SmokeSensitivity>
         </value>
       </li>

--- a/Patches/Dishonored Assassin Coat/ThingDefs_Misc/Apparel.xml
+++ b/Patches/Dishonored Assassin Coat/ThingDefs_Misc/Apparel.xml
@@ -45,7 +45,7 @@
 							<ReloadSpeed>0.1</ReloadSpeed>
 							<MoveSpeed>0.15</MoveSpeed>
 						    <CarryBulk>15</CarryBulk>
-							<ToxicSensitivity>-0.3</ToxicSensitivity>
+							<ToxicResistance>0.3</ToxicResistance>
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Dishonored Assassin Mask/ThingDefs_Misc/Apparel_Headhear.xml
+++ b/Patches/Dishonored Assassin Mask/ThingDefs_Misc/Apparel_Headhear.xml
@@ -33,7 +33,7 @@
 					<value>
 					    <equippedStatOffsets>
 						    <SmokeSensitivity>-0.6</SmokeSensitivity>
-							<ToxicSensitivity>-0.2</ToxicSensitivity>
+							<ToxicResistance>0.20</ToxicResistance>
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Doom Factions/DoomFactions_Apperal.xml
+++ b/Patches/Doom Factions/DoomFactions_Apperal.xml
@@ -49,7 +49,7 @@
 			<value>
 				<CarryWeight>150</CarryWeight> <!-- Has a built-in exoskeleton -->
 				<CarryBulk>120</CarryBulk> <!-- has a TacVest and backpack -->
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 			</value>
 		</li>
 			
@@ -105,7 +105,7 @@
 				<equippedStatOffsets>
 					<PsychicSensitivity>-0.2</PsychicSensitivity>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 					<MoveSpeed>-0.02</MoveSpeed>
 					<ShootingAccuracyPawn>0.40</ShootingAccuracyPawn>
@@ -167,7 +167,7 @@
 				<equippedStatOffsets>
 					<CarryWeight>150</CarryWeight> <!-- Built-in exoskeleton -->
 					<CarryBulk>150</CarryBulk> <!-- has a TacVest and backpack -->
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>1</MoveSpeed>
 					<MeleeHitChance>1</MeleeHitChance>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
@@ -234,7 +234,7 @@
 					<MentalBreakThreshold>-0.04</MentalBreakThreshold>
 					<PsychicSensitivity>-0.2</PsychicSensitivity>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</equippedStatOffsets>
 			</value>

--- a/Patches/Eisenhans Power Armor/ThingDefs_Various.xml
+++ b/Patches/Eisenhans Power Armor/ThingDefs_Various.xml
@@ -50,7 +50,7 @@
           <value>
             <equippedStatOffsets>
               <PsychicSensitivity>-0.1</PsychicSensitivity>
-              <ToxicSensitivity>-0.50</ToxicSensitivity>
+              <ToxicResistance>0.50</ToxicResistance>
               <SmokeSensitivity>-1</SmokeSensitivity>
               <ShootingAccuracyPawn>-0.10</ShootingAccuracyPawn>
             </equippedStatOffsets>
@@ -137,7 +137,7 @@
             <equippedStatOffsets>
               <CarryWeight>80</CarryWeight>
               <CarryBulk>15</CarryBulk>
-              <ToxicSensitivity>-0.50</ToxicSensitivity>
+              <ToxicResistance>0.50</ToxicResistance>
               <MoveSpeed>-2</MoveSpeed>
             </equippedStatOffsets>
           </value>

--- a/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
+++ b/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
@@ -307,7 +307,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>-0.8</MoveSpeed>
 				</value>
 			</li>
@@ -347,7 +347,7 @@
 				<xpath>Defs/ThingDef[defName="Apparel_EponaSpaceSuitHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
@@ -78,7 +78,7 @@
 				<li Class="PatchOperationAdd">
    				 <xpath>Defs/ThingDef[defName="FF_ForsakenH"]/equippedStatOffsets</xpath>
     				<value>
-      				<ToxicSensitivity>-0.50</ToxicSensitivity>
+      				<ToxicResistance>0.50</ToxicResistance>
       				<SmokeSensitivity>-1</SmokeSensitivity>
     				</value>
 				</li>

--- a/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
+++ b/Patches/Genetic Rim/GeneticRim_CE_Patch_Projectiles.xml
@@ -195,7 +195,7 @@
 						<damageAmountBase>1</damageAmountBase>
 			<explosionRadius >5.9</explosionRadius >
 			<explosionDelay>1</explosionDelay>
-			<postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+			<postExplosionGasType>BlindSmoke</postExplosionGasType>
 			<postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>
 			<postExplosionSpawnChance>1</postExplosionSpawnChance>
 					</projectile>

--- a/Patches/Half Dragons/Apparel_Various.xml
+++ b/Patches/Half Dragons/Apparel_Various.xml
@@ -54,7 +54,7 @@
 			<value>
 				<CarryWeight>80</CarryWeight>
 				<CarryBulk>10</CarryBulk>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 			</value>
 		</li>
 	
@@ -92,7 +92,7 @@
 			<xpath>/Defs/ThingDef[@Name="ApparelDragonArmorHelmetPowerBase"]/equippedStatOffsets</xpath>
 			<value>
 			  <PsychicSensitivity>-0.2</PsychicSensitivity>
-			  <ToxicSensitivity>-0.50</ToxicSensitivity>
+			  <ToxicResistance>0.50</ToxicResistance>
 			  <SmokeSensitivity>-1</SmokeSensitivity>
 			</value>
 		</li>

--- a/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
+++ b/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
@@ -126,7 +126,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>21</speed>
     </projectile>

--- a/Patches/JDS The Forge - NCR Armory/Defs_Apparel.xml
+++ b/Patches/JDS The Forge - NCR Armory/Defs_Apparel.xml
@@ -220,7 +220,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="JDS_NCR_SalvagedPowerArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 					</value>
 				</li>
 

--- a/Patches/JDS The Forge - NCR Armory/Defs_Headgear.xml
+++ b/Patches/JDS The Forge - NCR Armory/Defs_Headgear.xml
@@ -60,7 +60,7 @@
 					<value>
 					  <equippedStatOffsets>
 						<SmokeSensitivity>-0.10</SmokeSensitivity>
-						<ToxicSensitivity>-0.10</ToxicSensitivity>
+						<ToxicResistance>0.10</ToxicResistance>
 					  </equippedStatOffsets>	
 					</value>
 				</li>
@@ -116,7 +116,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="JDS_NCR_Ranger_Combat_Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -158,7 +158,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="JDS_NCR_SalvagedPowerArmor_Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>

--- a/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Apparel.xml
+++ b/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Apparel.xml
@@ -317,7 +317,7 @@
                <xpath>Defs/ThingDef[ @Name="WW2GasMask"]/equippedStatOffsets</xpath>
                <value>
                   <equippedStatOffsets>
-                     <ToxicSensitivity>-0.5</ToxicSensitivity>
+                     <ToxicResistance>0.5</ToxicResistance>
                      <SmokeSensitivity>-1</SmokeSensitivity>
                   </equippedStatOffsets>
                </value>

--- a/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
+++ b/Patches/Kijin 2.0/Ammo/Ammo_Kijin_Misc.xml
@@ -75,7 +75,7 @@
 					  <explosionDelay>30</explosionDelay>
 					  <dropsCasings>true</dropsCasings>
 					  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
-					  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+					  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 					  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 					  <speed>8</speed>
 					  <gravityFactor>2</gravityFactor>

--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Apparel.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Apparel.xml
@@ -165,7 +165,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -225,7 +225,7 @@
 				  <equippedStatOffsets>
 					<PsychicSensitivity>-0.2</PsychicSensitivity>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				  </equippedStatOffsets>
 				</value>

--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Weapons_Ranged.xml
@@ -293,7 +293,7 @@
 					  <li Class="CombatExtended.CompProperties_ExplosiveCE">
 						<explosiveDamageType>Smoke</explosiveDamageType>
 						<explosiveRadius>3</explosiveRadius>
-						<postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+						<postExplosionGasType>BlindSmoke</postExplosionGasType>
 						<preExplosionSpawnChance>1</preExplosionSpawnChance>
 					  </li>
 					</comps>

--- a/Patches/LF Command And Conquer NOD Combat Armor/CE_Nod.xml
+++ b/Patches/LF Command And Conquer NOD Combat Armor/CE_Nod.xml
@@ -51,7 +51,7 @@
           <value>
             <equippedStatOffsets>
               <PsychicSensitivity>-0.1</PsychicSensitivity>
-              <ToxicSensitivity>-0.50</ToxicSensitivity>
+              <ToxicResistance>0.50</ToxicResistance>
               <SmokeSensitivity>-1</SmokeSensitivity>
               <ShootingAccuracyPawn>0.1</ShootingAccuracyPawn>
             </equippedStatOffsets>
@@ -142,7 +142,7 @@
           <value>
             <equippedStatOffsets>
               <CarryBulk>8</CarryBulk>
-              <ToxicSensitivity>-0.20</ToxicSensitivity>
+              <ToxicResistance>0.20</ToxicResistance>
             </equippedStatOffsets>
           </value>
         </li>

--- a/Patches/LF Red Dawn/82mmMortar.xml
+++ b/Patches/LF Red Dawn/82mmMortar.xml
@@ -171,7 +171,7 @@
         <explosiveRadius>6</explosiveRadius>
         <explosiveDamageType>Smoke</explosiveDamageType>
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-        <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+        <postExplosionGasType>BlindSmoke</postExplosionGasType>
         <preExplosionSpawnChance>1</preExplosionSpawnChance>
 		    <explodeOnKilled>True</explodeOnKilled>
         <wickTicks>30~82</wickTicks>
@@ -305,7 +305,7 @@
       <soundExplode>Explosion_EMP</soundExplode>
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Patches/LF Red Dawn/RespiratorsHelmets_RD.xml
+++ b/Patches/LF Red Dawn/RespiratorsHelmets_RD.xml
@@ -26,7 +26,7 @@
         ]/equippedStatOffsets</xpath>
         <value>
         <equippedStatOffsets>
-          <ToxicSensitivity>-0.5</ToxicSensitivity>
+          <ToxicResistance>0.5</ToxicResistance>
           <SmokeSensitivity>-1</SmokeSensitivity>
         </equippedStatOffsets>
         </value>

--- a/Patches/LF Red Dawn/Softhead.xml
+++ b/Patches/LF Red Dawn/Softhead.xml
@@ -66,7 +66,7 @@
 				<xpath>Defs/ThingDef[defName="RD_Facemask"]</xpath>
 				<value>
         				<equippedStatOffsets>
-          					<ToxicSensitivity>-0.05</ToxicSensitivity>
+          					<ToxicResistance>0.05</ToxicResistance>
           					<SmokeSensitivity>-0.1</SmokeSensitivity>
         				</equippedStatOffsets>
 				</value>

--- a/Patches/Mechanite Plague/Patch_AddAmmo.xml
+++ b/Patches/Mechanite Plague/Patch_AddAmmo.xml
@@ -593,7 +593,7 @@
 					<speed>25</speed>
 					<damageDef>Smoke</damageDef>
 					<explosionRadius>5.8</explosionRadius>
-					<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+					<postExplosionGasType>BlindSmoke</postExplosionGasType>
 					<preExplosionSpawnChance>1</preExplosionSpawnChance>
 					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 				</projectile>
@@ -620,7 +620,7 @@
 					<speed>25</speed>
 					<damageDef>Smoke</damageDef>
 					<explosionRadius>1.8</explosionRadius>
-					<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>
+					<postExplosionGasType>BlindSmoke</postExplosionGasType>
 					<preExplosionSpawnChance>1</preExplosionSpawnChance>
 					<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 				</projectile>

--- a/Patches/Mechanoid Bench 2 JGH/Apparel_MB2.xml
+++ b/Patches/Mechanoid Bench 2 JGH/Apparel_MB2.xml
@@ -31,7 +31,7 @@
                             <CarryWeight>90</CarryWeight>
                             <CarryBulk>13.5</CarryBulk>
                             <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-                            <ToxicSensitivity>-0.50</ToxicSensitivity>
+                            <ToxicResistance>0.50</ToxicResistance>
                         </equippedStatOffsets>
                     </value>
                 </li>
@@ -103,7 +103,7 @@
                         <equippedStatOffsets>
                             <PsychicSensitivity>-0.2</PsychicSensitivity>
                             <AimingAccuracy>0.20</AimingAccuracy>
-                            <ToxicSensitivity>-0.50</ToxicSensitivity>
+                            <ToxicResistance>0.50</ToxicResistance>
                             <SmokeSensitivity>-1</SmokeSensitivity>
                             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
                         </equippedStatOffsets>

--- a/Patches/Mechanoid Bench 3 JGH/Apparel_MB3.xml
+++ b/Patches/Mechanoid Bench 3 JGH/Apparel_MB3.xml
@@ -60,7 +60,7 @@
                     <xpath>Defs/ThingDef[defName="Apparel_MechaHeavyHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
                     <value>
                         <AimingAccuracy>0.15</AimingAccuracy>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <SmokeSensitivity>-1</SmokeSensitivity>
                         <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
                     </value>
@@ -103,7 +103,7 @@
                         <CarryWeight>95</CarryWeight>
                         <CarryBulk>12.2</CarryBulk>
                         <ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                     </value>
                 </li>
 
@@ -146,7 +146,7 @@
                     <xpath>Defs/ThingDef[defName="Apparel_MechaCombatHelmet"]/equippedStatOffsets/MeleeDodgeChance</xpath>
                     <value>
                         <AimingAccuracy>0.20</AimingAccuracy>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <SmokeSensitivity>-1</SmokeSensitivity>
                         <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
                         <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -190,7 +190,7 @@
                         <CarryWeight>90</CarryWeight>
                         <CarryBulk>13.5</CarryBulk>
                         <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <MoveSpeed>0.1</MoveSpeed>
                     </value>
                 </li>
@@ -230,7 +230,7 @@
                     <xpath>Defs/ThingDef[defName="Apparel_MechaSniperHelmet"]/equippedStatOffsets/AimingDelayFactor</xpath>
                     <value>
                         <AimingAccuracy>0.25</AimingAccuracy>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <SmokeSensitivity>-1</SmokeSensitivity>
                         <NightVisionEfficiency_Apparel>0.8</NightVisionEfficiency_Apparel>
                         <AimingDelayFactor>-0.1</AimingDelayFactor>
@@ -274,7 +274,7 @@
                         <CarryWeight>85</CarryWeight>
                         <CarryBulk>12.5</CarryBulk>
                         <ShootingAccuracyPawn>0.4</ShootingAccuracyPawn>
-                        <ToxicSensitivity>-0.50</ToxicSensitivity>
+                        <ToxicResistance>0.50</ToxicResistance>
                         <ReloadSpeed>0.2</ReloadSpeed>
                     </value>
                 </li>

--- a/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_ArchotechSpecial.xml
+++ b/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_ArchotechSpecial.xml
@@ -18,7 +18,7 @@
 									<ArmorRating_Sharp>0.36</ArmorRating_Sharp>
 									<ArmorRating_Blunt>0.661</ArmorRating_Blunt>
 									<ArmorRating_Heat>0.048</ArmorRating_Heat>
-									<ToxicSensitivity>-0.5</ToxicSensitivity>
+									<ToxicResistance>0.5</ToxicResistance>
 								</statOffsets>
 							</li>
 						</stages>

--- a/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_BionicSpecial.xml
+++ b/Patches/Medical System Expansion - Revived/HediffDefs/Hediffs_AddedParts/Hediffs_AddedParts_BionicSpecial.xml
@@ -18,7 +18,7 @@
 									<ArmorRating_Sharp>0.127</ArmorRating_Sharp>
 									<ArmorRating_Blunt>0.234</ArmorRating_Blunt>
 									<ArmorRating_Heat>0.024</ArmorRating_Heat>
-									<ToxicSensitivity>-0.25</ToxicSensitivity>
+									<ToxicResistance>0.25</ToxicResistance>
 								</statOffsets>
 							</li>
 						</stages>

--- a/Patches/Medieval Overhaul/MO_Weapons_Grenades.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Grenades.xml
@@ -341,7 +341,7 @@
                     <explosionRadius>3</explosionRadius>
                     <damageDef>Smoke</damageDef>
                     <explosionDelay>100</explosionDelay>
-                    <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+                    <postExplosionGasType>BlindSmoke</postExplosionGasType>
                     <postExplosionSpawnChance>1</postExplosionSpawnChance>                    
                     <speed>10</speed>
                     <gravityFactor>2</gravityFactor>
@@ -391,7 +391,7 @@
                     <explosiveRadius>2.5</explosiveRadius>
                     <explosiveDamageType>Stun</explosiveDamageType>
                     <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-                    <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+                    <postExplosionGasType>BlindSmoke</postExplosionGasType>
                     <preExplosionSpawnChance>1</preExplosionSpawnChance>
                     <explodeOnKilled>True</explodeOnKilled>
                     <wickTicks>60~100</wickTicks>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
@@ -235,7 +235,7 @@
 					<CarryWeight>40</CarryWeight>
 					<CarryBulk>20</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>0.3</MoveSpeed>
 				</equippedStatOffsets>
 				</value>
@@ -351,7 +351,7 @@
 				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -117,7 +117,7 @@
 				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -181,7 +181,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>30</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -328,7 +328,7 @@
 				<value>
 					<CarryWeight>85</CarryWeight>
 					<CarryBulk>10</CarryBulk>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -450,7 +450,7 @@
 				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -518,7 +518,7 @@
 					<equippedStatOffsets>
 						<CarryWeight>75</CarryWeight>
 						<CarryBulk>10</CarryBulk>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -634,7 +634,7 @@
 				<value>
 					<equippedStatOffsets>
 						<SmokeSensitivity>-1</SmokeSensitivity>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -170,7 +170,7 @@
 					<CarryWeight>85</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -283,7 +283,7 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -347,7 +347,7 @@
 					<CarryWeight>60</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>0.1</MoveSpeed>
 				</value>
 			</li>
@@ -461,7 +461,7 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			

--- a/Patches/Moyo light in the abyss/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo light in the abyss/ThingDefs_Misc/Moyo_Apparel.xml
@@ -496,7 +496,7 @@
 				<value>
 					<CarryWeight>110</CarryWeight>
 					<CarryBulk>15</CarryBulk>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<MoveSpeed>-0.75</MoveSpeed>
 				</value>
 			</li>
@@ -606,7 +606,7 @@
 				<xpath>Defs/ThingDef[defName="RedMoyo_AbyssHelmet"]/equippedStatOffsets</xpath>
 				<value>
 						<SmokeSensitivity>-1</SmokeSensitivity>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			

--- a/Patches/Nanosuit/Armor_Crysis.xml
+++ b/Patches/Nanosuit/Armor_Crysis.xml
@@ -45,7 +45,7 @@
 						<AimingDelayFactor>-0.05</AimingDelayFactor>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.1</AimingAccuracy>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 						<Suppressability>-0.1</Suppressability>
 					</equippedStatOffsets>
@@ -98,7 +98,7 @@
 					<CarryWeight>60</CarryWeight>
 					<CarryBulk>80</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.5</ToxicSensitivity>
+					<ToxicResistance>0.5</ToxicResistance>
 					<MoveSpeed>1</MoveSpeed>
 					<ReloadSpeed>0.15</ReloadSpeed>
 					<Suppressability>-0.33</Suppressability>

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -81,7 +81,7 @@
 					<CarryBulk>10</CarryBulk>
 					<MoveSpeed>-0.5</MoveSpeed>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -124,7 +124,7 @@
 					<CarryWeight>70</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -167,7 +167,7 @@
 					<CarryWeight>70</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -248,7 +248,7 @@
 				]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -277,7 +277,7 @@
 				<value>
 					<equippedStatOffsets>
 						<CarryBulk>30</CarryBulk>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					</equippedStatOffsets>	
 				</value>

--- a/Patches/Nyaron/ThingDefs_Misc/Nyaron_Apparel.xml
+++ b/Patches/Nyaron/ThingDefs_Misc/Nyaron_Apparel.xml
@@ -188,7 +188,7 @@
 			<value>
 				<CarryWeight>35</CarryWeight>
 				<CarryBulk>10</CarryBulk>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 			</value>
 		</li>
 		

--- a/Patches/O21 Outer Rim Galaxies/Clone Wars/Patch_OuterRim_CloneWars_Apparel.xml
+++ b/Patches/O21 Outer Rim Galaxies/Clone Wars/Patch_OuterRim_CloneWars_Apparel.xml
@@ -108,7 +108,7 @@
 				<xpath>Defs/ThingDef[@Name="CloneArmorPhaseOneCuirassBase"]</xpath>
 				<value>
 				<equippedStatOffsets>
-					<ToxicSensitivity>-0.40</ToxicSensitivity>
+					<ToxicResistance>0.40</ToxicResistance>
 					<CarryBulk>25</CarryBulk>
 				</equippedStatOffsets>
 				</value>
@@ -162,7 +162,7 @@
 				<xpath>Defs/ThingDef[@Name="CloneCuirassIIBase"]</xpath>
 				<value>
 				<equippedStatOffsets>
-					<ToxicSensitivity>-0.40</ToxicSensitivity>
+					<ToxicResistance>0.40</ToxicResistance>
 					<CarryBulk>30</CarryBulk>
 				</equippedStatOffsets>
 				</value>
@@ -211,7 +211,7 @@
 				<value>
 				  <equippedStatOffsets>
 					<AimingAccuracy>0.1</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				  </equippedStatOffsets>
 				</value>
@@ -266,7 +266,7 @@
 				<value>
 				  <equippedStatOffsets>
 					<AimingAccuracy>0.1</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				  </equippedStatOffsets>
 				</value>

--- a/Patches/O21 Outer Rim Galaxies/Mandalore/Patch_OuterRim_Mandalore_Apparel.xml
+++ b/Patches/O21 Outer Rim Galaxies/Mandalore/Patch_OuterRim_Mandalore_Apparel.xml
@@ -40,7 +40,7 @@
 						<xpath>Defs/ThingDef[@Name="MandalorianChestBase"]</xpath>
 						<value>
 						<equippedStatOffsets>
-							<ToxicSensitivity>-0.40</ToxicSensitivity>
+							<ToxicResistance>0.40</ToxicResistance>
 							<CarryBulk>25</CarryBulk>
 						</equippedStatOffsets>
 						</value>
@@ -76,7 +76,7 @@
 						<xpath>Defs/ThingDef[@Name="MandalorianHelmetBase"]</xpath>
 						<value>
 						<equippedStatOffsets>
-							<ToxicSensitivity>-0.40</ToxicSensitivity>
+							<ToxicResistance>0.40</ToxicResistance>
 						</equippedStatOffsets>
 						</value>
 					</li>

--- a/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
+++ b/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
@@ -204,7 +204,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>5</explosionRadius>
       <damageDef>Smoke</damageDef>
-      <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
     <comps>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -497,7 +497,7 @@
 					  <soundExplode>Explosion_EMP</soundExplode>
 					  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 					  <soundAmbient>MortarRound_Ambient</soundAmbient>
-					  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+					  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 					  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 					  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 					  <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -48,7 +48,7 @@
 						<CarryWeight>80</CarryWeight>
 						<CarryBulk>10</CarryBulk>
 						<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 					</value>
 				</li>
 				<li Class="PatchOperationRemove">
@@ -110,7 +110,7 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<AimingAccuracy>0.2</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -172,7 +172,7 @@
 						<CarryWeight>80</CarryWeight>
 						<CarryBulk>10</CarryBulk>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 					</value>
 				</li>
 				<li Class="PatchOperationRemove">
@@ -234,7 +234,7 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<AimingAccuracy>0.15</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -296,7 +296,7 @@
 						<CarryWeight>60</CarryWeight>
 						<CarryBulk>8</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 					</value>
 				</li>
 				<!-- costList -->
@@ -355,7 +355,7 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<AimingAccuracy>0.05</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -84,7 +84,7 @@
             <equippedStatOffsets>
                 <PsychicSensitivity>-0.2</PsychicSensitivity>
                 <AimingAccuracy>0.15</AimingAccuracy>
-                <ToxicSensitivity>-0.50</ToxicSensitivity>
+                <ToxicResistance>0.50</ToxicResistance>
                 <SmokeSensitivity>-1</SmokeSensitivity>
             </equippedStatOffsets>
             </value>
@@ -164,7 +164,7 @@
             <value>
             <equippedStatOffsets>
                 <CarryWeight>25</CarryWeight>
-                <ToxicSensitivity>-0.50</ToxicSensitivity>
+                <ToxicResistance>0.50</ToxicResistance>
                 <MoveSpeed>0.4</MoveSpeed>
             </equippedStatOffsets>
             </value>

--- a/Patches/RH2 Rimmu-Nation² - Clothing/Respirators_Rimmu.xml
+++ b/Patches/RH2 Rimmu-Nation² - Clothing/Respirators_Rimmu.xml
@@ -33,7 +33,7 @@
         ]/equippedStatOffsets</xpath>
         <value>
         <equippedStatOffsets>
-          <ToxicSensitivity>-0.5</ToxicSensitivity>
+          <ToxicResistance>0.5</ToxicResistance>
           <SmokeSensitivity>-1</SmokeSensitivity>
         </equippedStatOffsets>
         </value>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
@@ -378,7 +378,7 @@
 				<value>
 					<CarryBulk>10</CarryBulk>
 					<ReloadSpeed>0.10</ReloadSpeed>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<CarryWeight>60</CarryWeight>
 				</value>
@@ -422,7 +422,7 @@
 				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/RadWorld/ThingDefs_Misc.xml
+++ b/Patches/RadWorld/ThingDefs_Misc.xml
@@ -32,7 +32,7 @@
 			<xpath>Defs/ThingDef[defName="RW_Apparel_GasMask_Black" or defName="RW_Apparel_GasMask_Yellow"]</xpath>
 			<value>
 				<equippedStatOffsets>
-					<ToxicSensitivity>-0.5</ToxicSensitivity>
+					<ToxicResistance>0.5</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</equippedStatOffsets>
 			</value>

--- a/Patches/Ratnik-3 Prototype Armor/Ratnik_CE.xml
+++ b/Patches/Ratnik-3 Prototype Armor/Ratnik_CE.xml
@@ -45,7 +45,7 @@
         <xpath>/Defs/ThingDef[defName="Apparel_Ratnik-3_Helmet"]/equippedStatOffsets</xpath>
         <value>
           <equippedStatOffsets>
-            <ToxicSensitivity>-0.33</ToxicSensitivity>
+            <ToxicResistance>0.33</ToxicResistance>
             <SmokeSensitivity>-0.66</SmokeSensitivity>
           </equippedStatOffsets>
         </value>
@@ -137,7 +137,7 @@
           <equippedStatOffsets>
             <CarryWeight>25</CarryWeight>
             <CarryBulk>20</CarryBulk>
-            <ToxicSensitivity>-0.30</ToxicSensitivity>
+            <ToxicResistance>0.30</ToxicResistance>
             <MoveSpeed>0.1</MoveSpeed>
           </equippedStatOffsets>
         </value>

--- a/Patches/Red Horse Faction UAC/RH_UAC_CE_Patch_Apparel_Armor.xml
+++ b/Patches/Red Horse Faction UAC/RH_UAC_CE_Patch_Apparel_Armor.xml
@@ -23,7 +23,7 @@
 				<value>
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>20</CarryBulk>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 
@@ -56,7 +56,7 @@
 				<value>
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>20</CarryBulk>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 

--- a/Patches/Red Horse Faction UAC/RH_UAC_CE_Patch_Armor_Marine.xml
+++ b/Patches/Red Horse Faction UAC/RH_UAC_CE_Patch_Armor_Marine.xml
@@ -21,7 +21,7 @@
 				<equippedStatOffsets>
 					<CarryWeight>60</CarryWeight>
 					<CarryBulk>20</CarryBulk>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</equippedStatOffsets>	
 				</value>
 			</li>

--- a/Patches/Rim-Effect Asari and Reapers/Armor_Asari.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Armor_Asari.xml
@@ -91,7 +91,7 @@
 						<CarryBulk>30</CarryBulk>
 						<ShootingAccuracyPawn>0.1</ShootingAccuracyPawn>
 						<AimingDelayFactor>-0.075</AimingDelayFactor>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<MoveSpeed>0.4</MoveSpeed>
 						<ReloadSpeed>0.15</ReloadSpeed>
 					</value>
@@ -168,7 +168,7 @@
 						<CarryWeight>20</CarryWeight>
 						<CarryBulk>40</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<ReloadSpeed>0.1</ReloadSpeed>
 					</value>
 				</li>

--- a/Patches/Rim-Effect Core/Armor_ME.xml
+++ b/Patches/Rim-Effect Core/Armor_ME.xml
@@ -87,7 +87,7 @@
 					<value>
     						<equippedStatOffsets>
 						<AimingDelayFactor>-0.05</AimingDelayFactor>
-						<ToxicSensitivity>-0.1</ToxicSensitivity>
+						<ToxicResistance>0.10</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
     						</equippedStatOffsets>
 					</value>
@@ -199,7 +199,7 @@
 						<CarryWeight>12</CarryWeight>
 						<CarryBulk>35</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<MoveSpeed>0.3</MoveSpeed>
 						<ReloadSpeed>0.1</ReloadSpeed>
     					</equippedStatOffsets>
@@ -322,7 +322,7 @@
 						<equippedStatOffsets>
 							<PsychicSensitivity>-0.1</PsychicSensitivity>
 							<AimingDelayFactor>-0.05</AimingDelayFactor>
-							<ToxicSensitivity>-0.25</ToxicSensitivity>
+							<ToxicResistance>0.25</ToxicResistance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
 						</equippedStatOffsets>
 					</value>
@@ -421,7 +421,7 @@
 						<CarryWeight>20</CarryWeight>
 						<CarryBulk>40</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<ReloadSpeed>0.1</ReloadSpeed>
 					</value>
 				</li>
@@ -532,7 +532,7 @@
 						<equippedStatOffsets>
 							<PsychicSensitivity>-0.3</PsychicSensitivity>
 							<AimingAccuracy>0.3</AimingAccuracy>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<CarryWeight>5.4</CarryWeight>
 							<CarryBulk>1</CarryBulk>
 							<SmokeSensitivity>-1</SmokeSensitivity>
@@ -626,7 +626,7 @@
 							<CarryWeight>75</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<PainShockThreshold>0.05</PainShockThreshold>
       							<MoveSpeed>-0.4</MoveSpeed>
 							<ReloadSpeed>0.1</ReloadSpeed>
@@ -717,7 +717,7 @@
 							<CarryWeight>40</CarryWeight>
 							<CarryBulk>50</CarryBulk>
 							<ShootingAccuracyPawn>0.3</ShootingAccuracyPawn>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<PainShockThreshold>0.1</PainShockThreshold>
       							<MoveSpeed>0.5</MoveSpeed>
 							<ReloadSpeed>0.1</ReloadSpeed>

--- a/Patches/Rim-Effect N7/Armor_N7.xml
+++ b/Patches/Rim-Effect N7/Armor_N7.xml
@@ -58,7 +58,7 @@
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/equippedStatOffsets</xpath>
 					<value>
 						<AimingDelayFactor>-0.075</AimingDelayFactor>
-						<ToxicSensitivity>-0.2</ToxicSensitivity>
+						<ToxicResistance>0.20</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -168,7 +168,7 @@
 						<CarryWeight>12</CarryWeight>
 						<CarryBulk>40</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<MoveSpeed>0.6</MoveSpeed>
 						<Suppressability>-0.1</Suppressability>
 						<ReloadSpeed>0.15</ReloadSpeed>
@@ -290,7 +290,7 @@
 					<value>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingDelayFactor>-0.075</AimingDelayFactor>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -388,7 +388,7 @@
 						<CarryWeight>22</CarryWeight>
 						<CarryBulk>45</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 						<MoveSpeed>0.2</MoveSpeed>
 						<Suppressability>-0.1</Suppressability>
 						<ReloadSpeed>0.15</ReloadSpeed>
@@ -501,7 +501,7 @@
 						<equippedStatOffsets>
 							<PsychicSensitivity>-0.3</PsychicSensitivity>
 							<AimingAccuracy>0.25</AimingAccuracy>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<CarryWeight>5</CarryWeight>
 							<CarryBulk>1</CarryBulk>
 							<SmokeSensitivity>-1</SmokeSensitivity>
@@ -596,7 +596,7 @@
 							<CarryWeight>75</CarryWeight>
 							<CarryBulk>60</CarryBulk>
 							<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<PainShockThreshold>0.1</PainShockThreshold>
 							<MoveSpeed>-0.25</MoveSpeed>
 							<Suppressability>-0.15</Suppressability>

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Apparel_RS_CE.xml
@@ -232,7 +232,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_ProtectiveGear"]/equippedStatOffsets</xpath>
 				<value>
-					<ToxicSensitivity>-0.30</ToxicSensitivity>
+					<ToxicResistance>0.30</ToxicResistance>
 					<MeleeDodgeChance>-0.25</MeleeDodgeChance>
 				</value>
 			</li>
@@ -376,7 +376,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/equippedStatOffsets</xpath>
 				<value>
-					<ToxicSensitivity>-0.20</ToxicSensitivity>
+					<ToxicResistance>0.20</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>	
 					<AimingAccuracy>-0.2</AimingAccuracy>
 					<MeleeHitChance>-1</MeleeHitChance>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -105,7 +105,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/equippedStatOffsets</xpath>
 				<value>
-					<ToxicSensitivity>-0.8</ToxicSensitivity>
+					<ToxicResistance>0.80</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
@@ -322,7 +322,7 @@
 				<value>
 					<CarryWeight>70</CarryWeight>
 					<CarryBulk>10</CarryBulk>
-					<ToxicSensitivity>-0.45</ToxicSensitivity>
+					<ToxicResistance>0.45</ToxicResistance>
 			</value>
 		    </li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -177,7 +177,7 @@
 				<damageAmountBase>5</damageAmountBase>
 				<explosionRadius>3.2</explosionRadius>			
 				<speed>30</speed>
-				<preExplosionSpawnThingDef>Gas_Smoke</preExplosionSpawnThingDef>				
+				<postExplosionGasType>BlindSmoke</postExplosionGasType>				
 			  </projectile>
 			</value>
 		  </li>

--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -563,7 +563,7 @@
 			  <soundExplode>Explosion_EMP</soundExplode>
 			  <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			  <soundAmbient>MortarRound_Ambient</soundAmbient>
-			  <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+			  <postExplosionGasType>BlindSmoke</postExplosionGasType>
 			  <preExplosionSpawnChance>1</preExplosionSpawnChance>
 			  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			  <explosionEffect>ExtinguisherExplosion</explosionEffect>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -350,7 +350,7 @@
                                 <explosiveDamageType>Smoke</explosiveDamageType>
                                 <explosiveRadius>6</explosiveRadius>
                                 <explosionSound>Explosion_EMP</explosionSound>
-                                <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+                                <postExplosionGasType>BlindSmoke</postExplosionGasType>
                                 <preExplosionSpawnChance>1</preExplosionSpawnChance>
                                 <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                             </li>

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -29,7 +29,7 @@
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBody"]/equippedStatOffsets</xpath>
 		<value>
-                         <ToxicSensitivity>-0.50</ToxicSensitivity>
+                         <ToxicResistance>0.50</ToxicResistance>
 		</value>
 	   </li>
 
@@ -154,7 +154,7 @@
 			<value>
 				<Bulk>100</Bulk>
 				<WornBulk>15</WornBulk>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<Flammability>0</Flammability>
 			</value>
 		</li>
@@ -178,7 +178,7 @@
 		<value>
 			<CarryBulk>10</CarryBulk>
 			<CarryWeight>80</CarryWeight>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<ToxicResistance>0.50</ToxicResistance>
 		</value>
 		</li>
 		</operations>

--- a/Patches/Sergal/Sergal_Apparel.xml
+++ b/Patches/Sergal/Sergal_Apparel.xml
@@ -256,7 +256,7 @@
 					<equippedStatOffsets>
 						<CarryWeight>50</CarryWeight>
 						<CarryBulk>8</CarryBulk>
-						<ToxicSensitivity>-0.50</ToxicSensitivity>
+						<ToxicResistance>0.50</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -358,7 +358,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 

--- a/Patches/Solark Race/ThingDefs_Misc/Solark_Apparel.xml
+++ b/Patches/Solark Race/ThingDefs_Misc/Solark_Apparel.xml
@@ -63,7 +63,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -159,7 +159,7 @@
 				]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Patches/Spartan Foundry/Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/Apparel_Armors.xml
@@ -30,7 +30,7 @@
 						<CarryWeight>93.7</CarryWeight>
 						<CarryBulk>10.8</CarryBulk>
 						<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -82,7 +82,7 @@
 						<CarryWeight>82.3</CarryWeight>
 						<CarryBulk>12</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<ConstructionSpeed>0.15</ConstructionSpeed>
 						<FixBrokenDownBuildingSuccessChance>0.10</FixBrokenDownBuildingSuccessChance>
 					</equippedStatOffsets>
@@ -135,7 +135,7 @@
 						<CarryWeight>83.5</CarryWeight>
 						<CarryBulk>11.1</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<PlantWorkSpeed>0.12</PlantWorkSpeed>
 						<ResearchSpeedFactor>0.2</ResearchSpeedFactor>
 					</equippedStatOffsets>
@@ -188,7 +188,7 @@
 						<CarryWeight>90.4</CarryWeight>
 						<CarryBulk>16</CarryBulk>
 						<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<ReloadSpeed>-0.3</ReloadSpeed>
 					</equippedStatOffsets>
 				</value>
@@ -240,7 +240,7 @@
 						<CarryWeight>110.5</CarryWeight>
 						<CarryBulk>17.1</CarryBulk>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -293,7 +293,7 @@
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
 						<MiningSpeed>0.2</MiningSpeed>
 						<Flammability>-1</Flammability>
-						<ToxicSensitivity>-1</ToxicSensitivity>
+						<ToxicResistance>1</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -344,7 +344,7 @@
 						<CarryWeight>82.3</CarryWeight>
 						<CarryBulk>12</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<NegotiationAbility>0.15</NegotiationAbility>
 						<GlobalLearningFactor>0.3</GlobalLearningFactor>
 					</equippedStatOffsets>
@@ -397,7 +397,7 @@
 						<CarryWeight>82.3</CarryWeight>
 						<CarryBulk>12</CarryBulk>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MedicalPotency>0.1</MedicalPotency>
 						<MedicalTendQuality>0.15</MedicalTendQuality>
 						<MedicalTendSpeed>0.6</MedicalTendSpeed>
@@ -451,7 +451,7 @@
 						<CarryWeight>87.3</CarryWeight>
 						<CarryBulk>11.20</CarryBulk>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MoveSpeed>0.4</MoveSpeed>
 						<TrapSpringChance>-1</TrapSpringChance>
 					</equippedStatOffsets>
@@ -503,7 +503,7 @@
 					<equippedStatOffsets>
 						<CarryWeight>88.1</CarryWeight>
 						<CarryBulk>10.7</CarryBulk>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MeleeHitChance>0.05</MeleeHitChance>
 						<MeleeCritChance>0.1</MeleeCritChance>
 						<MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -557,7 +557,7 @@
 					<equippedStatOffsets>
 						<CarryWeight>82.7</CarryWeight>
 						<CarryBulk>10.7</CarryBulk>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MeleeHitChance>0.025</MeleeHitChance>
 						<MeleeCritChance>0.5</MeleeCritChance>
 						<MeleeDodgeChance>0.075</MeleeDodgeChance>
@@ -612,7 +612,7 @@
 						<CarryWeight>72.6</CarryWeight>
 						<CarryBulk>8.2</CarryBulk>
 						<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MoveSpeed>0.4</MoveSpeed>
 						<WorkSpeedGlobal>0.1</WorkSpeedGlobal>
 						<CarryingCapacity>30</CarryingCapacity>

--- a/Patches/Spartan Foundry/Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/Apparel_Headgear.xml
@@ -23,7 +23,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.2</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<PainShockThreshold>0.2</PainShockThreshold>
 						<SmokeSensitivity>-1</SmokeSensitivity>
             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
@@ -77,7 +77,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.05</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<ConstructSuccessChance>0.2</ConstructSuccessChance>
 						<FixBrokenDownBuildingSuccessChance>0.1</FixBrokenDownBuildingSuccessChance>
 						<ConstructionSpeed>0.1</ConstructionSpeed>
@@ -133,7 +133,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.3</PsychicSensitivity>
 						<AimingAccuracy>0.05</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<PlantHarvestYield>0.1</PlantHarvestYield>
 						<TameAnimalChance>0.1</TameAnimalChance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
@@ -188,7 +188,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.35</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 					</equippedStatOffsets>
@@ -241,7 +241,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.45</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<AimingDelayFactor>-0.15</AimingDelayFactor>
 						<SmokeSensitivity>-1</SmokeSensitivity>
             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
@@ -295,7 +295,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-1</PsychicSensitivity>
 						<AimingAccuracy>0.05</AimingAccuracy>
-						<ToxicSensitivity>-1</ToxicSensitivity>
+						<ToxicResistance>1</ToxicResistance>
 						<ImmunityGainSpeed>0.1</ImmunityGainSpeed>
 						<SmokeSensitivity>-1</SmokeSensitivity>
             <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
@@ -349,7 +349,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.05</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<GlobalLearningFactor>0.1</GlobalLearningFactor>
 						<NegotiationAbility>0.15</NegotiationAbility>
 						<SocialImpact>0.25</SocialImpact>
@@ -405,7 +405,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.15</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<MedicalTendQuality>0.10</MedicalTendQuality>
 						<MedicalOperationSpeed>0.15</MedicalOperationSpeed>
 						<SurgerySuccessChanceFactor>0.15</SurgerySuccessChanceFactor>
@@ -461,7 +461,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.5</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<AimingDelayFactor>0.2</AimingDelayFactor>
 						<SmokeSensitivity>-1</SmokeSensitivity>
             <NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
@@ -514,7 +514,7 @@
 				<value>
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.08</PsychicSensitivity>
-						<ToxicSensitivity>-0.20</ToxicSensitivity>
+						<ToxicResistance>0.20</ToxicResistance>
 						<MeleeHitChance>0.15</MeleeHitChance>
 						<MeleeCritChance>0.35</MeleeCritChance>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
@@ -570,7 +570,7 @@
 				<value>
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.08</PsychicSensitivity>
-						<ToxicSensitivity>-0.20</ToxicSensitivity>
+						<ToxicResistance>0.20</ToxicResistance>
 						<MeleeHitChance>0.075</MeleeHitChance>
 						<MeleeCritChance>0.15</MeleeCritChance>
 						<MeleeDodgeChance>0.025</MeleeDodgeChance>
@@ -627,7 +627,7 @@
 					<equippedStatOffsets>
 						<PsychicSensitivity>-0.2</PsychicSensitivity>
 						<AimingAccuracy>0.15</AimingAccuracy>
-						<ToxicSensitivity>-0.5</ToxicSensitivity>
+						<ToxicResistance>0.5</ToxicResistance>
 						<GeneralLaborSpeed>0.15</GeneralLaborSpeed>
 						<SmeltingSpeed>0.20</SmeltingSpeed>
 						<SmoothingSpeed>0.05</SmoothingSpeed>

--- a/Patches/Star Wars - Factions/Patch_Apparel.xml
+++ b/Patches/Star Wars - Factions/Patch_Apparel.xml
@@ -229,7 +229,7 @@
 				<equippedStatOffsets>
 					<CarryWeight>15</CarryWeight>
 					<CarryBulk>22</CarryBulk>
-					<ToxicSensitivity>-0.40</ToxicSensitivity>
+					<ToxicResistance>0.40</ToxicResistance>
 					<MoveSpeed>0.1</MoveSpeed>
 				</equippedStatOffsets>
 				</value>
@@ -342,7 +342,7 @@
 			<value>
 			  <equippedStatOffsets>
 				<PsychicSensitivity>-0.2</PsychicSensitivity>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<SmokeSensitivity>-1</SmokeSensitivity>
 			  </equippedStatOffsets>
 			</value>
@@ -358,7 +358,7 @@
 			  <equippedStatOffsets>
 				<PsychicSensitivity>-0.2</PsychicSensitivity>
 				<AimingAccuracy>0.1</AimingAccuracy>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<SmokeSensitivity>-1</SmokeSensitivity>
 			  </equippedStatOffsets>
 			</value>
@@ -509,7 +509,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</equippedStatOffsets>
 				</value>
 			</li>
@@ -574,7 +574,7 @@
 			  <equippedStatOffsets>
 				<PsychicSensitivity>-0.2</PsychicSensitivity>
 				<AimingAccuracy>0.15</AimingAccuracy>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<SmokeSensitivity>-1</SmokeSensitivity>
 			  </equippedStatOffsets>
 			</value>
@@ -822,7 +822,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</equippedStatOffsets>
 				</value>
 			</li>

--- a/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
@@ -337,7 +337,7 @@
                <xpath>Defs/ThingDef[defName="TSFApparel_OniHelmet"]/equippedStatOffsets</xpath>
                <value>
                   <AimingAccuracy>0.15</AimingAccuracy>
-                  <ToxicSensitivity>-0.50</ToxicSensitivity>
+                  <ToxicResistance>0.50</ToxicResistance>
                   <SmokeSensitivity>-1</SmokeSensitivity>
                   <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
                </value>
@@ -380,7 +380,7 @@
                   <CarryWeight>80</CarryWeight>
                   <CarryBulk>10</CarryBulk>
                   <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-                  <ToxicSensitivity>-0.50</ToxicSensitivity>
+                  <ToxicResistance>0.50</ToxicResistance>
                </value>
             </li>
 

--- a/Patches/The Joris Experience/Unique_Joris_Extended2.xml
+++ b/Patches/The Joris Experience/Unique_Joris_Extended2.xml
@@ -376,7 +376,7 @@
 			<MeatAmount>115</MeatAmount>
 			<LeatherAmount>200</LeatherAmount>
 			<PsychicSensitivity>0.1</PsychicSensitivity>
-			<ToxicSensitivity>0</ToxicSensitivity>
+			<ToxicResistance>1</ToxicResistance>
 			<ComfyTemperatureMin>-250</ComfyTemperatureMin>
 			<ComfyTemperatureMax>250</ComfyTemperatureMax>
 			<MarketValue>2500</MarketValue>

--- a/Patches/Ultratech - Altered Carbon Remastered/ThingDefs_Apparel.xml
+++ b/Patches/Ultratech - Altered Carbon Remastered/ThingDefs_Apparel.xml
@@ -59,7 +59,7 @@
             <equippedStatOffsets>
               <PsychicSensitivity>-0.2</PsychicSensitivity>
               <AimingAccuracy>0.15</AimingAccuracy>
-              <ToxicSensitivity>-0.50</ToxicSensitivity>
+              <ToxicResistance>0.50</ToxicResistance>
               <SmokeSensitivity>-1</SmokeSensitivity>
             </equippedStatOffsets>
           </value>
@@ -128,7 +128,7 @@
             <CarryWeight>80</CarryWeight>
             <CarryBulk>10</CarryBulk>
             <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-            <ToxicSensitivity>-0.50</ToxicSensitivity>
+            <ToxicResistance>0.50</ToxicResistance>
           </value>
         </li>
 

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -21,7 +21,7 @@
 					<value>
 						<equippedStatOffsets>
 							<SmokeSensitivity>-0.2</SmokeSensitivity>
-							<ToxicSensitivity>-0.1</ToxicSensitivity>
+							<ToxicResistance>0.10</ToxicResistance>
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -60,7 +60,7 @@
 					<value>
 						<PsychicSensitivity>-0.1</PsychicSensitivity>
 						<AimingAccuracy>0.1</AimingAccuracy>
-						<ToxicSensitivity>-0.1</ToxicSensitivity>
+						<ToxicResistance>0.10</ToxicResistance>
 					</value>
 				</li>
 
@@ -68,7 +68,7 @@
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalTrooperHelmet"]/equippedStatOffsets/MentalBreakThreshold</xpath>
 					<value>
 						<AimingAccuracy>0.1</AimingAccuracy>
-						<ToxicSensitivity>-0.1</ToxicSensitivity>
+						<ToxicResistance>0.10</ToxicResistance>
 					</value>
 				</li>
 
@@ -138,7 +138,7 @@
 						<CarryWeight>25</CarryWeight>
 						<CarryBulk>7.5</CarryBulk>
 						<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.3</ToxicSensitivity>
+						<ToxicResistance>0.3</ToxicResistance>
 					</value>
 				</li>
 
@@ -255,7 +255,7 @@
 						<equippedStatOffsets>
 							<PsychicSensitivity>-0.2</PsychicSensitivity>
 							<AimingAccuracy>0.15</AimingAccuracy>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
 							<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 						</equippedStatOffsets>
@@ -267,7 +267,7 @@
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>0.15</AimingAccuracy>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<SmokeSensitivity>-1</SmokeSensitivity>
 							<PsychicSensitivity>0.05</PsychicSensitivity>
 							<PsychicEntropyRecoveryRate>0.033</PsychicEntropyRecoveryRate>
@@ -354,7 +354,7 @@
 							<CarryWeight>100</CarryWeight>
 							<CarryBulk>20</CarryBulk>
 							<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 						</equippedStatOffsets>
 					</value>
 				</li>
@@ -366,7 +366,7 @@
 							<CarryWeight>100</CarryWeight>
 							<CarryBulk>20</CarryBulk>
 							<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-							<ToxicSensitivity>-0.5</ToxicSensitivity>
+							<ToxicResistance>0.5</ToxicResistance>
 							<PsychicSensitivity>0.05</PsychicSensitivity>
 							<PsychicEntropyRecoveryRate>0.033</PsychicEntropyRecoveryRate>
 						</equippedStatOffsets>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Various.xml
@@ -78,7 +78,7 @@
           <CarryWeight>80</CarryWeight>
           <CarryBulk>10</CarryBulk>
           <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-          <ToxicSensitivity>-0.50</ToxicSensitivity>
+          <ToxicResistance>0.50</ToxicResistance>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Headgear.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Headgear.xml
@@ -181,7 +181,7 @@
 			<equippedStatOffsets>
 				<PsychicSensitivity>-0.2</PsychicSensitivity>
 				<AimingAccuracy>0.1</AimingAccuracy>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<SmokeSensitivity>-1</SmokeSensitivity>
 			</equippedStatOffsets>
 			</value>
@@ -277,7 +277,7 @@
 				<equippedStatOffsets>
 				<PsychicSensitivity>-0.2</PsychicSensitivity>
 				<AimingAccuracy>0.15</AimingAccuracy>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 				<SmokeSensitivity>-1</SmokeSensitivity>
 				</equippedStatOffsets>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Viking.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Viking.xml
@@ -256,7 +256,7 @@
 			<equippedStatOffsets>
 				<CarryWeight>25</CarryWeight>
 				<CarryBulk>15</CarryBulk>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 			</equippedStatOffsets>
 			</value>
 		</li>
@@ -285,7 +285,7 @@
 				<CarryWeight>80</CarryWeight>
 				<CarryBulk>20</CarryBulk>
 				<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-				<ToxicSensitivity>-0.50</ToxicSensitivity>
+				<ToxicResistance>0.50</ToxicResistance>
 			</equippedStatOffsets>
 			</value>
 		</li>

--- a/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
+++ b/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
@@ -228,7 +228,7 @@
 					<damageAmountBase>1</damageAmountBase>
 					<explosionRadius>5.9</explosionRadius>
 					<explosionDelay>1</explosionDelay>
-					<postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
+					<postExplosionGasType>BlindSmoke</postExplosionGasType>
 					<postExplosionSpawnThingCount>1</postExplosionSpawnThingCount>
 					<postExplosionSpawnChance>1</postExplosionSpawnChance>
 				</projectile>

--- a/Patches/Xenn/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Xenn/ThingDefs_Misc/Apparel_Various.xml
@@ -57,7 +57,7 @@
 						<CarryWeight>110</CarryWeight>
 						<CarryBulk>25</CarryBulk>
 						<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.60</ToxicSensitivity>
+						<ToxicResistance>0.60</ToxicResistance>
 					</equippedStatOffsets>				
 				</value>
 			</li>
@@ -122,7 +122,7 @@
 						<CarryWeight>110</CarryWeight>
 						<CarryBulk>25</CarryBulk>
 						<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.60</ToxicSensitivity>
+						<ToxicResistance>0.60</ToxicResistance>
 					</equippedStatOffsets>
 				</value>
 			</li>
@@ -186,7 +186,7 @@
 						<CarryWeight>110</CarryWeight>
 						<CarryBulk>25</CarryBulk>
 						<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-						<ToxicSensitivity>-0.60</ToxicSensitivity>
+						<ToxicResistance>0.60</ToxicResistance>
 					</equippedStatOffsets>			
 				</value>
 			</li>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -86,7 +86,7 @@
 					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -143,7 +143,7 @@
 					<CarryWeight>45</CarryWeight>
 					<CarryBulk>12</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 				</value>
 			</li>
 			
@@ -247,7 +247,7 @@
 				]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<AimingAccuracy>0.15</AimingAccuracy>
-					<ToxicSensitivity>-0.50</ToxicSensitivity>
+					<ToxicResistance>0.50</ToxicResistance>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
@@ -70,7 +70,7 @@
 			<CarryWeight>100</CarryWeight>
 			<CarryBulk>20</CarryBulk>
 			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
-			<ToxicSensitivity>-0.50</ToxicSensitivity>
+			<ToxicResistance>0.50</ToxicResistance>
 			<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 		</value>
 	</Operation>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -161,7 +161,7 @@
       <equippedStatOffsets>
         <PsychicSensitivity>-0.2</PsychicSensitivity>
         <AimingAccuracy>0.15</AimingAccuracy>
-        <ToxicSensitivity>-0.50</ToxicSensitivity>
+        <ToxicResistance>0.50</ToxicResistance>
         <SmokeSensitivity>-1</SmokeSensitivity>
       </equippedStatOffsets>
     </value>


### PR DESCRIPTION
An initial pass of xml fixes needed for the update..

## Changes
- Change patches set for `HediffDef[defName="Burn"]` to target `HediffDef[@Name="BurnBase"]` which replaced it.
- Change patches set for PawnKindDef[defName="Mech_Centipede"] to target `ThingDef[@Name="MechCentipede"]` which replaced it.
- Change patches set for `ThingDef[defName="Mech_Centipede"]` to target `PawnKindDef[@Name="MechCentipedeBase"]` which replaced it.
- Change instances of `postExplosionSpawnThingDef` that are used to spawn smoke with `postExplosionGasType`, since the `Gas_Smoke` thingDef no longer exists.
- Replaced `<ToxicSensitivity>` with `<ToxicResistance>`and flipped the sign of the associated value.
- Removed a PatchRemoveOp for EMP grenades that targeted a node that no longer exists.

## References

## Reasoning

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
