### PR TITLE
Adjust suppression behavior

### DIFF
--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -195,7 +195,7 @@ namespace CombatExtended
                 cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 5f;
                 //float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.PassDoors).TotalCost;
                 float pathCost = (pawn.Position - cell).LengthHorizontal;
-                foreach (var pathCell in GenSightCE.PointsOnLineOfSight(pawn.Position.ToVector3(), cell.ToVector3()))
+                foreach (var pathCell in GenSight.PointsOnLineOfSight(pawn.Position, cell))
                 {
                     if (!pathCell.Standable(pawn.Map))
                     {

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -136,7 +136,7 @@ namespace CombatExtended
             // Line of sight is extremely important;
             if (!GenSight.LineOfSight(shooterPos, cell, pawn.Map))
             {
-                cellRating = 15f;
+                cellRating = 20f;
             }
             else
             {
@@ -195,8 +195,14 @@ namespace CombatExtended
                 cellRating -= lightingTracker.CombatGlowAtFor(shooterPos, cell) * 5f;
                 //float pathCost = pawn.Map.pathFinder.FindPath(pawn.Position, cell, TraverseMode.PassDoors).TotalCost;
                 float pathCost = (pawn.Position - cell).LengthHorizontal;
-                if (!GenSight.LineOfSight(pawn.Position, cell, pawn.Map))
-                    pathCost *= 4f;
+                foreach (var pathCell in GenSightCE.PointsOnLineOfSight(pawn.Position.ToVector3(), cell.ToVector3()))
+                {
+                    if (!pathCell.Standable(pawn.Map))
+                    {
+                        pathCost *= 2f;
+                        break;
+                    }
+                }
                 cellRating = cellRating - (pathCost * pathCostMultiplier);
             }
 


### PR DESCRIPTION
## Changes
- Made breaking line of sight be more important for cover;
- Replaced line of sight check for distance multiplication with a direct-path with all stand-able terrain check;
- Made the aforementioned distance multiplier smaller.

## References
- Should (hopefully) fix https://discord.com/channels/278818534069501953/278818534069501953/1029648986757410826

## Reasoning
- Makes pawns more likely to run back into cover instead of out;
- Embrasures were able to pass the line of sight check, although a pawn couldn't directly path trough them;
- Makes pawns consider moving around walls more often while under suppression, although pawn may path around large walls more often.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] Playtested a colony.
