### PR TITLE
Add will/resistance to Rim=Hivers pawnkinds

### DIFF
--- a/Patches/Rim-Hivers!/New_Hivers.xml
+++ b/Patches/Rim-Hivers!/New_Hivers.xml
@@ -128,6 +128,8 @@
     <combatPower>60</combatPower>
     <maxGenerationAge>60</maxGenerationAge>
     <canBeSapper>true</canBeSapper>
+    <initialWillRange>1~3</initialWillRange>
+    <initialResistanceRange>12~19</initialResistanceRange>
     <gearHealthRange>
       <min>0.5</min>
       <max>1.8</max>
@@ -174,6 +176,8 @@
     <race>Hiver_Soldier_South</race>
     <combatPower>60</combatPower>
     <maxGenerationAge>60</maxGenerationAge>
+    <initialWillRange>1~3</initialWillRange>
+    <initialResistanceRange>12~19</initialResistanceRange>    
     <gearHealthRange>
       <min>0.5</min>
       <max>1.8</max>


### PR DESCRIPTION
## Changes
- Add will and resistance stats to Hiver pawnkinds added by CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
