### PR TITLE
Enable build actions for the 1.4 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,14 @@ name: Build Branch
 on:
   workflow_dispatch:
   push:
-    branches: [ master, Development ]
+    branches: [ master, Development, Rimworld-Version-1.4 ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: prebuild
       run: |
         rm -rf AssemblyPublicizer

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,14 +6,14 @@ on:
         description: PR Number
         required: true
   pull_request_target:
-    branches: [ master, Development ]
+    branches: [ master, Development, Rimworld-Version-1.4 ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Prebuild
@@ -61,7 +61,7 @@ jobs:
         SSH_KEY_PUB: ${{secrets.ID_ECDSA_PUB}}
 
     - name: Create comment
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.pull_request.number }}${{ github.event.inputs.PR }}
         body: |


### PR DESCRIPTION
Run builds for PRs targeting the 1.4 branch & pushes for the 1.4 branch. Also bump some third-party workflow versions while we're at it.


