### PR TITLE
Remove Pawnkind Skill Patches

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -525,25 +525,6 @@
 
   <!-- ========== Spacer ========== -->
 
-  <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]/skills</xpath>
-   <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]</xpath>
-     <value>
-       <skills>
-         <li>
-           <skill>Shooting</skill>
-           <range>6~12</range>
-         </li>
-         <li>
-           <skill>Melee</skill>
-           <range>4~12</range>
-         </li>
-       </skills>
-     </value>
-   </nomatch>
-  </Operation>
-
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="AncientSoldier"]/weaponMoney</xpath>
     <value>
@@ -569,7 +550,7 @@
         <shieldTags>
           <li>OutlanderShield</li>
         </shieldTags>
-        <shieldChance>0.9</shieldChance>
+        <shieldChance>0.5</shieldChance>
         <sidearms>
           <li>
             <sidearmMoney>
@@ -931,21 +912,6 @@
      <value>
        <li>Apparel_Backpack</li>
      </value>
-  </Operation>
-
-  <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]/skills</xpath>
-   <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]</xpath>
-     <value>
-       <skills>
-         <li>
-           <skill>Shooting</skill>
-           <range>4~12</range>
-         </li>
-       </skills>
-     </value>
-   </nomatch>
   </Operation>
 
 </Patch>


### PR DESCRIPTION
## Changes
- Remove changes CE made to the skill requirements of the Stranger in Black and Ancient Soldiers.
- Reduce Ancient Soldier ballistic shield spawn rate from 0.9 to 0.5.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
