### PR TITLE
Add a few more Apparel Autopatcher presets.

### DIFF
--- a/Defs/ApparelAutoPatcherPresets/Helmets.xml
+++ b/Defs/ApparelAutoPatcherPresets/Helmets.xml
@@ -5,7 +5,7 @@
         <defName>Helmet</defName>
         <label>preset helmet</label>
         <Bulk>4</Bulk>
-        <BulkWorn>4</BulkWorn>
+        <BulkWorn>1</BulkWorn>
         <Mass>1</Mass>
         <!-- If both are present just uses the appropiate curve, that is you can for example use static for sharp and curve for blunt -->
         <ArmorStaticSharp>8</ArmorStaticSharp>
@@ -47,4 +47,37 @@
               </li>
         </partialStats>
     </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>LightHelmet</defName>
+        <label>preset light helmet</label>
+        <Bulk>4</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <Mass>1</Mass>
+        <!-- If both are present just uses the appropiate curve, that is you can for example use static for sharp and curve for blunt -->
+        <ArmorCurveSharp>
+            <points>
+                <li>0.35, 1</li>
+                <li>0.45, 2</li>
+                <li>0.55, 4</li>
+                <li>0.59, 6</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.35, 1.1</li>
+                <li>0.45, 3.2</li>
+                <li>0.55, 6.4</li>
+                <li>0.59, 8.65</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.35~0.59</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Overhead</li>
+        </neededLayers>
+        <neededGroups>
+            <li>UpperHead</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
 </Defs>

--- a/Defs/ApparelAutoPatcherPresets/Helmets.xml
+++ b/Defs/ApparelAutoPatcherPresets/Helmets.xml
@@ -80,4 +80,32 @@
         </neededGroups>
     </CombatExtended.ApparelPatcherPresetDef>
 
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>Hat</defName>
+        <label>preset hat</label>
+        <Bulk>1</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <Mass>1</Mass>
+        <!-- If both are present just uses the appropiate curve, that is you can for example use static for sharp and curve for blunt -->
+        <ArmorCurveSharp>
+            <points>
+                <li>0, 0</li>
+                <li>0.35, 0.25</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0, 0</li>
+                <li>0.35, 0.5</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.00~0.35</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Overhead</li>
+        </neededLayers>
+        <neededGroups>
+            <li>UpperHead</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
 </Defs>

--- a/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
+++ b/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
@@ -41,4 +41,120 @@
               </li>
         </partialStats>
     </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>LeatherJacket</defName>
+        <label>preset leather jacket</label>
+        <Bulk>5</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <ArmorCurveSharp>
+            <points>
+                <li>0.20, 0.08</li>
+                <li>0.45, 0.60</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.08, 0.14</li>
+                <li>0.16, 0.85</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.20~0.45</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Shell</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Torso</li>
+            <li>Neck</li>
+            <li>Shoulders</li>
+            <li>Arms</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>ShellClothing</defName>
+        <label>preset shell clothing</label>
+        <Bulk>1</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <ArmorCurveSharp>
+            <points>
+                <li>0.20, 0.08</li>
+                <li>0.45, 0.60</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.08, 0.14</li>
+                <li>0.16, 0.85</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.20~0.45</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Shell</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Torso</li>
+            <li>Neck</li>
+            <li>Shoulders</li>
+            <li>Arms</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>MiddleClothing</defName>
+        <label>preset middle clothing</label>
+        <Bulk>1</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <ArmorCurveSharp>
+            <points>
+                <li>0.08, 0.04</li>
+                <li>0.28, 0.15</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0, 0</li>
+                <li>0.08, 0.08</li>
+                <li>0.28, 0.25</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.08~0.28</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Middle</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Torso</li>
+            <li>Shoulders</li>
+            <li>Arms</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>SkinClothing</defName>
+        <label>preset skin clothing</label>
+        <Bulk>1</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <ArmorCurveSharp>
+            <points>
+                <li>0.10, 0.05</li>
+                <li>0.35, 0.25</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.10, 0.18</li>
+                <li>0.35, 0.45</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.10~0.35</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Skin</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Torso</li>
+            <li>Shoulders</li>
+            <li>Arms</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
 </Defs>

--- a/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
+++ b/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
@@ -157,4 +157,30 @@
         </neededGroups>
     </CombatExtended.ApparelPatcherPresetDef>
 
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>PantsClothing</defName>
+        <label>preset pants</label>
+        <Bulk>1</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <ArmorCurveSharp>
+            <points>
+                <li>0.10, 0.05</li>
+                <li>0.35, 0.25</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.10, 0.18</li>
+                <li>0.35, 0.45</li>
+            </points>
+        </ArmorCurveBlunt>
+        <vanillaArmorRatingRange>0.10~0.35</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Skin</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Legs</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
 </Defs>

--- a/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
+++ b/Defs/ApparelAutoPatcherPresets/TorsoSets.xml
@@ -148,7 +148,7 @@
         </ArmorCurveBlunt>
         <vanillaArmorRatingRange>0.10~0.35</vanillaArmorRatingRange>
         <neededLayers>
-            <li>Skin</li>
+            <li>OnSkin</li>
         </neededLayers>
         <neededGroups>
             <li>Torso</li>
@@ -176,7 +176,7 @@
         </ArmorCurveBlunt>
         <vanillaArmorRatingRange>0.10~0.35</vanillaArmorRatingRange>
         <neededLayers>
-            <li>Skin</li>
+            <li>OnSkin</li>
         </neededLayers>
         <neededGroups>
             <li>Legs</li>

--- a/Defs/ApparelAutoPatcherPresets/Vests.xml
+++ b/Defs/ApparelAutoPatcherPresets/Vests.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
+
     <CombatExtended.ApparelPatcherPresetDef>
         <defName>ArmorVest</defName>
         <label>preset armor vest</label>
@@ -32,4 +33,36 @@
             <li>Shoulders</li>
         </neededGroups>
     </CombatExtended.ApparelPatcherPresetDef>
+
+    <CombatExtended.ApparelPatcherPresetDef>
+        <defName>LightArmorVest</defName>
+        <label>preset light armor vest</label>
+        <Bulk>5</Bulk>
+        <BulkWorn>1</BulkWorn>
+        <Mass>3</Mass>
+        <!-- If both are present just uses the appropiate curve, that is you can for example use static for sharp and curve for blunt -->
+        <ArmorCurveSharp>
+            <points>
+                <li>0.55, 1.5</li>
+                <li>0.99, 8</li>
+            </points>
+        </ArmorCurveSharp>
+        <ArmorCurveBlunt>
+            <points>
+                <li>0.55, 2.65</li>
+                <li>0.99, 14</li>
+            </points>
+        </ArmorCurveBlunt>
+        <!-- IMPORTANT: This is SHARP armor range OR StuffEffectMultiplierArmor range-->
+        <vanillaArmorRatingRange>0.55~0.99</vanillaArmorRatingRange>
+        <neededLayers>
+            <li>Middle</li>
+        </neededLayers>
+        <neededGroups>
+            <li>Torso</li>
+            <li>Neck</li>
+            <li>Shoulders</li>
+        </neededGroups>
+    </CombatExtended.ApparelPatcherPresetDef>
+
 </Defs>


### PR DESCRIPTION
## Additions
- Added new apparel autopatcher presets for leather jackets, light vests, light helmets, hats, and other items of non-armored clothing.

## Changes
- Reduced the wornbulk of the preset helmet from 4 to 1. This makes it consistent with the wornBulk of patched modern/industrial helmets.

## Reasoning
The apparel autopatcher had a very limited number of templates, and didn't necessarily cover items with lower armor values, such as medieval-tier gear or heavier non-armored items like heavy jackets. Adding a few more improves its consistency and improves the player's experience by applying autopatched stats that are more in-line with their patched equivalents. 


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
