### PR TITLE
Various turret adjustments

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -159,7 +159,6 @@
     <uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>80000</WorkToBuild>
-      <MarketValue>2150</MarketValue>
       <MaxHitPoints>550</MaxHitPoints>
       <Flammability>0.05</Flammability>
       <Mass>60</Mass>
@@ -210,7 +209,6 @@
     <uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>40000</WorkToBuild>
-      <MarketValue>750</MarketValue>
       <MaxHitPoints>300</MaxHitPoints>
       <Flammability>0.5</Flammability>
       <Mass>30</Mass>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -45,7 +45,6 @@
     <description>Charge blaster attached to a turret mount.</description>
     <soundInteract>Interact_ChargeRifle</soundInteract>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.06</ShotSpread>
       <SwayFactor>0.86</SwayFactor>
@@ -89,7 +88,6 @@
     </graphicData>
     <description>High caliber gun on a turret mount.</description>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.31</SwayFactor>
@@ -132,7 +130,6 @@
     </graphicData>
     <description>Full powered cartridge gun on a turret mount.</description>
     <statBases>
-      <MarketValue>500</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.05</ShotSpread>
       <SwayFactor>0.94</SwayFactor>
@@ -175,7 +172,6 @@
     </graphicData>
     <description>An automated heavy machine gun designed to be mounted on a turret, effective against infantry and light vehicles.</description>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.61</SwayFactor>
@@ -188,7 +184,7 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
-        <warmupTime>4.3</warmupTime>
+        <warmupTime>1.3</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>
@@ -200,7 +196,7 @@
     </verbs>
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
-        <magazineSize>80</magazineSize>
+        <magazineSize>100</magazineSize>
         <reloadTime>7.8</reloadTime>
         <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
       </li>
@@ -225,7 +221,6 @@
       <drawSize>(2,2)</drawSize>
     </graphicData>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>2.36</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.89</SwayFactor>
@@ -272,7 +267,6 @@
     </graphicData>
     <description>Heavy machine gun for use against light vehicles.</description>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.42</SwayFactor>
@@ -319,7 +313,6 @@
     </graphicData>
     <description>M240B machine gun mounted on a tripod.</description>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.04</ShotSpread>
       <SwayFactor>0.96</SwayFactor>
@@ -367,7 +360,6 @@
     </graphicData>
     <soundInteract>Artillery_ShellLoaded</soundInteract>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>2.3</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.41</SwayFactor>
@@ -416,7 +408,6 @@
     </graphicData>
     <description>AGS-30 attached to a tripod.</description>
     <statBases>
-      <MarketValue>2000</MarketValue>
       <SightsEfficiency>2.16</SightsEfficiency>
       <ShotSpread>0.15</ShotSpread>
       <SwayFactor>0.92</SwayFactor>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -100,7 +100,7 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_145x114mm_FMJ</defaultProjectile>
-        <warmupTime>1.3</warmupTime>
+        <warmupTime>1.6</warmupTime>
         <range>55</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -184,7 +184,7 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
-        <warmupTime>1.3</warmupTime>
+        <warmupTime>2.3</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
         <burstShotCount>10</burstShotCount>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -220,7 +220,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName = "Turret_Autocannon"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.5</AimingAccuracy>
+			<AimingAccuracy>0.75</AimingAccuracy>
 		</value>
 	</Operation>
 
@@ -237,7 +237,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name = "AutocannonTurret"]/statBases/MaxHitPoints</xpath>
 		<value>
-			<MaxHitPoints>500</MaxHitPoints>
+			<MaxHitPoints>750</MaxHitPoints>
 		</value>
 	</Operation>
 

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -332,7 +332,7 @@
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
-			  <warmupTime>4.3</warmupTime>
+			  <warmupTime>2.3</warmupTime>
 			  <range>78</range>
 			  <burstShotCount>12</burstShotCount>
 			  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -343,7 +343,7 @@
 			</Properties>
 			<AmmoUser>
 			  <magazineSize>120</magazineSize>
-			  <reloadTime>9.8</reloadTime>
+			  <reloadTime>7.8</reloadTime>
 			  <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 			</AmmoUser>
 			<FireModes>


### PR DESCRIPTION
## Changes

- Buffed the autocannon turret in possible areas according to the gun spreadsheet.
- Removed certain redundant nodes that the base game calculates on its own.

https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- The autocannon being a 2x2 building was not properly superior to the CE's Heavy Turret. make certain adjustments so that it is a viable option to use considering the associated cost that comes with it.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors