### PR TITLE
Various ammo adjustments

### DIFF
--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -99,7 +99,7 @@
 		<label>.22 LR bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.22 LR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>4</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.22 LR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>1.5</armorPenetrationSharp>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -99,7 +99,7 @@
 		<label>.357 SIG bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>13.62</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.357 SIG bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>13.62</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -99,7 +99,7 @@
     <label>.38 Special bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>9</damageAmountBase>
-      <armorPenetrationSharp>4</armorPenetrationSharp>
+      <armorPenetrationSharp>3.5</armorPenetrationSharp>
       <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -109,7 +109,7 @@
     <label>.38 Special bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>6</damageAmountBase>
-      <armorPenetrationSharp>8</armorPenetrationSharp>
+      <armorPenetrationSharp>7</armorPenetrationSharp>
       <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -99,7 +99,7 @@
 		<label>.45 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.45 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -21,6 +21,18 @@
 		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
 
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45ACP410Bore_SB</defName>
+		<label>.45 ACP/.410 bore</label>
+		<ammoTypes>
+			<Ammo_45ACP_FMJ>Bullet_45ACP_FMJ</Ammo_45ACP_FMJ>
+			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
+			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
+			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+		</ammoTypes>
+		<similarTo>AmmoSet_RevolverShotgun</similarTo>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="45ACPBase" ParentName="SmallAmmoBase" Abstract="True">

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -18,7 +18,7 @@
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
 		</ammoTypes>
-		<similarTo>AmmoSet_PistolMagnum</similarTo>
+		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -123,7 +123,7 @@
 		<label>.45 Colt bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.440</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -133,7 +133,7 @@
 		<label>.45 Colt bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.440</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -99,7 +99,7 @@
 		<label>7.62mm Tokarev bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.62mm Tokarev bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -99,7 +99,7 @@
 		<label>7.62mmR pistol bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.62mm pistol bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>7.62mm pistol bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>6.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -99,7 +99,7 @@
 		<label>7.63mm Mauser bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.63mm Mauser bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -145,7 +145,7 @@
 		<label>.277 Fury bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>.277 Fury bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>.277 Fury bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
-		  <armorPenetrationSharp>16</armorPenetrationSharp>
+		  <armorPenetrationSharp>15</armorPenetrationSharp>
 		  <armorPenetrationBlunt>74.52</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -191,7 +191,7 @@
 		<label>.277 Fury bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
-		  <armorPenetrationSharp>8</armorPenetrationSharp>
+		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>74.52</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -207,7 +207,7 @@
 		<label>.277 Fury bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>28</armorPenetrationSharp>
+		  <armorPenetrationSharp>26.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>95.76</armorPenetrationBlunt>
 		  <speed>273</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -207,7 +207,7 @@
 		<label>.277 Fury bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>26.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>26.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>95.76</armorPenetrationBlunt>
 		  <speed>273</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>5.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -163,7 +163,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>11</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -187,7 +187,7 @@
 		<label>.300 AAC Blackout bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>11</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -203,7 +203,7 @@
 		<label>.300 AAC Blackout bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>16</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -219,7 +219,7 @@
 		<label>.300 AAC Blackout bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>19.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>46.74</armorPenetrationBlunt>
 		  <speed>203</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -219,7 +219,7 @@
 		<label>.300 AAC Blackout bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>19.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>46.74</armorPenetrationBlunt>
 		  <speed>203</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -17,7 +17,7 @@
 			<Ammo_303British_FMJ>Bullet_303British_FMJ</Ammo_303British_FMJ>
 			<Ammo_303British_AP>Bullet_303British_AP</Ammo_303British_AP>
 			<Ammo_303British_HP>Bullet_303British_HP</Ammo_303British_HP>
-		    <Ammo_303British_Incendiary>Bullet_303British_Incendiary</Ammo_303British_Incendiary>
+			<Ammo_303British_Incendiary>Bullet_303British_Incendiary</Ammo_303British_Incendiary>
 			<Ammo_303British_HE>Bullet_303British_HE</Ammo_303British_HE>
 			<Ammo_303British_Sabot>Bullet_303British_Sabot</Ammo_303British_Sabot>				
 		</ammoTypes>
@@ -145,7 +145,7 @@
 		<label>.303 British bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>.303 British bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>.303 British bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
-		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationSharp>13</armorPenetrationSharp>
 		  <armorPenetrationBlunt>67</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -191,7 +191,7 @@
 		<label>.303 British bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>6.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>67</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>.303 British bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>23</armorPenetrationSharp>
 		  <armorPenetrationBlunt>86.72</armorPenetrationBlunt>
 		  <speed>224</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -146,7 +146,7 @@
 		<label>.44-40 Winchester bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -157,7 +157,7 @@
 		<label>.44-40 Winchester bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -167,7 +167,7 @@
 		<label>.44-40 Winchester bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -177,7 +177,7 @@
 		<label>.44-40 Winchester bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>9</damageAmountBase>
-		  <armorPenetrationSharp>16</armorPenetrationSharp>
+		  <armorPenetrationSharp>10</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -193,7 +193,7 @@
 		<label>.44-40 Winchester bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
-		  <armorPenetrationSharp>8</armorPenetrationSharp>
+		  <armorPenetrationSharp>5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -209,7 +209,7 @@
 		<label>.44-40 Winchester bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>7</damageAmountBase>
-		  <armorPenetrationSharp>28</armorPenetrationSharp>
+		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>23.94</armorPenetrationBlunt>
 		  <speed>114</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -17,7 +17,7 @@
 			<Ammo_4570Gov_FMJ>Bullet_4570Gov_FMJ</Ammo_4570Gov_FMJ>
 			<Ammo_4570Gov_AP>Bullet_4570Gov_AP</Ammo_4570Gov_AP>
 			<Ammo_4570Gov_HP>Bullet_4570Gov_HP</Ammo_4570Gov_HP>
-		    <Ammo_4570Gov_Incendiary>Bullet_4570Gov_Incendiary</Ammo_4570Gov_Incendiary>
+			<Ammo_4570Gov_Incendiary>Bullet_4570Gov_Incendiary</Ammo_4570Gov_Incendiary>
 			<Ammo_4570Gov_HE>Bullet_4570Gov_HE</Ammo_4570Gov_HE>
 			<Ammo_4570Gov_Sabot>Bullet_4570Gov_Sabot</Ammo_4570Gov_Sabot>					
 		</ammoTypes>
@@ -145,7 +145,7 @@
 		<label>.45-70 Government cartridge (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
-			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>.45-70 Government cartridge (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>.45-70 Government cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>30</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>.45-70 bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>15</damageAmountBase>
-		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -191,7 +191,7 @@
 		<label>.45-70 bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>24</damageAmountBase>
-		  <armorPenetrationSharp>7</armorPenetrationSharp>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>77.4</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>.45-70 bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>24.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>99.54</armorPenetrationBlunt>
 		  <speed>190</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>17</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>5.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -163,7 +163,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>11</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -187,7 +187,7 @@
 		<label>7.62mm Soviet bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>11</armorPenetrationSharp>
 		  <armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -203,7 +203,7 @@
 		<label>7.62mm Soviet bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>17</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>41.08</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -219,7 +219,7 @@
 		<label>7.62mm Soviet bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>19.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		  <speed>216</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -219,7 +219,7 @@
 		<label>7.62mm Soviet bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>19.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		  <speed>216</speed>
 		</projectile>


### PR DESCRIPTION
## Changes

- What it says on the tin, adjusted various pistol cartridge sharp AP values.
- Decreased the sharp armor penetration of .277 Fury by 0.5 for the FMJ rounds and adjusted the rest accordingly since the cartridge was overtuned.
- Did the same as above for 7.62x39, .300 BO and .303 and a couple more cartridges have been rebalanced.
- Adjusted .22LR's sharp AP values since the sheet is using rifle barrel figures instead of pistol barrel data, kept the rest of the values intact to not make te cartridge absolutely garbage.
- Added the .45 ACP/.410 Bore ammo set to be used by the S&W Governor in CE Guns.

https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- While adjusting the .45 Colt and ACP cartridges, I noticed that there are inconsistencies among pistol cartridge sharp armor penetration values which made no sense when you compare various other cartridges with them (slower and heavier bullets having more sharp AP), adjusted them according to the available data in the sheets and brought them more in line with other ammo types.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors