### PR TITLE
Don't magically teleport projectiles to the center of their target

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1141,7 +1141,7 @@ namespace CombatExtended
                 }
             }
 
-            var explodePos = hitThing?.DrawPos ?? ExactPosition;
+            var explodePos = ExactPosition;
 
             if (!explodePos.ToIntVec3().IsValid)
             {


### PR DESCRIPTION

## Changes

Projectiles are teleported to the center of their target, causing explosions from projectiles hitting things to fail to generate.


## Reasoning

Teleportation is bad in general.
Explosives fail if they aren't on the surface of the target.

## Alternatives

Describe alternative implementations you have considered, e.g.
Break explosives doing direct damage and return them to exploding on the floor no matter what they hit.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (seconds)
