### PR TITLE
Adjust skill ranges for 1.4

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -139,18 +139,6 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
-   <xpath>/Defs/PawnKindDef[@Name="MercenaryGunnerBase"]/skills</xpath>
-   <value>
-     <skills>
-       <li>
-         <skill>Shooting</skill>
-         <range>4~16</range>
-       </li>
-     </skills>
-   </value>
-  </Operation>
-
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/PawnKindDef[defName="Mercenary_Gunner"]</xpath>
     <value>
@@ -202,18 +190,6 @@
         </sidearms>
       </li>
     </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-   <xpath>/Defs/PawnKindDef[@Name="MercenarySniperBase"]/skills</xpath>
-   <value>
-     <skills>
-       <li>
-         <skill>Shooting</skill>
-         <range>6~18</range>
-       </li>
-     </skills>
-   </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
@@ -524,6 +500,16 @@
   </Operation>
 
   <!-- ========== Spacer ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]/skills</xpath>
+    <value>
+      <li>
+        <skill>Melee</skill>
+        <range>4~12</range>
+      </li>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="AncientSoldier"]/weaponMoney</xpath>


### PR DESCRIPTION
## Changes

- Adjusted our skill range patches after the changes in 1.4.3520

## Reasoning

- Merc pawns received a proper skill range value and the ancient soldiers got a shooting skill range, made the adjustments accordingly.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
