### PR TITLE
Patch mechanoid warning letter

### DIFF
--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
@@ -32,7 +32,7 @@ namespace CombatExtended
 
         public static ThingDef Gas_BlackSmoke;
 
-        public static ThingDef Mech_Centipede;
+        public static ThingDef Mech_CentipedeBlaster;
 
         public static ThingDef Gun_BinocularsRadio;
     }

--- a/Source/CombatExtended/CombatExtended/LetterTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LetterTracker.cs
@@ -26,7 +26,7 @@ namespace CombatExtended
                     : PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_Colonists.RandomElement();
 
                 var label = "CE_MechWarningLabel".Translate();
-                var text = "CE_MechWarningText".Translate(suggestingPawn?.LabelShort ?? "CE_MechWarningText_UnnamedColonist".Translate(), CE_ThingDefOf.Mech_Centipede.GetStatValueAbstract(StatDefOf.ArmorRating_Sharp));
+                var text = "CE_MechWarningText".Translate(suggestingPawn?.LabelShort ?? "CE_MechWarningText_UnnamedColonist".Translate(), CE_ThingDefOf.Mech_CentipedeBlaster.GetStatValueAbstract(StatDefOf.ArmorRating_Sharp));
 
                 Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NegativeEvent);
                 _sentMechWarning = true;


### PR DESCRIPTION
## Reasoning

  Fix mechanoid "Strange Signals" letter referencing obsolete def

## Alternatives

Write function to find mechanoid with the highest armor value, then display that in the letter.
This would handle mods/DLCs that add mechs with more armor than a standard centipede.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
      (well there's one less than before this patch)
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
