### PR TITLE
LetterTracker: Fix invalid Mech_Centipede def reference

### DIFF
--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
@@ -32,7 +32,7 @@ namespace CombatExtended
 
         public static ThingDef Gas_BlackSmoke;
 
-        public static ThingDef Mech_Centipede;
+        public static ThingDef Mech_CentipedeBlaster;
 
         public static ThingDef Gun_BinocularsRadio;
     }

--- a/Source/CombatExtended/CombatExtended/LetterTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LetterTracker.cs
@@ -26,7 +26,7 @@ namespace CombatExtended
                     : PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_Colonists.RandomElement();
 
                 var label = "CE_MechWarningLabel".Translate();
-                var text = "CE_MechWarningText".Translate(suggestingPawn?.LabelShort ?? "CE_MechWarningText_UnnamedColonist".Translate(), CE_ThingDefOf.Mech_Centipede.GetStatValueAbstract(StatDefOf.ArmorRating_Sharp));
+                var text = "CE_MechWarningText".Translate(suggestingPawn?.LabelShort ?? "CE_MechWarningText_UnnamedColonist".Translate(), CE_ThingDefOf.Mech_CentipedeBlaster.GetStatValueAbstract(StatDefOf.ArmorRating_Sharp));
 
                 Find.LetterStack.ReceiveLetter(label, text, LetterDefOf.NegativeEvent);
                 _sentMechWarning = true;


### PR DESCRIPTION
## Changes
With 1.4, Mech_Centipede is now an abstract def that is used as a base for different variants, like Mech_CentipedeBlaster and Mech_CentipedeGunner (minigun). Accordingly, LetterTracker throws an error when it tries to use this abstract def to compute the armor value of centipedes. Let's use the Mech_CentipedeBlaster def instead which should be suitable for our purposes here.


## Reasoning
It doesn't seem like abstract defs can be referenced at all in DefOfs anyways (there's a corresponding load error), so this seems the most straightforward way to go.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - used a test map to verify that the mech warning letter now shows up
