### PR TITLE
Fix black smoke rendering and propagation

### DIFF
--- a/Defs/ThingDefs_Misc/Gas_Various.xml
+++ b/Defs/ThingDefs_Misc/Gas_Various.xml
@@ -1,17 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-  <ThingDef ParentName="BaseGas">
+  <ThingDef>
     <defName>Gas_BlackSmoke</defName>
     <thingClass>CombatExtended.Smoke</thingClass>
+    <category>Gas</category>
+    <altitudeLayer>Gas</altitudeLayer>
+    <useHitPoints>false</useHitPoints>
+    <tickerType>Normal</tickerType>
     <label>black smoke</label>
     <graphicData>
       <graphicClass>CombatExtended.Graphic_Smoke</graphicClass>
       <texPath>Things/Gas/Smoke</texPath>
       <drawSize>3.0</drawSize>
       <color>(0.0,0.0,0.0,1.0)</color>
+      <shaderType>Transparent</shaderType>
     </graphicData>
-    <gas>
+    <gas Class="CombatExtended.GasPropertiesCE">
       <expireSeconds>
         <min>15</min>
         <max>30</max>

--- a/Source/CombatExtended/CombatExtended/Defs/GasPropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/GasPropertiesCE.cs
@@ -1,0 +1,23 @@
+using RimWorld;
+
+namespace CombatExtended
+{
+    /// <summary>
+    /// CE-specific gas properties for the object gas system.
+    /// </summary>
+    /// <remarks>
+    /// This effectively reimplements the fields that were contained in <see cref="GasProperties"/>
+    /// prior to the RimWorld 1.4 update, which replaced core object gases with a hardcoded system.
+    /// </remarks>
+    public class GasPropertiesCE : GasProperties
+    {
+        /// <summary>
+        /// Accuracy penalty multiplier applied by the presence of this gas (0 to 1)
+        /// </summary>
+        public float accuracyPenalty;
+        /// <summary>
+        /// Whether automated turrets should be able to track targets across this gas.
+        /// </summary>
+        public bool blockTurretTracking;
+    }
+}


### PR DESCRIPTION


## Changes

Black smoke uses the pre-1.4 object gas system, which is still present in core, but the BaseGas def has been removed along with some fields from GasProperties. Augment the smoke def with missing data that used to be in the base def, and introduce a new CE-specific gas property class to store the fields removed from core GasProperties.

This does not yet fix the interaction of combat with black smoke - we should do that in a followup patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - started a fire on a test map and verified the rendering and propagation for black smoke.
