### PR TITLE
Fix rendering hair over hats/headgear

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -229,7 +229,7 @@ namespace CombatExtended.HarmonyCE
                 return true;
             }
 
-            private static void DrawHeadApparel(PawnRenderer renderer, Pawn pawn, Vector3 rootLoc, Vector3 headLoc, Vector3 headOffset, Rot4 bodyFacing, Quaternion quaternion, PawnRenderFlags flags, Rot4 headFacing, ref bool hideHair)
+            private static void DrawHeadApparel(PawnRenderer renderer, Pawn pawn, Vector3 rootLoc, Vector3 headLoc, Vector3 headOffset, Rot4 bodyFacing, Quaternion quaternion, PawnRenderFlags flags, Rot4 headFacing, ref bool shouldRenderHair)
             {
                 if (flags.FlagSet(PawnRenderFlags.Portrait) && Prefs.HatsOnlyOnMap)
                     return;
@@ -250,7 +250,7 @@ namespace CombatExtended.HarmonyCE
                     ApparelGraphicRecord apparelRecord = apparelGraphics[i];
                     if (apparelRecord.sourceApparel.def.apparel.LastLayer == ApparelLayerDefOf.Overhead && !apparelRecord.sourceApparel.def.apparel.hatRenderedFrontOfFace)
                     {
-                        hideHair = apparelRecord.sourceApparel?.def?.GetModExtension<ApperalRenderingExtension>()?.HideHair ?? true;
+                        shouldRenderHair = !apparelRecord.sourceApparel?.def?.GetModExtension<ApperalRenderingExtension>()?.HideHair ?? false;
                     }
                     else if (apparelRecord.sourceApparel.def.apparel.LastLayer.GetModExtension<ApparelLayerExtension>()?.IsHeadwear ?? false)
                     {
@@ -268,7 +268,7 @@ namespace CombatExtended.HarmonyCE
                         {
                             Matrix4x4 matrix = new Matrix4x4();
                             if(!quickFast_Loaded)
-                                hideHair = apparelRecord.sourceApparel?.def?.GetModExtension<ApperalRenderingExtension>()?.HideHair ?? true;
+                                shouldRenderHair = !apparelRecord.sourceApparel?.def?.GetModExtension<ApperalRenderingExtension>()?.HideHair ?? false;
                             headwearPos.y += interval;
                             matrix.SetTRS(headwearPos, quaternion, customScale);
                             GenDraw.DrawMeshNowOrLater(mesh, matrix, apparelMat, flags.FlagSet(PawnRenderFlags.DrawNow));
@@ -353,7 +353,7 @@ namespace CombatExtended.HarmonyCE
                         yield return new CodeInstruction(OpCodes.Ldloc_0); // PawnRenderFlags flags
                         yield return new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(displayType, "headFacing"));
 
-                        yield return new CodeInstruction(OpCodes.Ldloca_S, 2);  // ref bool hideHair
+                        yield return new CodeInstruction(OpCodes.Ldloca_S, 2);  // ref bool shouldRenderHair
 
                         yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_PawnRenderer_DrawHeadHair), nameof(DrawHeadApparel)));
                         code.labels = new List<Label>();


### PR DESCRIPTION

## Changes

The boolean in core's DrawHeadHair() method that would control whether to hide hair was inverted in 1.4 - it now controls whether to *show* hair. Update our pawn renderer patch accordingly so that assignments to it are negated.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned in some headgear (war mask, cata helmet, tuque) and checked if they show/hide hair accordingly.
