### PR TITLE
Hotfix for the barbed wire

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
@@ -52,8 +52,6 @@
     <neverMultiSelect>true</neverMultiSelect>
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
     <designationCategory>Security</designationCategory>
-    <constructEffect>ConstructDirt</constructEffect>
-    <repairEffect>ConstructDirt</repairEffect>
     <staticSunShadowHeight>0.0</staticSunShadowHeight>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- Removed the `constructEffect` and `repairEffect` from the building since it is automatically handled by the game based on the material the building is made out of.
- 
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
