### PR TITLE
Tweak the Bren's magazine size

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -720,7 +720,7 @@
       <recoilPattern>Mounted</recoilPattern>
     </Properties>
     <AmmoUser>
-      <magazineSize>100</magazineSize>
+      <magazineSize>50</magazineSize>
       <reloadTime>4.9</reloadTime>
       <ammoSet>AmmoSet_303British</ammoSet>
     </AmmoUser>


### PR DESCRIPTION
## Changes

- Changed the Bren's mag size from 100 to 50 rounds to make it resemble its texture properly.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
