### PR TITLE
Don't show melee targeting gizmo for pawns not controlled by the player

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -169,6 +169,12 @@ namespace CombatExtended
         #region Methods
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
+            // Don't let people control melee targeting for non-colonist pawns or colonists in a mental state
+            if (!PawnParent.IsColonist || PawnParent.InAggroMentalState)
+            {
+                yield break;
+            }
+
             if (SkillReqA)
             {
                 yield return new Command_Action


### PR DESCRIPTION


## Changes
Don't display the melee targeting gizmo for pawns that are not colonists or are otherwise not under the player's control (e.g. are in an aggressive mental state).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested that gizmo is absent with the patch for enemies & still present for player pawns of appropriate skill
