### PR TITLE
Fix drafted pawns becoming guilty when drafted & ordered to attack 

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -441,7 +441,8 @@ namespace CombatExtended
                 dinfo.Angle,
                 dinfo.Instigator,
                 GetOuterMostParent(hitPart),
-                partialPen ? null : dinfo.Weapon); //To not apply the secondary damage twice on partial penetrations.
+                partialPen ? null : dinfo.Weapon, //To not apply the secondary damage twice on partial penetrations.
+                instigatorGuilty: dinfo.InstigatorGuilty);
             newDinfo.SetBodyRegion(dinfo.Height, dinfo.Depth);
             newDinfo.SetWeaponBodyPartGroup(dinfo.WeaponBodyPartGroup);
             newDinfo.SetWeaponHediff(dinfo.WeaponLinkedHediff);

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -78,7 +78,8 @@ namespace CombatExtended
                           ExactRotation.eulerAngles.y,
                           launcher,
                           null,
-                          def);
+                          def,
+                          instigatorGuilty: InstigatorGuilty);
 
                 // Set impact height
                 BodyPartDepth partDepth = damDefCE.harmOnlyOutsideLayers ? BodyPartDepth.Outside : BodyPartDepth.Undefined;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -84,6 +84,14 @@ namespace CombatExtended
         }
         #endregion
 
+        /// <summary>
+        /// Determine whether the pawn that fired this projectile (if it was a pawn)
+        /// should be considered guilty if this projectile hits a friendly target.
+        /// </summary>
+        /// <remarks>
+        /// This effectively aims to prevent people drafting pawns and ordering them to attack friendly targets to cheese guilt.
+        /// </remarks>
+        protected bool InstigatorGuilty => !(launcher is Pawn launcherPawn && launcherPawn.Drafted);
 
         public Thing intendedTargetThing
         {

--- a/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
+++ b/Source/CombatExtended/CombatExtended/SecondaryDamage.cs
@@ -35,7 +35,8 @@ namespace CombatExtended
                             primaryDinfo.Angle,
                             primaryDinfo.Instigator,
                             primaryDinfo.HitPart,
-                            primaryDinfo.Weapon);
+                            primaryDinfo.Weapon,
+                            instigatorGuilty: primaryDinfo.InstigatorGuilty);
             dinfo.SetBodyRegion(primaryDinfo.Height, primaryDinfo.Depth);
             return dinfo;
         }

--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -92,7 +92,7 @@ namespace CombatExtended.HarmonyCE
                 var dmgAmount = dinfo.Amount;
                 if (__instance.parent is Pawn p && (p.RaceProps?.IsFlesh ?? false)) dmgAmount = Mathf.RoundToInt(dmgAmount * 0.25f);
                 var newDinfo = new DamageInfo(CE_DamageDefOf.Electrical, dmgAmount, 9999, // Hack to avoid double-armor application (EMP damage reduced -> proportional electric damage reduced again)
-                    dinfo.Angle, dinfo.Instigator, dinfo.HitPart, dinfo.Weapon, dinfo.Category);
+                    dinfo.Angle, dinfo.Instigator, dinfo.HitPart, dinfo.Weapon, dinfo.Category, instigatorGuilty: dinfo.InstigatorGuilty);
                 __instance.parent.TakeDamage(newDinfo);
             }
         }


### PR DESCRIPTION

## Changes


Ensure pawns won't be considered guilty when drafted and ordered to
attack a friendly pawn. This prevents an exploit where players
could draft an undesired pawn and have them punch a colonist or colony
animal so that they'd become guilty & be banished with a lesser impact
on the colony.

Both melee and ranged attacks are covered.



## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - used an autotest colony to check that drafted pawns don't become guilty when ordered to attack but berserk etc. ones do.
