### PR TITLE
Fix ranged shield belt users unable to use ranged weapons

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_CompShield.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompShield.cs
@@ -14,7 +14,16 @@ namespace CombatExtended.HarmonyCE
     {
         internal static bool Prefix(ref bool __result, Verb verb, CompShield __instance)
         {
-            __result = (__instance.ShieldState != ShieldState.Active) || verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
+            if (__instance.Props.blocksRangedWeapons)
+            {
+                __result = (__instance.ShieldState != ShieldState.Active) || verb is Verb_MarkForArtillery || !(verb is Verb_LaunchProjectileCE || verb is Verb_LaunchProjectile);
+            }
+            else
+            {
+                // Let pawns use ranged weapons with Biotech's ranged shield belts
+                __result = true;
+            }
+
             return false;
         }
     }


### PR DESCRIPTION



## Changes

Let Biotech's ranged shield belt wearers use ranged weapons as with vanilla.




## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony 
