### PR TITLE
Fix new Centurion/Legionary shields

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -17,13 +17,6 @@ namespace CombatExtended
         private static RulePackDef cookOffDamageEvent = null;
 
         public static RulePackDef CookOff => cookOffDamageEvent ?? (cookOffDamageEvent = DefDatabase<RulePackDef>.GetNamed("DamageEvent_CookOff"));
-        public virtual float DamageAmount
-        {
-            get
-            {
-                return def.projectile.GetDamageAmount(1);
-            }
-        }
 
         public virtual float PenetrationAmount
         {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -105,6 +105,9 @@ namespace CombatExtended
         public bool landed;
         public int ticksToImpact;
         private Sustainer ambientSustainer;
+
+        public virtual float DamageAmount => def.projectile.GetDamageAmount(1);
+
         #endregion
 
         private float suppressionAmount;
@@ -639,19 +642,45 @@ namespace CombatExtended
             }
             interceptorComp.lastInterceptAngle = lastExactPos.AngleToFlat(interceptorThing.TrueCenter());
             interceptorComp.lastInterceptTicks = Find.TickManager.TicksGame;
-            var areWeLucky = Rand.Chance((def.projectile as ProjectilePropertiesCE)?.empShieldBreakChance ?? 0);
+
+            var projectileProperties = def.projectile as ProjectilePropertiesCE;
+            var areWeLucky = Rand.Chance(projectileProperties?.empShieldBreakChance ?? 0);
             if (areWeLucky)
             {
-                var firstEMPSecondaryDamage = (def.projectile as ProjectilePropertiesCE)?.secondaryDamage?.FirstOrDefault(sd => sd.def == DamageDefOf.EMP);
-                if (def.projectile.damageDef == DamageDefOf.EMP)
+                // If the chance check for this EMP projectile succeeds, break the shield using the appropriate damage type
+                // (primary if the primary damage is EMP itself and secondary if EMP damage is only a secondary effect.)
+                // Note that empShieldBreakChance defaults to 1 even for non-EMP projectiles, so a non-EMP projectile
+                // may still technically pass the chance check.
+                var empDamageDef = def.projectile.damageDef == DamageDefOf.EMP
+                    ? def.projectile.damageDef
+                    : projectileProperties?.secondaryDamage?.Select(sd => sd.def).FirstOrDefault(sdDef => sdDef == DamageDefOf.EMP);
+
+                if (empDamageDef != null)
                 {
-                    interceptorComp.BreakShieldEmp(new DamageInfo(def.projectile.damageDef, def.projectile.damageDef.defaultDamage));
-                }
-                else if (firstEMPSecondaryDamage != null)
-                {
-                    interceptorComp.BreakShieldEmp(new DamageInfo(firstEMPSecondaryDamage.def, firstEMPSecondaryDamage.def.defaultDamage));
+                    interceptorComp.BreakShieldEmp(new DamageInfo(empDamageDef, empDamageDef.defaultDamage));
+
+                    // Ensure we reset hit points for Biotech's new shields if broken by EMP
+                    interceptorComp.currentHitPoints = 0;
                 }
             }
+
+            // Handle Biotech's new shields used e.g. on the Centurion mech, which, unlike mech cluster shields, can only take
+            // a finite amount of damage before breaking.
+            // This simply mirrors the corresponding vanilla logic - we apply the incoming damage from our projectile to the shield
+            // and break it if we manage to decrease its hitpoints to zero or lower.
+            if (interceptorComp.currentHitPoints > 0)
+            {
+                interceptorComp.currentHitPoints -= Mathf.FloorToInt(this.DamageAmount);
+
+                if (interceptorComp.currentHitPoints <= 0)
+                {
+                    interceptorComp.currentHitPoints = 0;
+                    interceptorComp.nextChargeTick = Find.TickManager.TicksGame;
+                    interceptorComp.BreakShieldHitpoints(new DamageInfo(projectileProperties.damageDef, this.DamageAmount));
+                    return true;
+                }
+            }
+
             Effecter eff = new Effecter(EffecterDefOf.Interceptor_BlockedProjectile);
             eff.Trigger(new TargetInfo(newExactPos.ToIntVec3(), interceptorThing.Map, false), TargetInfo.Invalid);
             eff.Cleanup();


### PR DESCRIPTION


## Changes
Biotech's new Centurion/Legionary mechs use shields with finite hitpoints that break if they take enough damage. Our custom intercept logic in ProjectileCE must be updated to handle these shields.

Solve this by just applying the appropriate vanilla logic - applying damage from the projectile to the shield and breaking it if it reaches zero hitpoints. For this to work, move the definition of DamageAmount from BulletCE to ProjectileCE so that we can obtain the scaled damage amount in the interception logic.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (working as intended)
