### PR TITLE
Support spawning vanilla gases from explosive projectile detonation

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -53,7 +53,7 @@ namespace CombatExtended
                     Props.postExplosionSpawnThingDef,
                     Props.postExplosionSpawnChance,
                     Props.postExplosionSpawnThingCount,
-                    postExplosionGasType: null,
+                    Props.postExplosionGasType,
                     Props.applyDamageToExplosionCellsNeighbors,
                     Props.preExplosionSpawnThingDef,
                     Props.preExplosionSpawnChance,

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
@@ -34,6 +34,11 @@ namespace CombatExtended
         public bool damageFalloff = true;
         public float chanceToStartFire;
 
+        /// <summary>
+        /// The type of built-in core game gas to spawn on detonation.
+        /// </summary>
+        public GasType? postExplosionGasType;
+
         public CompProperties_ExplosiveCE()
         {
             compClass = typeof(CompExplosiveCE);


### PR DESCRIPTION



## Changes
Add support for the postExplosionGasType XML tag in CompProperties_ExplosiveCE, which allows our explosive projectiles to spawn a built-in gas type on detonation. We seem to be already using it in XML, the code just was not ready to use it.




## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned in some smoke grenades and tested that they now properly spawn blind smoke on detonation.
