### PR TITLE
Make 5x100mm Toxic ammo Biotech-only

### DIFF
--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -19,7 +19,7 @@
 		<similarTo>AmmoSet_Rifle</similarTo>
 	</CombatExtended.AmmoSetDef>
 
-	<CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef MayRequire="Ludeon.RimWorld.Biotech">
 		<defName>AmmoSet_5x100mmCaselessToxic</defName>
 		<label>5x100mm Caseless (Toxic)</label>
 		<ammoTypes>
@@ -80,7 +80,7 @@
 		</projectile>
 	  </ThingDef>
 
-	  <ThingDef ParentName="Base5x100mmCaselessBullet">
+	  <ThingDef ParentName="Base5x100mmCaselessBullet" MayRequire="Ludeon.RimWorld.Biotech">
 		<defName>Bullet_5x100mmCaseless_Toxic</defName>
 		<label>5x100 Caseless bullet (Toxic)</label>
 		<graphicData>


### PR DESCRIPTION
## Changes

- Added the `MayRequire="Ludeon.RimWorld.Biotech"`  to the toxic version of the 5x100mm ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
