### PR TITLE
Reduce noise in logs when dev mode is active

### DIFF
--- a/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/GizmoAmmoStatus.cs
@@ -8,29 +8,17 @@ using UnityEngine;
 
 namespace CombatExtended
 {
+    [StaticConstructorOnStartup]
     public class GizmoAmmoStatus : Command
     {
-        private static bool initialized;
 
         public CompAmmoUser compAmmo;
         public string prefix = "";
-
-        private static Texture2D FullTex;
-        private static Texture2D EmptyTex;
-        private static new Texture2D BGTex;
+        private static readonly new Texture2D BGTex = ContentFinder<Texture2D>.Get("UI/Widgets/DesButBG", true);
 
         public override float GetWidth(float maxWidth)
         {
             return 120;
-        }
-
-        public GizmoAmmoStatus()
-        {
-            if (!initialized)
-            {
-                InitializeTextures();
-                initialized = true;
-            }
         }
 
         public override GizmoResult GizmoOnGUI(Vector2 topLeft, float maxWidth, GizmoRenderParms parms)
@@ -56,16 +44,6 @@ namespace CombatExtended
             }
 
             return new GizmoResult(GizmoState.Clear);
-        }
-
-        private void InitializeTextures()
-        {
-            if (FullTex == null)
-                FullTex = SolidColorMaterials.NewSolidColorTexture(new Color(0.2f, 0.2f, 0.24f));
-            if (EmptyTex == null)
-                EmptyTex = SolidColorMaterials.NewSolidColorTexture(Color.clear);
-            if (BGTex == null)
-                BGTex = ContentFinder<Texture2D>.Get("UI/Widgets/DesButBG", true);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -11,6 +11,7 @@ using Verse.Sound;
 
 namespace CombatExtended
 {
+
     public class ITab_Inventory : ITab_Pawn_Gear
     {
         #region Fields
@@ -21,7 +22,7 @@ namespace CombatExtended
         private const float _thingLeftX = 36f;
         private const float _thingRowHeight = 28f;
         private const float _topPadding = 20f;
-        private static Texture2D _iconEditAttachments;
+        private static readonly CachedTexture _iconEditAttachments = new CachedTexture("UI/Icons/gear");
         private const float _standardLineHeight = 22f;
         private static readonly Color _highlightColor = new Color(0.5f, 0.5f, 0.5f, 1f);
         private Vector2 _scrollPosition = Vector2.zero;
@@ -86,13 +87,6 @@ namespace CombatExtended
         #endregion Properties
 
         #region Methods
-
-        public override void OnOpen()
-        {            
-            _iconEditAttachments ??= ContentFinder<Texture2D>.Get("UI/Icons/gear");
-
-            base.OnOpen();
-        }
 
         public override void FillTab()
         {            
@@ -269,7 +263,7 @@ namespace CombatExtended
             {
                 Rect rect3 = new Rect(rect.width - 24f, y, 24f, 24f);
                 TooltipHandler.TipRegion(rect3, "CE_EditWeapon".Translate());
-                if (Widgets.ButtonImage(rect3, _iconEditAttachments))
+                if (Widgets.ButtonImage(rect3, _iconEditAttachments.Texture))
                 {
                     SoundDefOf.Tick_High.PlayOneShotOnCamera(null);
                     if (!Find.WindowStack.IsOpen<Window_AttachmentsEditor>())


### PR DESCRIPTION

## Changes

There are a few warnings in logs about texture-type fields when dev mode is active. To get rid of the noise, switch GizmoAmmoStatus to initialize its textures on startup with [StaticConstructorOnStartup], and use a CachedTexture instead of a raw texture in ITab_Inventory (which is what vanilla ITabs do).

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
