### PR TITLE
ProjectileCE: Fix duplicate DamageAmount property after merge

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -134,8 +134,6 @@ namespace CombatExtended
         public int ticksToImpact;
         private Sustainer ambientSustainer;
 
-        public virtual float DamageAmount => def.projectile.GetDamageAmount(1);
-
         #endregion
 
         private float suppressionAmount;


### PR DESCRIPTION
There can only be one.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - took a potshot at an emu with a bolty to verify basic functionality
