### PR TITLE
Fix XML error in CombinationDefs

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -566,10 +566,10 @@
 								<building>VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry</building>
 								<items>
 									<li>Chemfuel</li>
-								</secondItems>
-								<thirdItems>
+								</items>
+								<secondItems>
 									<li>ComponentIndustrial</li>
-								</thirdItems>
+								</secondItems>
 								<amount>
 									<li>94</li>
 									<li>20</li>


### PR DESCRIPTION
Some start/end tags got mismatched.



## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony  - loaded up a quicktest map
