### PR TITLE
Turret tweaks

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -103,7 +103,7 @@
         <warmupTime>1.6</warmupTime>
         <range>55</range>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-        <burstShotCount>10</burstShotCount>
+        <burstShotCount>5</burstShotCount>
         <soundCast>HeavyMG</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>16</muzzleFlashScale>
@@ -154,7 +154,7 @@
     </verbs>
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
-        <magazineSize>60</magazineSize>
+        <magazineSize>80</magazineSize>
         <reloadTime>7.8</reloadTime>
         <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
       </li>
@@ -187,7 +187,7 @@
         <warmupTime>2.3</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-        <burstShotCount>10</burstShotCount>
+        <burstShotCount>5</burstShotCount>
         <soundCast>HeavyMG</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>16</muzzleFlashScale>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -187,7 +187,7 @@
         <warmupTime>2.3</warmupTime>
         <range>78</range>
         <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
-        <burstShotCount>5</burstShotCount>
+        <burstShotCount>10</burstShotCount>
         <soundCast>HeavyMG</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>16</muzzleFlashScale>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -321,7 +321,7 @@
 			  <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
 			  <warmupTime>2.3</warmupTime>
 			  <range>78</range>
-			  <burstShotCount>10</burstShotCount>
+			  <burstShotCount>12</burstShotCount>
 			  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 			  <soundCast>Shot_Autocannon</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
@@ -329,7 +329,7 @@
 			  <recoilPattern>Mounted</recoilPattern>
 			</Properties>
 			<AmmoUser>
-			  <magazineSize>100</magazineSize>
+			  <magazineSize>120</magazineSize>
 			  <reloadTime>7.8</reloadTime>
 			  <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 			</AmmoUser>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -321,7 +321,7 @@
 			  <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
 			  <warmupTime>2.3</warmupTime>
 			  <range>78</range>
-			  <burstShotCount>12</burstShotCount>
+			  <burstShotCount>10</burstShotCount>
 			  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 			  <soundCast>Shot_Autocannon</soundCast>
 			  <soundCastTail>GunTail_Heavy</soundCastTail>
@@ -329,7 +329,7 @@
 			  <recoilPattern>Mounted</recoilPattern>
 			</Properties>
 			<AmmoUser>
-			  <magazineSize>120</magazineSize>
+			  <magazineSize>100</magazineSize>
 			  <reloadTime>7.8</reloadTime>
 			  <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
 			</AmmoUser>


### PR DESCRIPTION
## Changes

- Changed the burst shot count of the Heavy and Autocannon turrets from 10 to 5 rounds.
- Increased the magazine capacity of the Medium turret from 60 to 80 rounds.
- Tweaked the Double Autocannon turret from VFE-Security to bring it more in line with the vanilla turret.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
