### PR TITLE
Fix VFE - Classical Patch

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -43,7 +43,6 @@
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>
 		<li>Rah.RVTE</li>
-		<li>OskarPotocki.VFE.Classical</li>
 		<li>miho.fortifiedoutremer</li>		
 	</loadBefore>
 	<loadAfter>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -59,8 +59,7 @@
 						<MeleeCritChance>-0.08</MeleeCritChance>
 						<MeleeParryChance>1.0</MeleeParryChance>
 					</equippedStatOffsets>
-					<comps>
-						<li Class="CompOversizedWeapon.CompProperties_OversizedWeapon"/>							
+					<comps>							
 						<li>
 							<compClass>CompColorable</compClass>
 						</li>								

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -10,10 +10,18 @@
 
 			<!-- === Javelin === -->
 
+			<!-- This dummy parent just provides a workaround so VFE - Classical can be loaded before CE. -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs</xpath>
+				<value>
+					<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="JavelinBase_VFEC" Abstract="True" />
+				</value>				
+			</li>	
+
 			<li Class="PatchOperationAttributeSet">
 				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<attribute>ParentName</attribute>
-				<value>BaseWeaponAndAmmoNeolithic</value>				
+				<value>JavelinBase_VFEC</value>				
 			</li>	
 
 			<li Class="PatchOperationAttributeAdd">


### PR DESCRIPTION
## Changes
- Add a dummy parent for the javelin, so it doesn't need to be loaded after Combat Extended. Remove the load order requirement.
- Remove the OversizedWeapon comp from the VFE:C melee shield, since CE treats shields as apparel, not weapons.

## Reasoning
- A dummy parent is the cleanest way to implement it, short of just creating a duplicate of the actual parent it's using.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)