### PR TITLE
Minigun and Charge Lance consistency check

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -858,7 +858,12 @@
       <ShotSpread>0.06</ShotSpread>
       <SwayFactor>3.22</SwayFactor>
       <Bulk>10</Bulk>
+      <WorkToMake>52000</WorkToMake>
     </statBases>
+    <costList>
+      <Steel>110</Steel>
+      <ComponentIndustrial>11</ComponentIndustrial>
+    </costList>
     <Properties>
       <recoilAmount>0.97</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
@@ -901,20 +906,6 @@
           <linkedBodyPartsGroup>Barrels</linkedBodyPartsGroup>
         </li>
       </tools>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/Steel</xpath>
-    <value>
-      <Steel>200</Steel>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Gun_Minigun"]/costList/ComponentIndustrial</xpath>
-    <value>
-      <ComponentIndustrial>14</ComponentIndustrial>
     </value>
   </Operation>
 
@@ -1430,7 +1421,7 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Gun_ChargeLance"]/statBases</xpath>
     <value>
-      <MarketValue>2200</MarketValue>
+      <MarketValue>1400</MarketValue>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes

- Changed the market value of the charge lance from 2200 to 1400, same as other mechanoid weapons.
- Tweaked the recipe of the Minigun based on the values from the Gun spreadsheet.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
