### PR TITLE
Vanilla Pikeman adjustments and 66mm tweaks

### DIFF
--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -70,7 +70,7 @@
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
       <dropsCasings>false</dropsCasings>
-      <gravityFactor>20</gravityFactor> <!-- value intentionally increased to maek the shells land faster -->
+      <gravityFactor>8</gravityFactor> <!-- value intentionally increased to make the shells land faster -->
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -70,7 +70,7 @@
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
       <dropsCasings>false</dropsCasings>
-      <gravityFactor>8</gravityFactor> <!-- value intentionally increased to make the shells land faster -->
+      <gravityFactor>10</gravityFactor> <!-- value intentionally increased to make the shells land faster -->
     </projectile>
   </ThingDef>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -449,4 +449,19 @@
 		</value>
 	</Operation>
 
+	<!--Only apply if Biotech isn't loaded-->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Biotech</li>
+		</mods>
+		<nomatch Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[defName="Mech_Pikeman"]/weaponTags</xpath>
+			<value>
+				<weaponTags>
+					<li>MechanoidGunIndirect</li>
+				</weaponTags>
+			</value>
+		</nomatch>
+	</Operation>
+
 </Patch>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -84,6 +84,34 @@
 			</value>
 		  </li>
 
+		<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Biotech</li>
+			</mods>
+			<nomatch Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="VFE_Mech_Pikeman"]/weaponTags</xpath>
+				<value>
+					<weaponTags>
+						<li>MechanoidGunIndirect</li>
+					</weaponTags>
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Biotech</li>
+			</mods>
+			<nomatch Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="VFE_Mech_AdvancedPikeman"]/weaponTags</xpath>
+				<value>
+					<weaponTags>
+						<li>VFE_AdvMechanoidGunIndirect</li>
+					</weaponTags>
+				</value>
+			</nomatch>
+		</li>
+
       </operations>
     </match>
   </Operation>


### PR DESCRIPTION
## Additions

- Adds the Bolt Projector for the Pikeman when Biotech is disabled to keep the niche of an indirect fire mech for non-DLC users

## Changes

- Reduced the gravity factor of 6mm thermal bolts as they were too fast to reliably maneuver around and retaliate against, the new values should still keep a visible arc for the player to see

## Reasoning

- With the TBP being moved to the Legionary it leaves the vanilla mech roster lacking in an indirect fire option and has both Lancers and Pikemen take up the role of a single shot precision rifle
- TBP's intended use is to be a deterrent of static positions and to force the player to reposition their pawns, having too fast projectiles detracts from this niche by not allowing the player to reliably retaliate and makes it significantly harder to fight up close where the projectile lands even faster

## Alternatives

- Revert the TBP swap from Legionary in Biotech as well, leaving the ally shield as their main gimmick, Pikeman would still retain his original niche while leaving the Lancer as the precision mech

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
