### PR TITLE
Biotech balance pass

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -31,14 +31,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Tunneler"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>67.5</ArmorRating_Blunt>
+			<ArmorRating_Blunt>60</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Tunneler"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>30</ArmorRating_Sharp>
+			<ArmorRating_Sharp>24</ArmorRating_Sharp>
 		</value>
 	</Operation>
 

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -70,7 +70,7 @@
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
       <dropsCasings>false</dropsCasings>
-      <gravityFactor>20</gravityFactor> <!-- value intentionally increased to maek the shells land faster -->
+      <gravityFactor>10</gravityFactor> <!-- value intentionally increased to maek the shells land faster -->
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -70,7 +70,7 @@
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
       <dropsCasings>false</dropsCasings>
-      <gravityFactor>10</gravityFactor> <!-- value intentionally increased to maek the shells land faster -->
+      <gravityFactor>10</gravityFactor> <!-- value intentionally increased to make the shells land faster -->
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- Tweaked the armor values of the Tunneler mech to a milder value of 24/60 sharp/blunt rating.
- Lowered the gravity factor of the 66mm Bolts to 10, the previous value was for testing purposes and was not changed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors