### PR TITLE
Increase Tox Grenadier Ammo Count

### DIFF
--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
@@ -12,4 +12,18 @@
     </value>
   </Operation>
 
+  <!-- ========== Tox Grenadier ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Grenadier_Tox"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>14</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes
- Increase the number of grenades the Tox Grenadier can spawn with. Their parent is unpatched and only receives the default magazine count, so they could do with carrying a few more.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
