### PR TITLE
Patch 1.4 Turrets

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -130,7 +130,7 @@
     <label>foam bolt</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Extinguish</damageDef>
-      <explosionRadius>6.5</explosionRadius>
+      <explosionRadius>3</explosionRadius>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
@@ -173,7 +173,7 @@
     </ingredients>
     <fixedIngredientFilter>
       <thingDefs>
-            <li>ComponentIndustrial</li>	  
+        <li>ComponentIndustrial</li>	  
         <li>Steel</li>
         <li>Prometheum</li>
       </thingDefs>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -126,7 +126,7 @@
     <detonateProjectile>Bullet_60mmMortarShell_Firefoam</detonateProjectile>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>7</damageAmountBase>
+		<damageAmountBase>3.5</damageAmountBase>
 		<explosiveDamageType>Extinguish</explosiveDamageType>
 		<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
 		<postExplosionSpawnChance>1</postExplosionSpawnChance>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -147,7 +147,7 @@
     <comps>
 	  <!-- Vanilla values -->
       <li Class="CompProperties_Explosive">
-        <explosiveRadius>9.5</explosiveRadius>
+        <explosiveRadius>5</explosiveRadius>
         <explosiveDamageType>Extinguish</explosiveDamageType>
         <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
         <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -418,7 +418,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
         <explosiveDamageType>Extinguish</explosiveDamageType>
-        <explosiveRadius>6.5</explosiveRadius>
+        <explosiveRadius>3.5</explosiveRadius>
         <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
         <postExplosionSpawnChance>1</postExplosionSpawnChance>
         <postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -24,7 +24,6 @@
   
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/description</xpath>
-    
     <value>
       <description>A portable automatic turret. Its dumb AI brain can't be directly controlled, so beware of friendly fire.</description>
     </value>
@@ -265,6 +264,22 @@
 		</costList>  
 		</value>
     </Operation>
+
+	<!-- ========== Foam Turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName = "Turret_FoamTurret"]/comps/li[@Class = "CompProperties_Refuelable"]/fuelMultiplier</xpath>
+		<value>
+			<fuelMultiplier>0.20</fuelMultiplier>	
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName = "Turret_FoamTurret"]/comps/li[@Class = "CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
+		<value>
+			<li>Ammo_30x64mmFuel_Foam</li>	
+		</value>
+	</Operation>
 
 	<!-- ========== Mortar Base ========== -->
 

--- a/Patches/LF Red Dawn/82mmMortar.xml
+++ b/Patches/LF Red Dawn/82mmMortar.xml
@@ -274,7 +274,7 @@
       <damageDef>Extinguish</damageDef>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>9.5</explosionRadius>
+      <explosionRadius>4.75</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
       <soundExplode>Explosion_EMP</soundExplode>


### PR DESCRIPTION
## Additions
- Patch the ammo type and capacity of the foam turret.

## Changes
- Reduce the radius of fire foam rounds by roughly half. They covered extremely large areas compared to the size of the shell, especially since the have 100% coverage. Now coverage is still large, but more reasonable.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
