### PR TITLE
Ammo bench research prerequisite

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -60,7 +60,7 @@
 	  <forceShowRoomStats>true</forceShowRoomStats>
     </building>
     <researchPrerequisites>
-      <li>Machining</li>
+      <li>Gunsmithing</li>
     </researchPrerequisites>
     <placeWorkers>
       <li>PlaceWorker_ShowFacilitiesConnections</li>


### PR DESCRIPTION
## Changes

- Changed the research prerequisite of the Ammo Bench to Gunsmithing. It does not make sense for pawns to craft ammo before knowing what firearms are.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors