### PR TITLE
Update HAR compat patch

### DIFF
--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlienRace.cs
@@ -105,7 +105,7 @@ namespace CombatExtended.HarmonyCE.Compatibility
         }
 
         [HarmonyPatch]
-        public static class Harmony_AlienPartGenerator_GetPawnHairMesh
+        public static class Harmony_AlienPartGenerator_GetHumanlikeHeadSetForPawnHelper
         {
             public static bool Prepare()
             {
@@ -114,16 +114,14 @@ namespace CombatExtended.HarmonyCE.Compatibility
 
             public static MethodBase TargetMethod()
             {
-                return AccessTools.Method(typeof(Harmony_PawnRenderer), nameof(Harmony_PawnRenderer.GetHeadMesh));
+                return AccessTools.Method(typeof(Harmony_PawnRenderer), nameof(Harmony_PawnRenderer.GetHumanlikeHeadSetForPawnHelper));
             }
 
             public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
             {
-                yield return new CodeInstruction(OpCodes.Ldarg_0);
-                yield return new CodeInstruction(OpCodes.Ldarg_1);
-                yield return new CodeInstruction(OpCodes.Ldarg_2);
-                yield return new CodeInstruction(OpCodes.Ldarg_3);
-                yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(TypeOf_HarmonyPatches, "GetPawnHairMesh"));
+                yield return new CodeInstruction(OpCodes.Ldarg_0); // lifeStageFactor
+                yield return new CodeInstruction(OpCodes.Ldarg_1); // pawn
+                yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(TypeOf_HarmonyPatches, "GetHumanlikeHeadSetForPawnHelper"));
                 yield return new CodeInstruction(OpCodes.Ret);
             }
         }

--- a/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnRenderer.cs
@@ -56,7 +56,7 @@ namespace CombatExtended.HarmonyCE
         /// Intended to allow an easy point that allow other mods or CE to patch the rendering in runtime
         /// </summary>                
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Mesh GetHeadMesh(PawnRenderFlags renderFlags, Pawn pawn, Rot4 headFacing, PawnGraphicSet graphics)
+        public static GraphicMeshSet GetHumanlikeHeadSetForPawnHelper(float lifeStageFactor, Pawn pawn)
         {
             return null;
         }
@@ -243,7 +243,10 @@ namespace CombatExtended.HarmonyCE
                 Vector3 customScale = Vec2ToVec3(GetHeadCustomSize(pawn.def));
                 Vector3 headwearPos = headLoc + Vec2ToVec3(GetHeadCustomOffset(pawn.def));
 
-                Mesh mesh = GetHeadMesh(flags, pawn, headFacing, renderer.graphics) ?? renderer.graphics.HairMeshSet.MeshAt(bodyFacing);
+                // Let other mods such as HAR inject an alternative graphic for the hair/head
+                float lifeStageFactor = pawn.ageTracker.CurLifeStage.bodySizeFactor;
+                GraphicMeshSet gms = GetHumanlikeHeadSetForPawnHelper(lifeStageFactor, pawn);
+                Mesh mesh = gms?.MeshAt(bodyFacing) ?? renderer.graphics.HairMeshSet.MeshAt(bodyFacing);
 
                 for (int i = 0; i < apparelGraphics.Count; i++)
                 {


### PR DESCRIPTION

## Changes

Fix our HAR compat patch for 1.4 by updating the HAR method that will be called within our pawn rendering compat hook. GetHairMesh() was replaced by GetHumanlikeHeadSetForPawnHelper() on the HAR side.





## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x]  ...with and without patched mod loaded
- [x] Playtested a colony- spawned a HAR-based pawn in autotest
