### PR TITLE
Hide ammo status and armor reload gizmos for non-colonist pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -689,11 +689,14 @@ namespace CombatExtended
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            GizmoAmmoStatus ammoStatusGizmo = new GizmoAmmoStatus { compAmmo = this };
-            yield return ammoStatusGizmo;
             var mannableComp = turret?.GetMannable();
-            if ((IsEquippedGun && Wielder.Faction == Faction.OfPlayer) || (turret != null && turret.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo)))
+            var isPlayerControlled = Wielder?.IsColonistPlayerControlled ?? (turret?.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo));
+
+            if (isPlayerControlled)
             {
+                GizmoAmmoStatus ammoStatusGizmo = new GizmoAmmoStatus { compAmmo = this };
+                yield return ammoStatusGizmo;
+
                 Action action = null;
                 if (IsEquippedGun) action = SyncedTryStartReload;
                 else if (mannableComp != null) action = SyncedTryForceReload;

--- a/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompReloadable.cs
@@ -20,15 +20,20 @@ namespace CombatExtended.HarmonyCE
                 yield return g;
             }
 
-            yield return new Command_ReloadArmor
+            // Don't show the "reload worn armor" gizmo for non-colonist pawns / pawns in a mental break etc.
+            if (__instance.Wearer.IsColonistPlayerControlled)
             {
-                compReloadable = __instance,
-                action = () => TryReloadArmor(__instance),
-                defaultLabel = (string)"CE_ReloadLabel".Translate() + " worn armor",
-                defaultDesc = "CE_ReloadDesc".Translate(),
-                icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload", true)
 
-            };
+                yield return new Command_ReloadArmor
+                {
+                    compReloadable = __instance,
+                    action = () => TryReloadArmor(__instance),
+                    defaultLabel = (string)"CE_ReloadLabel".Translate() + " worn armor",
+                    defaultDesc = "CE_ReloadDesc".Translate(),
+                    icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload", true)
+
+                };
+            }
 
         }
 


### PR DESCRIPTION


## Reasoning

For consistency with other related gizmos.




## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony - tested that gizmos show/don't show for friendly, non-friendly and colonist pawns in autotest
