### PR TITLE
Use mechanoid faction style for mech cluster ammo drop pods

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoResupplyOnWakeup.cs
@@ -130,7 +130,18 @@ namespace CombatExtended
             list.Add(thing);
 
             //If turrets are near-empty or empty, call in ammo droppod
-            DropPodUtility.DropThingsNear(cell, parent.Map, list, 110, false, false, true, true);
+            DropPodUtility.DropThingsNear(
+                cell,
+                parent.Map,
+                list,
+                openDelay: 110,
+                canInstaDropDuringInit: false,
+                leaveSlag: false,
+                canRoofPunch: true,
+                forbid: true,
+                // Use the mechanoid faction as the faction for the drop pods, to match style
+                faction: parent.Faction
+            );
         }
     }
 }


### PR DESCRIPTION


## Reasoning

This is the same style used for the pods that drop the cluster itself.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - spawned mech cluster and verified drop pod style for incoming ammo resupply.
