### PR TITLE
Add Generic Ammo to Mech Ammo

### DIFF
--- a/Biotech/Patches/Misc/Ammo_Generic.xml
+++ b/Biotech/Patches/Misc/Ammo_Generic.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <!-- Charged Rifle -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_5x35mmCharged" or defName="AmmoSet_6x22mmCharged"]/similarTo</xpath>
+    <value>
+      <similarTo>AmmoSet_ChargedRifle</similarTo>
+    </value>
+  </Operation>
+
+  <!-- Charged Heavy -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_12x64mmCharged"]/similarTo</xpath>
+    <value>
+      <similarTo>AmmoSet_ChargedHeavy</similarTo>
+    </value>
+  </Operation>
+
+  <!-- Charged Shotgun -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_15x65mmDiffusingCharged"]/similarTo</xpath>
+    <value>
+      <similarTo>AmmoSet_ChargedShotgun</similarTo>
+    </value>
+  </Operation>
+
+  <!-- Mech Shells -->
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_66mmThermalBolt" or defName="AmmoSet_80x256mmFuel"]/similarTo</xpath>
+  </Operation>
+
+</Patch>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_12x64mmCharged>Bullet_12x64mmCharged</Ammo_12x64mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_MechRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_12x64mmCharged>Bullet_12x64mmCharged</Ammo_12x64mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_MechRifle</similarTo>
+    <similarTo>AmmoSet_MechCharged</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_15x65mmDiffusingCharged_Buck>Bullet_15x65mmDiffusingCharged_Buck</Ammo_15x65mmDiffusingCharged_Buck>
     </ammoTypes>
+    <similarTo>AmmoSet_MechRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_15x65mmDiffusingCharged_Buck>Bullet_15x65mmDiffusingCharged_Buck</Ammo_15x65mmDiffusingCharged_Buck>
     </ammoTypes>
-    <similarTo>AmmoSet_MechRifle</similarTo>
+    <similarTo>AmmoSet_MechCharged</similarTo>
   </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_164x284mmDemo>Bullet_164x284mmDemo</Ammo_164x284mmDemo>
     </ammoTypes>
+    <similarTo>AmmoSet_MechShell</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->
@@ -45,7 +46,7 @@
     <statBases>
       <MarketValue>10.97</MarketValue> <!-- value intentionally decreased to help reduce wealth bloat/free silver -->
     </statBases>
-    <ammoClass>ThermobaricFuel</ammoClass>
+    <ammoClass>GrenadeIncendiary</ammoClass>
 	<detonateProjectile>Bullet_164x284mmDemo</detonateProjectile>
 	<comps>
     <li Class="CompProperties_Explosive">

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_5x35mmCharged>Bullet_5x35mmCharged</Ammo_5x35mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_MechRifle</similarTo>
+    <similarTo>AmmoSet_MechCharged</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_5x35mmCharged>Bullet_5x35mmCharged</Ammo_5x35mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_MechRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_66mmThermalBolt_Incendiary>Bullet_66mmThermalBolt_Incendiary</Ammo_66mmThermalBolt_Incendiary>     
     </ammoTypes>
-    <similarTo>Ammo_MechShell</similarTo>
+    <similarTo>AmmoSet_MechShell</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_66mmThermalBolt_Incendiary>Bullet_66mmThermalBolt_Incendiary</Ammo_66mmThermalBolt_Incendiary>     
     </ammoTypes>
+    <similarTo>Ammo_MechShell</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_6x22mmCharged>Bullet_6x22mmCharged</Ammo_6x22mmCharged>
     </ammoTypes>
-    <similarTo>AmmoSet_MechRifle</similarTo>
+    <similarTo>AmmoSet_MechCharged</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_6x22mmCharged>Bullet_6x22mmCharged</Ammo_6x22mmCharged>
     </ammoTypes>
+    <similarTo>AmmoSet_MechRifle</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -16,7 +16,7 @@
     <ammoTypes>
       <Ammo_80x256mmFuel_Incendiary>Bullet_80x256mmFuel_Incendiary</Ammo_80x256mmFuel_Incendiary>
     </ammoTypes>
-    <similarTo>Ammo_MechShell</similarTo>
+    <similarTo>AmmoSet_MechShell</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -16,6 +16,7 @@
     <ammoTypes>
       <Ammo_80x256mmFuel_Incendiary>Bullet_80x256mmFuel_Incendiary</Ammo_80x256mmFuel_Incendiary>
     </ammoTypes>
+    <similarTo>Ammo_MechShell</similarTo>
   </CombatExtended.AmmoSetDef>
 
   <!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/GENERIC/Charged.xml
+++ b/Defs/Ammo/GENERIC/Charged.xml
@@ -198,7 +198,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyChargeAmmo">
     <defName>Ammo_HeavyCharged</defName>
-    <label>Heavy Charged cartridge</label>
+    <label>Heavy charged cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/Regular</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -208,7 +208,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyChargeAmmo">
     <defName>Ammo_HeavyCharged_AP</defName>
-    <label>Heavy Charged cartridge (Conc.)</label>
+    <label>Heavy charged cartridge (Conc.)</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/Concentrated</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -218,7 +218,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="HeavyChargeAmmo">
     <defName>Ammo_HeavyCharged_Ion</defName>
-    <label>Heavy Charged cartridge (Ion)</label>
+    <label>Heavy charged cartridge (Ion)</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/Ion</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<!-- ==================== Mech Ammo ========================== -->
+
+	<!-- ============= Category ============= -->
+
+  <ThingCategoryDef>
+    <defName>AmmoMechRifle</defName>
+    <label>Mech Rifle Ammo</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+  </ThingCategoryDef>
+
+  <ThingCategoryDef>
+    <defName>AmmoMechShell</defName>
+    <label>Mech Shell</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberFuelLarge</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_MechRifle</defName>
+    <label>mech rifle ammo</label>
+    <ammoTypes>
+      <Ammo_MechRifle>Bullet_5x35mmCharged</Ammo_MechRifle>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_MechShell</defName>
+    <label>mech shell</label>
+    <ammoTypes>
+      <Ammo_MechShell>Bullet_80x256mmFuel_Incendiary</Ammo_MechShell>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+
+	<!-- ============= Ammo ============= -->
+
+  <!-- Mech Rifle -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="MechRifleAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>Charged shot ammo used by mechanoid weaponry.</description>
+    <statBases>
+      <Mass>0.013</Mass>
+      <Bulk>0.01</Bulk>
+      <MarketValue>0.45</MarketValue>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
+    <thingCategories>
+      <li>AmmoMechRifle</li>
+    </thingCategories>
+    <stackLimit>5000</stackLimit>	
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechRifleAmmo">
+    <defName>AmmoSet_MechRifle</defName>
+    <label>mech rifle cartridge</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/Regular</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <ammoClass>Charged</ammoClass>
+  </ThingDef>
+
+  <!-- Mech Shell -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="MechShellAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>Large shell used by mechanoid cannons and heavy weapons.</description>
+    <statBases>
+      <Mass>0.85</Mass>
+      <Bulk>3.87</Bulk>  
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
+    <thingCategories>
+      <li>AmmoMechShell</li>
+    </thingCategories>
+    <stackLimit>25</stackLimit>	
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechShellAmmo">
+    <defName>Ammo_MechShell</defName>
+    <label>Mech Shell</label>
+    <graphicData>
+      <texPath>Things/Ammo/FuelCell/Large</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <ammoClass>GrenadeIncendiary</ammoClass>
+    <comps>
+      <li Class="CompProperties_Explosive">
+        <explosiveRadius>1.9</explosiveRadius>
+        <damageAmountBase>5</damageAmountBase>
+        <explosiveDamageType>PrometheumFlame</explosiveDamageType>
+        <explosiveExpandPerStackcount>0.10</explosiveExpandPerStackcount>
+        <startWickHitPointsPercent>0.33</startWickHitPointsPercent>
+        <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+        <explodeOnKilled>True</explodeOnKilled>
+        <wickTicks>60~300</wickTicks>
+      </li>
+    </comps>    
+  </ThingDef>
+
+</Defs>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -7,14 +7,14 @@
 
   <ThingCategoryDef>
     <defName>AmmoMechCharged</defName>
-    <label>Mech Rifle Ammo</label>
+    <label>mech charged ammo</label>
     <parent>AmmoAdvanced</parent>
     <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
   </ThingCategoryDef>
 
   <ThingCategoryDef>
     <defName>AmmoMechShell</defName>
-    <label>Mech Shell</label>
+    <label>mech shell</label>
     <parent>AmmoAdvanced</parent>
     <iconPath>UI/Icons/ThingCategories/CaliberFuelLarge</iconPath>
   </ThingCategoryDef>
@@ -39,7 +39,7 @@
 
 	<!-- ============= Ammo ============= -->
 
-  <!-- Mech Rifle -->
+  <!-- Mech Charged -->
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
     <description>Charged shot ammo used by mechanoid weaponry.</description>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -58,7 +58,7 @@
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechRifleAmmo">
-    <defName>AmmoSet_MechRifle</defName>
+    <defName>Ammo_MechRifle</defName>
     <label>mech rifle cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/Regular</texPath>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -6,7 +6,7 @@
 	<!-- ============= Category ============= -->
 
   <ThingCategoryDef>
-    <defName>AmmoMechRifle</defName>
+    <defName>AmmoMechCharged</defName>
     <label>Mech Rifle Ammo</label>
     <parent>AmmoAdvanced</parent>
     <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
@@ -22,10 +22,10 @@
   <!-- ==================== AmmoSet ========================== -->
 
   <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_MechRifle</defName>
-    <label>mech rifle ammo</label>
+    <defName>AmmoSet_MechCharged</defName>
+    <label>mech charged ammo</label>
     <ammoTypes>
-      <Ammo_MechRifle>Bullet_5x35mmCharged</Ammo_MechRifle>
+      <Ammo_MechCharged>Bullet_5x35mmCharged</Ammo_MechCharged>
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 
@@ -41,7 +41,7 @@
 
   <!-- Mech Rifle -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="MechRifleAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
     <description>Charged shot ammo used by mechanoid weaponry.</description>
     <statBases>
       <Mass>0.013</Mass>
@@ -52,14 +52,14 @@
       <li>CE_AutoEnableTrade_Sellable</li>
     </tradeTags>
     <thingCategories>
-      <li>AmmoMechRifle</li>
+      <li>AmmoMechCharged</li>
     </thingCategories>
     <stackLimit>5000</stackLimit>	
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechRifleAmmo">
-    <defName>Ammo_MechRifle</defName>
-    <label>mech rifle cartridge</label>
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="MechChargedAmmo">
+    <defName>Ammo_MechCharged</defName>
+    <label>mech charged cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/Charged/Regular</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -87,6 +87,7 @@
 					<li>Ammo_5x35mmCharged</li>
 					<li>Ammo_6x22mmCharged</li>
 					<li>Ammo_12x64mmCharged</li>
+					<li>Ammo_MechCharged</li>
 				</thingDefs>
 			</filter>
 			<count>200</count>
@@ -97,6 +98,7 @@
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
+				<li>Ammo_MechCharged</li>				
 			</thingDefs>		
 		</fixedIngredientFilter>
 		<products>
@@ -125,6 +127,7 @@
 					<li>Ammo_5x35mmCharged</li>
 					<li>Ammo_6x22mmCharged</li>
 					<li>Ammo_12x64mmCharged</li>
+					<li>Ammo_MechCharged</li>
 				</thingDefs>
 			</filter>
 			<count>200</count>
@@ -135,6 +138,7 @@
 				<li>Ammo_5x35mmCharged</li>
 				<li>Ammo_6x22mmCharged</li>
 				<li>Ammo_12x64mmCharged</li>
+				<li>Ammo_MechCharged</li>
 			</thingDefs>		
 		</fixedIngredientFilter>
 		<products>
@@ -163,6 +167,7 @@
 					<li>Ammo_66mmThermalBolt_Incendiary</li>
 					<li>Ammo_80x256mmFuel_Incendiary</li>
 					<li>Ammo_164x284mmDemo</li>
+					<li>Ammo_MechShell</li>
 				</thingDefs>
 			</filter>
 			<count>5</count>
@@ -173,6 +178,7 @@
 				<li>Ammo_66mmThermalBolt_Incendiary</li>
 				<li>Ammo_80x256mmFuel_Incendiary</li>
 				<li>Ammo_164x284mmDemo</li>
+				<li>Ammo_MechShell</li>
 			</thingDefs>		
 		</fixedIngredientFilter>
 		<products>


### PR DESCRIPTION
## Additions
- Add two new generic ammo sets; Mech Charged and Mech Shells and assign them to appropriate mechanoid ammo. These are non-craftable, but sellable, like normal mech ammo.
- With Biotech, patch the mech ammo to use either an appropriate generic charged ammo or (for shells) not use a generic at all.

## Changes
- Made the capitalization of the generic charged heavy label consistent.
- Added the new generic mech ammo types to the recycling recipes.
- Changed the `ammoClass` of the mech demo shell to incendiary, so it works with the Mech Shell generic ammo.

## Reasoning
With the introduction of player-controlled mechs in Biotech, the player now needs access to mechanoid ammo. As such, it makes sense to plug them into the Generic Ammo system using the existing spacer charged ammo. Rather than creating a full new set of mech-specific generic ammo that is functionally identical to the existing charged generic ammo, it's more straightforward to plug them into the existing charged set, since the player needs a craftable ammo to supply to their mechs anyhow.

Even for players not using Biotech, it's desirable for the mech weapons to use a generic ammo in Generic Ammo Mode rather than having their own specific ammos. This makes them both more thematically consistent with the Generic Ammo system and reduces the number of ammo types circulating overall. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
