### PR TITLE
Mechanoid HP scaling tweaks, mech related tweaks and housekeeping

### DIFF
--- a/Biotech/Patches/Bodies/BodyParts_Mechanoid.xml
+++ b/Biotech/Patches/Bodies/BodyParts_Mechanoid.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="SmallMechanicalLeg"]/hitPoints</xpath>
+    <value>
+      <hitPoints>13</hitPoints>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyPartDef[defName="SmallMechanicalFoot"]/hitPoints</xpath>
+    <value>
+      <hitPoints>7</hitPoints>
+    </value>
+  </Operation>
+
+</Patch>

--- a/Biotech/Patches/DamageDefs/Damages_Misc.xml
+++ b/Biotech/Patches/DamageDefs/Damages_Misc.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- ========== Beam ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="Beam"]/defaultDamage</xpath>
+		<value>
+			<defaultDamage>15</defaultDamage>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="Beam"]/defaultArmorPenetration</xpath>
+		<value>
+			<defaultArmorPenetration>0.25</defaultArmorPenetration>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Medium.xml
@@ -62,6 +62,20 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_BeamGraser"]/verbs/li/burstShotCount</xpath>
+    <value>
+      <burstShotCount>10</burstShotCount>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Gun_BeamGraser"]/verbs/li/ticksBetweenBurstShots</xpath>
+    <value>
+      <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+    </value>
+  </Operation>
+
   <!-- ========== Toxic Needle Gun ========== -->
 
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
@@ -14,15 +14,16 @@
     <Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+      <defaultProjectile>Bullet_8x50mmCharged</defaultProjectile>
       <range>55</range>
       <burstShotCount>1</burstShotCount>
       <soundCast>Shot_ChargeBlaster</soundCast>
       <soundCastTail>GunTail_Heavy</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
-      <defaultCooldownTime>5.0</defaultCooldownTime> <!-- Combined warmup and cooldown time of the HCB turret -->
+      <defaultCooldownTime>3.5</defaultCooldownTime>
       <linkedBodyPartsGroup>BulbTurret</linkedBodyPartsGroup>
       <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+      <ticksBetweenBurstShots>210</ticksBetweenBurstShots>
     </Properties>
   </Operation>
 

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -68,24 +68,24 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>22</power>
-					<cooldownTime>2.0</cooldownTime>
+					<power>36</power>
+					<cooldownTime>3.17</cooldownTime>
 					<linkedBodyPartsGroup>LeftPowerClaw</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>1</armorPenetrationSharp>
-					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<armorPenetrationSharp>2</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right power claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>22</power>
-					<cooldownTime>2.0</cooldownTime>
+					<power>36</power>
+					<cooldownTime>3.17</cooldownTime>
 					<linkedBodyPartsGroup>RightPowerClaw</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>1</armorPenetrationSharp>
-					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<armorPenetrationSharp>2</armorPenetrationSharp>
+					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -60,7 +60,6 @@
 					<cooldownTime>2.0</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 				</li>
 			</tools>
@@ -143,7 +142,6 @@
 					<cooldownTime>3.0</cooldownTime>
 					<linkedBodyPartsGroup>Torso</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>3.0</armorPenetrationBlunt>
 				</li>
 			</tools>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -111,7 +111,6 @@
 					<power>7</power>
 					<cooldownTime>1.11</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -123,7 +122,6 @@
 					<power>7</power>
 					<cooldownTime>1.11</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -136,7 +134,6 @@
 					<cooldownTime>1.85</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.7</armorPenetrationBlunt>
 				</li>
 			</tools>
@@ -180,13 +177,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>2.0</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/tools</xpath>
 		<value>
 			<tools>
@@ -199,7 +189,6 @@
 					<cooldownTime>2.0</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 				</li>
 			</tools>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -154,11 +154,23 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases</xpath>
 		<value>
-			<ArmorRating_Blunt>36</ArmorRating_Blunt>
-			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>30</CarryBulk>
-			<MaxHitPoints>300</MaxHitPoints>
+			<MaxHitPoints>600</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>60</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>24</ArmorRating_Sharp>
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -67,13 +67,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>1.8</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>2.6</baseBodySize>
@@ -99,7 +92,6 @@
 					<power>27</power>
 					<cooldownTime>3.0</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>10</armorPenetrationBlunt>
 					<chanceFactor>0.2</chanceFactor>
 				</li>
@@ -143,13 +135,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>3.0</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>3.0</baseBodySize>
@@ -169,7 +154,6 @@
 					<cooldownTime>2.0</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>2.0</armorPenetrationBlunt>
 					<chanceFactor>0.2</chanceFactor>
 				</li>
@@ -204,13 +188,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>2.6</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>3.0</baseBodySize>
@@ -230,7 +207,6 @@
 					<cooldownTime>3.6</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>16</armorPenetrationBlunt>
 				</li>
 			</tools>

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -122,7 +122,6 @@
 		<label>9mm Para bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<!--<armorPenetrationBase>0.31</armorPenetrationBase>-->
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.66</armorPenetrationBlunt>
 		</projectile>
@@ -133,7 +132,6 @@
 		<label>9mm Para bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<!--<armorPenetrationBase>0.46</armorPenetrationBase>-->
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.66</armorPenetrationBlunt>
 		</projectile>
@@ -144,7 +142,6 @@
 		<label>9mm Para bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<!--<armorPenetrationBase>0.16</armorPenetrationBase>-->
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>9.66</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -89,10 +89,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageDef>BulletToxic</damageDef>
-		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>18</armorPenetrationSharp>
-		  <armorPenetrationBlunt>75</armorPenetrationBlunt>
-		  <speed>200</speed>
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>20</armorPenetrationSharp>
+		  <armorPenetrationBlunt>108</armorPenetrationBlunt>
+		  <speed>240</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Patches/Core/Bodies/BodyParts_Mechanoid.xml
+++ b/Patches/Core/Bodies/BodyParts_Mechanoid.xml
@@ -32,42 +32,42 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodyFirstRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>100</hitPoints>
+      <hitPoints>50</hitPoints>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodySecondRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>90</hitPoints>
+      <hitPoints>45</hitPoints>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodyThirdRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>80</hitPoints>
+      <hitPoints>40</hitPoints>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodyFourthRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>70</hitPoints>
+      <hitPoints>35</hitPoints>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodyFifthRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>60</hitPoints>
+      <hitPoints>30</hitPoints>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyPartDef[defName="MechanicalCentipedeBodySixthRing"]/hitPoints</xpath>
     <value>
-      <hitPoints>50</hitPoints>
+      <hitPoints>25</hitPoints>
     </value>
   </Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -883,11 +883,12 @@
       <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
     </AmmoUser>
     <FireModes>
-      <aiAimMode>SuppressFire</aiAimMode>
       <aimedBurstShotCount>25</aimedBurstShotCount>
+      <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
       <li>CE_AI_Suppressive</li>
+      <li>NoSwitch</li>
     </weaponTags>    
   </Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -128,13 +128,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="MechCentipede"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>2.5</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>2.0</baseBodySize>
@@ -153,7 +146,6 @@
 					<power>35</power>
 					<cooldownTime>3.51</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>15</armorPenetrationBlunt>
 				</li>
 			</tools>
@@ -216,13 +208,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/race/baseHealthScale</xpath>
-		<value>
-			<baseHealthScale>1.85</baseHealthScale>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Termite"]/race/baseBodySize</xpath>
 		<value>
 			<baseBodySize>1.8</baseBodySize>
@@ -241,7 +226,6 @@
 					<power>25</power>
 					<cooldownTime>3.01</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>13.5</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -349,7 +333,6 @@
 					<cooldownTime>5.9</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
 				</li>
 			</tools>
@@ -368,7 +351,6 @@
 					<power>5</power>
 					<cooldownTime>1.11</cooldownTime>
 					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -380,7 +362,6 @@
 					<power>5</power>
 					<cooldownTime>1.11</cooldownTime>
 					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
@@ -393,7 +374,6 @@
 					<cooldownTime>1.85</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
 				</li>
 			</tools>
@@ -441,7 +421,6 @@
 					<power>15</power>
 					<cooldownTime>3.51</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -223,12 +223,6 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/race/baseHealthScale</xpath>
-				<value>
-					<baseHealthScale>2.2</baseHealthScale>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Mechanoid_Goliath"]/tools</xpath>
 				<value>
 					<tools>
@@ -287,12 +281,6 @@
 				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>22</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Mechanoid_Kraken"]/race/baseHealthScale</xpath>
-				<value>
-					<baseHealthScale>3.0</baseHealthScale>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -238,13 +238,6 @@
                 </li>
                 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>4</baseHealthScale>
-                    </value>
-                </li>
-                
-                <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Mech_Mammoth"]/tools</xpath>
                     <value>
                         <tools>

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Machines.xml
@@ -72,13 +72,6 @@
                     </value>
                 </li>
 
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="RM_AncientDroid_Combat"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>4</baseHealthScale>
-                    </value>
-                </li>
-
                 <!-- ===== Ancient Worker Droid ===== -->
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="RM_AncientDroid_Worker"]/statBases/ArmorRating_Sharp</xpath>
@@ -91,13 +84,6 @@
                     <xpath>Defs/ThingDef[defName="RM_AncientDroid_Worker"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
                         <ArmorRating_Blunt>7</ArmorRating_Blunt>
-                    </value>
-                </li>
-
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="RM_AncientDroid_Worker"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>4</baseHealthScale>
                     </value>
                 </li>
 
@@ -128,13 +114,6 @@
                     <xpath>Defs/ThingDef[defName="RM_Droid_Spartan"]/statBases/ArmorRating_Blunt</xpath>
                     <value>
                         <ArmorRating_Blunt>12</ArmorRating_Blunt>
-                    </value>
-                </li>
-
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="RM_Droid_Spartan"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>4.5</baseHealthScale>
                     </value>
                 </li>
 

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Mechanoids.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Races/RM_Races_Mechanoids.xml
@@ -331,13 +331,6 @@
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>2.5</baseHealthScale>
-                    </value>
-                </li>
-
-                <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="RM_Mech_Behemoth"]/race/baseBodySize</xpath>
                     <value>
                         <baseBodySize>2.0</baseBodySize>
@@ -506,13 +499,6 @@
                     <xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]/statBases/ArmorRating_Sharp</xpath>
                     <value>
                         <ArmorRating_Sharp>16</ArmorRating_Sharp>
-                    </value>
-                </li>
-
-                <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="RM_Mech_Caretaker"]/race/baseHealthScale</xpath>
-                    <value>
-                        <baseHealthScale>3</baseHealthScale>
                     </value>
                 </li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -82,13 +82,6 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2.5</baseHealthScale>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>2.1</baseBodySize>
@@ -526,13 +519,6 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2.5</baseHealthScale>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>2.0</baseBodySize>
@@ -596,13 +582,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2.0</baseHealthScale>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -298,13 +298,6 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2</baseHealthScale>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>1.8</baseBodySize>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -83,13 +83,6 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2.5</baseHealthScale>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>2.0</baseBodySize>
@@ -530,13 +523,6 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>2.5</baseHealthScale>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>2.0</baseBodySize>
@@ -600,13 +586,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>18</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/race/baseHealthScale</xpath>
-      <value>
-        <baseHealthScale>1.85</baseHealthScale>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -203,7 +203,7 @@
             <warmupTime>2.7</warmupTime>
             <range>57</range>
             <burstShotCount>40</burstShotCount>
-            <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
+            <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
             <soundCast>VFEP_Shot_Minigun</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
@@ -218,8 +218,7 @@
           </AmmoUser>
           <FireModes>
             <aimedBurstShotCount>20</aimedBurstShotCount>
-            <aiUseBurstMode>FALSE</aiUseBurstMode>
-            <aiAimMode>SuppressFire</aiAimMode>
+            <aiAimMode>Snapshot</aiAimMode>
           </FireModes>
         </li>
 


### PR DESCRIPTION
## Changes

- Removed the HP scaling patches of mechanoid pawns.
- Adjusted Centipedes' bodyring HP.
- Patches the small mechanoid leg and foot HP.
- Rebalanced the mounted HCB turret on super heavy mechs.
- Tweaked the Tunneler's melee tools based on a heavier but slower variant of Power Claws.
- Switched the Minigun to Snapshot default fire mode.
- Tweaked the Graser to fire in 10 burst counts with 10 ticks between each burst to make it hit stuff more reliably, also increased its Beam damageDef to deal 15 damage instead of 10 with 0.25 Heat AP to make it penetrate normal clothing more easily.
- Updated the stats of the Apocriton mech and its toxic needle gun according to the latest RW ver 1.4.3546 build, it has super heavy mech tier armor with higher blunt armor and its gun deals more damage, opted for a faster projectile to replicate.

https://docs.google.com/spreadsheets/d/1gJreRqm--zvrJlpSd1Jq6G3v4b7aHwhwtDotXcFB9mQ/edit#gid=647442519

## Reasoning

- Centipedes had been patched to have x2.2 of their bodyring HP and in return x2.5 of their health scale instead of the vanilla x4.32, adjusted the ring HP to the vanilla value +5 to preserve the intention of keeping their rings stronger and removed the health scale nerf patch to get the overall same bodyring HP which is also appropriate in comparison with boss mechanoids. Did the same for other modded mechanoids that have ringed body shapes or the similar scaling issue in general. This will result in overall higher internal bodypart HP on mechs with ringed bodies (except the Biotech boss mechs that were nerfed HP-wise without the ring HP increase) which is not a bad thing since their internal parts were artificially weakened and too squishy for a big mechanoid to begin with.
- Biotech boss mechs had not had their ring HPs increased similar to centipedes but had had their health scale lowered which was an overall big nerf to them despite having a higher base ring HP to begin with (55 vs 45 for the first ring and so on), the health scale patches were an oversight in the first place so this PR fixes that.
- The small mechanoid legs and feet are patched the same way that the normal sized mech legs and feet have had their HP increased by a factor of x1.3.
- The mounted HCB turret on super heavy mechs fired 12x64mm in its first iteration which proved to be very strong as it did not miss most of the time, players encountered it very early and did not run out of ammo so to rebalance it a bit, I opted for changing its projectile to 8x50mm which is still potent, can deal damage to heavy mechs, is not absurdly strong, can be countered with good ammo and fits a smaller version of the HCB gun/turret.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
