### PR TITLE
Patch Biotech Pawnkinds and Adjust forcedAmmoClass

### DIFF
--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <!-- ========== Archer Fire ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Tribal_Archer_Fire"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension" inherit="false">
+				<primaryMagazineCount>
+					<min>8</min>
+					<max>14</max>
+				</primaryMagazineCount>
+				<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Tribal_Archer_Fire"]/weaponTags</xpath>
+		<value>
+			<li>NeolithicRangedBasic</li>
+			<li>NeolithicRangedDecent</li>
+		</value>
+	</Operation>
+
+  <!-- ========== Hunter Fire ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Tribal_Hunter_Fire"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension" inherit="false">
+				<primaryMagazineCount>
+					<min>12</min>
+					<max>24</max>
+				</primaryMagazineCount>
+				<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Tribal_Hunter_Fire"]/weaponTags</xpath>
+		<value>
+			<li>NeolithicRangedDecent</li>
+			<li>NeolithicRangedHeavy</li>			
+		</value>
+	</Operation>
+
+
+</Patch>

--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
@@ -3,16 +3,29 @@
 
   <!-- ========== Archer Fire ========== -->
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Tribal_Archer_Fire"]</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Tribal_Archer_Fire"]</xpath>
 		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension" inherit="false">
-				<primaryMagazineCount>
-					<min>8</min>
-					<max>14</max>
-				</primaryMagazineCount>
-				<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
-			</li>
+			<modExtensions Inherit="false">
+				<li Class="CombatExtended.LoadoutPropertiesExtension" >
+					<primaryMagazineCount>
+						<min>20</min>
+						<max>40</max>
+					</primaryMagazineCount>
+					<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
+					<sidearms>
+					<li>
+						<sidearmMoney>
+						<min>80</min>
+						<max>160</max>
+						</sidearmMoney>
+						<weaponTags>
+						<li>CE_Sidearm_Tribal</li>
+						</weaponTags>
+					</li>
+					</sidearms>				
+				</li>
+			</modExtensions>
 		</value>
 	</Operation>
 
@@ -26,16 +39,29 @@
 
   <!-- ========== Hunter Fire ========== -->
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Tribal_Hunter_Fire"]</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Tribal_Hunter_Fire"]</xpath>
 		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension" inherit="false">
-				<primaryMagazineCount>
-					<min>12</min>
-					<max>24</max>
-				</primaryMagazineCount>
-				<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
-			</li>
+			<modExtensions Inherit="false">
+				<li Class="CombatExtended.LoadoutPropertiesExtension" >
+					<primaryMagazineCount>
+						<min>25</min>
+						<max>50</max>
+					</primaryMagazineCount>
+					<forcedAmmoCategory>FlameArrow</forcedAmmoCategory>
+					<sidearms>
+					<li>
+						<sidearmMoney>
+						<min>80</min>
+						<max>240</max>
+						</sidearmMoney>
+						<weaponTags>
+						<li>CE_Sidearm_Tribal</li>
+						</weaponTags>
+					</li>
+					</sidearms>					
+				</li>
+			</modExtensions>
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
@@ -4,7 +4,7 @@
   <!-- ========== Heavy Waster Mercenary ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]/weaponTags</xpath>
+	<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]/weaponTags</xpath>
     <value>
       <weaponTags>
         <li>GunGrenadeLauncher</li>
@@ -22,6 +22,21 @@
 					<min>6</min>
 					<max>14</max>
 				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+  <!-- ========== Tox Heavy ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>16</max>
+				</primaryMagazineCount>
+				<forcedAmmoCategory>Toxic</forcedAmmoCategory>
 			</li>
 		</value>
 	</Operation>

--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Waster.xml
@@ -3,14 +3,27 @@
 
   <!-- ========== Heavy Waster Mercenary ========== -->
 
-  <Operation Class="PatchOperationReplace">
-	<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]/weaponTags</xpath>
-    <value>
-      <weaponTags>
-        <li>GunGrenadeLauncher</li>
-      </weaponTags>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]/weaponTags</xpath>
+		<value>
+			<weaponTags>
+			<li>GunGrenadeLauncher</li>
+			</weaponTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>14</max>
+				</primaryMagazineCount>
+				<forcedAmmoCategory>Toxic</forcedAmmoCategory>
+			</li>
+		</value>
+	</Operation>
 
   <!-- ========== Tox Grenadier ========== -->
 
@@ -22,21 +35,6 @@
 					<min>6</min>
 					<max>14</max>
 				</primaryMagazineCount>
-			</li>
-		</value>
-	</Operation>
-
-  <!-- ========== Tox Heavy ========== -->
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/PawnKindDef[defName="Mercenary_HeavyTox"]</xpath>
-		<value>
-			<li Class="CombatExtended.LoadoutPropertiesExtension">
-				<primaryMagazineCount>
-					<min>6</min>
-					<max>16</max>
-				</primaryMagazineCount>
-				<forcedAmmoCategory>Toxic</forcedAmmoCategory>
 			</li>
 		</value>
 	</Operation>

--- a/Biotech/Patches/Weapons/RangedIndustrial.xml
+++ b/Biotech/Patches/Weapons/RangedIndustrial.xml
@@ -180,46 +180,10 @@
 		</weaponTags>
 	</Operation>
 
-  <!-- ========== Flamebow ========== -->
+	<!-- ========== Flamebow ========== -->
 
-	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-		<defName>Flamebow</defName>
-		<statBases>
-			<SightsEfficiency>0.6</SightsEfficiency>
-			<ShotSpread>1</ShotSpread>
-			<SwayFactor>2</SwayFactor>
-			<Bulk>3.00</Bulk>
-			<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
-		</statBases>
-		<Properties>
-			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-			<hasStandardCommand>true</hasStandardCommand>
-			<defaultProjectile>Projectile_Arrow_Flame</defaultProjectile>
-			<warmupTime>1</warmupTime>
-			<range>14</range>
-			<soundCast>Bow_Small</soundCast>
-		</Properties>
-		<AmmoUser>
-			<ammoSet>AmmoSet_FlameArrow</ammoSet>
-		</AmmoUser>
-		<FireModes />
-		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Flamebow"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>7</power>
-					<cooldownTime>1.6</cooldownTime>
-					<armorPenetrationBlunt>0.65</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Flamebow"]</xpath>
 	</Operation>
 
 </Patch>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -23,15 +23,6 @@
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 
-  <!-- Flamebow -->
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_FlameArrow</defName>
-    <label>arrows</label>
-    <ammoTypes>
-      <Ammo_Arrow_Flame>Projectile_Arrow_Flame</Ammo_Arrow_Flame>
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
-
   <!-- Recurve Bow -->
   <CombatExtended.AmmoSetDef>
     <defName>AmmoSet_StreamlinedArrow</defName>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -179,8 +179,8 @@
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>1</min>
-          <max>4</max>
+          <min>6</min>
+          <max>14</max>
         </primaryMagazineCount>
         <forcedSidearm>
           <sidearmMoney>

--- a/Patches/RadWorld/PawnKinds_RadWorld.xml
+++ b/Patches/RadWorld/PawnKinds_RadWorld.xml
@@ -269,8 +269,8 @@
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
-              <min>1</min>
-              <max>4</max>
+              <min>6</min>
+              <max>14</max>
             </primaryMagazineCount>
             <forcedSidearm>
               <sidearmMoney>

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -216,7 +216,7 @@ namespace CombatExtended
                 return;
             }
             // Determine ammo
-            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && a.ammo.generateAllowChance > 0f).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
+            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f && a.ammo.ammoClass != this.forcedAmmoCategory)).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
 
             AmmoDef ammoToLoad = availableAmmo.RandomElementByWeight(a => a.generateAllowChance);
 
@@ -256,7 +256,7 @@ namespace CombatExtended
 
                 if (forcedAmmoCategory != null)
                 {
-                    IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && a.ammo.generateAllowChance > 0f).Select(a => a.ammo);
+                    IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f && a.ammo.ammoClass != this.forcedAmmoCategory)).Select(a => a.ammo);
                     if (availableAmmo.Any(x => x.ammoClass == forcedAmmoCategory))
                     {
                         thingToAdd = availableAmmo.Where(x => x.ammoClass == forcedAmmoCategory).FirstOrFallback();

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -216,7 +216,7 @@ namespace CombatExtended
                 return;
             }
             // Determine ammo
-            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f && a.ammo.ammoClass != this.forcedAmmoCategory)).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
+            IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f || a.ammo.ammoClass == this.forcedAmmoCategory)).Select(a => a.ammo); //Running out of options. alwaysHaulable does exist in xml.
 
             AmmoDef ammoToLoad = availableAmmo.RandomElementByWeight(a => a.generateAllowChance);
 
@@ -256,7 +256,7 @@ namespace CombatExtended
 
                 if (forcedAmmoCategory != null)
                 {
-                    IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f && a.ammo.ammoClass != this.forcedAmmoCategory)).Select(a => a.ammo);
+                    IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && (a.ammo.generateAllowChance > 0f || a.ammo.ammoClass == this.forcedAmmoCategory)).Select(a => a.ammo);
                     if (availableAmmo.Any(x => x.ammoClass == forcedAmmoCategory))
                     {
                         thingToAdd = availableAmmo.Where(x => x.ammoClass == forcedAmmoCategory).FirstOrFallback();

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -253,17 +253,17 @@ namespace CombatExtended
                 // Generate currently loaded ammo
                 thingToAdd = compAmmo.CurrentAmmo;
                 unitCount = Mathf.Max(1, compAmmo.MagSize);  // Guns use full magazines as units
-            }
 
-            if (forcedAmmoCategory != null)
-            {
-                IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && a.ammo.generateAllowChance > 0f).Select(a => a.ammo);
-                if (availableAmmo.Any(x => x.ammoClass == forcedAmmoCategory))
+                if (forcedAmmoCategory != null)
                 {
-                    thingToAdd = availableAmmo.Where(x => x.ammoClass == forcedAmmoCategory).FirstOrFallback();
+                    IEnumerable<AmmoDef> availableAmmo = compAmmo.Props.ammoSet.ammoTypes.Where(a => a.ammo.alwaysHaulable && !a.ammo.menuHidden && a.ammo.generateAllowChance > 0f).Select(a => a.ammo);
+                    if (availableAmmo.Any(x => x.ammoClass == forcedAmmoCategory))
+                    {
+                        thingToAdd = availableAmmo.Where(x => x.ammoClass == forcedAmmoCategory).FirstOrFallback();
+                    }
                 }
             }
-
+            
             var ammoThing = thingToAdd.MadeFromStuff ? ThingMaker.MakeThing(thingToAdd, gun.Stuff) : ThingMaker.MakeThing(thingToAdd);
             ammoThing.stackCount = ammoCount * unitCount;
             int maxCount;


### PR DESCRIPTION
## Additions
- Patches for new Tox and Imp pawnkinds. Statistically the same as the base game pawnkinds, but restricted to an ammo appropriate to their specific faction.

## Changes
- Increased the magazine count for `Mercenary_Heavy,` as the current count can leave the pawn with only a few rounds for their grenade launcher.
- Remove the flamebow, as it's no longer needed since pawns can spawn with a specific kind of ammo.
- Fix error when pawn kind using forcedAmmoCategory attempted to spawn with weapon that lacked an ammodef.
- Fix ammo generateAllowChance of 0 blocking forcedAmmoCategory. Hopefully.

## Testing

**Issues:**
- [x] `forcedAmmoCategory` doesn't ignore ammo allow chance.
- [x] If a pawnkind with a `forcedAmmoCategory` tries to spawn with a weapon that lacks ~~that ammo category~~ an ammo comp, there is an error and the pawn fails to spawn.  

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
