### PR TITLE
AP ammo workAmount adjustments

### DIFF
--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_127x108mm_AP>200</Ammo_127x108mm_AP>
     </products>
-    <workAmount>5400</workAmount>
+    <workAmount>6480</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_132x92mmSRTuF_AP>200</Ammo_132x92mmSRTuF_AP>
 		</products>
-		<workAmount>5800</workAmount>
+		<workAmount>6960</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_145x114mm_AP>200</Ammo_145x114mm_AP>
     </products>
-    <workAmount>7600</workAmount>
+    <workAmount>9120</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -214,7 +214,7 @@
 		<products>
 			<Ammo_2Bore_FMJ>200</Ammo_2Bore_FMJ>
 		</products>
-    <workAmount>19200</workAmount>
+		<workAmount>19200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -240,7 +240,7 @@
 		<products>
 			<Ammo_2Bore_AP>200</Ammo_2Bore_AP>
 		</products>
-    <workAmount>23040</workAmount>
+		<workAmount>23040</workAmount>
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -28,8 +28,8 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo2BoreBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>An extremely large caliber sporting cartridge, almost impractical for any purpose, but capable of bringing down large targets like elephants or rhinoceroses.</description>
 		<statBases>
-		<Mass>0.477</Mass>
-		<Bulk>0.36</Bulk>
+			<Mass>0.477</Mass>
+			<Bulk>0.36</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -63,7 +63,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.91</MarketValue>
+			<MarketValue>1.92</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_2Bore_AP</cookOffProjectile>
@@ -240,7 +240,7 @@
 		<products>
 			<Ammo_2Bore_AP>200</Ammo_2Bore_AP>
 		</products>
-    <workAmount>19200</workAmount>
+    <workAmount>23040</workAmount>
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -189,7 +189,7 @@
 		<products>
 			<Ammo_20x102mmNATO_AP>200</Ammo_20x102mmNATO_AP>
 		</products>
-		<workAmount>10400</workAmount>
+		<workAmount>12480</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -189,7 +189,7 @@
     <products>
       <Ammo_20x110mmHispano_AP>200</Ammo_20x110mmHispano_AP>
     </products>
-    <workAmount>10400</workAmount>
+    <workAmount>12480</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -48,7 +48,7 @@
         <graphicClass>Graphic_StackCount</graphicClass>
       </graphicData>
       <statBases>
-        <MarketValue>1.41</MarketValue>
+        <MarketValue>1.42</MarketValue>
       </statBases>
       <ammoClass>ArmorPiercing</ammoClass>
       <cookOffProjectile>Bullet_20x128mmOerlikon_AP</cookOffProjectile>
@@ -189,7 +189,7 @@
       <products>
         <Ammo_20x128mmOerlikon_AP>200</Ammo_20x128mmOerlikon_AP>
       </products>
-      <workAmount>14200</workAmount>
+      <workAmount>17040</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -48,7 +48,7 @@
         <graphicClass>Graphic_StackCount</graphicClass>
       </graphicData>
       <statBases>
-        <MarketValue>1.19</MarketValue>
+        <MarketValue>1.2</MarketValue>
       </statBases>
       <ammoClass>ArmorPiercing</ammoClass>
       <cookOffProjectile>Bullet_20x138mmB_AP</cookOffProjectile>
@@ -180,7 +180,7 @@
       <products>
         <Ammo_20x138mmB_AP>200</Ammo_20x138mmB_AP>
       </products>
-      <workAmount>12000</workAmount>
+      <workAmount>14400</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -189,7 +189,7 @@
     <products>
       <Ammo_20x82mmMauser_AP>200</Ammo_20x82mmMauser_AP>
     </products>
-    <workAmount>7000</workAmount>
+    <workAmount>8400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -189,7 +189,7 @@
     <products>
       <Ammo_20x99mmRShVAK_AP>200</Ammo_20x99mmRShVAK_AP>
     </products>
-    <workAmount>8800</workAmount>
+    <workAmount>10560</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -48,7 +48,7 @@
         <graphicClass>Graphic_StackCount</graphicClass>
       </graphicData>
       <statBases>
-        <MarketValue>2.01</MarketValue>
+        <MarketValue>2.02</MarketValue>
       </statBases>
       <ammoClass>ArmorPiercing</ammoClass>
       <cookOffProjectile>Bullet_25x137mmNATO_AP</cookOffProjectile>
@@ -189,7 +189,7 @@
       <products>
         <Ammo_25x137mmNATO_AP>200</Ammo_25x137mmNATO_AP>
       </products>
-      <workAmount>20200</workAmount>
+      <workAmount>24240</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_300WinchesterMagnum_AP>200</Ammo_300WinchesterMagnum_AP>
     </products>
-    <workAmount>1600</workAmount>
+    <workAmount>1920</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.99</MarketValue>
+			<MarketValue>2.0</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_30x113mmB_AP</cookOffProjectile>
@@ -189,7 +189,7 @@
 		<products>
 			<Ammo_30x113mmB_AP>150</Ammo_30x113mmB_AP>
 		</products>
-		<workAmount>15000</workAmount>
+		<workAmount>18000</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -48,7 +48,7 @@
         <graphicClass>Graphic_StackCount</graphicClass>
       </graphicData>
       <statBases>
-        <MarketValue>3.34</MarketValue>
+        <MarketValue>3.36</MarketValue>
       </statBases>
       <ammoClass>ArmorPiercing</ammoClass>
       <cookOffProjectile>Bullet_30x173mmNATO_AP</cookOffProjectile>
@@ -189,7 +189,7 @@
       <products>
         <Ammo_30x173mmNATO_AP>200</Ammo_30x173mmNATO_AP>
       </products>
-      <workAmount>16800</workAmount>
+      <workAmount>20160</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_338Lapua_AP>200</Ammo_338Lapua_AP>
     </products>
-    <workAmount>2000</workAmount>
+    <workAmount>2400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_338Norma_AP>200</Ammo_338Norma_AP>
     </products>
-    <workAmount>2000</workAmount>
+    <workAmount>2400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_408CheyenneTactical_AP>200</Ammo_408CheyenneTactical_AP>
     </products>
-    <workAmount>3200</workAmount>
+    <workAmount>3840</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>8.53</MarketValue>
+			<MarketValue>8.64</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_40x311mmR_AP</cookOffProjectile>
@@ -189,7 +189,7 @@
       <products>
         <Ammo_40x311mmR_AP>50</Ammo_40x311mmR_AP>
       </products>
-      <workAmount>21600</workAmount>
+      <workAmount>25920</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -48,7 +48,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.24</MarketValue>
+      <MarketValue>0.26</MarketValue>
     </statBases>
   	<ammoClass>FullMetalJacket</ammoClass>
     <cookOffProjectile>Bullet_470NitroExpress_FMJ</cookOffProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.24</MarketValue>
+			<MarketValue>0.26</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_470NitroExpress_AP</cookOffProjectile>
@@ -76,7 +76,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.34</MarketValue>
+      <MarketValue>0.39</MarketValue>
     </statBases>
     <ammoClass>IncendiaryAP</ammoClass>
     <cookOffProjectile>Bullet_470NitroExpress_Incendiary</cookOffProjectile>
@@ -90,7 +90,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.57</MarketValue>
+      <MarketValue>0.62</MarketValue>
     </statBases>
     <ammoClass>ExplosiveAP</ammoClass>
     <cookOffProjectile>Bullet_470NitroExpress_HE</cookOffProjectile>
@@ -104,7 +104,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.29</MarketValue>
+      <MarketValue>0.3</MarketValue>
 	  <Mass>0.046</Mass>
     </statBases>
     <ammoClass>Sabot</ammoClass>
@@ -192,8 +192,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_FMJ</defName>
-    <label>make .470 Nitro Express (FMJ) cartridge x350</label>
-    <description>Craft 500 .470 Nitro Express (FMJ) cartridges.</description>
+    <label>make .470 Nitro Express (FMJ) cartridge x200</label>
+    <description>Craft 200 .470 Nitro Express (FMJ) cartridges.</description>
     <jobString>Making .470 Nitro Express (FMJ) cartridges.</jobString>
     <ingredients>
       <li>
@@ -202,7 +202,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>60</count>
+        <count>26</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -211,15 +211,15 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_470NitroExpress_FMJ>500</Ammo_470NitroExpress_FMJ>
+      <Ammo_470NitroExpress_FMJ>200</Ammo_470NitroExpress_FMJ>
     </products>
-    <workAmount>6000</workAmount>
+    <workAmount>2600</workAmount>
   </RecipeDef>
 
  	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_470NitroExpress_AP</defName>
-		<label>make .470 Nitro Express (AP) cartridge x500</label>
-		<description>Craft 500 .470 Nitro Express (AP) cartridges.</description>
+		<label>make .470 Nitro Express (AP) cartridge x200</label>
+		<description>Craft 200 .470 Nitro Express (AP) cartridges.</description>
 		<jobString>Making .470 Nitro Express (AP) cartridges.</jobString>
 		<ingredients>
 			<li>
@@ -228,7 +228,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>60</count>
+				<count>26</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -237,15 +237,15 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_470NitroExpress_AP>500</Ammo_470NitroExpress_AP>
+			<Ammo_470NitroExpress_AP>200</Ammo_470NitroExpress_AP>
 		</products>
-    <workAmount>6000</workAmount>		
+    <workAmount>3120</workAmount>		
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_Incendiary</defName>
-    <label>make .470 Nitro Express (AP-I) cartridge x500</label>
-    <description>Craft 500 .470 Nitro Express (AP-I) cartridges.</description>
+    <label>make .470 Nitro Express (AP-I) cartridge x200</label>
+    <description>Craft 200 .470 Nitro Express (AP-I) cartridges.</description>
     <jobString>Making .470 Nitro Express (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -254,7 +254,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>60</count>
+        <count>26</count>
       </li>
       <li>
         <filter>
@@ -262,7 +262,7 @@
             <li>Prometheum</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>4</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -272,15 +272,15 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_470NitroExpress_Incendiary>500</Ammo_470NitroExpress_Incendiary>
+      <Ammo_470NitroExpress_Incendiary>200</Ammo_470NitroExpress_Incendiary>
     </products>
-    <workAmount>9200</workAmount>
+    <workAmount>4200</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_HE</defName>
-    <label>make .470 Nitro Express (HE) cartridge x500</label>
-    <description>Craft 500 .470 Nitro Express (HE) cartridges.</description>
+    <label>make .470 Nitro Express (HE) cartridge x200</label>
+    <description>Craft 200 .470 Nitro Express (HE) cartridges.</description>
     <jobString>Making .470 Nitro Express (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -289,7 +289,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>60</count>
+        <count>26</count>
       </li>
       <li>
         <filter>
@@ -297,7 +297,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>16</count>
+        <count>7</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -307,15 +307,15 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_470NitroExpress_HE>500</Ammo_470NitroExpress_HE>
+      <Ammo_470NitroExpress_HE>200</Ammo_470NitroExpress_HE>
     </products>
-    <workAmount>12400</workAmount>
+    <workAmount>5400</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_Sabot</defName>
-    <label>make .470 Nitro Express (Sabot) cartridge x500</label>
-    <description>Craft 500 .470 Nitro Express (Sabot) cartridges.</description>
+    <label>make .470 Nitro Express (Sabot) cartridge x200</label>
+    <description>Craft 200 .470 Nitro Express (Sabot) cartridges.</description>
     <jobString>Making .470 Nitro Express (Sabot) cartridges.</jobString>
     <ingredients>
       <li>
@@ -324,7 +324,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>28</count>
+        <count>12</count>
       </li>
       <li>
         <filter>
@@ -332,7 +332,7 @@
             <li>Uranium</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>4</count>
       </li>
       <li>
         <filter>
@@ -340,7 +340,7 @@
             <li>Chemfuel</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>4</count>
       </li>		  
     </ingredients>
     <fixedIngredientFilter>
@@ -351,9 +351,9 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_470NitroExpress_Sabot>500</Ammo_470NitroExpress_Sabot>
+      <Ammo_470NitroExpress_Sabot>200</Ammo_470NitroExpress_Sabot>
     </products>
-    <workAmount>8800</workAmount>
+    <workAmount>3600</workAmount>
   </RecipeDef>
   
 </Defs>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_50BMG_AP>200</Ammo_50BMG_AP>
     </products>
-    <workAmount>5000</workAmount>
+    <workAmount>6000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_55Boys_AP>200</Ammo_55Boys_AP>
 		</products>
-		<workAmount>5600</workAmount>
+		<workAmount>6720</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -239,7 +239,7 @@
     <products>
       <Ammo_600NitroExpress_AP>200</Ammo_600NitroExpress_AP>
     </products>
-    <workAmount>4400</workAmount>
+    <workAmount>5280</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -240,7 +240,7 @@
     <products>
       <Ammo_792x94mmPatronen_AP>200</Ammo_792x94mmPatronen_AP>
     </products>
-    <workAmount>5000</workAmount>
+    <workAmount>6000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>1.29</MarketValue>
+			<MarketValue>1.3</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_950JDJ_AP</cookOffProjectile>
@@ -239,7 +239,7 @@
 		<products>
 			<Ammo_950JDJ_AP>200</Ammo_950JDJ_AP>
 		</products>
-		<workAmount>13000</workAmount>
+		<workAmount>15600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -56,7 +56,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.35</MarketValue>
+			<MarketValue>0.4</MarketValue>
 		</statBases>
 		<ammoClass>MusketBall</ammoClass>
 	</ThingDef>
@@ -83,7 +83,7 @@
 			<speed>90</speed>	
 			<damageAmountBase>26</damageAmountBase>		
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>65.8</armorPenetrationBlunt>				
+			<armorPenetrationBlunt>64.8</armorPenetrationBlunt>				
 		</projectile>
 	</ThingDef>
 
@@ -104,10 +104,10 @@
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_MusketBall</defName>
-		<label>make musket ball x500</label>
-		<description>Craft 500 musket balls.</description>
+		<label>make musket ball x100</label>
+		<description>Craft 100 musket balls.</description>
 		<jobString>Making musket balls.</jobString>
-    	<workAmount>8800</workAmount>		
+    	<workAmount>2000</workAmount>		
 		<ingredients>
 			<li>
 			<filter>
@@ -115,7 +115,7 @@
 					<li>Steel</li>
 				</thingDefs>
 			</filter>
-			<count>88</count>
+			<count>20</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -124,7 +124,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MusketBall>500</Ammo_MusketBall>
+			<Ammo_MusketBall>100</Ammo_MusketBall>
 		</products>
 	</RecipeDef>
 	

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_10mmAuto_AP>500</Ammo_10mmAuto_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/13mmGyrojet.xml
+++ b/Defs/Ammo/Pistols/13mmGyrojet.xml
@@ -174,7 +174,7 @@
 		<products>
 			<Ammo_13mmGyrojet_AP>500</Ammo_13mmGyrojet_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 	
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_22LR_AP>500</Ammo_22LR_AP>
 		</products>
-		<workAmount>600</workAmount>
+		<workAmount>720</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -148,7 +148,7 @@
 		<products>
 			<Ammo_22Short_FMJ>500</Ammo_22Short_FMJ>
 		</products>
-		<workAmount>480</workAmount>
+		<workAmount>400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -174,7 +174,7 @@
 		<products>
 			<Ammo_22Short_AP>500</Ammo_22Short_AP>
 		</products>
-		<workAmount>400</workAmount>
+		<workAmount>480</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -148,7 +148,7 @@
 		<products>
 			<Ammo_22Short_FMJ>500</Ammo_22Short_FMJ>
 		</products>
-		<workAmount>400</workAmount>
+		<workAmount>480</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_25ACP_AP>500</Ammo_25ACP_AP>
 		</products>
-		<workAmount>800</workAmount>
+		<workAmount>960</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -147,7 +147,7 @@
 		<products>
 			<Ammo_32ACP_FMJ>500</Ammo_32ACP_FMJ>
 		</products>
-		<workAmount>960</workAmount>
+		<workAmount>800</workAmount>
 	</RecipeDef>
 	
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -173,7 +173,7 @@
 		<products>
 			<Ammo_32ACP_AP>500</Ammo_32ACP_AP>
 		</products>
-		<workAmount>800</workAmount>
+		<workAmount>960</workAmount>
 	</RecipeDef>
 	
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -147,7 +147,7 @@
 		<products>
 			<Ammo_32ACP_FMJ>500</Ammo_32ACP_FMJ>
 		</products>
-		<workAmount>800</workAmount>
+		<workAmount>960</workAmount>
 	</RecipeDef>
 	
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -189,7 +189,7 @@
 		<products>
 			<Ammo_357Magnum_AP>500</Ammo_357Magnum_AP>
 		</products>
-		<workAmount>1800</workAmount>
+		<workAmount>2160</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_357SIG_AP>500</Ammo_357SIG_AP>
 		</products>
-		<workAmount>1800</workAmount>
+		<workAmount>2160</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/380ACP.xml
+++ b/Defs/Ammo/Pistols/380ACP.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_380ACP_AP>500</Ammo_380ACP_AP>
 		</products>
-		<workAmount>1000</workAmount>
+		<workAmount>1200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/38ACP.xml
+++ b/Defs/Ammo/Pistols/38ACP.xml
@@ -174,7 +174,7 @@
 		<products>
 			<Ammo_38ACP_AP>500</Ammo_38ACP_AP>
 		</products>
-		<workAmount>1600</workAmount>
+		<workAmount>1920</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -139,7 +139,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>16</count>
+        <count>14</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -150,41 +150,8 @@
     <products>
       <Ammo_38Special_FMJ>500</Ammo_38Special_FMJ>
     </products>
-    <workAmount>1600</workAmount>
+    <workAmount>1400</workAmount>
   </RecipeDef>
-
-  <!-- Crafting Spot -->
-  <!--
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_38Special_FMJ_Alt</defName>
-    <label>make .38 Special (FMJ) cartridge x50 (inefficient)</label>
-    <description>Craft 50 .38 Special (FMJ) cartridges.\n\nTakes longer, and is proportionally more expensive.</description>
-    <jobString>Making .38 Special (FMJ) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>3</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_38Special_FMJ>50</Ammo_38Special_FMJ>
-    </products>
-    <researchPrerequisite>Smithing</researchPrerequisite>
-    <recipeUsers>
-    	<li>CraftingSpot</li>
-    </recipeUsers>
-    <workAmount>3000</workAmount>
-  </RecipeDef>
--->
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_38Special_AP</defName>
@@ -198,7 +165,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>16</count>
+        <count>14</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -209,7 +176,7 @@
     <products>
       <Ammo_38Special_AP>500</Ammo_38Special_AP>
     </products>
-    <workAmount>1600</workAmount>
+    <workAmount>1680</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -224,7 +191,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>16</count>
+        <count>14</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -235,7 +202,7 @@
     <products>
       <Ammo_38Special_HP>500</Ammo_38Special_HP>
     </products>
-    <workAmount>1600</workAmount>
+    <workAmount>1400</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_40SW_AP>500</Ammo_40SW_AP>
 		</products>
-		<workAmount>1800</workAmount>
+		<workAmount>2160</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/41Rimfire.xml
+++ b/Defs/Ammo/Pistols/41Rimfire.xml
@@ -149,7 +149,7 @@
 		<products>
 			<Ammo_41Rimfire_FMJ>500</Ammo_41Rimfire_FMJ>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/41Rimfire.xml
+++ b/Defs/Ammo/Pistols/41Rimfire.xml
@@ -149,7 +149,7 @@
 		<products>
 			<Ammo_41Rimfire_FMJ>500</Ammo_41Rimfire_FMJ>
 		</products>
-		<workAmount>1440</workAmount>
+		<workAmount>1200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_41Rimfire_AP>500</Ammo_41Rimfire_AP>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -221,7 +221,7 @@
 		<products>
 			<Ammo_44Magnum_AP>500</Ammo_44Magnum_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -193,7 +193,7 @@
 		<products>
 			<Ammo_454Casull_AP>500</Ammo_454Casull_AP>
 		</products>
-		<workAmount>3400</workAmount>
+		<workAmount>4080</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/455Webley.xml
+++ b/Defs/Ammo/Pistols/455Webley.xml
@@ -99,7 +99,7 @@
 		<label>.455 Webley bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.455 Webley bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.455 Webley bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_455Webley_AP>500</Ammo_455Webley_AP>
 		</products>
-		<workAmount>2200</workAmount>
+		<workAmount>3120</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -201,7 +201,7 @@
 		<products>
 			<Ammo_455Webley_HP>500</Ammo_455Webley_HP>
 		</products>
-		<workAmount>2200</workAmount>
+		<workAmount>2600</workAmount>
 	</RecipeDef>
 
 

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -187,7 +187,7 @@
 		<products>
 			<Ammo_45ACP_AP>500</Ammo_45ACP_AP>
 		</products>
-		<workAmount>2200</workAmount>
+		<workAmount>2640</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -199,7 +199,7 @@
 		<products>
 			<Ammo_45Colt_AP>500</Ammo_45Colt_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_46x30mm_AP>500</Ammo_46x30mm_AP>
 		</products>
-		<workAmount>800</workAmount>
+		<workAmount>960</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_500SWMagnum_AP>500</Ammo_500SWMagnum_AP>
 		</products>
-		<workAmount>3800</workAmount>
+		<workAmount>4560</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -174,7 +174,7 @@
 		<products>
 			<Ammo_50AE_HP>500</Ammo_50AE_HP>
 		</products>
-		<workAmount>3000</workAmount>
+		<workAmount>3600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -150,32 +150,6 @@
 		</products>
 		<workAmount>3000</workAmount>
 	</RecipeDef>
-	
-	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_50AE_HP</defName>
-		<label>make .50 AE (HP) cartridge x500</label>
-		<description>Craft 500 .50 AE (HP) cartridges.</description>
-		<jobString>Making .50 AE (HP) cartridges.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Steel</li>
-					</thingDefs>
-				</filter>
-				<count>30</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Steel</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Ammo_50AE_HP>500</Ammo_50AE_HP>
-		</products>
-		<workAmount>3600</workAmount>
-	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
 		<defName>MakeAmmo_50AE_AP</defName>
@@ -200,8 +174,33 @@
 		<products>
 			<Ammo_50AE_AP>500</Ammo_50AE_AP>
 		</products>
-		<workAmount>3000</workAmount>
+		<workAmount>3600</workAmount>
 	</RecipeDef>
 
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_50AE_HP</defName>
+		<label>make .50 AE (HP) cartridge x500</label>
+		<description>Craft 500 .50 AE (HP) cartridges.</description>
+		<jobString>Making .50 AE (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>30</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_50AE_HP>500</Ammo_50AE_HP>
+		</products>
+		<workAmount>3000</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Pistols/58x21mmDAP92.xml
+++ b/Defs/Ammo/Pistols/58x21mmDAP92.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_58x21mmDAP92_AP>500</Ammo_58x21mmDAP92_AP>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_762x25mmTokarev_AP>500</Ammo_762x25mmTokarev_AP>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_762x38mmR_AP>500</Ammo_762x38mmR_AP>
 		</products>
-		<workAmount>1600</workAmount>
+		<workAmount>1920</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -175,7 +175,7 @@
 		<products>
 		  <Ammo_763x25mmMauser_AP>500</Ammo_763x25mmMauser_AP>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_765x20mmLongue_AP>500</Ammo_765x20mmLongue_AP>
 		</products>
-		<workAmount>1000</workAmount>
+		<workAmount>1200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_8x22mmNambu_AP>500</Ammo_8x22mmNambu_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -175,7 +175,7 @@
     <products>
       <Ammo_9x18mmMakarov_AP>500</Ammo_9x18mmMakarov_AP>
     </products>
-    <workAmount>1200</workAmount>
+    <workAmount>1440</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -231,7 +231,7 @@
 		<products>
 			<Ammo_9x19mmPara_AP>500</Ammo_9x19mmPara_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/9x21mmGyurza.xml
+++ b/Defs/Ammo/Pistols/9x21mmGyurza.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_9x21mmGyurza_AP>500</Ammo_9x21mmGyurza_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Pistols/FN57x28mm.xml
+++ b/Defs/Ammo/Pistols/FN57x28mm.xml
@@ -175,7 +175,7 @@
 		<products>
 			<Ammo_FN57x28mm_AP>500</Ammo_FN57x28mm_AP>
 		</products>
-		<workAmount>1000</workAmount>
+		<workAmount>1200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -265,7 +265,7 @@
 		<products>
 			<Ammo_127x55mm_AP>500</Ammo_127x55mm_AP>
 		</products>
-		<workAmount>8200</workAmount>
+		<workAmount>9840</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_277Fury_AP>500</Ammo_277Fury_AP>
 		</products>
-		<workAmount>2600</workAmount>
+		<workAmount>3120</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_3006Springfield_AP>500</Ammo_3006Springfield_AP>		
 		</products>
-		<workAmount>2800</workAmount>			
+		<workAmount>3360</workAmount>			
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_300AACBlackout_AP>500</Ammo_300AACBlackout_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_303British_AP>500</Ammo_303British_AP>
 		</products>
-		<workAmount>2800</workAmount>
+		<workAmount>3360</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_30Carbine_AP>500</Ammo_30Carbine_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>	
 	
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -267,7 +267,7 @@
 		<products>
 			<Ammo_44-40Winchester_AP>500</Ammo_44-40Winchester_AP>
 		</products>
-	    <workAmount>2600</workAmount>			
+	    <workAmount>3120</workAmount>			
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_4570Gov_AP>500</Ammo_4570Gov_AP>
 		</products>
-	    <workAmount>3800</workAmount>			
+	    <workAmount>4560</workAmount>			
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -263,7 +263,7 @@
 		<products>
 			<Ammo_473x33mmCaseless_AP>500</Ammo_473x33mmCaseless_AP>
 		</products>
-    <workAmount>1000</workAmount>
+    <workAmount>1200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_545x39mmSoviet_AP>500</Ammo_545x39mmSoviet_AP>
 		</products>
-		<workAmount>1200</workAmount>
+		<workAmount>1440</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_556x45mmNATO_AP>500</Ammo_556x45mmNATO_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_5656Spencer_AP>500</Ammo_5656Spencer_AP>
 		</products>
-    <workAmount>3400</workAmount>		
+    <workAmount>4080</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_58x42mmDBP10_AP>500</Ammo_58x42mmDBP10_AP>
 		</products>
-    	<workAmount>1800</workAmount>
+    	<workAmount>2160</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_65x48mmBlackout_AP>500</Ammo_65x48mmBlackout_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_65x50mmSRArisaka_AP>500</Ammo_65x50mmSRArisaka_AP>
 		</products>
-    <workAmount>2400</workAmount>
+    <workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_792x57mmMauser_AP>500</Ammo_792x57mmMauser_AP>
 		</products>
-    	<workAmount>3000</workAmount>		
+    	<workAmount>3600</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_75x54mmFrench_AP>500</Ammo_75x54mmFrench_AP>
 		</products>
-    	<workAmount>2600</workAmount>
+    	<workAmount>3120</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_762x39mmSoviet_AP>500</Ammo_762x39mmSoviet_AP>
 		</products>
-		<workAmount>1800</workAmount>
+		<workAmount>2160</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -238,7 +238,7 @@
 		<products>
 			<Ammo_762x51mmNATO_FMJ>500</Ammo_762x51mmNATO_FMJ>
 		</products>
-	<workAmount>2600</workAmount>		
+	<workAmount>3120</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -238,7 +238,7 @@
 		<products>
 			<Ammo_762x51mmNATO_FMJ>500</Ammo_762x51mmNATO_FMJ>
 		</products>
-	<workAmount>3120</workAmount>		
+	<workAmount>2600</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_762x51mmNATO_AP>500</Ammo_762x51mmNATO_AP>
 		</products>
-	<workAmount>2600</workAmount>		
+	<workAmount>3120</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_762x54mmR_AP>500</Ammo_762x54mmR_AP>
 		</products>
-		<workAmount>2800</workAmount>
+		<workAmount>3360</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -266,7 +266,7 @@
 		<products>
 			<Ammo_77x58mmArisaka_AP>500</Ammo_77x58mmArisaka_AP>
 		</products>
-	<workAmount>3000</workAmount>		
+	<workAmount>3600</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_792x33mmKurz_AP>500</Ammo_792x33mmKurz_AP>
 		</products>
-	<workAmount>2000</workAmount>		
+	<workAmount>2400</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_86x43mmBlackout_AP>500</Ammo_86x43mmBlackout_AP>
 		</products>
-		<workAmount>2800</workAmount>
+		<workAmount>3360</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_8x50mmRLebel_AP>500</Ammo_8x50mmRLebel_AP>
 		</products>
-	<workAmount>3000</workAmount>		
+	<workAmount>3600</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -262,7 +262,7 @@
 		<products>
 			<Ammo_9x39mmSoviet_AP>500</Ammo_9x39mmSoviet_AP>
 		</products>
-    <workAmount>3000</workAmount>
+    <workAmount>3600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">


### PR DESCRIPTION
## Changes

- AP ammo type now require 20% more work than FMJ to craft.
- Some minor housekeeping.

## References

- Closes https://github.com/CombatExtended-Continued/CombatExtended/issues/1744
- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
