### PR TITLE
Remote Shielder Implant patch

### DIFF
--- a/Biotech/Patches/HediffDefs/Hediffs_Mechanitor.xml
+++ b/Biotech/Patches/HediffDefs/Hediffs_Mechanitor.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <!-- Remote Shielder Implant -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/HediffDef[defName="RemoteShielderImplant"]/stages/li[1]/statOffsets/MechRemoteShieldEnergy</xpath>
+    <value>
+      <MechRemoteShieldEnergy>110</MechRemoteShieldEnergy>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/HediffDef[defName="RemoteShielderImplant"]/stages/li[2]/statOffsets/MechRemoteShieldEnergy</xpath>
+    <value>
+      <MechRemoteShieldEnergy>220</MechRemoteShieldEnergy>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/HediffDef[defName="RemoteShielderImplant"]/stages/li[3]/statOffsets/MechRemoteShieldEnergy</xpath>
+    <value>
+      <MechRemoteShieldEnergy>330</MechRemoteShieldEnergy>
+    </value>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

- Patch the energy shield capacity of the Remote Shielder Implant ability that had gone unnoticed by 50% like other energy shields in CE.

## References

![image](https://user-images.githubusercontent.com/56392968/201492347-1f44fb20-921d-4bfe-81ac-364cdc6594be.png)

## Reasoning

- As per the uploaded image, the shield capacity will be increased, this patch is made with that in mind.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
