### PR TITLE
Vanilla Expanded 1.4 Patch Fixes

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/CombinationDefs/CombinationDefs.xml
@@ -120,7 +120,7 @@
 			<li Class="PatchOperationReplace" MayRequire="sarg.alphabiomes">
 				<xpath>Defs/ItemProcessor.CombinationDef[defName="VFEM_MunitionsAndArmamentFactory_ArtilleryFoundry_AB_Shell_Tar"]/result</xpath>
 				<value>
-					<result>Tar_shell_81mm</result>
+					<result>AB_Shell_Tar</result>
 				</value>
 			</li>
 			

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
@@ -12,23 +12,6 @@
 					
 			<match Class="PatchOperationSequence">
 				<operations>
-              
-        <!-- === verbClass === -->
-        <li Class="PatchOperationReplace">
-          <xpath>
-            /Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/verbs/li/verbClass
-          </xpath>
-          <value>
-            <verbClass>Verb_Shoot</verbClass>
-          </value>
-        </li>
-
-        <!-- === CompOversizedWeapon === -->
-        <li Class="PatchOperationRemove">
-          <xpath>
-            /Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/comps/li[compClass="CompOversizedWeapon.CompOversizedWeapon"]
-          </xpath>
-        </li>
 
         <!-- === Tools === -->
 
@@ -96,13 +79,6 @@
             <noSingleShot>true</noSingleShot>
           </FireModes>
           <AllowWithRunAndGun>false</AllowWithRunAndGun>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/recipeMaker/researchPrerequisite</xpath>
-          <value>
-            <researchPrerequisite>VWEFT_FrontierWeapons</researchPrerequisite>
-          </value>
         </li>
 
         <li Class="PatchOperationAddModExtension">

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -104,12 +104,13 @@
       <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/stuffCategories</xpath>
     </li>
 
-    <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/smeltable</xpath>
       <value>
         <thingClass>CombatExtended.AmmoThing</thingClass>
         <stackLimit>75</stackLimit>
         <resourceReadoutPriority>First</resourceReadoutPriority>
+        <smeltable>False</smeltable>	
       </value>
     </li>
 


### PR DESCRIPTION
## Changes
Resolve some other patch issues.
- Make throwing shards non-smeltable.
- Update a VFE: Mech artillery foundry reference to the update tar shell defName.
- Remove operations from the Frontier + Heavy Weapons patch that are no longer needed.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
