### PR TITLE
Display ammo status gizmo for colony mech

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -690,7 +690,12 @@ namespace CombatExtended
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
             var mannableComp = turret?.GetMannable();
-            var isPlayerControlled = Wielder?.IsColonistPlayerControlled ?? (turret?.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo));
+
+            // Only show ammo status for colonists under player control (i.e. not mental breaking / slave rebelling) and colony mechs.
+            // Note that we use IsColonyMech rather than IsColonyMechPlayerControlled for checking whether the pawn is a colony mech,
+            // as the latter would only apply to mechs currently controlled by a mechanitor.
+            var isColonyMechOrColonist = Wielder != null && (Wielder.IsColonistPlayerControlled || Wielder.IsColonyMech);
+            var isPlayerControlled = isColonyMechOrColonist || (turret?.Faction == Faction.OfPlayer && (mannableComp != null || UseAmmo));
 
             if (isPlayerControlled)
             {


### PR DESCRIPTION
e91cf7234da06a481ce987b76face915a6c89621 unintentionally hid the ammo status gizmo for colony mechs. Make it show up again for them.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors)
