### PR TITLE
Remove Prometheum-Soaked Hediff on Death

### DIFF
--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -347,6 +347,7 @@
         <severityPerDay>-12</severityPerDay>
       </li>
       <li Class="CombatExtended.HediffCompProperties_Prometheum" />
+      <li Class="HediffCompProperties_DisappearsOnDeath"/>
     </comps>
     <stages>
       <li>


### PR DESCRIPTION
## Changes
- Remove the `Prometheum-Soaked` hediff on death. Your enemies will no longer burn for eternity in the afterlife, and resurrected pawns will not burst into flames.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
