### PR TITLE
Mech melee chance stat and bodySize adjustments

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Heavy.xml
@@ -45,9 +45,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Tunneler"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.04</MeleeDodgeChance>
-			<MeleeCritChance>0.13</MeleeCritChance>
-			<MeleeParryChance>0.36</MeleeParryChance>
+			<MeleeDodgeChance>0.03</MeleeDodgeChance>
+			<MeleeCritChance>0.19</MeleeCritChance>
+			<MeleeParryChance>0.48</MeleeParryChance>
 			<MaxHitPoints>300</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -84,9 +84,9 @@
 			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.19</MeleeDodgeChance>
-			<MeleeCritChance>0.22</MeleeCritChance>
-			<MeleeParryChance>0.09</MeleeParryChance>
+			<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			<MeleeCritChance>0.05</MeleeCritChance>
+			<MeleeParryChance>0.05</MeleeParryChance>
 			<MaxHitPoints>150</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -64,6 +64,9 @@
 		<value>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>40</CarryBulk>
+			<MeleeDodgeChance>0.12</MeleeDodgeChance>
+			<MeleeCritChance>0.11</MeleeCritChance>
+			<MeleeParryChance>0.09</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -96,6 +99,15 @@
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
 			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Scorcher"]/statBases</xpath>
+		<value>
+			<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
+			<MeleeParryChance>0.09</MeleeParryChance>
 		</value>
 	</Operation>
 
@@ -156,6 +168,9 @@
 		<value>
 			<CarryWeight>60</CarryWeight>
 			<CarryBulk>30</CarryBulk>
+			<MeleeDodgeChance>0.07</MeleeDodgeChance>
+			<MeleeCritChance>0.13</MeleeCritChance>
+			<MeleeParryChance>0.13</MeleeParryChance>
 			<MaxHitPoints>600</MaxHitPoints>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_SuperHeavy.xml
@@ -59,17 +59,14 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.01</MeleeDodgeChance>
-			<MeleeCritChance>0.17</MeleeCritChance>
-			<MeleeParryChance>0.45</MeleeParryChance>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>50</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.20</MeleeCritChance>
+			<MeleeParryChance>0.57</MeleeParryChance>
 			<MaxHitPoints>550</MaxHitPoints>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Centurion"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>2.6</baseBodySize>
 		</value>
 	</Operation>
 
@@ -127,17 +124,14 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/statBases</xpath>
 		<value>
-			<MeleeDodgeChance>0.01</MeleeDodgeChance>
-			<MeleeCritChance>0.2</MeleeCritChance>
-			<MeleeParryChance>0.5</MeleeParryChance>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>50</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.02</MeleeDodgeChance>
+			<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeParryChance>0.64</MeleeParryChance>
 			<MaxHitPoints>600</MaxHitPoints>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Warqueen"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>3.0</baseBodySize>
 		</value>
 	</Operation>
 
@@ -175,22 +169,15 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/statBases</xpath>
 		<value>
-			<CarryWeight>400</CarryWeight>
-			<CarryBulk>80</CarryBulk>
+			<CarryWeight>300</CarryWeight>
+			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.01</MeleeDodgeChance>
-			<MeleeCritChance>0.2</MeleeCritChance>
-			<MeleeParryChance>0.5</MeleeParryChance>
+			<MeleeDodgeChance>0.03</MeleeDodgeChance>
+			<MeleeCritChance>0.42</MeleeCritChance>
+			<MeleeParryChance>0.64</MeleeParryChance>
 			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>600</MaxHitPoints>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Diabolus"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>3.0</baseBodySize>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -101,13 +101,13 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases</xpath>
 		<value>
-			<CarryWeight>400</CarryWeight>
-			<CarryBulk>80</CarryBulk>
+			<CarryWeight>250</CarryWeight>
+			<CarryBulk>60</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.02</MeleeDodgeChance>
-			<MeleeCritChance>0.15</MeleeCritChance>
-			<MeleeParryChance>0.41</MeleeParryChance>
+			<MeleeDodgeChance>0.03</MeleeDodgeChance>
+			<MeleeCritChance>0.26</MeleeCritChance>
+			<MeleeParryChance>0.52</MeleeParryChance>
 			<AimingDelayFactor>1.25</AimingDelayFactor>
 			<MaxHitPoints>500</MaxHitPoints>
 		</value>
@@ -124,13 +124,6 @@
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>20</ArmorRating_Sharp>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[@Name="MechCentipede"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>2.0</baseBodySize>
 		</value>
 	</Operation>
 
@@ -167,72 +160,6 @@
 		</value>
 	</Operation>-->
 
-	<!-- ========== Termite ========== -->
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>QuadrupedLow</bodyShape>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases</xpath>
-		<value>
-			<CarryWeight>300</CarryWeight>
-			<CarryBulk>60</CarryBulk>
-			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.02</MeleeDodgeChance>
-			<MeleeCritChance>0.15</MeleeCritChance>
-			<MeleeParryChance>0.41</MeleeParryChance>
-			<AimingDelayFactor>1.65</AimingDelayFactor>
-			<MaxHitPoints>350</MaxHitPoints>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>40</ArmorRating_Blunt>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>18</ArmorRating_Sharp>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/race/baseBodySize</xpath>
-		<value>
-			<baseBodySize>1.8</baseBodySize>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>25</power>
-					<cooldownTime>3.01</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>13.5</armorPenetrationBlunt>
-					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-			</tools>
-		</value>
-	</Operation>
-
 	<!-- ========== Scyther ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
@@ -251,8 +178,8 @@
 			<CarryBulk>20</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
 			<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-			<MeleeDodgeChance>0.19</MeleeDodgeChance>
-			<MeleeCritChance>0.22</MeleeCritChance>
+			<MeleeDodgeChance>0.13</MeleeDodgeChance>
+			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
@@ -398,9 +325,9 @@
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>			
 			<CarryWeight>80</CarryWeight>
 			<CarryBulk>40</CarryBulk>
-			<MeleeDodgeChance>0.00</MeleeDodgeChance>
-			<MeleeCritChance>0.15</MeleeCritChance>
-			<MeleeParryChance>0.41</MeleeParryChance>
+			<MeleeDodgeChance>0.04</MeleeDodgeChance>
+			<MeleeCritChance>0.13</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</Operation>
@@ -441,6 +368,65 @@
 				</weaponTags>
 			</value>
 		</nomatch>
+	</Operation>
+
+	<!-- ========== Termite ========== -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>QuadrupedLow</bodyShape>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases</xpath>
+		<value>
+			<CarryWeight>300</CarryWeight>
+			<CarryBulk>60</CarryBulk>
+			<AimingAccuracy>1.0</AimingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+			<MeleeDodgeChance>0.04</MeleeDodgeChance>
+			<MeleeCritChance>0.14</MeleeCritChance>
+			<MeleeParryChance>0.24</MeleeParryChance>
+			<AimingDelayFactor>1.25</AimingDelayFactor>
+			<MaxHitPoints>350</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>40</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>18</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>25</power>
+					<cooldownTime>3.01</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>13.5</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+			</tools>
+		</value>
 	</Operation>
 
 </Patch>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -55,13 +55,13 @@
     <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases</xpath>
       <value>
-        <CarryWeight>400</CarryWeight>
-        <CarryBulk>80</CarryBulk>
+        <CarryWeight>260</CarryWeight>
+        <CarryBulk>70</CarryBulk>
         <AimingAccuracy>1.05</AimingAccuracy>
         <ShootingAccuracyPawn>1.05</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.15</MeleeCritChance>
-        <MeleeParryChance>0.41</MeleeParryChance>
+        <MeleeDodgeChance>0.03</MeleeDodgeChance>
+        <MeleeCritChance>0.30</MeleeCritChance>
+        <MeleeParryChance>0.52</MeleeParryChance>
         <AimingDelayFactor>1.20</AimingDelayFactor>
         <MaxHitPoints>500</MaxHitPoints>
       </value>
@@ -84,7 +84,7 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseBodySize</xpath>
       <value>
-        <baseBodySize>2.1</baseBodySize>
+        <baseBodySize>3.0</baseBodySize>
       </value>
     </li>
 
@@ -126,9 +126,9 @@
         <CarryBulk>20</CarryBulk>
         <AimingAccuracy>1.1</AimingAccuracy>
         <ShootingAccuracyPawn>1.6</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.26</MeleeDodgeChance>
-        <MeleeCritChance>0.26</MeleeCritChance>
-        <MeleeParryChance>0.15</MeleeParryChance>
+        <MeleeDodgeChance>0.15</MeleeDodgeChance>
+        <MeleeCritChance>0.14</MeleeCritChance>
+        <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
     </li>
@@ -277,9 +277,9 @@
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>			
 			<CarryWeight>80</CarryWeight>
 			<CarryBulk>40</CarryBulk>
-			<MeleeDodgeChance>0.00</MeleeDodgeChance>
+			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
-			<MeleeParryChance>0.41</MeleeParryChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</li>
@@ -324,8 +324,8 @@
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
-        <MeleeDodgeChance>0.19</MeleeDodgeChance>
-        <MeleeCritChance>0.22</MeleeCritChance>
+        <MeleeDodgeChance>0.13</MeleeDodgeChance>
+        <MeleeCritChance>0.12</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
@@ -407,8 +407,8 @@
         <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1.1</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.19</MeleeDodgeChance>
-        <MeleeCritChance>0.22</MeleeCritChance>
+        <MeleeDodgeChance>0.07</MeleeDodgeChance>
+        <MeleeCritChance>0.04</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
@@ -497,9 +497,9 @@
       <value>
         <CarryWeight>400</CarryWeight>
         <CarryBulk>80</CarryBulk>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.15</MeleeCritChance>
-        <MeleeParryChance>0.41</MeleeParryChance>
+        <MeleeDodgeChance>0.04</MeleeDodgeChance>
+        <MeleeCritChance>0.47</MeleeCritChance>
+        <MeleeParryChance>0.52</MeleeParryChance>
         <MaxHitPoints>500</MaxHitPoints>
       </value>
     </li>
@@ -515,13 +515,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>2.0</baseBodySize>
       </value>
     </li>
 
@@ -563,10 +556,10 @@
         <CarryBulk>60</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.17</MeleeCritChance>
-        <MeleeParryChance>0.45</MeleeParryChance>
-        <AimingDelayFactor>1.65</AimingDelayFactor>
+        <MeleeDodgeChance>0.04</MeleeDodgeChance>
+        <MeleeCritChance>0.16</MeleeCritChance>
+        <MeleeParryChance>0.24</MeleeParryChance>
+        <AimingDelayFactor>1.25</AimingDelayFactor>
         <MaxHitPoints>400</MaxHitPoints>
       </value>
     </li>
@@ -582,13 +575,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>1.8</baseBodySize>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -272,13 +272,13 @@
     <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases</xpath>
       <value>
-        <CarryWeight>300</CarryWeight>
-        <CarryBulk>80</CarryBulk>
+        <CarryWeight>200</CarryWeight>
+        <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.17</MeleeCritChance>
-        <MeleeParryChance>0.45</MeleeParryChance>
+        <MeleeDodgeChance>0.03</MeleeDodgeChance>
+        <MeleeCritChance>0.26</MeleeCritChance>
+        <MeleeParryChance>0.52</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
     </li>
@@ -294,13 +294,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>6</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>1.8</baseBodySize>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -56,13 +56,13 @@
     <li Class="PatchOperationAdd">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases</xpath>
       <value>
-        <CarryWeight>400</CarryWeight>
-        <CarryBulk>80</CarryBulk>
+        <CarryWeight>250</CarryWeight>
+        <CarryBulk>60</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.15</MeleeCritChance>
-        <MeleeParryChance>0.41</MeleeParryChance>
+        <MeleeDodgeChance>0.03</MeleeDodgeChance>
+        <MeleeCritChance>0.26</MeleeCritChance>
+        <MeleeParryChance>0.52</MeleeParryChance>
         <AimingDelayFactor>1.25</AimingDelayFactor>
         <MaxHitPoints>500</MaxHitPoints>
       </value>
@@ -85,7 +85,7 @@
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseBodySize</xpath>
       <value>
-        <baseBodySize>2.0</baseBodySize>
+        <baseBodySize>3.0</baseBodySize>
       </value>
     </li>
 
@@ -127,8 +127,8 @@
         <CarryBulk>20</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.19</MeleeDodgeChance>
-        <MeleeCritChance>0.22</MeleeCritChance>
+        <MeleeDodgeChance>0.13</MeleeDodgeChance>
+        <MeleeCritChance>0.12</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
@@ -278,9 +278,9 @@
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>			
 			<CarryWeight>80</CarryWeight>
 			<CarryBulk>40</CarryBulk>
-			<MeleeDodgeChance>0.00</MeleeDodgeChance>
-			<MeleeCritChance>0.15</MeleeCritChance>
-			<MeleeParryChance>0.41</MeleeParryChance>
+			<MeleeDodgeChance>0.04</MeleeDodgeChance>
+			<MeleeCritChance>0.13</MeleeCritChance>
+			<MeleeParryChance>0.15</MeleeParryChance>
 			<MaxHitPoints>200</MaxHitPoints>
 		</value>
 	</li>
@@ -327,8 +327,8 @@
         <CarryBulk>20</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1.25</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.19</MeleeDodgeChance>
-        <MeleeCritChance>0.22</MeleeCritChance>
+        <MeleeDodgeChance>0.13</MeleeDodgeChance>
+        <MeleeCritChance>0.11</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
@@ -410,8 +410,8 @@
         <CarryBulk>50</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1.0</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.19</MeleeDodgeChance>
-        <MeleeCritChance>0.22</MeleeCritChance>
+        <MeleeDodgeChance>0.06</MeleeDodgeChance>
+        <MeleeCritChance>0.03</MeleeCritChance>
         <MeleeParryChance>0.09</MeleeParryChance>
         <MaxHitPoints>200</MaxHitPoints>
       </value>
@@ -501,9 +501,9 @@
       <value>
         <CarryWeight>400</CarryWeight>
         <CarryBulk>80</CarryBulk>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.15</MeleeCritChance>
-        <MeleeParryChance>0.41</MeleeParryChance>
+        <MeleeDodgeChance>0.03</MeleeDodgeChance>
+        <MeleeCritChance>0.40</MeleeCritChance>
+        <MeleeParryChance>0.39</MeleeParryChance>
         <MaxHitPoints>500</MaxHitPoints>
       </value>
     </li>
@@ -519,13 +519,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>20</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>2.0</baseBodySize>
       </value>
     </li>
 
@@ -567,10 +560,10 @@
         <CarryBulk>60</CarryBulk>
         <AimingAccuracy>1.0</AimingAccuracy>
         <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
-        <MeleeDodgeChance>0.02</MeleeDodgeChance>
-        <MeleeCritChance>0.15</MeleeCritChance>
-        <MeleeParryChance>0.41</MeleeParryChance>
-        <AimingDelayFactor>1.65</AimingDelayFactor>
+        <MeleeDodgeChance>0.04</MeleeDodgeChance>
+        <MeleeCritChance>0.14</MeleeCritChance>
+        <MeleeParryChance>0.24</MeleeParryChance>
+        <AimingDelayFactor>1.25</AimingDelayFactor>
         <MaxHitPoints>350</MaxHitPoints>
       </value>
     </li>
@@ -586,13 +579,6 @@
       <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>18</ArmorRating_Sharp>
-      </value>
-    </li>
-
-    <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/race/baseBodySize</xpath>
-      <value>
-        <baseBodySize>1.8</baseBodySize>
       </value>
     </li>
 


### PR DESCRIPTION
## Changes

- Removed the bodySize patches of mechanoid pawns and adjusted their carry bulk and weight capacities accordingly.
- Adjusted the vanilla and DLC mechanoids' melee chance stats based on the updated values of the Animal Spreadsheet, they were outdated in the sheet to begin with.
- Gave the two super heavy mechs that lacked carry bulk and mass patches an increase capacity and also shooting accuracy stats.
- Some minor housekeeping.

## References

- https://docs.google.com/spreadsheets/d/1Q7MXo-3qcZtTslZ3q4PS89jKLArD7k_RHLo_OqSeeHA/edit#gid=1020770989

## Reasoning

- Centipedes have a bodySize of 3.0 in vanilla now and since the bodySize node does nothing in CE apart from melee chance stats, I opted for removing the patches and update the melee stats to keep things consistent and cleaner.
- All of the colony mechs can be used in caravans now so it made sense for all the super heavy mechs to have proper and increased carry mass and bulk capacities.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
