### PR TITLE
Add Conditional Checks for Stable Build, Housekeeping

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -1,19 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+	<!-- ========== Adjust combatPower ========== -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="Mech_Legionary" or defName="Mech_Tesseron"]/combatPower</xpath>
 		<value>
 			<combatPower>200</combatPower>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/PawnKindDef[defName="Mech_Legionary"]/weaponTags</xpath>
-		<value>
-			<weaponTags>
-				<li>MechanoidGunIndirect</li>
-			</weaponTags>
 		</value>
 	</Operation>
 
@@ -23,6 +16,8 @@
 			<combatPower>900</combatPower>
 		</value>
 	</Operation>
+
+	<!-- ========== Loadouts ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Mech_Legionary"]</xpath>
@@ -49,6 +44,15 @@
 	</Operation>
 
 	<!-- ========== Legionary & Tesseron ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Mech_Legionary"]/weaponTags</xpath>
+		<value>
+			<weaponTags>
+				<li>MechanoidGunIndirect</li>
+			</weaponTags>
+		</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Mech_Legionary" or defName="Mech_Tesseron"]</xpath>
@@ -174,6 +178,30 @@
 			<MaxHitPoints>600</MaxHitPoints>
 		</value>
 	</Operation>
+
+	<!-- Temporary conditional checks. Remove after the unstable build rolls into stable. -->
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName = "Mech_Apocriton"]/statBases/ArmorRating_Sharp</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName = "Mech_Apocriton"]/statBases</xpath>
+			<value>
+				<ArmorRating_Sharp />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName = "Mech_Apocriton"]/statBases/ArmorRating_Blunt</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName = "Mech_Apocriton"]/statBases</xpath>
+			<value>
+				<ArmorRating_Blunt />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<!-- -->
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Mech_Apocriton"]/statBases/ArmorRating_Blunt</xpath>

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -81,6 +81,7 @@
 					<amount>66</amount>
 				</li>
 			</secondaryDamage>
+			<screenShakeFactor>0</screenShakeFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/PlasmaCellPistol.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellPistol.xml
@@ -79,6 +79,7 @@
 					<amount>9</amount>
 				</li>
 			</secondaryDamage>
+			<screenShakeFactor>0</screenShakeFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/PlasmaCellRifle.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellRifle.xml
@@ -80,6 +80,7 @@
 					<amount>13</amount>
 				</li>
 			</secondaryDamage>
+			<screenShakeFactor>0</screenShakeFactor>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes
- Add some temporary conditional checks for Apoticon armor nodes. The current patch has a `Replace` operation that works in the current unstable build, but throws an error in the stable build. This check safely prevents that error. The added operation can be removed after stable updates, but will not cause any trouble when it does.
- Made sure that plasma projectiles don't shake the screen upon impact.
- Housekeeping.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)