### PR TITLE
Fix VAE headgear bulk for the autopatcher

### DIFF
--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Apparel_Industrial.xml
@@ -12,6 +12,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Trousers" or defName="VAE_Headgear_Fedora" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_FleeceShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+						<Bulk>1</Bulk>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -40,6 +40,7 @@
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap" or defName="VAE_Headgear_ChefsToque"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+						<Bulk>1</Bulk>
 					</value>
 				</li>
 				<!-- Miscellaneous -->
@@ -52,18 +53,37 @@
 					</value>
 				</li>
 
-				<!-- == VAE_Headgear_Hardhat / Chef's Toque == -->
+				<!-- == VAE_Headgear_Hardhat == -->
 				<!-- statBases -->
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
+						<Bulk>2</Bulk>
+						<WornBulk>1</WornBulk>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<!-- == VAE_Headgear_SurgicalMask == -->
+				<!-- statBases -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_SurgicalMask"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>0.02</ArmorRating_Blunt>
+						<Bulk>1</Bulk>
+						<WornBulk>0</WornBulk>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_SurgicalMask"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.03</ArmorRating_Sharp>
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes
- Add the default bulk to a few pieces of headgear so the autopatch doesn't try to apply presents.
- Patch the surgical mask, even though the armor values don't really change.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
