### PR TITLE
Fix 'PickUp' Translation Key Error

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -136,7 +136,7 @@ namespace CombatExtended.HarmonyCE
                         // Pick up x
                         else if (count == 1)
                         {
-                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("CE_PickUp".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
+                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUpOne".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
                         }
                         else
                         {

--- a/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony_FloatMenuMakerMap.cs
@@ -136,7 +136,7 @@ namespace CombatExtended.HarmonyCE
                         // Pick up x
                         else if (count == 1)
                         {
-                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("PickUp".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
+                            opts.Add(FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("CE_PickUp".Translate(item.Label, item), () => Pickup(pawn, item), MenuOptionPriority.High, null, null, 0f, null, null), pawn, item, "ReservedBy"));
                         }
                         else
                         {


### PR DESCRIPTION
## Changes
Changed `PickUp` to `PickUpOne` in the FloatMenuOption .cs file, allowing it to connect with the existing `PickUpOne` translation key in base RW. Given the more complete nature of the base game translations, it makes more sense to use those rather than CE's where possible.

With the 1.3 to 1.4 update, in the base game translation keys `<PickUp>Pick up {1_label}</PickUp>` became `<PickUpOne>Pick up {1_labelShort} x1</PickUpOne>`.

## Alternatives
Could just use the `CE_PickUp` translation key, but it's preferable to use base RW's translation keys  where possible instead of CE's translations.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
