### PR TITLE
Headgear Apparel Layer Fixes

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -104,10 +104,24 @@
 					<hediff>WearingGasMask</hediff>
 				</li>
 				<li Class="CombatExtended.ApperalRenderingExtension">
-					<HideHair>true</HideHair>
+					<HideHair>false</HideHair>
 					<HideBeard>true</HideBeard>
 				</li>
 			</modExtensions>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/hatRenderedFrontOfFace</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<bodyPartGroups>
+                <li>Eyes</li>
+                <li>Teeth</li>
+			</bodyPartGroups>  
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -111,8 +111,11 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/hatRenderedFrontOfFace</xpath>
+		<value>
+			<hatRenderedFrontOfFace>false</hatRenderedFrontOfFace>
+		</value>	
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -122,8 +122,8 @@
 		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/bodyPartGroups</xpath>
 		<value>
 			<bodyPartGroups>
-                <li>Eyes</li>
-                <li>Teeth</li>
+				<li>Eyes</li>
+				<li>Teeth</li>
 			</bodyPartGroups>
 		</value>
 	</Operation>

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -124,7 +124,7 @@
 			<bodyPartGroups>
                 <li>Eyes</li>
                 <li>Teeth</li>
-			</bodyPartGroups>  
+			</bodyPartGroups>
 		</value>
 	</Operation>
 

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -46,6 +46,8 @@
             <wornGraphicPath>Things/Apparel/PlateHelmet/CE_PlateHelmet</wornGraphicPath>
             <layers>
                 <li>Overhead</li>
+                <li>OnHead</li>
+                <li>StrappedHead</li>                
             </layers>
             <tags>
                 <li>MedievalMilitary</li>                


### PR DESCRIPTION
## Changes
- Adjust Biotech gas mask:
   - Set to the same body parts as the CE gas mask.
   - Remove node that made it render over top of other apparel.
- Adjust plate helm layers to match other closed, full-head helmets like the recon helmet. Can no longer wear hats/gas masks beneath it. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
