### PR TITLE
Patch the Hood headgear

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -4,7 +4,7 @@
   <!-- ========== Cowboy Hat,  Bowler Hat and Tuque ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="Apparel_CowboyHat" or defName="Apparel_BowlerHat" or defName="Apparel_Tuque"]/statBases/StuffEffectMultiplierArmor</xpath>
+    <xpath>Defs/ThingDef[defName="Apparel_CowboyHat" or defName="Apparel_BowlerHat" or defName="Apparel_Tuque" or defName="Apparel_HatHood"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
       <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
     </value>


### PR DESCRIPTION
## Additions

- Patch the now base game's Hood headgear's `StuffEffectMultiplierArmor` which was somehow left unpatched.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
