### PR TITLE
Misc tweaks and housekeeping

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -57,8 +57,6 @@
 		<li>VanillaExpanded.VWEFT</li>
 		<li>oskarpotocki.vfe.mechanoid</li>
 		<li>hlx.ReinforcedMechanoids</li>
-		<li>sarg.alphaanimals</li>
-		<li>sarg.magicalmenagerie</li>
 		<li>oskarpotocki.vanillafactionsexpanded.medievalmodule</li>
 		<li>vanillaexpanded.vwe</li>
 		<li>HLX.RimworldUNSCArmoury</li>

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -19,58 +19,71 @@
 		</value>
 	</Operation>
 
-	<!-- Integrator Headset  -->
+	<!-- Mechanitor Helmet Base -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_IntegratorHeadset"]/statBases</xpath>
+		<xpath>Defs/ThingDef[@Name="ApparelArmorHelmetMechanitorBase"]</xpath>
 		<value>
-			<Bulk>4</Bulk>
-			<WornBulk>1</WornBulk>
+			<equippedStatOffsets Inherit="False">
+			</equippedStatOffsets>
+			<statBases Inherit="False">
+				<WorkToMake>15750</WorkToMake>
+				<MaxHitPoints>120</MaxHitPoints>
+				<Mass>1</Mass>
+				<Bulk>4</Bulk>
+				<WornBulk>1</WornBulk>
+				<EquipDelay>2</EquipDelay>
+			</statBases>
 		</value>
 	</Operation>
 
 	<!-- Mech Commander Helmet  -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechCommander"]/statBases</xpath>
-		<value>
-			<Bulk>4</Bulk>
-			<WornBulk>1</WornBulk>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechCommander"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>210</MaxHitPoints>
+			<Mass>3.0</Mass>
+			<Flammability>0.25</Flammability>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechCommander"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechCommander"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+			<ArmorRating_Blunt>16</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<!-- Mech Commander Helmet  -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/statBases</xpath>
-		<value>
-			<Bulk>4</Bulk>
-			<WornBulk>1</WornBulk>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>270</MaxHitPoints>
+			<Mass>3.0</Mass>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+			<ArmorRating_Blunt>26</ArmorRating_Blunt>
+			<Flammability>0.25</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<AimingAccuracy>-0.25</AimingAccuracy>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetMechlordHelmet"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>150</Plasteel>
+			<DevilstrandCloth>15</DevilstrandCloth>
 		</value>
 	</Operation>
 

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -132,16 +132,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/bodyPartGroups</xpath>
-		<value>
-			<bodyPartGroups>
-				<li>Eyes</li>
-				<li>Teeth</li>
-			</bodyPartGroups>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/layers</xpath>
 		<value>
 			<layers>

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_Various.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_Various.xml
@@ -5,29 +5,101 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/statBases</xpath>
 		<value>
-			<Bulk>100</Bulk>
-			<WornBulk>15</WornBulk>
+			<Bulk>90</Bulk>
+			<WornBulk>13</WornBulk>
+			<Mass>40</Mass>
+			<MaxHitPoints>450</MaxHitPoints>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>18</ArmorRating_Sharp>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>38</ArmorRating_Blunt>
+			<ArmorRating_Blunt>34</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>150</Plasteel>
+			<DevilstrandCloth>40</DevilstrandCloth>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+		<value>
+			<ShootingAccuracyPawn>-1</ShootingAccuracyPawn>
+			<CarryWeight>65</CarryWeight>
+			<CarryBulk>10</CarryBulk>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="Apparel_MechlordSuit"]</xpath>
 		<value>
-			<DevilstrandCloth>35</DevilstrandCloth>
+			<modExtensions Inherit="False">
+			  <li Class="CombatExtended.PartialArmorExt">
+				  <stats>
+					  <li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					  </li>
+					  <li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					  </li>
+				  </stats>
+			  </li>
+			</modExtensions>
 		</value>
 	</Operation>
 

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -27,7 +27,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large 6.27 gauge shotgun caliber designed to be fired by the KS-23 shotgun.</description>
     <statBases>
-	  <Mass>0.093</Mass>
+	  <Mass>0.096</Mass>
 	  <Bulk>0.1</Bulk>
     </statBases>
 	<tradeTags>
@@ -119,10 +119,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
-			<pelletCount>16</pelletCount>
+			<damageAmountBase>10</damageAmountBase>
+			<pelletCount>15</pelletCount>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>5.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>7.6</armorPenetrationBlunt>
 			<spreadMult>7.9</spreadMult>
 		</projectile>
 	</ThingDef>

--- a/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Defs/HediffDefs/Hediffs_CE.xml
@@ -15,11 +15,8 @@
       <li>
         <label>wearing</label>
         <minSeverity>0</minSeverity>
+        <restFallFactorOffset>0.1</restFallFactorOffset>
         <capMods>
-          <li>
-            <capacity>Breathing</capacity>
-            <offset>-0.3</offset>
-          </li>
           <li>
             <capacity>Sight</capacity>
             <offset>-0.1</offset>

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -126,7 +126,7 @@
                 <li>StrappedHead</li>
             </layers>
             <tags>
-                <li>IndustrialMilitaryAdvanced</li>
+                <li>IndustrialMilitaryBasic</li>
                 <li>GasMask</li>
             </tags>
             <hatRenderedFrontOfFace>false</hatRenderedFrontOfFace>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -176,7 +176,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicBolt</damageDef>
-							<damageAmountBase>12</damageAmountBase>
+							<damageAmountBase>10</damageAmountBase>
 							<speed>27</speed>
 							<armorPenetrationSharp>2.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.6</armorPenetrationBlunt>
@@ -190,7 +190,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicBolt</damageDef>
-							<damageAmountBase>12</damageAmountBase>
+							<damageAmountBase>6</damageAmountBase>
 							<speed>27</speed>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
@@ -204,7 +204,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>Flame</damageDef>
-							<damageAmountBase>24</damageAmountBase>
+							<damageAmountBase>25</damageAmountBase>
 							<speed>30</speed>
 							<armorPenetrationSharp>16</armorPenetrationSharp>
 							<armorPenetrationBlunt>14.4</armorPenetrationBlunt>
@@ -218,7 +218,7 @@
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
 							<damageDef>AA_ToxicBolt</damageDef>
-							<damageAmountBase>18</damageAmountBase>
+							<damageAmountBase>15</damageAmountBase>
 							<speed>19</speed>
 							<armorPenetrationSharp>1.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>3</armorPenetrationBlunt>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -30,6 +30,8 @@
 					<power>5</power>
 					<cooldownTime>1.11</cooldownTime>
 					<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -47,6 +49,8 @@
 					<power>9</power>
 					<cooldownTime>0.83</cooldownTime>
 					<armorPenetrationBlunt>3.00</armorPenetrationBlunt>
+					<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -66,6 +70,8 @@
 					<armorPenetrationSharp>0.8</armorPenetrationSharp>
 					<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+					<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
+					<soundMeleeMiss>Pawn_Melee_PowerClaw_Miss</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>

--- a/Patches/EPOE Forked Royalty DLC expansion/Bionics_Patch.xml
+++ b/Patches/EPOE Forked Royalty DLC expansion/Bionics_Patch.xml
@@ -22,7 +22,9 @@
 							<cooldownTime>1.88</cooldownTime>
 							<armorPenetrationSharp>0.04</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.32</armorPenetrationBlunt>
-							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>					
+							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>		
+							<soundMeleeHit>MeleeHit_DrillArm</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_DrillArm</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -42,6 +44,8 @@
 							<armorPenetrationSharp>0.00</armorPenetrationSharp>
 							<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_FieldHand</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_FieldHand</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -62,6 +66,8 @@
 							<armorPenetrationSharp>0.3</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>talon</label>
@@ -74,6 +80,8 @@
 							<armorPenetrationSharp>0.6</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -103,6 +111,8 @@
 							<armorPenetrationSharp>0.3</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -123,6 +133,8 @@
 							<armorPenetrationSharp>1.0</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -143,6 +155,8 @@
 							<armorPenetrationSharp>0.25</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>talon</label>
@@ -155,6 +169,8 @@
 							<armorPenetrationSharp>0.5</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -184,6 +200,8 @@
 							<armorPenetrationSharp>0.25</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -204,6 +222,8 @@
 							<armorPenetrationSharp>0.75</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 							<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>

--- a/Patches/EPOE Forked/Bionics_Patch.xml
+++ b/Patches/EPOE Forked/Bionics_Patch.xml
@@ -23,6 +23,8 @@
 							<armorPenetrationSharp>0.8</armorPenetrationSharp>
 							<cooldownTime>1.29</cooldownTime>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>blade</label>
@@ -34,6 +36,8 @@
 							<armorPenetrationSharp>2.56</armorPenetrationSharp>
 							<cooldownTime>1.29</cooldownTime>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -67,6 +71,8 @@
 							<power>5</power>
 							<cooldownTime>1.11</cooldownTime>
 							<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+							<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -83,6 +89,8 @@
 							<power>6</power>
 							<cooldownTime>1.11</cooldownTime>
 							<armorPenetrationBlunt>1.988</armorPenetrationBlunt>
+							<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
+							<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -101,6 +109,8 @@
 							<armorPenetrationSharp>0.8</armorPenetrationSharp>
 							<armorPenetrationBlunt>4</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
+							<soundMeleeMiss>Pawn_Melee_PowerClaw_Miss</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>
@@ -119,6 +129,8 @@
 							<armorPenetrationSharp>0.96</armorPenetrationSharp>
 							<armorPenetrationBlunt>4.75</armorPenetrationBlunt>
 							<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+							<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
+							<soundMeleeMiss>Pawn_Melee_PowerClaw_Miss</soundMeleeMiss>
 						</li>
 					</tools>
 				</value>

--- a/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Apparel.xml
+++ b/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Apparel.xml
@@ -345,7 +345,7 @@
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[ @Name="WW2GasMask"]/apparel/tags</xpath>
                <value>
-                  <li>IndustrialMilitaryAdvanced</li>
+                  <li>IndustrialMilitaryBasic</li>
                   <li>GasMask</li>
                </value>
             </li>

--- a/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
+++ b/Patches/Reinforced Mechanoids Tyrikan-Line/ThingDefs_Misc/RM_Ammo_Mech.xml
@@ -65,7 +65,7 @@
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE" Inherit="False">
                                 <damageDef>Bullet</damageDef>
-                                <damageAmountBase>90</damageAmountBase>
+                                <damageAmountBase>9</damageAmountBase>
                                 <speed>160</speed>
                                 <secondaryDamage>
                                     <li>

--- a/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
+++ b/Royalty/Patches/HeDiffDefs/Hediffs_Implants.xml
@@ -17,6 +17,8 @@
 					<armorPenetrationSharp>0.04</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.32</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_DrillArm</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_DrillArm</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -36,6 +38,8 @@
 					<armorPenetrationSharp>0.00</armorPenetrationSharp>
 					<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_FieldHand</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_FieldHand</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -56,6 +60,8 @@
 					<armorPenetrationSharp>0.18</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>talon</label>
@@ -68,6 +74,8 @@
 					<armorPenetrationSharp>0.34</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -88,6 +96,8 @@
 					<armorPenetrationSharp>0.18</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -108,6 +118,8 @@
 					<armorPenetrationSharp>0.58</armorPenetrationSharp>
 					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
@@ -147,20 +159,15 @@
 					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
 					<armorPenetrationSharp>0.18</armorPenetrationSharp>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<soundMeleeHit>MeleeHit_BionicSlash</soundMeleeHit>
+					<soundMeleeMiss>MeleeMiss_BionicSlash</soundMeleeMiss>
 				</li>
 			</tools>
 		</value>
 	</Operation>
 
 	<!-- Bionics -->
-<!--
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Coagulator"]/stages/li/totalBleedFactor</xpath>
-		<value>
-			<totalBleedFactor>0.5</totalBleedFactor>
-		</value>
-	</Operation>
--->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/HediffDef[defName="ToughskinGland"]/stages/li/statOffsets/ArmorRating_Sharp</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Removed the load order rule for Alpha Animals and Mythology since they were no longer needed.
- Adjusted some damage values in the Alpha Animals projectile patches.
- Changed the projectile of the 23mm buckshot from 000 to 0000 pellets and adjusted the necessary values accordingly.
- Fixed a typo in the Reinforced Mechanoids patch.
- Sorted out the inheritance issues with Mechanitor gear that was causing wrong stats to be assigned to wrong items.
- Patched the recipes of the Mechlord set.
- Tweaked the Gas Mask hediff to reflect a more realistic effect of the wearer and changed its tag to cover more pawnKinds, closer to what the Biotech gas mask tried to do.
- Removed the `bodyPartGroups` patch of the Biotech gas mask as it was indirectly causing issues.
- Added the missing `soundMeleeHit` and `soundMeleeMiss` sounds to bionics.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
