### PR TITLE
Fix possible NRE in CompFireModes

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -233,7 +233,7 @@ namespace CombatExtended
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            if (CasterPawn != null && CasterPawn.Faction.Equals(Faction.OfPlayer))
+            if (CasterPawn?.Faction == Faction.OfPlayer)
             {
                 foreach (Command com in GenerateGizmos())
                 {


### PR DESCRIPTION



## Changes

Adjust the faction check to be null-safe, which is also consistent with everywhere else the game is checking faction membership.




## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
