### PR TITLE
Allow multiple pawns to reserve and pickup ammo from the same stack.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -188,7 +188,7 @@ namespace CombatExtended
                 findItem = t => curSlot.genericDef.lambda(t.GetInnerIfMinified().def);
             else
                 findItem = t => t.GetInnerIfMinified().def == curSlot.thingDef;
-            Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t) && !isFoodInPrison(t) && AllowedByBiocode(t, pawn);
+            Predicate<Thing> search = t => findItem(t) && !t.IsForbidden(pawn) && pawn.CanReserve(t, 10, 1) && !isFoodInPrison(t) && AllowedByBiocode(t, pawn);
 
             // look for a thing near the pawn.
             curThing = GenClosest.ClosestThingReachable(
@@ -310,9 +310,9 @@ namespace CombatExtended
                         {
                             return JobMaker.MakeJob(JobDefOf.Equip, closestThing);
                         }
-                        Job job = JobMaker.MakeJob(JobDefOf.TakeInventory, closestThing);
-                        job.MakeDriver(pawn);
+                        Job job = JobMaker.MakeJob(JobDefOf.TakeCountToInventory, closestThing);
                         job.count = Mathf.Min(closestThing.stackCount, count);
+                        job.MakeDriver(pawn);
                         return job;
                     }
                     else


### PR DESCRIPTION
A similar change is probably warranted for reloading turrets.

## Changes

Pawns use the pickup-count job instead of the pickup job, so up to 10 pawns can target a single stack of ammo (or other loadout things) at a time.

## References
#2040 

## Reasoning

Reduces the need to split ammo into smaller stacks.



## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (specify how long)
