### PR TITLE
Fix Rimsenal smoke grenade removal

### DIFF
--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Weapons_Ranged_CE.xml
@@ -11,10 +11,11 @@
 
 			<!-- ========== Remove Duplicate Rimsenal Smoke Grenade =========== -->
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmoke" and description="A canister-type grenade used as a signaling device, target or landing zone marking device, or as a screening device for unit movements."]</xpath>
+				<xpath>Defs/thingDef[defName="Proj_GrenadeSmoke" and graphicData/texPath="Things/Projectile/SmokeGrenade"]</xpath>
 			</li>
+			
 			<li Class="PatchOperationRemove">
-				<xpath>Defs/ThingDef[defName="Proj_GrenadeSmoke" and thingClass="Projectile_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="Weapon_GrenadeSmoke" and graphicData/texPath="Things/A16/SmokeGrenades"]</xpath>
 			</li>
 			
 			<!-- ========== Compound Bow =========== -->


### PR DESCRIPTION

## Changes

Change the xpath targets for the smoke grenade removal, and update the projectile one to thingDef rather than Thingdef, which might be part of it

## Reasoning

Texture path is pretty easy to update and unlikely to change given the author's previous history with rimsenal vanilla.
Not likely to overlap with anything more than rimsenal vanilla itself will.


## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
