### PR TITLE
Biotech DamageDefs tweak

### DIFF
--- a/Biotech/Patches/DamageDefs/Damages_Misc.xml
+++ b/Biotech/Patches/DamageDefs/Damages_Misc.xml
@@ -30,13 +30,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/DamageDef[defName="Vaporize"]/defaultArmorPenetration</xpath>
-		<value>
-			<defaultArmorPenetration>2.0</defaultArmorPenetration>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="Vaporize"]/defaultDamage</xpath>
 		<value>
 			<defaultDamage>1000</defaultDamage>

--- a/Biotech/Patches/DamageDefs/Damages_Misc.xml
+++ b/Biotech/Patches/DamageDefs/Damages_Misc.xml
@@ -13,4 +13,34 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="AcidBurn"]/armorCategory</xpath>
+		<value>
+			<armorCategory>Heat</armorCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/DamageDef[defName="Vaporize"]</xpath>
+		<value>
+			<li Class="CombatExtended.DamageDefExtensionCE">
+				<isAmbientDamage>true</isAmbientDamage>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="Vaporize"]/defaultArmorPenetration</xpath>
+		<value>
+			<defaultArmorPenetration>2.0</defaultArmorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="Vaporize"]/defaultDamage</xpath>
+		<value>
+			<defaultDamage>1000</defaultDamage>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- Changed the `AcidBurn` damage type to be impacted by Heat armor instead of Sharp.
- Made sure that Vaporize damage type has enough damage since pawns in CE have a bit more HP and is properly calculated against Heat armor.

## Reasoning

- Since `AcidBurn` is inheriting from Flame damage and has all the associated mod extensions with it and it is also the anti-mechanoid version of the fire spray in vanilla, changed its armorCategory to Heat so that it can deal damage against armor with its 80% Heat AP but be countered by heat armor so that it can damage mechs as well as normal pawns but not be countered by 0.8mm of sharp armor.

## Alternatives

- Keep the `AcidBurn` armorCategory as Sharp and increase its sharp AP which in this case it'd be useless against mechs that in return is contrary to its original purpose unless it has high enough sharp AP which in that case it'd be pretty OP against lightly armored pawns.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Stuff works as intended)
