### PR TITLE
VFE Mechanoids tweaks

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -32,12 +32,21 @@
 	</li>
 
 
-	  <!-- Advanced mechs retain their original heat armor to represent proper sealing of sensitive electronics. Minor improvement to EMP resistance as well-->
-	  
+	<!-- Advanced mechs retain some heat armor to represent sealing of sensitive electronics. Minor improvement to EMP resistance as well-->
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases/ArmorRating_Heat</xpath>
+      <value>
+        <ArmorRating_Heat>0.5</ArmorRating_Heat>
+      </value>
+    </li>
+
 	<li Class="PatchOperationAdd">
     <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
       <value>
+        <SmokeSensitivity>0</SmokeSensitivity>
         <ArmorRating_Electric>0.10</ArmorRating_Electric>
+        <NightVisionEfficiency>0.85</NightVisionEfficiency>
       </value>
     </li>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -31,14 +31,14 @@
 		</value>
 	</li>
 
-	  <!--Consistency with vanilla mechs-->
-	  
+    <!--Consistency with vanilla mechs-->
+
     <li Class="PatchOperationReplace">
       <xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]/statBases/ArmorRating_Heat</xpath>
       <value>
         <ArmorRating_Heat>0</ArmorRating_Heat>
         <SmokeSensitivity>0</SmokeSensitivity>
-        <NightVisionEfficiency>0.80</NightVisionEfficiency>        
+        <NightVisionEfficiency>0.80</NightVisionEfficiency>
       </value>
     </li>
 


### PR DESCRIPTION
## Changes

- Added some missing nodes to the base Advanced Mechanoid race patch.
- Tweaked Advanced Mechanoids to have 0.5 heat armor instead of full 2.0.

## Reasoning

- Giving the advanced mechs full immunity to heat armor is a hard counter to AP-I ammo which is already nerfed against pawns with high armor (this change was made after the initial patch for VFE-Mechs was made). They are already immune to small caliber AP-I roudns but them being completely immune to any burn damage source no matter the intensity is kinda unbalanced. Giving them 50% heat armor instead of 200% helps with their armor value being currently too overtuned.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
