### PR TITLE
Add 20x105mm charged autocannon ammo

### DIFF
--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -93,7 +93,6 @@
     </projectile>
   </ThingDef>
 
-  <!-- normal charged bullets -->
   <ThingDef ParentName="Base12x72mmChargedBullet">
     <defName>Bullet_12x72mmCharged</defName>
     <label>12x72mm Charged bullet</label>
@@ -110,7 +109,6 @@
     </projectile>
   </ThingDef>
 
-  <!-- concentrated bullets -->
   <ThingDef ParentName="Base12x72mmChargedBullet">
     <defName>Bullet_12x72mmCharged_AP</defName>
     <label>12x72mm Charged bullet (Conc.)</label>
@@ -127,7 +125,6 @@
     </projectile>
   </ThingDef>
 
-  <!-- ion bullets -->
   <ThingDef ParentName="Base12x72mmChargedBullet">
     <defName>Bullet_12x72mmCharged_Ion</defName>
     <label>12x72mm Charged bullet (Ion)</label>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -1,0 +1,279 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingCategoryDef>
+    <defName>Ammo20x105mmCharged</defName>
+    <label>20x105mm Charged</label>
+    <parent>AmmoAdvanced</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberCharge</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_20x105mmCharged</defName>
+    <label>20x105mm Charged</label>
+    <ammoTypes>
+      <Ammo_20x105mmCharged>Bullet_20x105mmCharged</Ammo_20x105mmCharged>
+      <Ammo_20x105mmCharged_AP>Bullet_20x105mmCharged_AP</Ammo_20x105mmCharged_AP>
+      <Ammo_20x105mmCharged_Ion>Bullet_20x105mmCharged_Ion</Ammo_20x105mmCharged_Ion>
+    </ammoTypes>
+    <similarTo>AmmoSet_ChargedHeavy</similarTo>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="20x105mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+    <description>High-caliber charged shot ammo used by autocannons.</description>
+    <statBases>
+      <Mass>0.13</Mass>
+      <Bulk>0.12</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting_FabricationBench</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo20x105mmCharged</li>
+    </thingCategories>
+    <stackLimit>5000</stackLimit>	
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
+    <defName>Ammo_20x105mmCharged</defName>
+    <label>20x105mm Charged cartridge</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/LargeRegular</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>16.86</MarketValue>
+    </statBases>
+    <ammoClass>Charged</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
+    <defName>Ammo_20x105mmCharged_AP</defName>
+    <label>20x105mm Charged cartridge (Conc.)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/LargeConc</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>16.86</MarketValue>
+    </statBases>
+    <ammoClass>ChargedAP</ammoClass>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x105mmChargedBase">
+    <defName>Ammo_20x105mmCharged_Ion</defName>
+    <label>20x105mm Charged cartridge (Ion)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Charged/LargeIon</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>16.86</MarketValue>
+    </statBases>
+    <ammoClass>Ionized</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
+  </ThingDef>
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef Name="Base20x105mmChargedBullet" ParentName="BaseBullet" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Charged/ChargeShot</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+      <drawSize>(1.4,1.4)</drawSize>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>200</speed>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base20x105mmChargedBullet">
+    <defName>Bullet_20x105mmCharged</defName>
+    <label>20x105mm Charged bullet</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>69</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>21</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationBlunt>1000</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base20x105mmChargedBullet">
+    <defName>Bullet_20x105mmCharged_AP</defName>
+    <label>20x105mm Charged bullet (Conc.)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>54</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>Bomb_Secondary</def>
+          <amount>8</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>80</armorPenetrationSharp>
+      <armorPenetrationBlunt>1000</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base20x105mmChargedBullet">
+    <defName>Bullet_20x105mmCharged_Ion</defName>
+    <label>20x105mm Charged bullet (Ion)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>54</damageAmountBase>
+      <secondaryDamage>
+        <li>
+          <def>EMP</def>
+          <amount>33</amount>
+        </li>
+      </secondaryDamage>
+      <armorPenetrationSharp>60</armorPenetrationSharp>
+      <armorPenetrationBlunt>1000</armorPenetrationBlunt>
+      <empShieldBreakChance>1</empShieldBreakChance>
+    </projectile>
+  </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_20x105mmCharged</defName>
+    <label>make 20x105mm Charged cartridge x100</label>
+    <description>Craft 100 20x105mm Charged cartridges.</description>
+    <jobString>Making 20x105mm Charged cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_20x105mmCharged>100</Ammo_20x105mmCharged>
+    </products>
+    <workAmount>40600</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_20x105mmCharged_AP</defName>
+    <label>make 20x105mm Charged (Conc.) cartridge x100</label>
+    <description>Craft 100 20x105mm Charged (Conc.) cartridges.</description>
+    <jobString>Making 20x105mm Charged (Conc.) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_20x105mmCharged_AP>100</Ammo_20x105mmCharged_AP>
+    </products>
+    <workAmount>40600</workAmount>		
+  </RecipeDef>
+
+  <RecipeDef ParentName="ChargeAmmoRecipeBase">
+    <defName>MakeAmmo_20x105mmCharged_Ion</defName>
+    <label>make 20x105mm Charged (Ion) cartridge x100</label>
+    <description>Craft 100 20x105mm Charged (Ion) cartridges.</description>
+    <jobString>Making 20x105mm Charged (Ion) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Plasteel</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>	  
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>40</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Plasteel</li>
+        <li>Steel</li>		
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_20x105mmCharged_Ion>100</Ammo_20x105mmCharged_Ion>
+    </products>
+    <workAmount>40600</workAmount>	
+  </RecipeDef>
+
+</Defs>


### PR DESCRIPTION
## Additions

- What it says on the tin.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- We lacked a charged autocannon round which might become useful later down the line after the Vehicle Framework is released.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
