### PR TITLE
Update PatchOperationFindMod - Censored Armory, Kaiser Armory, Tsar Armory

### DIFF
--- a/Patches/Censored Armory/30mm Rifle Grenade.xml
+++ b/Patches/Censored Armory/30mm Rifle Grenade.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>Censored Armory [1.3]</li>
+      <li>Censored Armory</li>
     </mods>
     <match Class="PatchOperationAdd">
       <xpath>Defs</xpath>

--- a/Patches/Censored Armory/37x249mmR.xml
+++ b/Patches/Censored Armory/37x249mmR.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationAdd">
 			<xpath>Defs</xpath>

--- a/Patches/Censored Armory/75cm leIG18.xml
+++ b/Patches/Censored Armory/75cm leIG18.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationAdd">
 			<xpath>Defs</xpath>

--- a/Patches/Censored Armory/75x714mmR.xml
+++ b/Patches/Censored Armory/75x714mmR.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>Censored Armory [1.3]</li>
+      <li>Censored Armory</li>
     </mods>
     <match Class="PatchOperationAdd">
       <xpath>Defs</xpath>

--- a/Patches/Censored Armory/80mm Panzerfaust.xml
+++ b/Patches/Censored Armory/80mm Panzerfaust.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationAdd">
 			<xpath>Defs</xpath>

--- a/Patches/Censored Armory/Recipes_Grenades.xml
+++ b/Patches/Censored Armory/Recipes_Grenades.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Censored Armory/Weapons_Melee.xml
+++ b/Patches/Censored Armory/Weapons_Melee.xml
@@ -3,7 +3,7 @@
 
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>Censored Armory [1.3]</li>
+      <li>Censored Armory</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>

--- a/Patches/Censored Armory/Weapons_Turrets.xml
+++ b/Patches/Censored Armory/Weapons_Turrets.xml
@@ -3,7 +3,7 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Censored Armory [1.3]</li>
+			<li>Censored Armory</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>

--- a/Patches/Kaiser Armory/105x155mmR.xml
+++ b/Patches/Kaiser Armory/105x155mmR.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Kaiser Armory [1.3]</li>
+			<li>Kaiser Armory</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Kaiser Armory/77x230mmR.xml
+++ b/Patches/Kaiser Armory/77x230mmR.xml
@@ -4,7 +4,7 @@
 
 <Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>Kaiser Armory [1.3]</li>
+			<li>Kaiser Armory</li>
 		</mods>
 	<match Class="PatchOperationAdd">
 		<xpath>Defs</xpath>

--- a/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.3]</li>
+		<li>Kaiser Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.3]</li>
+		<li>Kaiser Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Kaiser Armory/KaiserArmory_Melee.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Melee.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.3]</li>
+		<li>Kaiser Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Kaiser Armory/KaiserArmory_Turrets.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Turrets.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Kaiser Armory [1.3]</li>
+		<li>Kaiser Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.3]</li>
+		<li>Tsar Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>

--- a/Patches/Tsar Armory/TsarArmory_Recipes.xml
+++ b/Patches/Tsar Armory/TsarArmory_Recipes.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.3]</li>
+		<li>Tsar Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Tsar Armory/TsarArmory_Turrets.xml
+++ b/Patches/Tsar Armory/TsarArmory_Turrets.xml
@@ -3,7 +3,7 @@
 <Patch>
 	<Operation Class="PatchOperationFindMod">
     <mods>
-		<li>Tsar Armory [1.3]</li>
+		<li>Tsar Armory</li>
     </mods>
 		<match Class="PatchOperationSequence">
 		 <operations>


### PR DESCRIPTION
## Changes

- Updated the old mod names to their new version. Mod couldn't be patched as it was looking for the wrong mod. Turns out having the game version in the name is a bad idea for a game that is still receiving updates.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (duration of last beta release + 30 mins after official release)
