### PR TITLE
Add god mode gizmos for emptying and refilling CompAmmoUser

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -731,8 +731,16 @@ namespace CombatExtended
                 };
                 yield return reloadCommandGizmo;
 
+                // God mode gizmos for emptying and filling the magazine
                 if (DebugSettings.godMode)
                 {
+                    Command_Action devSetAmmoToMinCommandGizmo = new Command_Action
+                    {
+                        action = delegate { CurMagCount = 0; },
+                        defaultLabel = "DEV: Set ammo to 0"
+                    };
+                    yield return devSetAmmoToMinCommandGizmo;
+
                     Command_Action devSetAmmoToMaxCommandGizmo = new Command_Action
                     {
                         action = delegate { ResetAmmoCount(); },

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -743,7 +743,7 @@ namespace CombatExtended
 
                     Command_Action devSetAmmoToMaxCommandGizmo = new Command_Action
                     {
-                        action = delegate { ResetAmmoCount(); },
+                        action = delegate { CurMagCount = MagSize; },
                         defaultLabel = "DEV: Set ammo to max"
                     };
                     yield return devSetAmmoToMaxCommandGizmo;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -730,6 +730,16 @@ namespace CombatExtended
                     tutorTag = tag
                 };
                 yield return reloadCommandGizmo;
+
+                if (DebugSettings.godMode)
+                {
+                    Command_Action devSetAmmoToMaxCommandGizmo = new Command_Action
+                    {
+                        action = delegate { ResetAmmoCount(); },
+                        defaultLabel = "DEV: Set ammo to max"
+                    };
+                    yield return devSetAmmoToMaxCommandGizmo;
+                }
             }
         }
 


### PR DESCRIPTION
## Additions

- Add (god mode only) gizmos to instantly empty and refill the magazine of any weapon with CompAmmoUser

## References

- Closes https://github.com/CombatExtended-Continued/CombatExtended/issues/2026

## Reasoning

- Expedites testing of weapons without having to separately spawn in ammo, and then waiting for pawns to reload

## Alternatives

- Toggling the ammo system on/off in mod settings, which is not recommended for existing savegames

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony for 30 mins, and verified that the gizmo works for both pawn-equipped weapons and turret guns, and only when God Mode is enabled
