### PR TITLE
Fix a miscalculation in 23x75mmR buckshot shells

### DIFF
--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -8,7 +8,7 @@
       <iconPath>UI/Icons/ThingCategories/CaliberShotgun</iconPath>
     </ThingCategoryDef>
 	
-	<!-- ==================== AmmoSet ========================== -->
+  <!-- ==================== AmmoSet ========================== -->
 
   <CombatExtended.AmmoSetDef>
     <defName>AmmoSet_23x75mmR</defName>
@@ -22,12 +22,12 @@
     <similarTo>AmmoSet_Shotgun</similarTo>
   </CombatExtended.AmmoSetDef>
 	
-	<!-- ==================== Ammo ========================== -->
+  <!-- ==================== Ammo ========================== -->
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="SmallAmmoBase" Abstract="True">
     <description>Large 6.27 gauge shotgun caliber designed to be fired by the KS-23 shotgun.</description>
     <statBases>
-	  <Mass>0.096</Mass>
+	  <Mass>0.095</Mass>
 	  <Bulk>0.1</Bulk>
     </statBases>
 	<tradeTags>
@@ -120,9 +120,9 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<pelletCount>15</pelletCount>
+			<pelletCount>14</pelletCount>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>7.6</armorPenetrationBlunt>
+			<armorPenetrationBlunt>8.1</armorPenetrationBlunt>
 			<spreadMult>7.9</spreadMult>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, 0000 projectiles were given less mass than what they should have been.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors