### PR TITLE
Use lock on verb properties cache when writing to it.

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_VerbProperties.cs
+++ b/Source/CombatExtended/Harmony/Harmony_VerbProperties.cs
@@ -20,8 +20,11 @@ namespace CombatExtended.HarmonyCE
             {
                 if (!cache.TryGetValue(__instance, out __result))
                 {
-                    __result = typeof(Verb_LaunchProjectileCE).IsAssignableFrom(__instance.verbClass);
-                    cache[__instance] = __result;
+		    lock(cache)
+		    {
+			__result = typeof(Verb_LaunchProjectileCE).IsAssignableFrom(__instance.verbClass);
+			cache[__instance] = __result;
+		    }
                 }
             }
         }


### PR DESCRIPTION

## Reasoning

1.4 introduced multi-threaded loading, which means multiple threads can try to check if a VerbProperties instance is one of ours.  When this happens, it can try to write to the cache from 2 threads at once, corrupting the internal state of the dictionary, or throwing an array out of bounds error.  This adds a lock on writing, which will marginally reduce the performance gain from the cache on first access, but should not impact performance beyond first use of each verb.

## Alternatives

Disable the cache.
Make the cache smartly multithread aware.
Build the whole cache in a single thread early in game load.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [x] Game runs without errors
