### PR TITLE
Places load after rules for AA and AM

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -71,5 +71,7 @@
 		<li>OskarPotocki.VFE.Pirates</li>
 		<li>JGH.MechanoidBench3</li>
 		<li>VanillaExpanded.VTEXE.SOS2</li>
+		<li>sarg.alphaanimals</li>
+		<li>sarg.magicalmenagerie</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
Fixes issues where sometimes AA+AM would load after CE causing patching failures for combination of mods. AA+AM add defs via patches which may cause issue with the patching system if it requests finding another mod.

## Additions

Load After rules for Alpha animals and Alpha mythology

## Reasoning

If for whatever reason you had AA, VFE-M, and CE together and AA is after CE, CE will not be able to find the alpha animals slurrymaster and cause a patch failure. Same thing with Alpha mythology and a dog said.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
