### PR TITLE
Medium mech Cover-Seeking behavior

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+	<!-- ========== Cover-Seeking Behavior ========== -->
+  
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName="Mech_Legionary" or defName="Mech_Tesseron" or defName="Mech_Apocriton"]</xpath>
+		<value>
+			<aiAvoidCover>false</aiAvoidCover>
+		</value>
+	</Operation>
+
 	<!-- ========== Adjust combatPower ========== -->
 
 	<Operation Class="PatchOperationReplace">

--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -4,7 +4,7 @@
 	<!-- ========== Cover-Seeking Behavior ========== -->
   
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName="Mech_Legionary" or defName="Mech_Tesseron" or defName="Mech_Apocriton"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Mech_Tesseron" or defName="Mech_Apocriton"]</xpath>
 		<value>
 			<aiAvoidCover>false</aiAvoidCover>
 		</value>


### PR DESCRIPTION
## Changes

- Enabled the Apocriton and Tesseron mech to seek cover.

## Reasoning

- Tesseron is in the same class as Lancer and Apocriton is described as intelligent so it fits.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
