### PR TITLE
Faster repeat shots

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -77,10 +77,10 @@
   <CE_Settings_ShowExtraStats_Title>Show extra stats</CE_Settings_ShowExtraStats_Title>
 
   <CE_Settings_FragmentsFromWalls_Desc>If true, damaging walls can generate fragments</CE_Settings_FragmentsFromWalls_Desc>
-  <CE_Settings_FragmentsFromWalls_Title>Fragments From Walls</CE_Settings_FragmentsFromWalls_Title>
+  <CE_Settings_FragmentsFromWalls_Title>Fragments from walls</CE_Settings_FragmentsFromWalls_Title>
 
   <CE_Settings_FasterRepeatShots_Desc>If true, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
-  <CE_Settings_FasterRepeatShots_Title>Faster Repeat Shots</CE_Settings_FasterRepeatShots_Title>
+  <CE_Settings_FasterRepeatShots_Title>Faster subsequent shots</CE_Settings_FasterRepeatShots_Title>
 
   <!-- ========== Bipod settings ========== -->
 

--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -79,6 +79,9 @@
   <CE_Settings_FragmentsFromWalls_Desc>If true, damaging walls can generate fragments</CE_Settings_FragmentsFromWalls_Desc>
   <CE_Settings_FragmentsFromWalls_Title>Fragments From Walls</CE_Settings_FragmentsFromWalls_Title>
 
+  <CE_Settings_FasterRepeatShots_Desc>If true, subsequent shots at the same, or nearby, targets are faster.</CE_Settings_FasterRepeatShots_Desc>
+  <CE_Settings_FasterRepeatShots_Title>Faster Repeat Shots</CE_Settings_FasterRepeatShots_Title>
+
   <!-- ========== Bipod settings ========== -->
 
   <CE_Settings_BipodSettings>Bipod settings</CE_Settings_BipodSettings>

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -35,7 +35,7 @@ namespace CombatExtended
 
         private bool fragmentsFromWalls = false;
 
-	private bool fasterRepeatShots = false;
+        private bool fasterRepeatShots = false;
 
         public bool ShowCasings => showCasings;
 
@@ -124,7 +124,7 @@ namespace CombatExtended
 
         public bool FragmentsFromWalls => fragmentsFromWalls;
 
-	public bool FasterRepeatShots => fasterRepeatShots;
+        public bool FasterRepeatShots => fasterRepeatShots;
 
         #endregion
 
@@ -188,7 +188,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref autosetup, "autosetup", true);
 
             Scribe_Values.Look(ref fragmentsFromWalls, "fragmentsFromWalls", false);
-	    Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
+            Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
 
             lastAmmoSystemStatus = enableAmmoSystem;    // Store this now so we can monitor for changes
         }
@@ -213,7 +213,7 @@ namespace CombatExtended
             list.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
-	    list.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
+            list.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
 
             // Only Allow these settings to be changed in the main menu since doing while a
             // map is loaded will result in rendering issues.

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -35,6 +35,8 @@ namespace CombatExtended
 
         private bool fragmentsFromWalls = false;
 
+	private bool fasterRepeatShots = false;
+
         public bool ShowCasings => showCasings;
 
         public bool BipodMechanics => bipodMechanics;
@@ -122,6 +124,8 @@ namespace CombatExtended
 
         public bool FragmentsFromWalls => fragmentsFromWalls;
 
+	public bool FasterRepeatShots => fasterRepeatShots;
+
         #endregion
 
         private bool lastAmmoSystemStatus;
@@ -184,6 +188,7 @@ namespace CombatExtended
             Scribe_Values.Look(ref autosetup, "autosetup", true);
 
             Scribe_Values.Look(ref fragmentsFromWalls, "fragmentsFromWalls", false);
+	    Scribe_Values.Look(ref fasterRepeatShots, "fasterRepeatShots", false);
 
             lastAmmoSystemStatus = enableAmmoSystem;    // Store this now so we can monitor for changes
         }
@@ -208,7 +213,7 @@ namespace CombatExtended
             list.CheckboxLabeled("CE_Settings_TurretsBreakShields_Title".Translate(), ref turretsBreakShields, "CE_Settings_TurretsBreakShields_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowExtraTooltips_Title".Translate(), ref showExtraTooltips, "CE_Settings_ShowExtraTooltips_Desc".Translate());
             list.CheckboxLabeled("CE_Settings_ShowExtraStats_Title".Translate(), ref showExtraStats, "CE_Settings_ShowExtraStats_Desc".Translate());
-
+	    list.CheckboxLabeled("CE_Settings_FasterRepeatShots_Title".Translate(), ref fasterRepeatShots, "CE_Settings_FasterRepeatShots_Desc".Translate());
 
             // Only Allow these settings to be changed in the main menu since doing while a
             // map is loaded will result in rendering issues.

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -960,17 +960,17 @@ namespace CombatExtended
                 projectile.intendedTarget = currentTarget;
                 projectile.mount = caster.Position.GetThingList(caster.Map).FirstOrDefault(t => t is Pawn && t != caster);
                 projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
-		if (firingWithoutTarget)
-		{
-		    shotAngle = lastShotAngle;
-		    shotRotation = lastShotRotation;
-		    GetSwayVec(ref shotRotation, ref shotAngle);
-		    GetRecoilVec(ref shotRotation, ref shotAngle);
+                if (firingWithoutTarget)
+                {
+                    shotAngle = lastShotAngle;
+                    shotRotation = lastShotRotation;
+                    GetSwayVec(ref shotRotation, ref shotAngle);
+                    GetRecoilVec(ref shotRotation, ref shotAngle);
 
-		}
-		this.lastShotAngle = shotAngle;
-		this.lastShotRotation = shotRotation;
-		this.lastShootLine = shootLine;
+                }
+                this.lastShotAngle = shotAngle;
+                this.lastShotRotation = shotRotation;
+                this.lastShootLine = shootLine;
                 if (instant)
                 {
                     var shotHeight = ShotHeight;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -256,8 +256,8 @@ namespace CombatExtended
             repeating = false;
             storedShotReduction = null;
         }
-
-        public override void ExposeData() {
+        public override void ExposeData()
+        {
             base.ExposeData();
             Scribe_Values.Look<bool>(ref this.shootingAtDowned, "shootingAtDowned", false, false);
             Scribe_TargetInfo.Look(ref this.lastTarget, "lastTarget");

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -578,12 +578,12 @@ namespace CombatExtended
             float minY = -recoil / 3;
 
             float recoilMagnitude = numShotsFired == 0 ? 0 : Mathf.Pow((5 - ShootingAccuracy), (Mathf.Min(10, numShotsFired) / 6.25f));
-	    float nextRecoilMagnitude = Mathf.Pow((5 - ShootingAccuracy), (Mathf.Min(10, numShotsFired + 1) / 6.25f));
+            float nextRecoilMagnitude = Mathf.Pow((5 - ShootingAccuracy), (Mathf.Min(10, numShotsFired + 1) / 6.25f));
 
             rotation += recoilMagnitude * Rand.Range(minX, maxX);
-	    var trd = Rand.Range(minY, maxY);
+            var trd = Rand.Range(minY, maxY);
             angle += recoilMagnitude * Mathf.Deg2Rad * trd;
-	    lastRecoilDeg += nextRecoilMagnitude * trd;
+            lastRecoilDeg += nextRecoilMagnitude * trd;
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -318,7 +318,7 @@ namespace CombatExtended
             var newShotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x)) % 360;
             var delta = Mathf.Abs(newShotRotation - lastShotRotation) + lastRecoilDeg;
             lastRecoilDeg = 0;
-            var maxReduction = storedShotReduction ?? (CompFireModes.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);
+            var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);
             var reduction = Mathf.Max(maxReduction, delta / 45f);
             storedShotReduction = reduction;
             if (reduction < 1.0f)


### PR DESCRIPTION

## Changes

The primary warmup time for Verb_ShootCE is now reduced based on how close the new target is to the previous target.  
The time reduction is capped at 90%, and does not change the weapon cooldown time.  It is calculated based on the relative angle between the current target and the last real shot angle, so weapons with high recoil or high sway benefit less.  Additionally, burst and full auto fire stack the recoil effect, reducing the speed bonus from shooting in the same direction.

## References

- Closes #1474 

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (5 large battles)
