### PR TITLE
Feral Twin 9mm Fixes

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Ammo_Feral.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Ammo_Feral.xml
@@ -190,17 +190,17 @@
 	<!-- ==================== Twin 9x19mm Para ========================== -->
 	
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_9x19mmParaTwin</defName>
+		<defName>AmmoSet_9x19mmParaTwin_Feral</defName>
 		<label>Twin 9x19mm Para</label>
 		<ammoTypes>
-			<Ammo_9x19mmPara_FMJ>Bullet_9x19mmParaTwin_FMJ</Ammo_9x19mmPara_FMJ>
-			<Ammo_9x19mmPara_AP>Bullet_9x19mmParaTwin_AP</Ammo_9x19mmPara_AP>
-			<Ammo_9x19mmPara_HP>Bullet_9x19mmParaTwin_HP</Ammo_9x19mmPara_HP>
+			<Ammo_9x19mmPara_FMJ>Bullet_9x19mmParaTwin_Feral_FMJ</Ammo_9x19mmPara_FMJ>
+			<Ammo_9x19mmPara_AP>Bullet_9x19mmParaTwin_Feral_AP</Ammo_9x19mmPara_AP>
+			<Ammo_9x19mmPara_HP>Bullet_9x19mmParaTwin_Feral_HP</Ammo_9x19mmPara_HP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 	
 	<ThingDef ParentName="Base9x19mmParaBullet">
-		<defName>Bullet_9x19mmParaTwin_FMJ</defName>
+		<defName>Bullet_9x19mmParaTwin_Feral_FMJ</defName>
 		<label>9mm Para bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
@@ -212,7 +212,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base9x19mmParaBullet">
-		<defName>Bullet_9x19mmParaTwin_AP</defName>
+		<defName>Bullet_9x19mmParaTwin_Feral_AP</defName>
 		<label>9mm Para bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
@@ -224,7 +224,7 @@
 	</ThingDef>
 
 	<ThingDef ParentName="Base9x19mmParaBullet">
-		<defName>Bullet_9x19mmParaTwin_HP</defName>
+		<defName>Bullet_9x19mmParaTwin_Feral_HP</defName>
 		<label>9mm Para bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_RangedWeapons.xml
@@ -167,7 +167,7 @@
 					<recoilAmount>1.8</recoilAmount>
 					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 					<hasStandardCommand>true</hasStandardCommand>
-					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<defaultProjectile>Bullet_9x19mmParaTwin_Feral_FMJ</defaultProjectile>
 					<warmupTime>1.0</warmupTime>
 					<range>11</range>
 					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
@@ -179,7 +179,7 @@
 				<AmmoUser>
 					<magazineSize>16</magazineSize>
 					<reloadTime>4.6</reloadTime>
-					<ammoSet>AmmoSet_9x19mmParaTwin</ammoSet>
+					<ammoSet>AmmoSet_9x19mmParaTwin_Feral</ammoSet>
 				</AmmoUser>
 				<FireModes>
 				</FireModes>
@@ -245,7 +245,7 @@
             <recoilAmount>2.65</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
-            <defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_9x19mmParaTwin_Feral_FMJ</defaultProjectile>
             <warmupTime>0.8</warmupTime>
             <range>16</range>
             <burstShotCount>4</burstShotCount>
@@ -258,7 +258,7 @@
             <AmmoUser>
             <magazineSize>40</magazineSize>
             <reloadTime>4.8</reloadTime>
-            <ammoSet>AmmoSet_9x19mmParaTwin</ammoSet>
+            <ammoSet>AmmoSet_9x19mmParaTwin_Feral</ammoSet>
             </AmmoUser>
             <FireModes>
             <aimedBurstShotCount>2</aimedBurstShotCount>


### PR DESCRIPTION

## Changes

Fixed incorrect ammodef for default
Added mod specific tag since at the moment it's not a generic but someone else may want to do the same/may want to implement it as a generic for whatever reason.

## Alternatives

Can intergrate it, and potentially other twinned ammosetdefs into the base ammo if so desired.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
