### PR TITLE
Turret cooldown time tweaks

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -268,6 +268,7 @@
     <building>
       <turretGunDef>Gun_M240B</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.36</turretBurstCooldownTime>
     </building>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>
@@ -304,6 +305,7 @@
     <building>
       <turretGunDef>Gun_KPV</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.37</turretBurstCooldownTime>
     </building>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>
@@ -341,6 +343,7 @@
     <building>
       <turretGunDef>Gun_AGSThirty</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.40</turretBurstCooldownTime>
     </building>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>
@@ -390,6 +393,7 @@
       <turretGunDef>Gun_FlakTurret</turretGunDef>
       <ai_combatDangerous>true</ai_combatDangerous>
       <turretTopDrawSize>4</turretTopDrawSize>
+      <turretBurstCooldownTime>2.5</turretBurstCooldownTime>
     </building>
     <placeWorkers>
       <li>PlaceWorker_TurretTop</li>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -224,7 +224,7 @@
       <SightsEfficiency>2.36</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.89</SwayFactor>
-      <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
       <NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
       <Mass>50</Mass>
     </statBases>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -140,7 +140,7 @@
     <Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>0.5</turretBurstCooldownTime>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</value>
     </Operation>
 
@@ -214,7 +214,7 @@
     <Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>0.37</turretBurstCooldownTime>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</value>
     </Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -66,7 +66,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</value>
 	</Operation>
 
@@ -140,7 +140,7 @@
     <Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>0.5</turretBurstCooldownTime>
 		</value>
     </Operation>
 
@@ -214,7 +214,7 @@
     <Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
+			<turretBurstCooldownTime>0.37</turretBurstCooldownTime>
 		</value>
     </Operation>
 

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -18,6 +18,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.75</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases</xpath>
 				<value>
@@ -28,7 +35,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases/Mass</xpath>
 				<value>
-					<Mass>80</Mass>
+					<Mass>300</Mass>
 				</value>
 			</li>
 
@@ -46,7 +53,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+					<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 				</value>
 			</li>
 			
@@ -73,7 +80,7 @@
 				  <muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<FireModes>
-				  <aiAimMode>SuppressFire</aiAimMode>
+				  <aiAimMode>AimedShot</aiAimMode>
 				  <noSingleShot>true</noSingleShot>
 				</FireModes>
 			</li>
@@ -87,6 +94,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases</xpath>
 				<value>
@@ -97,7 +111,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases/Mass</xpath>
 				<value>
-					<Mass>80</Mass>
+					<Mass>85</Mass>
 				</value>
 			</li>
 
@@ -133,7 +147,7 @@
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>VFE_Bullet_5x35mmHyper</defaultProjectile>
-				  <warmupTime>2.5</warmupTime>
+				  <warmupTime>2.0</warmupTime>
 				  <range>86</range>
 				  <burstShotCount>1</burstShotCount>
 				  <soundCast>ChargeLance_Fire</soundCast>
@@ -156,6 +170,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases</xpath>
 				<value>
@@ -166,7 +187,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases/Mass</xpath>
 				<value>
-					<Mass>325</Mass>
+					<Mass>600</Mass>
 				</value>
 			</li>
 
@@ -184,7 +205,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>12.53</turretBurstCooldownTime>
+					<turretBurstCooldownTime>12.0</turretBurstCooldownTime>
 				</value>
 			</li>
 			
@@ -202,7 +223,7 @@
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-				  <warmupTime>4.3</warmupTime>
+				  <warmupTime>8.6</warmupTime>
 				  <range>86</range>
 				  <ticksBetweenBurstShots>60</ticksBetweenBurstShots>
 				  <burstShotCount>3</burstShotCount>
@@ -210,7 +231,7 @@
 				  <soundCastTail>GunTail_Light</soundCastTail>
 				  <muzzleFlashScale>14</muzzleFlashScale>
 				  <ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-				  <minRange>4.9</minRange>
+				  <minRange>9.9</minRange>
 				  <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 				  <recoilPattern>Mounted</recoilPattern>
 				</Properties>
@@ -229,10 +250,17 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases</xpath>
 				<value>
-					<AimingAccuracy>0.5</AimingAccuracy>
+					<AimingAccuracy>0.25</AimingAccuracy>
 				</value>
 			</li>
 			
@@ -327,7 +355,7 @@
 						<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_66mmThermalBolt_Incendiary</defaultProjectile>
-						<warmupTime>5.5</warmupTime>
+						<warmupTime>11</warmupTime>
 						<minRange>32</minRange>
 						<range>700</range>
 						<burstShotCount>1</burstShotCount>
@@ -352,10 +380,17 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases</xpath>
 				<value>
-					<AimingAccuracy>3</AimingAccuracy>
+					<AimingAccuracy>2</AimingAccuracy>
 				</value>
 			</li>
 			
@@ -380,7 +415,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>18.9</turretBurstCooldownTime>
+					<turretBurstCooldownTime>18.0</turretBurstCooldownTime>
 				</value>
 			</li>
 			

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -17,6 +17,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases</xpath>
 				<value>
@@ -50,7 +57,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+					<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 				</value>
 			</li>
 			
@@ -80,6 +87,7 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>1.33</SwayFactor>
 				  <Bulk>13.00</Bulk>
+				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>1.08</recoilAmount>
@@ -89,7 +97,7 @@
 				  <warmupTime>2.0</warmupTime>
 				  <range>75</range>
 				  <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-				  <burstShotCount>20</burstShotCount>
+				  <burstShotCount>10</burstShotCount>
 				  <soundCast>Shot_ChargeBlaster</soundCast>
 				  <soundCastTail>GunTail_Heavy</soundCastTail>
 				  <muzzleFlashScale>9</muzzleFlashScale>
@@ -112,6 +120,13 @@
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1.5</ShootingAccuracyTurret>
 				</value>
 			</li>
 
@@ -148,7 +163,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>0.5</turretBurstCooldownTime>
+					<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 				</value>
 			</li>
 			
@@ -163,6 +178,7 @@
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>0.44</SwayFactor>
 				  <Bulk>13.00</Bulk>
+				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
 				  <recoilAmount>0.75</recoilAmount>
@@ -196,6 +212,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases/ShootingAccuracyTurret</xpath>
+				<value>
+					<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
+				</value>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases</xpath>
 				<value>
@@ -206,7 +229,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
-					<turretBurstCooldownTime>3.5</turretBurstCooldownTime>
+					<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
 				</value>
 			</li>
 			
@@ -215,15 +238,6 @@
 				<value>
 					<Mass>325</Mass>
 					<Bulk>100</Bulk>
-				</value>
-			</li>
-			
-			<!--Heavy-->
-			
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/terrainAffordanceNeeded</xpath>
-				<value>
-					<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 				</value>
 			</li>
 
@@ -262,15 +276,16 @@
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 				<defName>VFE_Gun_AutoInfernoCannon</defName>
 				<statBases>
-				  <Mass>300.00</Mass>
+				  <Mass>200.00</Mass>
 				  <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
 				  <SightsEfficiency>1</SightsEfficiency>
 				  <ShotSpread>0.01</ShotSpread>
 				  <SwayFactor>0.82</SwayFactor>
 				  <Bulk>20.00</Bulk>
+				  <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 				</statBases>
 				<Properties>
-				  <recoilAmount>0.82</recoilAmount>
+				  <recoilAmount>1.01</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
 				  <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
@@ -305,9 +320,16 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases</xpath>
+				<value>
+					<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases</xpath>
 				<value>
-					<AimingAccuracy>0.5</AimingAccuracy>
+					<AimingAccuracy>0.25</AimingAccuracy>
 				</value>
 			</li>
 			

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -11,7 +11,7 @@
       <description>Charge blaster attached to a turret mount.</description>
       <soundInteract>Interact_ChargeRifle</soundInteract>
       <statBases>
-        <MarketValue>2000</MarketValue>
+        <Mass>10</Mass>
         <SightsEfficiency>1</SightsEfficiency>
         <ShotSpread>0.08</ShotSpread>
         <SwayFactor>0.72</SwayFactor>
@@ -42,7 +42,7 @@
           <ammoSet>AmmoSet_6x22mmCharged</ammoSet>
         </li>
         <li Class="CombatExtended.CompProperties_FireModes">
-          <aiAimMode>SuppressFire</aiAimMode>
+          <aiAimMode>AimedShot</aiAimMode>
         </li>            
       </comps>
     </ThingDef>
@@ -51,8 +51,8 @@
 
   <ThingDef ParentName="BaseAutoTurretGun">
     <defName>Gun_ChargeBlasterHeavyTurret</defName>
-    <label>auto charge blaster turret gun</label>
-    <description>Heavy charge blaster on a turret mount.</description>
+    <label>light charge blaster turret gun</label>
+    <description>Light charge blaster on a turret mount.</description>
     <graphicData>
       <texPath>Things/Item/Equipment/WeaponRanged/ChargeBlasterLight</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -63,7 +63,6 @@
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>1.33</SwayFactor>
-      <Bulk>13.00</Bulk>
       <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
@@ -72,11 +71,11 @@
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
-        <warmupTime>2.0</warmupTime>
+        <warmupTime>2.0</warmupTime>   <!-- Intentionally increased from 1.3s -->
         <range>75</range>
         <minRange>2.9</minRange>
-        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-        <burstShotCount>20</burstShotCount>
+        <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+        <burstShotCount>10</burstShotCount>
         <soundCast>Shot_ChargeBlaster</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>
@@ -85,11 +84,11 @@
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>200</magazineSize>
-        <reloadTime>10</reloadTime>
+        <reloadTime>9.2</reloadTime>
         <ammoSet>AmmoSet_12x64mmCharged</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
-        <aiAimMode>SuppressFire</aiAimMode>
+        <aiAimMode>AimedShot</aiAimMode>
       </li>   
     </comps>
 	<tools Inherit="false" />
@@ -106,21 +105,20 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>	
     <statBases>
-      <Mass>300.00</Mass>
-      <RangedWeapon_Cooldown>9.8</RangedWeapon_Cooldown>
+      <Mass>200.00</Mass>
+      <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.01</ShotSpread>
       <SwayFactor>0.82</SwayFactor>
-      <Bulk>20.00</Bulk>
       <NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
     </statBases>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <recoilAmount>0.82</recoilAmount>
+        <recoilAmount>1.01</recoilAmount>
         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
         <defaultProjectile>Bullet_80x256mmFuel_Incendiary</defaultProjectile>
-        <warmupTime>3.5</warmupTime>
+        <warmupTime>3.5</warmupTime>   <!-- Intentionally decreased from 4.3s -->
         <range>86</range>
         <burstShotCount>1</burstShotCount>
         <soundCast>InfernoCannon_Fire</soundCast>
@@ -137,7 +135,7 @@
       <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
     </li>
     <li Class="CombatExtended.CompProperties_FireModes">
-      <aiAimMode>SuppressFire</aiAimMode>
+      <aiAimMode>AimedShot</aiAimMode>
     </li>         
     </comps>	
 	<tools Inherit="false" />

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -69,21 +69,21 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.35</AimingAccuracy>
+			<AimingAccuracy>0.75</AimingAccuracy>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/statBases/Mass</xpath>
 		<value>
-			<Mass>45</Mass>
+			<Mass>35</Mass>
 		</value>
 	</Operation>
 
@@ -101,7 +101,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>2.6</turretBurstCooldownTime>
+			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>   <!-- Intentionally increased from 1.0s of CE auto turrets-->
 		</value>
 	</Operation>
 
@@ -124,21 +124,21 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.45</AimingAccuracy>
+			<AimingAccuracy>0.5</AimingAccuracy>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/statBases/Mass</xpath>
 		<value>
-			<Mass>85</Mass>
+			<Mass>100</Mass>
 		</value>
 	</Operation>
 
@@ -156,7 +156,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>3.2</turretBurstCooldownTime>
+			<turretBurstCooldownTime>2.0</turretBurstCooldownTime>   <!-- Intentionally increased from 1.0s of CE auto turrets-->
 		</value>
 	</Operation>
 
@@ -179,21 +179,21 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases</xpath>
 		<value>
-			<AimingAccuracy>0.25</AimingAccuracy>
+			<AimingAccuracy>0.5</AimingAccuracy>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>1.0</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/statBases/Mass</xpath>
 		<value>
-			<Mass>45</Mass>
+			<Mass>400</Mass>
 		</value>
 	</Operation>
 
@@ -211,7 +211,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/building/turretBurstCooldownTime</xpath>
 		<value>
-			<turretBurstCooldownTime>3.2</turretBurstCooldownTime>
+			<turretBurstCooldownTime>2.5</turretBurstCooldownTime>   <!-- Intentionally increased from 1.0s of CE auto turrets-->
 		</value>
 	</Operation>
 
@@ -240,10 +240,17 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Turret_AutoMortar"]/statBases</xpath>
+		<value>
+			<AimingAccuracy>0.25</AimingAccuracy>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_AutoMortar"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
-			<ShootingAccuracyTurret>0.25</ShootingAccuracyTurret>
+			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Updated vanilla turret cooldown times based on the CE's 1 second time for autoturrets.
- Adjusted manned turret cooldown times to be the same as the gun that is mounted on them.
- Ran a consistency check on mechanoid turrets.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- https://discord.com/channels/278818534069501953/322827713335394304/1044536333470814278
- https://discord.com/channels/278818534069501953/322827713335394304/1044699966532227082

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
