### PR TITLE
Make PA helmets immune to Tox Gas

### DIFF
--- a/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
+++ b/Patches/Ancient Fallout Armory/Headgears_Fallout.xml
@@ -53,6 +53,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Fallarmory_FlightHelmet" or defName="Fallarmory_USFlightHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -127,6 +137,16 @@
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="FallArmory_SecretServiceHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationAdd">

--- a/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
+++ b/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
@@ -215,6 +215,16 @@
           </value>
         </li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationAdd">
           <xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]</xpath>
           <value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
@@ -114,6 +114,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]</xpath>
 					<value>

--- a/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
+++ b/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
@@ -326,7 +326,17 @@
 					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_A"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_A"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_A"]/equippedStatOffsets</xpath>
 				<value>
@@ -414,7 +424,17 @@
 					<ArmorRating_Blunt>62.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_C"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_C"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_C"]/equippedStatOffsets</xpath>
 				<value>
@@ -502,7 +522,17 @@
 					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_D"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_D"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="AT_AP_Power_Head_D"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
+++ b/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
@@ -55,6 +55,15 @@
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName = "Apparel_Psymask"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
+++ b/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
@@ -151,6 +151,15 @@
 					<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName = "Apparello_Gassy" or defName = "Apparello_Sandtrader"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName = "Apparello_Gassy" or defName = "Apparello_Sandtrader"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName = "Apparello_Gassy" or defName="Apparello_Sandtrader"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Arachne/ApparelNew_Arachne.xml
+++ b/Patches/Arachne/ApparelNew_Arachne.xml
@@ -354,6 +354,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="Arachne_Scout_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachne_Scout_Helmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Arachne_Scout_Helmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Arachne/Apparel_Arachne.xml
+++ b/Patches/Arachne/Apparel_Arachne.xml
@@ -324,6 +324,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>/Defs/ThingDef[defName="Arachne_Power_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>/Defs/ThingDef[defName="Arachne_Power_Helmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Arachne_Power_Helmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Arasaka Corporation [1.3]/Cyberweeb_Hats.xml
+++ b/Patches/Arasaka Corporation [1.3]/Cyberweeb_Hats.xml
@@ -28,8 +28,18 @@
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
-          					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+          				<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Apparel_Hazmat_Mask_AC"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Apparel_Hazmat_Mask_AC"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationAdd">

--- a/Patches/Archotech PowerArmor/Apparel_JDS.xml
+++ b/Patches/Archotech PowerArmor/Apparel_JDS.xml
@@ -67,6 +67,16 @@
                     </value>
                 </li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[@Name="APA_HelmetBase"]/equippedStatOffsets</xpath>
                     <value>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Apparel_Armor_Headgear.xml
@@ -46,6 +46,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RHApparel_DOOM2016_PraetorSuitHelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Apparel_Armor_Headgear.xml
@@ -45,6 +45,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_PraetorSuitHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -98,6 +108,16 @@
 				<value>
 					<ArmorRating_Electric>0.75</ArmorRating_Electric>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_DOOMClassic_OriginalSecurityHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationAdd">

--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -218,6 +218,13 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/apparel</xpath>
+    <value>
+      <immuneToToxGasExposure>true</immuneToToxGasExposure>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/apparel/layers</xpath>
     <value>
       <li>OnHead</li>
@@ -329,6 +336,13 @@
     <value>
       <Plasteel>50</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/apparel</xpath>
+    <value>
+      <immuneToToxGasExposure>true</immuneToToxGasExposure>
     </value>
   </Operation>
 

--- a/Patches/Doom Factions/DoomFactions_Apperal.xml
+++ b/Patches/Doom Factions/DoomFactions_Apperal.xml
@@ -98,7 +98,17 @@
 				<ArmorRating_Blunt>60</ArmorRating_Blunt>
 			</value>
         </li>
-		
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="Apparel_UACWildcatHelm" or defName="Apparel_UACSheperdHelm" or defName="Apparel_UACRavenHelm" or defName="Apparel_UACLEETHelm" or defName="Apparel_UACASPHelm"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_UACWildcatHelm" or defName="Apparel_UACSheperdHelm" or defName="Apparel_UACRavenHelm" or defName="Apparel_UACLEETHelm" or defName="Apparel_UACASPHelm"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/ThingDef[defName="Apparel_UACWildcatHelm" or defName="Apparel_UACSheperdHelm" or defName="Apparel_UACRavenHelm" or defName="Apparel_UACLEETHelm" or defName="Apparel_UACASPHelm"]/equippedStatOffsets</xpath>
 			<value>
@@ -224,7 +234,17 @@
 				<ArmorRating_Blunt>60</ArmorRating_Blunt>
 			</value>
         </li>
-		
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="Apparel_DOOMPraetorHelm" or defName="Apparel_DOOMGuyHelm"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_DOOMPraetorHelm" or defName="Apparel_DOOMGuyHelm"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="Apparel_DOOMPraetorHelm" or defName="Apparel_DOOMGuyHelm"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Dubs Rimatomics/Apparel_Atomic.xml
+++ b/Patches/Dubs Rimatomics/Apparel_Atomic.xml
@@ -48,6 +48,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]/apparel/layers</xpath>
 				<value>

--- a/Patches/Eisenhans Power Armor/ThingDefs_Various.xml
+++ b/Patches/Eisenhans Power Armor/ThingDefs_Various.xml
@@ -45,6 +45,16 @@
           </value>
         </li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="Apparel_Eisenhans_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_Eisenhans_Helmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="Apparel_Eisenhans_Helmet"]/equippedStatOffsets</xpath>
           <value>

--- a/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
+++ b/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
@@ -342,7 +342,17 @@
 					<ArmorRating_Blunt>36</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_EponaSpaceSuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_EponaSpaceSuitHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_EponaSpaceSuitHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>

--- a/Patches/FROG Suit Set/Armor_Spacer.xml
+++ b/Patches/FROG Suit Set/Armor_Spacer.xml
@@ -32,6 +32,16 @@
 			</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="FROG_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="FROG_Helmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[defName="FROG_Helmet"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Fallout New Vegas - Elite Riot Gear/Apparel_RiotGear.xml
+++ b/Patches/Fallout New Vegas - Elite Riot Gear/Apparel_RiotGear.xml
@@ -61,6 +61,16 @@
 
 		<!-- Riot Helmet -->
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName= "2SP_StuffableEliteRiotHelmet" or defName= "2SP_EliteRiotHelmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName= "2SP_StuffableEliteRiotHelmet" or defName= "2SP_EliteRiotHelmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName= "2SP_StuffableEliteRiotHelmet" or defName= "2SP_EliteRiotHelmet"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_ApparelDefs.xml
@@ -75,19 +75,29 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="FF_ForsakenH"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="FF_ForsakenH"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
    				 <xpath>Defs/ThingDef[defName="FF_ForsakenH"]/equippedStatOffsets</xpath>
     				<value>
-      				<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
-      				<SmokeSensitivity>-1</SmokeSensitivity>
+						<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
+						<SmokeSensitivity>-1</SmokeSensitivity>
     				</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
     				<xpath>Defs/ThingDef[defName="FF_ForsakenH"]/statBases</xpath>
-    					<value>
+    				<value>
       					<Flammability>0</Flammability>
-    					</value>
+    				</value>
 				</li>
   
 

--- a/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
+++ b/Patches/Fort's Firefighter Gadget/Apparel_Industrial.xml
@@ -46,6 +46,24 @@
 				</value>
 			</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[
+					defName="Apparel_FirefighterHelmetA" or
+					defName="Apparel_FirefighterHelmetB" or
+					defName="Apparel_FirefighterHelmetC" or
+					defName="Apparel_FirefighterHelmetG"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+						defName="Apparel_FirefighterHelmetA" or
+						defName="Apparel_FirefighterHelmetB" or
+						defName="Apparel_FirefighterHelmetC" or
+						defName="Apparel_FirefighterHelmetG"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[
 				defName="Apparel_FirefighterHelmetA" or

--- a/Patches/Half Dragons/Apparel_Various.xml
+++ b/Patches/Half Dragons/Apparel_Various.xml
@@ -87,7 +87,17 @@
 			  <ArmorRating_Blunt>36</ArmorRating_Blunt>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[@Name="ApparelDragonArmorHelmetPowerBase"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="ApparelDragonArmorHelmetPowerBase"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/ThingDef[@Name="ApparelDragonArmorHelmetPowerBase"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
@@ -437,7 +437,17 @@
 					<WornBulk>3</WornBulk>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="ExiledDawn_Knight_Headgear"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="ExiledDawn_Knight_Headgear"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ExiledDawn_Knight_Headgear"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/JDS The Forge - NCR Armory/Defs_Headgear.xml
+++ b/Patches/JDS The Forge - NCR Armory/Defs_Headgear.xml
@@ -113,6 +113,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="JDS_NCR_Ranger_Combat_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="JDS_NCR_Ranger_Combat_Helmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="JDS_NCR_Ranger_Combat_Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
@@ -153,6 +163,16 @@
 					<value>
 						<ArmorRating_Blunt>34</ArmorRating_Blunt>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="JDS_NCR_SalvagedPowerArmor_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="JDS_NCR_SalvagedPowerArmor_Helmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationReplace">

--- a/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Apparel.xml
+++ b/Patches/Kijin 2.0/ThingDef_Misc/Kijin_Apparel.xml
@@ -218,7 +218,17 @@
 				  <DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmetDK"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmetDK"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmetDK"]</xpath>
 				<value>

--- a/Patches/LF Command And Conquer NOD Combat Armor/CE_Nod.xml
+++ b/Patches/LF Command And Conquer NOD Combat Armor/CE_Nod.xml
@@ -46,6 +46,16 @@
           </value>
         </li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="NOD_Militant_Helmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="NOD_Militant_Helmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="NOD_Militant_Helmet"]/equippedStatOffsets</xpath>
           <value>

--- a/Patches/Mechanoid Bench 2 JGH/Apparel_MB2.xml
+++ b/Patches/Mechanoid Bench 2 JGH/Apparel_MB2.xml
@@ -97,6 +97,16 @@
                     </value>
                 </li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Apparel_MechaHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Apparel_MechaHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
                 <li Class="PatchOperationAdd">
                     <xpath>/Defs/ThingDef[defName="Apparel_MechaHelmet"]</xpath>
                     <value>

--- a/Patches/Mechanoid Bench 3 JGH/Apparel_MB3.xml
+++ b/Patches/Mechanoid Bench 3 JGH/Apparel_MB3.xml
@@ -56,6 +56,16 @@
                     </value>
                 </li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Apparel_MechaHeavyHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Apparel_MechaHeavyHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Apparel_MechaHeavyHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
                     <value>
@@ -142,6 +152,16 @@
                     </value>
                 </li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Apparel_MechaCombatHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Apparel_MechaCombatHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Apparel_MechaCombatHelmet"]/equippedStatOffsets/MeleeDodgeChance</xpath>
                     <value>
@@ -225,6 +245,16 @@
                         <Mass>2</Mass>
                     </value>
                 </li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="Apparel_MechaSniperHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="Apparel_MechaSniperHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
 
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Apparel_MechaSniperHelmet"]/equippedStatOffsets/AimingDelayFactor</xpath>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel.xml
@@ -452,6 +452,16 @@
 				</value>
 			</li>			
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Marine"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Miho_Apparel_Hat_Marine"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Miho_Apparel_Hat_Marine"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Apparel.xml
@@ -346,7 +346,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Moyo_CShelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo Cartel/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -112,7 +112,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Moyo_CEhelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -445,7 +445,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
@@ -628,7 +638,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]</xpath>
 				<value>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -278,7 +278,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -456,7 +466,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Moyo light in the abyss/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo light in the abyss/ThingDefs_Misc/Moyo_Apparel.xml
@@ -402,7 +402,7 @@
 					<li>StrappedHead</li>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RedMoyo_GasMask"]/equippedStatOffsets</xpath>
 				<value>
@@ -601,7 +601,17 @@
 					<Flammability>0</Flammability>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="RedMoyo_AbyssHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RedMoyo_AbyssHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="RedMoyo_AbyssHelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Nanosuit/Armor_Crysis.xml
+++ b/Patches/Nanosuit/Armor_Crysis.xml
@@ -38,6 +38,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="NS_Apparel_NanosuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="NS_Apparel_NanosuitHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="NS_Apparel_NanosuitHelmet"]</xpath>
 				<value>

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -241,7 +241,17 @@
 					<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 				defName="HAR_NC_Heads_b"

--- a/Patches/O21 Outer Rim Galaxies/Clone Wars/Patch_OuterRim_CloneWars_Apparel.xml
+++ b/Patches/O21 Outer Rim Galaxies/Clone Wars/Patch_OuterRim_CloneWars_Apparel.xml
@@ -205,7 +205,17 @@
 					<ArmorRating_Heat>0.34</ArmorRating_Heat>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[@Name="CloneArmorPhaseOneHelmetBase"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="CloneArmorPhaseOneHelmetBase"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[@Name="CloneArmorPhaseOneHelmetBase"]</xpath>
 				<value>
@@ -260,7 +270,17 @@
 					<ArmorRating_Heat>0.34</ArmorRating_Heat>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[@Name="CloneHelmetIIBase"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="CloneHelmetIIBase"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[@Name="CloneHelmetIIBase"]</xpath>
 				<value>

--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -45,6 +45,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/equippedStatOffsets</xpath>
 					<value>

--- a/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -105,6 +105,15 @@
 						<Mass>5.2</Mass>
 					</value>
 				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
 				<!-- equippedStatOffsets -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/equippedStatOffsets</xpath>
@@ -229,6 +238,15 @@
 						<Mass>4.8</Mass>
 					</value>
 				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
 				<!-- equippedStatOffsets -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/equippedStatOffsets</xpath>
@@ -349,6 +367,15 @@
 					<value>
 						<Mass>1</Mass>
 					</value>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 				<!-- equippedStatOffsets -->
 				<li Class="PatchOperationAdd">

--- a/Patches/RH2 Faction - VOID/ThingDefs_Apparel/Apparel_Various.xml
+++ b/Patches/RH2 Faction - VOID/ThingDefs_Apparel/Apparel_Various.xml
@@ -344,6 +344,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[@Name="RH_ReactiveHelmet_VOIDBase"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[@Name="RH_ReactiveHelmet_VOIDBase"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[@Name="RH_ReactiveHelmet_VOIDBase"]/equippedStatOffsets</xpath>
 					<value>
@@ -434,6 +444,16 @@
 						<WornBulk>1</WornBulk>
 						<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[@Name="RH_ReactiveHelmet_DuskBase"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[@Name="RH_ReactiveHelmet_DuskBase"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationAdd">

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
@@ -417,7 +417,17 @@
 			</li>
 			
 			<!--Replace handling bonus with power armor helmet functions-->
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
@@ -28,7 +28,17 @@
 					<ArmorRating_Blunt>42.75</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Rim-Effect Core/Armor_ME.xml
+++ b/Patches/Rim-Effect Core/Armor_ME.xml
@@ -82,14 +82,24 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="RE_Apparel_LightAllianceHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="RE_Apparel_LightAllianceHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_LightAllianceHelmet"]</xpath>
 					<value>
-    						<equippedStatOffsets>
-						<AimingDelayFactor>-0.05</AimingDelayFactor>
-						<ToxicEnvironmentResistance>0.10</ToxicEnvironmentResistance>
-						<SmokeSensitivity>-1</SmokeSensitivity>
-    						</equippedStatOffsets>
+    					<equippedStatOffsets>
+							<AimingDelayFactor>-0.05</AimingDelayFactor>
+							<ToxicEnvironmentResistance>0.10</ToxicEnvironmentResistance>
+							<SmokeSensitivity>-1</SmokeSensitivity>
+    					</equippedStatOffsets>
 					</value>
 				</li>
 
@@ -316,6 +326,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_AllianceHelmet"]</xpath>
 					<value>
@@ -524,6 +544,16 @@
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="RE_Apparel_HeavyAllianceHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="RE_Apparel_HeavyAllianceHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationAdd">

--- a/Patches/Rim-Effect N7/Armor_N7.xml
+++ b/Patches/Rim-Effect N7/Armor_N7.xml
@@ -54,6 +54,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_N7AdeptMask"]/equippedStatOffsets</xpath>
 					<value>
@@ -285,6 +295,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
 					<value>
@@ -493,6 +513,16 @@
 					<value>
 						<MaxHitPoints>250</MaxHitPoints>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7HeavyHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="REN7_Apparel_N7HeavyHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationAdd">

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -404,6 +404,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_PioneerH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_PioneerH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
 				<value>
@@ -599,6 +609,16 @@
 				<value>
 					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_NomadH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_NomadH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationReplace">
@@ -996,6 +1016,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_DropsuitH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_DropsuitH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/equippedStatOffsets</xpath>
 				<value>
@@ -1173,7 +1203,17 @@
 					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_StrikesuitH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_StrikesuitH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/equippedStatOffsets</xpath>
 				<value>
@@ -1350,7 +1390,17 @@
 					<ArmorRating_Blunt>62.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
 				<value>
@@ -1497,6 +1547,16 @@
 				<value>
 					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_FSArmorH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_FSArmorH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationAdd">
@@ -1834,6 +1894,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_ReflactorArmorH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]</xpath>
 				<value>
@@ -1986,6 +2056,16 @@
 				<value>
 					<ArmorRating_Heat>1.5</ArmorRating_Heat>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_HazardCarapaceH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationAdd">
@@ -2148,6 +2228,16 @@
 				<value>
 					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
+			</li>
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_CloseCombatHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_CloseCombatHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 
 			<li Class="PatchOperationAdd">

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Apparel_RS_CE.xml
@@ -373,6 +373,15 @@
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/equippedStatOffsets/MoveSpeed</xpath>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_ProtectiveHelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -162,7 +162,17 @@
 					<ArmorRating_Blunt>28</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -65,6 +65,16 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -101,7 +111,17 @@
 					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -54,6 +54,15 @@
 				<ArmorRating_Blunt>20</ArmorRating_Blunt>
 			</value>
 	   </li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmet"]/equippedStatOffsets</xpath>
 		<value>
@@ -83,6 +92,15 @@
 				<ArmorRating_Blunt>36</ArmorRating_Blunt>
 			</value>
 	   </li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 	   <li Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/equippedStatOffsets</xpath>
 		<value>

--- a/Patches/Spartan Foundry/Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/Apparel_Headgear.xml
@@ -17,6 +17,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -70,6 +79,15 @@
 					<WornBulk>0.9</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
+			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/equippedStatOffsets</xpath>
@@ -127,6 +145,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -182,6 +209,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -234,6 +270,15 @@
 					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
+			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/equippedStatOffsets</xpath>
@@ -289,6 +334,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -342,6 +396,15 @@
 					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
+			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/equippedStatOffsets</xpath>
@@ -399,6 +462,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -455,6 +527,15 @@
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/equippedStatOffsets</xpath>
 				<value>
@@ -508,6 +589,15 @@
 					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
+			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/equippedStatOffsets</xpath>
@@ -564,6 +654,15 @@
 					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
+			</li>
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/equippedStatOffsets</xpath>

--- a/Patches/Star Wars - Factions/Patch_Apparel.xml
+++ b/Patches/Star Wars - Factions/Patch_Apparel.xml
@@ -334,6 +334,16 @@
 			</value>
 		  </li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="PJ_STHelm" or defName="PJ_SHHelm"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="PJ_STHelm" or defName="PJ_SHHelm"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 		  <li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[
 			defName="PJ_STHelm" or

--- a/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
+++ b/Patches/T's Samurai Faction/T_Samurai_Apparel.xml
@@ -333,6 +333,16 @@
                </value>
             </li>
 
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="TSFApparel_OniHelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="TSFApparel_OniHelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
             <li Class="PatchOperationAdd">
                <xpath>Defs/ThingDef[defName="TSFApparel_OniHelmet"]/equippedStatOffsets</xpath>
                <value>

--- a/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
+++ b/Patches/The GiantRace/ThingDefs_Misc/GiantApparel.xml
@@ -260,7 +260,17 @@
 					<ArmorRating_Blunt>72</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="GI_Powerhelmet"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="GI_Powerhelmet"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="GI_Powerhelmet"]/equippedStatOffsets</xpath>
 				<value>

--- a/Patches/Ultratech - Altered Carbon Remastered/ThingDefs_Apparel.xml
+++ b/Patches/Ultratech - Altered Carbon Remastered/ThingDefs_Apparel.xml
@@ -53,6 +53,16 @@
           </value>
         </li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[@Name="UT_ApparelArmorHelmetProtectorateBase"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[@Name="UT_ApparelArmorHelmetProtectorateBase"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
         <li Class="PatchOperationAdd">
           <xpath>/Defs/ThingDef[@Name="UT_ApparelArmorHelmetProtectorateBase"]</xpath>
           <value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -249,6 +249,16 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationConditional">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
+				</li>
+
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
 					<value>
@@ -260,6 +270,16 @@
 							<MeleeDodgeChance>-0.15</MeleeDodgeChance>
 						</equippedStatOffsets>
 					</value>
+				</li>
+
+				<li Class="PatchOperationConditional" MayRequire="ludeon.rimworld.royalty">
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/apparel/immuneToToxGasExposure</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/apparel</xpath>
+						<value>
+							<immuneToToxGasExposure>true</immuneToToxGasExposure>
+						</value>
+					</nomatch>
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets.xml
@@ -148,7 +148,17 @@
 				<WornBulk>5</WornBulk>
 			</value>
 		</li>
-	
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Warcasket"]/equippedStatOffsets</xpath>
 			<value>
@@ -275,7 +285,17 @@
 			  <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Marine"]/equippedStatOffsets</xpath>
 			<value>
@@ -400,7 +420,17 @@
 				<NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Recon"]/equippedStatOffsets</xpath>
 			<value>
@@ -524,7 +554,17 @@
 				<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Cataphract"]/equippedStatOffsets</xpath>
 			<value>
@@ -648,7 +688,17 @@
 				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Aerial"]/equippedStatOffsets</xpath>
 			<value>
@@ -822,6 +872,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barrage"]/equippedStatOffsets</xpath>
 			<value>
@@ -948,6 +1008,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Hazard"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Hazard"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Hazard"]/equippedStatOffsets</xpath>
 			<value>
@@ -1072,7 +1142,17 @@
 				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Shock"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Apparel_Warcaskets_Spacer.xml
@@ -113,6 +113,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Siegebreaker"]/equippedStatOffsets</xpath>
 			<value>
@@ -252,6 +262,16 @@
 				<WornBulk>10</WornBulk>
 				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
 			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Guardian"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
 		</li>
 
 		<li Class="PatchOperationAdd">
@@ -402,6 +422,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Controller"]/equippedStatOffsets</xpath>
 			<value>
@@ -541,6 +571,16 @@
 				<WornBulk>10</WornBulk>
 				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
 			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Sarcophagus"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
 		</li>
 
 		<li Class="PatchOperationAdd">
@@ -689,6 +729,16 @@
 				<WornBulk>10</WornBulk>
 				<NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
 			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Brute"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
 		</li>
 
 		<li Class="PatchOperationAdd">

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Headgear.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Headgear.xml
@@ -175,6 +175,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="VFEV_Apparel_CryptoLightHelmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEV_Apparel_CryptoLightHelmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="VFEV_Apparel_CryptoLightHelmet"]</xpath>
 			<value>
@@ -269,6 +279,16 @@
 			<value>
 			<ArmorRating_Blunt>36</ArmorRating_Blunt>
 			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/ThingDef[defName="VFEV_Apparel_CryptoHeavyHelmet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VFEV_Apparel_CryptoHeavyHelmet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
 		</li>
 
 		<li Class="PatchOperationAdd">

--- a/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
@@ -81,7 +81,17 @@
 				<WornBulk>6.25</WornBulk>
 			</value>
 		</li>
-	
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Sentinel"]/equippedStatOffsets</xpath>
 			<value>
@@ -170,7 +180,17 @@
 				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-	
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Guardian"]/equippedStatOffsets</xpath>
 			<value>
@@ -274,7 +294,17 @@
 				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-	
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Tyrant"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/WarCasket Gundam Addon/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Gundam Addon/Apparel_Warcaskets.xml
@@ -103,7 +103,17 @@
 				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_Barbatos"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Warcaskets - Adeptus Astartes/Apparel_Warcaskets_Astartes.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Apparel_Warcaskets_Astartes.xml
@@ -133,7 +133,17 @@
 			  <NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarine"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarine"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarine"]/equippedStatOffsets</xpath>
 			<value>
@@ -538,7 +548,17 @@
 			  <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarOne"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarOne"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarOne"]/equippedStatOffsets</xpath>
 			<value>
@@ -569,7 +589,17 @@
 			  <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarTwo" or defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarThree"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarTwo" or defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarThree"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarTwo" or defName="VFEP_WarcasketHelmet_SpaceMarinePrimaris_VarThree"]/equippedStatOffsets</xpath>
 			<value>
@@ -600,7 +630,17 @@
 			  <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineWings"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineWings"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineWings"]/equippedStatOffsets</xpath>
 			<value>
@@ -631,7 +671,17 @@
 			  <NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisSgt"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisSgt"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisSgt"]/equippedStatOffsets</xpath>
 			<value>
@@ -662,7 +712,17 @@
 			  <NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisCpt"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisCpt"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarinePrimarisCpt"]/equippedStatOffsets</xpath>
 			<value>
@@ -693,7 +753,17 @@
 			  <NightVisionEfficiency_Apparel>0.65</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnight"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnight"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnight"]/equippedStatOffsets</xpath>
 			<value>
@@ -724,7 +794,17 @@
 			  <NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnightVet"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnightVet"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineKnightVet"]/equippedStatOffsets</xpath>
 			<value>
@@ -755,7 +835,17 @@
 			  <NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineMkVI"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineMkVI"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineMkVI"]/equippedStatOffsets</xpath>
 			<value>
@@ -786,7 +876,17 @@
 			  <NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
 			</value>
 		</li>
-  
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineTerminator"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineTerminator"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketHelmet_SpaceMarineTerminator"]/equippedStatOffsets</xpath>
 			<value>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -240,7 +240,17 @@
 					<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationConditional">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/apparel/immuneToToxGasExposure</xpath>
+				<nomatch Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/apparel</xpath>
+					<value>
+						<immuneToToxGasExposure>true</immuneToToxGasExposure>
+					</value>
+				</nomatch>
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[
 				defName="HAR_XO_AH_f"

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -176,6 +176,13 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/apparel</xpath>
+    <value>
+      <immuneToToxGasExposure>true</immuneToToxGasExposure>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/apparel/layers</xpath>
     <value>
       <li>OnHead</li>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- Sealed helmets to provide black smoke immunity should provide immunity to Tox gas penalties upon being inhaled.
- Patches are conditional just in case a mod decides to add the specific node the their helmets resulting in the patches failing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
