### PR TITLE
Update the Antigrain shells' reward tag

### DIFF
--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -201,7 +201,7 @@
       <Bulk>6</Bulk>
     </statBases>
     <thingSetMakerTags>
-      <li>RewardStandardHighFreq</li>
+      <li>RewardStandardCore</li>
     </thingSetMakerTags>
     <tradeTags>
       <li>CE_AutoEnableTrade_Sellable</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, Antigrain shells' `thingSetMakerTags` has been changed to `RewardStandardCore` in vanilla hence the need for an update.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors