### PR TITLE
Replace `/Defs` with `Defs` in basegame and DLC patches

### DIFF
--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,56 +136,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -194,17 +194,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -245,7 +245,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -261,7 +261,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,19 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -146,56 +136,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -204,17 +194,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -255,7 +245,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -271,7 +261,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,56 +136,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -194,17 +194,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -245,7 +245,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -261,7 +261,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Heavy.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +88,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "PowerClaw"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -146,56 +146,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -204,17 +204,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -255,7 +255,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -271,7 +271,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Tunneler"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Tunneler"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +88,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,17 +136,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -187,7 +187,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -203,7 +203,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,19 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,58 +78,143 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="Reactor"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+  </Operation>
+
+  <!-- ========== Add new body parts ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.12</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.02</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.02</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCoolantTank</def>
+        <coverage>0.06</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalRollerBearing</def>
+        <coverage>0.04</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalUpperActuator</def>
+        <coverage>0.15</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalUpperPiston</def>
+        <coverage>0.25</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalLowerActuator</def>
+        <coverage>0.15</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalLowerPiston</def>
+        <coverage>0.25</coverage>
+        <depth>Inside</depth>
+      </li>
     </value>
   </Operation>
 

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Light.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Light"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Light"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts/li[def = "SmallMechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts/li[def="SmallMechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,17 +136,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -187,7 +187,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Agrihand"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Agrihand"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -203,7 +203,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Light" or defName = "Mech_Agrihand"]/corePart/parts/li[def = "SmallMechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Light" or defName="Mech_Agrihand"]/corePart/parts/li[def="SmallMechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,35 +88,35 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -125,17 +125,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -161,7 +161,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName = "Scorcher"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName = "Apocriton"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,35 +88,35 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -125,17 +125,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -161,7 +161,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,39 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName="Scorcher"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName="Apocriton"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,37 +88,91 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="Reactor"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+  </Operation>
+
+  <!-- ========== Add new body parts ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.10</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.02</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCoolantTank</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalLowerActuator</def>
+        <coverage>0.15</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalLowerPiston</def>
+        <coverage>0.25</coverage>
+        <depth>Inside</depth>
+      </li>
     </value>
   </Operation>
 

--- a/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
+++ b/Biotech/Patches/Bodies/Bodies_Mechanoid_Medium.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,35 +58,35 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scorcher" or defName = "Apocriton"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scorcher" or defName="Apocriton"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Biotech/Patches/Bodies/Mech_Centurion.xml
+++ b/Biotech/Patches/Bodies/Mech_Centurion.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,42 +68,42 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -112,17 +112,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -148,7 +148,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Mech_Centurion.xml
+++ b/Biotech/Patches/Bodies/Mech_Centurion.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,42 +58,42 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Biotech/Patches/Bodies/Mech_Centurion.xml
+++ b/Biotech/Patches/Bodies/Mech_Centurion.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,19 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,44 +68,98 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="Reactor"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+  </Operation>
+
+  <!-- ========== Add new body parts ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.10</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.02</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCoolantTank</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalLowerActuator</def>
+        <coverage>0.15</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalLowerPiston</def>
+        <coverage>0.25</coverage>
+        <depth>Inside</depth>
+      </li>
     </value>
   </Operation>
 

--- a/Biotech/Patches/Bodies/Mech_Centurion.xml
+++ b/Biotech/Patches/Bodies/Mech_Centurion.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,42 +68,42 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -112,17 +112,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -148,7 +148,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Centurion"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Centurion"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Biotech/Patches/Bodies/Mech_Diabolus.xml
+++ b/Biotech/Patches/Bodies/Mech_Diabolus.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +88,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Biotech/Patches/Bodies/Mech_Diabolus.xml
+++ b/Biotech/Patches/Bodies/Mech_Diabolus.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,17 +136,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -162,7 +162,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalCoolantTank</def>

--- a/Biotech/Patches/Bodies/Mech_Diabolus.xml
+++ b/Biotech/Patches/Bodies/Mech_Diabolus.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,19 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,58 +78,97 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+  </Operation>
+
+  <!-- ========== Add new body parts ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalWeaponActuator</def>
+        <coverage>0.03</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.07</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalCoolantTank</def>
+        <coverage>0.09</coverage>
+        <depth>Inside</depth>
+      </li>
     </value>
   </Operation>
 

--- a/Biotech/Patches/Bodies/Mech_Diabolus.xml
+++ b/Biotech/Patches/Bodies/Mech_Diabolus.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,56 +78,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts/li[def="MechanicalDiabolusBodyFourthRing"]/parts/li[def="MechanicalDiabolusBodyFifthRing"]/parts/li[def="MechanicalDiabolusBodySixthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts/li[def = "MechanicalDiabolusBodyFourthRing"]/parts/li[def = "MechanicalDiabolusBodyFifthRing"]/parts/li[def = "MechanicalDiabolusBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -136,17 +136,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def = "MechanicalDiabolusBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -162,7 +162,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def="MechanicalDiabolusBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Diabolus"]/corePart/parts/li[def="MechanicalDiabolusBodySecondRing"]/parts/li[def = "MechanicalDiabolusBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalCoolantTank</def>

--- a/Biotech/Patches/Bodies/Mech_Warqueen.xml
+++ b/Biotech/Patches/Bodies/Mech_Warqueen.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,19 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,51 +68,122 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+  </Operation>
+
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+  </Operation>
+
+  <!-- ========== Add new body parts ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.0875</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.1</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCapacitor</def>
+        <coverage>0.07</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalPowerCore</def>
+        <coverage>0.125</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalCoolantTank</def>
+        <coverage>0.09</coverage>
+        <depth>Inside</depth>
+      </li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts</xpath>
+    <value>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.068</coverage>
+        <depth>Inside</depth>
+      </li>
+      <li>
+        <def>MechanicalHeatSink</def>
+        <coverage>0.068</coverage>
+        <depth>Inside</depth>
+      </li>
     </value>
   </Operation>
 

--- a/Biotech/Patches/Bodies/Mech_Warqueen.xml
+++ b/Biotech/Patches/Bodies/Mech_Warqueen.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,49 +68,49 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -119,17 +119,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -140,7 +140,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -156,7 +156,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -172,7 +172,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalHeatSink</def>

--- a/Biotech/Patches/Bodies/Mech_Warqueen.xml
+++ b/Biotech/Patches/Bodies/Mech_Warqueen.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,49 +78,49 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Biotech/Patches/Bodies/Mech_Warqueen.xml
+++ b/Biotech/Patches/Bodies/Mech_Warqueen.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,49 +68,49 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts/li[def="MechanicalWarqueenBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts/li[def = "MechanicalWarqueenBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="BulbTurret"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "BulbTurret"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -119,17 +119,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -140,7 +140,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def = "MechanicalWarqueenBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -156,7 +156,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -172,7 +172,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def="MechanicalWarqueenBodyThirdRing"]/parts/li[def="MechanicalWarqueenBodyFourthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Mech_Warqueen"]/corePart/parts/li[def="MechanicalWarqueenBodySecondRing"]/parts/li[def = "MechanicalWarqueenBodyThirdRing"]/parts/li[def = "MechanicalWarqueenBodyFourthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalHeatSink</def>

--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
@@ -4,7 +4,7 @@
   <!-- ========== Archer Fire ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName = "Tribal_Archer_Fire"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Tribal_Archer_Fire"]</xpath>
 		<value>
 			<modExtensions Inherit="false">
 				<li Class="CombatExtended.LoadoutPropertiesExtension" >
@@ -30,7 +30,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName = "Tribal_Archer_Fire"]/weaponTags</xpath>
+		<xpath>Defs/PawnKindDef[defName="Tribal_Archer_Fire"]/weaponTags</xpath>
 		<value>
 			<li>NeolithicRangedBasic</li>
 			<li>NeolithicRangedDecent</li>
@@ -40,7 +40,7 @@
   <!-- ========== Hunter Fire ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName = "Tribal_Hunter_Fire"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="Tribal_Hunter_Fire"]</xpath>
 		<value>
 			<modExtensions Inherit="false">
 				<li Class="CombatExtended.LoadoutPropertiesExtension" >
@@ -66,7 +66,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/PawnKindDef[defName = "Tribal_Hunter_Fire"]/weaponTags</xpath>
+		<xpath>Defs/PawnKindDef[defName="Tribal_Hunter_Fire"]/weaponTags</xpath>
 		<value>
 			<li>NeolithicRangedDecent</li>
 			<li>NeolithicRangedHeavy</li>			

--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechPacks.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechPacks.xml
@@ -3,7 +3,7 @@
 
 	<!-- ========== Packs  ========== -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[
+		<xpath>Defs/ThingDef[
 		defName="Apparel_PackControl" or
 		defName="Apparel_PackBandwidth" or
 		defName="Apparel_PackTox"
@@ -14,7 +14,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[
+		<xpath>Defs/ThingDef[
 		defName="Apparel_PackControl" or
 		defName="Apparel_PackBandwidth" or
 		defName="Apparel_PackTox"
@@ -26,7 +26,7 @@
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>
-		/Defs/ThingDef[
+		Defs/ThingDef[
 			defName="Apparel_PackControl" or
 			defName="Apparel_PackBandwidth" or
 			defName="Apparel_PackTox"

--- a/Biotech/Patches/Weapons/RangedIndustrial_Biotech.xml
+++ b/Biotech/Patches/Weapons/RangedIndustrial_Biotech.xml
@@ -83,9 +83,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Proj_GrenadeTox"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Proj_GrenadeTox"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Proj_GrenadeTox"]</xpath>
+			<xpath>Defs/ThingDef[defName="Proj_GrenadeTox"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
@@ -2,84 +2,84 @@
 <Patch>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Tail"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Tail"]/coverage</xpath>
   <value>
     <coverage>0.03</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
   <value>
     <coverage>0.08</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   <value>
     <coverage>0.1</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   <value>
     <coverage>0.02</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
   <value>
     <coverage>0.1</coverage>
   </value>
 </Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/coverage</xpath>
   	<value>
       <coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/coverage</xpath>
   		<value>
       	<coverage>0.25</coverage>
   		</value>
 		</Operation>
 
 			<Operation Class="PatchOperationReplace">
-  			<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  			<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/parts/li[def = "Brain"]/coverage</xpath>
   			<value>
       		<coverage>0.9</coverage>
   			</value>
 			</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   		<value>
       	<coverage>0.1</coverage>
   		</value>
 		</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Beak"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Beak"]/coverage</xpath>
   		<value>
       	<coverage>0.4</coverage>
   		</value>
 		</Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
   <value>
     <coverage>0.17</coverage>
   </value>
 </Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Foot"]/coverage</xpath>	<!-- in 1.0: patch both left and right leg (no distinction made anymore) -->
+  	<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Foot"]/coverage</xpath>	<!-- in 1.0: patch both left and right leg (no distinction made anymore) -->
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
@@ -2,84 +2,84 @@
 <Patch>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Tail"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Tail"]/coverage</xpath>
   <value>
     <coverage>0.03</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   <value>
     <coverage>0.08</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   <value>
     <coverage>0.1</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   <value>
     <coverage>0.02</coverage>
   </value>
 </Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   <value>
     <coverage>0.1</coverage>
   </value>
 </Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/coverage</xpath>
   	<value>
       <coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   		<value>
       	<coverage>0.25</coverage>
   		</value>
 		</Operation>
 
 			<Operation Class="PatchOperationReplace">
-  			<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  			<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   			<value>
       		<coverage>0.9</coverage>
   			</value>
 			</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   		<value>
       	<coverage>0.1</coverage>
   		</value>
 		</Operation>
 
 		<Operation Class="PatchOperationReplace">
-  		<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Beak"]/coverage</xpath>
+  		<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Beak"]/coverage</xpath>
   		<value>
       	<coverage>0.4</coverage>
   		</value>
 		</Operation>
 
 <Operation Class="PatchOperationReplace">
-  <xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
+  <xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Leg"]/coverage</xpath>
   <value>
     <coverage>0.17</coverage>
   </value>
 </Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Foot"]/coverage</xpath>	<!-- in 1.0: patch both left and right leg (no distinction made anymore) -->
+  	<xpath>Defs/BodyDef[defName="Bird"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/coverage</xpath>	<!-- in 1.0: patch both left and right leg (no distinction made anymore) -->
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Insect/Beetlelike.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Insect/Beetlelike.xml
@@ -23,9 +23,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Elytra"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Elytra"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -33,16 +33,16 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Elytra"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Pronotum"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -50,14 +50,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -76,16 +76,16 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Elytra"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Elytra"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,16 +93,16 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Elytra"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -110,7 +110,7 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -119,28 +119,28 @@
   <!-- ==================== Patch coverage ==================== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/coverage</xpath>
   	<value>
     	<coverage>0.3</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "Antenna"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/parts/li[def="Antenna"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectNostril"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/parts/li[def="InsectNostril"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectMouth"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def="Pronotum"]/parts/li[def="InsectHead"]/parts/li[def="InsectMouth"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Insect/Beetlelike.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Insect/Beetlelike.xml
@@ -5,9 +5,9 @@
 
   <!-- Add groups entry if it doesn't exist already -->
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,16 +16,16 @@
 
   <!-- Add armor coverage -->
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -33,16 +33,16 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -50,14 +50,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="BeetleLike"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -66,9 +66,9 @@
   <!-- ==================== BeetleLikeWithClaw ==================== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,16 +76,16 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,16 +93,16 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Elytra"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]</xpath>
+			<xpath>Defs/BodyDef[defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -110,7 +110,7 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -119,28 +119,28 @@
   <!-- ==================== Patch coverage ==================== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/coverage</xpath>
   	<value>
     	<coverage>0.3</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "Antenna"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "Antenna"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectNostril"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectNostril"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectMouth"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="BeetleLike" or defName="BeetleLikeWithClaw"]/corePart/parts/li[def = "Pronotum"]/parts/li[def="InsectHead"]/parts/li[def = "InsectMouth"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/Monkey.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/Monkey.xml
@@ -6,70 +6,70 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Clavicle"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Clavicle"]/coverage</xpath>
   	<value>
     	<coverage>0.005</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>	<!-- b18: 12 ribs with 0.004 coverage (CE: 0.001 coverage) each. 1.0: ribcage with 0.045 coverage (CE: 0.012?) -->
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>	<!-- b18: 12 ribs with 0.004 coverage (CE: 0.001 coverage) each. 1.0: ribcage with 0.045 coverage (CE: 0.012?) -->
   	<value>
     	<coverage>0.012</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Pelvis"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
   	<value>
     	<coverage>0.005</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "Monkey"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="Monkey"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Tail"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Tail"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Leg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Leg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,49 +78,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Tail"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -129,112 +129,112 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Tail"]/coverage</xpath>
   	<value>
     	<coverage>0.01</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Heart"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Heart"]/coverage</xpath>
   	<value>
     	<coverage>0.04</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.015</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/coverage</xpath>
   	<value>
     	<coverage>0.75</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Jowl"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jowl"]/coverage</xpath>
   	<value>
     	<coverage>0.14</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Leg"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Tail"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -69,10 +69,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,49 +93,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -144,84 +144,84 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.29</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -81,9 +81,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -69,10 +69,10 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+      	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+      	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -81,9 +81,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,56 +93,56 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/parts/li[def = "Horn"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/parts/li[def="Horn"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -151,98 +151,98 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/coverage</xpath>
   	<value>
     	<coverage>0.75</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.3</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Nose"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
   	<value>
     	<coverage>0.29</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Hump"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Hump"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -79,10 +79,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -91,9 +91,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -103,56 +103,56 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Hump"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -161,77 +161,77 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.3</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Hump"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -91,9 +91,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -69,10 +69,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,49 +93,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -144,91 +144,91 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.3</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.24</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "Tusk"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/parts/li[def="Tusk"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -69,10 +69,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,49 +93,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -144,105 +144,105 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/coverage</xpath>
   	<value>
     	<coverage>0.75</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.15</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Trunk"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Trunk"]/coverage</xpath>
   	<value>
     	<coverage>0.14</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "Tusk"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/parts/li[def="Tusk"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Leg"]/parts/li[def="Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
@@ -5,9 +5,9 @@
 
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -15,9 +15,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -25,9 +25,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -35,9 +35,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -45,9 +45,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -55,9 +55,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -80,9 +80,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
@@ -5,9 +5,9 @@
 
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -15,9 +15,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -25,9 +25,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -35,9 +35,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -45,9 +45,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -55,9 +55,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,10 +68,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -80,9 +80,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -92,49 +92,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -143,84 +143,84 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.29</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -69,10 +69,10 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg" and not(groups)]</xpath>
+        <xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg" and not(groups)]</xpath>
         <value>
           <groups />
         </value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
+			<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -93,49 +93,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -144,91 +144,91 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Tail"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Tail"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
     	<coverage>0.29</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
   	<value>
     	<coverage>0.9</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
     	<coverage>0.2</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Leg"]/parts/li[def="Paw"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Neck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Skull"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "AnimalJaw"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -81,9 +81,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
+			<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/TurtleLike.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/TurtleLike.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="TurtleLike"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="TurtleLike"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]</xpath>
+			<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]</xpath>
 			<value>
 				<groups />
 			</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/TurtleLike.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/TurtleLike.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Plastron"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def = "Plastron"]</xpath>
+			<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Plastron"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -28,14 +28,14 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Plastron"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Plastron"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -44,49 +44,49 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Plastron"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Plastron"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Spine"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Spine"]/coverage</xpath>
   	<value>
     	<coverage>0.03</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Liver"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/BodyDef[defName = "TurtleLike"]/corePart/parts/li[def = "Head"]/coverage</xpath>
+  	<xpath>Defs/BodyDef[defName="TurtleLike"]/corePart/parts/li[def="Head"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -8,7 +8,7 @@
 <!--TOOK OUT because it breaks Character editor apparel screen-->
   <!--nose, because it wasn't there before for some reason
   <Operation Class="PatchOperationAdd"> 
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[def = "Nose"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
     <value>
       <li>Nose</li>
     </value>
@@ -27,56 +27,56 @@
 -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel="right eye"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel="left eye"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
   
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
   
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
     <value>
       <li>LeftArm</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
     <value>
       <li>RightArm</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
     <value>
       <li>LeftShoulder</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
     <value>
       <li>RightShoulder</li>
     </value>
@@ -85,140 +85,140 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
     <value>
       <coverage>0.012</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Pelvis"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Pelvis"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Stomach"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Heart"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Heart"]/coverage</xpath>
     <value>
       <coverage>0.04</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Lung"]/coverage</xpath>
     <value>
       <coverage>0.055</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Kidney"]/coverage</xpath>
     <value>
       <coverage>0.03</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Liver"]/coverage</xpath>
     <value>
       <coverage>0.06</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/coverage</xpath>
     <value>
       <coverage>0.055</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def="Brain"]/coverage</xpath>
     <value>
       <coverage>0.9</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Eye"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Eye"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Ear"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Nose"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Shoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/coverage</xpath>
     <value>
       <coverage>0.085</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Clavicle"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Clavicle"]/coverage</xpath>
     <value>
       <coverage>0.06</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Humerus"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Humerus"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Radius"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Femur"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Tibia"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Foot"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -227,91 +227,91 @@
   <!-- ========== Add armor coverage (for pawns with non-zero armor that use human body) ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Neck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Jaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Nose"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Ear"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Ear"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Shoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def = "Hand"]/parts/li[def = "Finger"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Hand"]/parts/li[def="Finger"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Leg"]/parts/li[def = "Foot"]/parts/li[def = "Toe"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/parts/li[def="Toe"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -27,58 +27,56 @@
 -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "right eye"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[customLabel = "left eye"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
   
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
-    <value>
-      <li>OutsideSquishy</li>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Nose"]/groups</xpath>
     <value>
       <li>OutsideSquishy</li>
     </value>
   </Operation>
 
-  
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Jaw"]/groups</xpath>
+    <value>
+      <li>OutsideSquishy</li>
+    </value>
+  </Operation>
   
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "left arm"]/groups</xpath>
     <value>
       <li>LeftArm</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[customLabel = "right arm"]/groups</xpath>
     <value>
       <li>RightArm</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
     <value>
       <li>LeftShoulder</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
     <value>
       <li>RightShoulder</li>
     </value>
@@ -87,140 +85,140 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
     <value>
       <coverage>0.012</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Pelvis"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Pelvis"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Stomach"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Heart"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Heart"]/coverage</xpath>
     <value>
       <coverage>0.04</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
     <value>
       <coverage>0.055</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
     <value>
       <coverage>0.03</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
     <value>
       <coverage>0.06</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Neck"]/coverage</xpath>
     <value>
       <coverage>0.055</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def="Skull"]/parts/li[def = "Brain"]/coverage</xpath>
     <value>
       <coverage>0.9</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Eye"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Eye"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Ear"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Ear"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Nose"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Neck"]/parts/li[def="Head"]/parts/li[def = "Nose"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Shoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Shoulder"]/coverage</xpath>
     <value>
       <coverage>0.085</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Clavicle"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Clavicle"]/coverage</xpath>
     <value>
       <coverage>0.06</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Humerus"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Humerus"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Radius"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def="Shoulder"]/parts/li[def = "Arm"]/parts/li[def="Radius"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Femur"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Femur"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Tibia"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Tibia"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Foot"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Leg"]/parts/li[def="Foot"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,19 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,49 +68,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -129,28 +119,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -159,21 +149,21 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -184,7 +174,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -200,7 +190,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -216,7 +206,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalHeatSink</def>
@@ -232,7 +222,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -248,4 +238,3 @@
   </Operation>
 
 </Patch>
-

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,49 +68,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -119,28 +119,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -149,21 +149,21 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -174,7 +174,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -190,7 +190,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -206,7 +206,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalHeatSink</def>
@@ -222,7 +222,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalCentipede.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,49 +78,49 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts/li[def="MechanicalCentipedeBodySixthRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -129,28 +129,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -159,21 +159,21 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -184,7 +184,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def = "MechanicalCentipedeBodySecondRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -200,7 +200,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -216,7 +216,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalHeatSink</def>
@@ -232,7 +232,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def="MechanicalCentipedeBodyThirdRing"]/parts/li[def="MechanicalCentipedeBodyFourthRing"]/parts/li[def="MechanicalCentipedeBodyFifthRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
   	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -38,28 +38,28 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -68,28 +68,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -98,17 +98,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -119,7 +119,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -135,7 +135,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
   	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]</xpath>
+			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -48,28 +48,28 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -78,28 +78,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -108,17 +108,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -129,7 +129,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -145,7 +145,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/MechanicalTermite.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,19 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +26,9 @@
 	</Operation>
 
   	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]</xpath>
+			<xpath>Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -48,28 +38,28 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -78,28 +68,28 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -108,17 +98,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li/parts/li/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -129,7 +119,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def = "MechanicalTermiteBodySecondRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalWeaponActuator</def>
@@ -145,7 +135,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def="MechanicalTermiteBodyThirdRing"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "MechanicalTermite"]/corePart/parts/li[def="MechanicalTermiteBodySecondRing"]/parts/li[def = "MechanicalTermiteBodyThirdRing"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -161,4 +151,3 @@
   </Operation>
 
 </Patch>
-

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,35 +58,35 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+  	<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -95,21 +95,21 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -118,17 +118,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Pikeman"]/corePart/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,19 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
+			<value>
+				<groups />
+			</value>
+		</nomatch>
+	</Operation>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -58,35 +68,35 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -95,21 +105,21 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -118,17 +128,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>
@@ -149,4 +159,3 @@
   </Operation>
 
 </Patch>
-

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Pikeman.xml
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[4]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[5]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -68,35 +68,35 @@
   <!-- ========== Add armor coverage ========== -->
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+  	<xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -105,21 +105,21 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
@@ -128,17 +128,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Pikeman"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Pikeman"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalCapacitor</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -78,70 +78,70 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/parts/li[def = "MechanicalFinger"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/parts/li[def="MechanicalFinger"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -150,56 +150,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -208,17 +208,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -259,7 +259,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -275,7 +275,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,19 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+		<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
-			<value>
-				<groups />
-			</value>
-		</nomatch>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+			<xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +78,70 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "Blade"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/parts/li[def = "MechanicalFinger"]/groups</xpath>
+    <value>
+      <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <value>
+      <li>CoveredByNaturalArmor</li>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -146,56 +150,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -204,17 +208,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -255,7 +259,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -271,7 +275,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+    <xpath>Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
@@ -6,9 +6,9 @@
   <!-- ========== Add groups entry if it doesn't exist already ========== -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart</xpath>
 			<value>
 				<groups />
 			</value>
@@ -16,9 +16,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -26,9 +26,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -36,9 +36,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -46,9 +46,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -56,9 +56,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -76,9 +76,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+		<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+			<xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
 			<value>
 				<groups />
 			</value>
@@ -88,56 +88,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="MechanicalHand"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -146,56 +146,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>
@@ -204,17 +204,17 @@
   <!-- ========== Remove unwanted vanilla body parts ========== -->
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="Reactor"]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
   </Operation>
 
   <!-- ========== Add new body parts ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts</xpath>
     <value>
       <li>
         <def>MechanicalPowerCore</def>
@@ -255,7 +255,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalUpperActuator</def>
@@ -271,7 +271,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts</xpath>
+    <xpath>/Defs/BodyDef[defName="Scyther" or defName="Lancer"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
     <value>
       <li>
         <def>MechanicalLowerActuator</def>

--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -188,7 +188,7 @@
 <!-- ========== Patch-out vanilla melee stun mechanic from blunt damage ========== -->
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>/Defs/DamageDef[@Name="BluntBase"]/*[self::bluntStunDuration or self::bluntStunChancePerDamagePctOfCorePartToHeadCurve or self::bluntStunChancePerDamagePctOfCorePartToBodyCurve]</xpath>
+		<xpath>Defs/DamageDef[@Name="BluntBase"]/*[self::bluntStunDuration or self::bluntStunChancePerDamagePctOfCorePartToHeadCurve or self::bluntStunChancePerDamagePctOfCorePartToBodyCurve]</xpath>
 	</Operation>	
 
   <!-- ========== Add electric armor to EMP damage ========== -->

--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -5,14 +5,14 @@
 
 <!--
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/DamageDef[workerClass = "DamageWorker_AddInjury"]/workerClass</xpath>
+  	<xpath>Defs/DamageDef[workerClass="DamageWorker_AddInjury"]/workerClass</xpath>
   	<value>
       <workerClass>CombatExtended.DamageWorker_AddInjuryCE</workerClass>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>Defs/DamageDef[workerClass = "DamageWorker_Flame"]/workerClass</xpath>
+  	<xpath>Defs/DamageDef[workerClass="DamageWorker_Flame"]/workerClass</xpath>
   	<value>
       <workerClass>CombatExtended.DamageWorker_FlameCE</workerClass>
   	</value>

--- a/Patches/Core/Drugs/Drugs.xml
+++ b/Patches/Core/Drugs/Drugs.xml
@@ -123,9 +123,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Beer"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="Beer"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Beer"]</xpath>
+			<xpath>Defs/ThingDef[defName="Beer"]</xpath>
 			<value>
 				<weaponTags />
 			</value>

--- a/Patches/Core/FactionDefs/Factions_Player.xml
+++ b/Patches/Core/FactionDefs/Factions_Player.xml
@@ -5,26 +5,26 @@
 
 
 	<Operation Class="PatchOperationConditional">
-           <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter</xpath>
+           <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter</xpath>
         <match Class="PatchOperationConditional">
-            <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs</xpath>
+            <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs</xpath>
             <match Class="PatchOperationConditional">
-                <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
+                <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
                 <match Class="PatchOperationReplace">
-                    <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
+                    <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs/li["Steel"]</xpath>
                     <value>
                         <li>Steel</li>
                     </value>
                 </match>
                 <nomatch Class="PatchOperationAdd">
-                    <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs</xpath>
+                    <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter/thingDefs</xpath>
                     <value>
                         <li>Steel</li>
                     </value>
                 </nomatch>
             </match>
             <nomatch Class="PatchOperationAdd">
-                <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter</xpath>
+                <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]/apparelStuffFilter</xpath>
                 <value>
                     <thingDefs>
                         <li>Steel</li>
@@ -33,7 +33,7 @@
             </nomatch>
         </match>
         <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/FactionDef[@Name="PlayerFactionBase"]</xpath>
+            <xpath>Defs/FactionDef[@Name="PlayerFactionBase"]</xpath>
             <value>
                 <apparelStuffFilter>
                     <thingDefs>

--- a/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
@@ -4,7 +4,7 @@
 	<!-- Add CompStabilize to all injury and missing part hediffs -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/HediffDef[defName = "MissingBodyPart"]/comps</xpath>
+		<xpath>Defs/HediffDef[defName="MissingBodyPart"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.HediffCompProperties_Stabilize" />
 		</value>
@@ -45,7 +45,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[@Name="BurnBase"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[@Name="BurnBase"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.07</infectionChancePerHourUntended>
@@ -54,7 +54,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/HediffDef[defName="Burn"]/comps/li[@Class = "HediffCompProperties_GetsPermanent"]</xpath>
+		<xpath>Defs/HediffDef[defName="Burn"]/comps/li[@Class="HediffCompProperties_GetsPermanent"]</xpath>
 		<value>
 			<becomePermanentChanceFactor>1.5</becomePermanentChanceFactor>
   	</value>
@@ -83,7 +83,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Crush"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Crush"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.04</infectionChancePerHourUntended>
@@ -123,7 +123,7 @@
 	<!-- Cut -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Cut"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Cut"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.015</infectionChancePerHourUntended>
@@ -132,7 +132,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/HediffDef[defName="Cut"]/comps/li[@Class = "HediffCompProperties_GetsPermanent"]</xpath>
+		<xpath>Defs/HediffDef[defName="Cut"]/comps/li[@Class="HediffCompProperties_GetsPermanent"]</xpath>
 		<value>
 			<becomePermanentChanceFactor>0.75</becomePermanentChanceFactor>
   	</value>
@@ -147,7 +147,7 @@
 	<!-- Scratch -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Scratch"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Scratch"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.015</infectionChancePerHourUntended>
@@ -156,7 +156,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/HediffDef[defName="Scratch"]/comps/li[@Class = "HediffCompProperties_GetsPermanent"]</xpath>
+		<xpath>Defs/HediffDef[defName="Scratch"]/comps/li[@Class="HediffCompProperties_GetsPermanent"]</xpath>
 		<value>
 			<becomePermanentChanceFactor>0.5</becomePermanentChanceFactor>
   	</value>
@@ -165,7 +165,7 @@
 	<!-- Bite -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Bite"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Bite"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.06</infectionChancePerHourUntended>
@@ -189,7 +189,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Stab"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Stab"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.03</infectionChancePerHourUntended>
@@ -207,7 +207,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Gunshot"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Gunshot"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.03</infectionChancePerHourUntended>
@@ -232,7 +232,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Shredded"]/comps/li[@Class = "HediffCompProperties_Infecter"]</xpath>
+		<xpath>Defs/HediffDef[defName="Shredded"]/comps/li[@Class="HediffCompProperties_Infecter"]</xpath>
 		<value>
       <li Class="CombatExtended.HediffCompProperties_InfecterCE">
         <infectionChancePerHourUntended>0.05</infectionChancePerHourUntended>
@@ -241,7 +241,7 @@
 	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/HediffDef[defName="Shredded"]/comps/li[@Class = "HediffCompProperties_GetsPermanent"]/permanentLabel</xpath>
+		<xpath>Defs/HediffDef[defName="Shredded"]/comps/li[@Class="HediffCompProperties_GetsPermanent"]/permanentLabel</xpath>
 		<value>
 			<permanentLabel>shrapnel scar</permanentLabel>
 		</value>

--- a/Patches/Core/Misc/ApparelLayerDefs/ApparelLayerDefs.xml
+++ b/Patches/Core/Misc/ApparelLayerDefs/ApparelLayerDefs.xml
@@ -2,14 +2,14 @@
 <Patch>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ApparelLayerDef[defName = "Overhead"]/label</xpath>
+		<xpath>Defs/ApparelLayerDef[defName="Overhead"]/label</xpath>
 		<value>
 			<label>outer (head)</label>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ApparelLayerDef[defName = "Overhead"]</xpath>
+		<xpath>Defs/ApparelLayerDef[defName="Overhead"]</xpath>
 		<value>
 			<li Class="CombatExtended.ApparelLayerExtension">
 				<IsHeadwear>true</IsHeadwear>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -227,7 +227,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[defName = "Mercenary_Slasher" or defName="Mercenary_Slasher_Acidifier"]</xpath>
+    <xpath>Defs/PawnKindDef[defName="Mercenary_Slasher" or defName="Mercenary_Slasher_Acidifier"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <shieldMoney>
@@ -258,7 +258,7 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[@Name = "MercenaryEliteTierBase"]/weaponMoney</xpath>
+    <xpath>Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/weaponMoney</xpath>
     <value>
       <weaponMoney>
         <min>850</min>
@@ -276,7 +276,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>Defs/PawnKindDef[@Name = "MercenaryEliteTierBase"  or defName="Mercenary_Elite_Acidifier"]</xpath>
+    <xpath>Defs/PawnKindDef[@Name="MercenaryEliteTierBase"  or defName="Mercenary_Elite_Acidifier"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -212,9 +212,9 @@
   </Operation>
 
   <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[@Name="MercenarySlasherBase"]/skills</xpath>
+   <xpath>Defs/PawnKindDef[@Name="MercenarySlasherBase"]/skills</xpath>
    <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[@Name="MercenarySlasherBase"]</xpath>
+     <xpath>Defs/PawnKindDef[@Name="MercenarySlasherBase"]</xpath>
      <value>
        <skills>
          <li>
@@ -243,9 +243,9 @@
   </Operation>
 
   <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/skills</xpath>
+   <xpath>Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/skills</xpath>
    <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]</xpath>
+     <xpath>Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]</xpath>
      <value>
        <skills>
          <li>
@@ -269,7 +269,7 @@
 
   <!-- Gives all elite-tier pirates and mercs access to charge weapons. -->
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/weaponTags</xpath>
+    <xpath>Defs/PawnKindDef[@Name="MercenaryEliteTierBase"]/weaponTags</xpath>
     <value>
       <li>SpacerGun</li>
     </value>
@@ -443,7 +443,7 @@
   <!-- ========== Spacer ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/PawnKindDef[defName="AncientSoldier"]/skills</xpath>
+    <xpath>Defs/PawnKindDef[defName="AncientSoldier"]/skills</xpath>
     <value>
       <li>
         <skill>Melee</skill>
@@ -705,9 +705,9 @@
   </Operation>
 
   <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefMelee"]/skills</xpath>
+   <xpath>Defs/PawnKindDef[defName="Tribal_ChiefMelee"]/skills</xpath>
    <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefMelee"]</xpath>
+     <xpath>Defs/PawnKindDef[defName="Tribal_ChiefMelee"]</xpath>
      <value>
        <skills>
          <li>
@@ -758,9 +758,9 @@
   </Operation>
 
   <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefRanged"]/skills</xpath>
+   <xpath>Defs/PawnKindDef[defName="Tribal_ChiefRanged"]/skills</xpath>
    <nomatch Class="PatchOperationAdd">
-     <xpath>/Defs/PawnKindDef[defName="Tribal_ChiefRanged"]</xpath>
+     <xpath>Defs/PawnKindDef[defName="Tribal_ChiefRanged"]</xpath>
      <value>
        <skills>
          <li>
@@ -790,7 +790,7 @@
   </Operation>
 
   <Operation Class="PatchOperationConditional">
-   <xpath>/Defs/PawnKindDef[@Name="TribalChiefBase"]/apparelRequired</xpath>
+   <xpath>Defs/PawnKindDef[@Name="TribalChiefBase"]/apparelRequired</xpath>
    <nomatch Class="PatchOperationAdd">
     <xpath>Defs/PawnKindDef[@Name="TribalChiefBase"]</xpath>
     <value>
@@ -810,7 +810,7 @@
   <!-- Combat drugs for tribals  -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/PawnKindDef[
+    <xpath>Defs/PawnKindDef[
         defName="Tribal_Berserker" or
         defName="Tribal_HeavyArcher" or
         @Name="TribalChiefBase"
@@ -823,7 +823,7 @@
 
   <!-- Stranger in Black -->
   <Operation Class="PatchOperationAddModExtension">
-    <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]</xpath>
+    <xpath>Defs/PawnKindDef[defName="StrangerInBlack"]</xpath>
     <value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
@@ -835,7 +835,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-   <xpath>/Defs/PawnKindDef[defName="StrangerInBlack"]/apparelRequired</xpath>
+   <xpath>Defs/PawnKindDef[defName="StrangerInBlack"]/apparelRequired</xpath>
      <value>
        <li>CE_Apparel_Backpack</li>
      </value>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -235,9 +235,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
 		<match Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+			<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
 		</match>
 	</Operation>
 
@@ -256,9 +256,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_Direct"]</xpath>
+		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_Direct"]</xpath>
 		<match Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+			<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
 		</match>
 	</Operation>
 

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -4,21 +4,21 @@
 	<!-- ========== General ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName = "Flammability"]</xpath>
+		<xpath>Defs/StatDef[defName="Flammability"]</xpath>
 		<value>
 			<workerClass>CombatExtended.StatWorker_Flammability</workerClass>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName = "Flammability"]/category</xpath>
+		<xpath>Defs/StatDef[defName="Flammability"]/category</xpath>
 		<value>
 			<category>Basics</category>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName = "Mass"]/parts</xpath>
+		<xpath>Defs/StatDef[defName="Mass"]/parts</xpath>
 		<value>
 			<li Class="CombatExtended.StatPart_LoadedAmmo"/>
 			<li Class="CombatExtended.StatPart_Attachments"/>			
@@ -30,20 +30,20 @@
 	<!-- Armor Cap -->
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/StatDef[@Name = "ArmorRatingBase"]/maxValue</xpath>
+		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/maxValue</xpath>
 	</Operation>
 
 	<!-- Armor Rating -->
 	
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[@Name = "ArmorRatingBase"]</xpath>
+		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]</xpath>
 		<value>
 			<workerClass>CombatExtended.StatWorker_ArmorPartial</workerClass>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[@Name = "ArmorRatingBase"]/parts/li[@Class = "StatPart_Quality"]</xpath>
+		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
 		<value>
 			<li Class="CombatExtended.StatPart_QualityConditional">
 			  <factorAwful>0.5</factorAwful>
@@ -104,21 +104,21 @@
 	<!-- Armor Descriptions -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName = "ArmorRating_Sharp"]/description</xpath>
+		<xpath>Defs/StatDef[defName="ArmorRating_Sharp"]/description</xpath>
 		<value>
-			<description>Mitigation effect on sharp damage such as bullets, knife stabs, and animal bites.\n\nThis armor rating is compared against an attack's armor penetration, with deflection occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8mm RHA armor is hit by a 10mm RHA projectile, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP = InitialAP - ArmorRating\nModifiedDamage = InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers. If an attack is deflected, it's converted to blunt, the damage is recalculated based off the base blunt armor penetration and the ratio of pre-deflecton sharp armor penetration to base sharp penetration, and is checked against the apparel's blunt armor rating. If an attack penetrated with some of its damage blocked, then additional blunt damage is applied based off the attack's base blunt penetration influenced by the ratio of blocked damage and blocked armor penetration to base damage and base armor penetration.</description>
+			<description>Mitigation effect on sharp damage such as bullets, knife stabs, and animal bites.\n\nThis armor rating is compared against an attack's armor penetration, with deflection occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8mm RHA armor is hit by a 10mm RHA projectile, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers. If an attack is deflected, it's converted to blunt, the damage is recalculated based off the base blunt armor penetration and the ratio of pre-deflecton sharp armor penetration to base sharp penetration, and is checked against the apparel's blunt armor rating. If an attack penetrated with some of its damage blocked, then additional blunt damage is applied based off the attack's base blunt penetration influenced by the ratio of blocked damage and blocked armor penetration to base damage and base armor penetration.</description>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName = "ArmorRating_Blunt"]/description</xpath>
+		<xpath>Defs/StatDef[defName="ArmorRating_Blunt"]/description</xpath>
 		<value>
-			<description>Mitigation effect on blunt-force damage such as maces, explosions, and animal hoofs.\n\nThis armor rating is compared against an attack's armor penetration, with no damage occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8 MPa armor is hit by a 10 MPa impact, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP = InitialAP - ArmorRating\nModifiedDamage = InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers.</description>
+			<description>Mitigation effect on blunt-force damage such as maces, explosions, and animal hoofs.\n\nThis armor rating is compared against an attack's armor penetration, with no damage occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8 MPa armor is hit by a 10 MPa impact, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers.</description>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName = "ArmorRating_Heat"]/description</xpath>
+		<xpath>Defs/StatDef[defName="ArmorRating_Heat"]/description</xpath>
 		<value>
 			<description>Percentage reduction of damage from extreme heat such as fire and incendiary explosions.\n\nHaving a value of 100% or above makes the creature immune to all flame damage in that body region.</description>
 		</value>
@@ -256,7 +256,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_Direct"]</xpath>
+		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
 		<match Class="PatchOperationRemove">
 			<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
 		</match>
@@ -266,10 +266,10 @@
 		<success>Always</success>
 		<operations>
 			<li Class="PatchOperationTest">
-				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_Direct"]</xpath>
+				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_Direct"]</xpath>
+				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
 				<value>
 					<li Class="SkillNeed_BaseBonus" />
 				</value>
@@ -278,7 +278,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class = "SkillNeed_BaseBonus"]</xpath>
+		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_BaseBonus"]</xpath>
 		<value>
 			<li Class="SkillNeed_BaseBonus">
 			  <skill>Shooting</skill>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -49,11 +49,11 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -92,11 +92,11 @@
 	<!-- ========== Sniper turret ========== -->
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -159,11 +159,11 @@
 	<!-- ========== Autocannon turret ========== -->
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -232,21 +232,21 @@
 	<!-- ========== Foam Turret ========== -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class = "CompProperties_Refuelable"]/fuelMultiplier</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class="CompProperties_Refuelable"]/fuelMultiplier</xpath>
 		<value>
 			<fuelMultiplier>0.20</fuelMultiplier>	
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class = "CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class="CompProperties_Refuelable"]/fuelFilter/thingDefs/li</xpath>
 		<value>
 			<li>Ammo_30x64mmFuel_Foam</li>	
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class = "CompProperties_Refuelable"]/initialFuelPercent</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_FoamTurret"]/comps/li[@Class="CompProperties_Refuelable"]/initialFuelPercent</xpath>
 		<value>
 			<initialFuelPercent>0</initialFuelPercent>
 		</value>
@@ -266,11 +266,11 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class = "CompProperties_Activable"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/comps/li[@Class="CompProperties_Activable"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -73,9 +73,9 @@
 	<!-- Add trade tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Turret_MiniTurret"]/tradeTags</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/tradeTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Turret_MiniTurret"]</xpath>
+			<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]</xpath>
 			<value>
 				<tradeTags />
 			</value>
@@ -296,7 +296,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/building/turretBurstCooldownTime</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>4.2</turretBurstCooldownTime>
 		</value>
@@ -310,9 +310,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Gun_RocketswarmLauncher"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Gun_RocketswarmLauncher"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Gun_RocketswarmLauncher"]</xpath>
+			<xpath>Defs/ThingDef[defName="Gun_RocketswarmLauncher"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -482,9 +482,9 @@
 	<!-- Add trade tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Turret_Mortar"]/tradeTags</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_Mortar"]/tradeTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Turret_Mortar"]</xpath>
+			<xpath>Defs/ThingDef[defName="Turret_Mortar"]</xpath>
 			<value>
 				<tradeTags />
 			</value>

--- a/Patches/Core/ThingDefs_Items/Items_General.xml
+++ b/Patches/Core/ThingDefs_Items/Items_General.xml
@@ -87,9 +87,9 @@
   <!-- Ensure chunks have stuffProps so they can be used in recipes (like "make stone sling bullets") whithout throwing "not a stuff" error -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[@Name="ChunkBase"]/stuffProps</xpath>
+		<xpath>Defs/ThingDef[@Name="ChunkBase"]/stuffProps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="ChunkBase"]</xpath>
+			<xpath>Defs/ThingDef[@Name="ChunkBase"]</xpath>
 			<value>
 				<stuffProps />
 			</value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -100,9 +100,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Proj_GrenadeFrag"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Proj_GrenadeFrag"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Proj_GrenadeFrag"]</xpath>
+			<xpath>Defs/ThingDef[defName="Proj_GrenadeFrag"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -954,9 +954,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
+			<xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -964,7 +964,7 @@
 	</Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
+    <xpath>Defs/ThingDef[defName="Bullet_DoomsdayRocket"]/comps</xpath>
     <value>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragSpeedFactor>1</fragSpeedFactor>
@@ -1052,9 +1052,9 @@
   </Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Bullet_Rocket"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
+			<xpath>Defs/ThingDef[defName="Bullet_Rocket"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
@@ -82,9 +82,9 @@
 	<!-- Add tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="MeleeWeapon_Knife"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Knife"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Knife"]</xpath>
+			<xpath>Defs/ThingDef[defName="MeleeWeapon_Knife"]</xpath>
 			<value>
 				<weaponTags />
 			</value>
@@ -154,9 +154,9 @@
 	<!-- Add tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="MeleeWeapon_Club"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Club"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Club"]</xpath>
+			<xpath>Defs/ThingDef[defName="MeleeWeapon_Club"]</xpath>
 			<value>
 				<weaponTags />
 			</value>
@@ -226,9 +226,9 @@
 	<!-- Add tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="MeleeWeapon_Mace"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Mace"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Mace"]</xpath>
+			<xpath>Defs/ThingDef[defName="MeleeWeapon_Mace"]</xpath>
 			<value>
 				<weaponTags />
 			</value>
@@ -309,9 +309,9 @@
 	<!-- Add tags -->
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="MeleeWeapon_Gladius"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Gladius"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="MeleeWeapon_Gladius"]</xpath>
+			<xpath>Defs/ThingDef[defName="MeleeWeapon_Gladius"]</xpath>
 			<value>
 				<weaponTags />
 			</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Base.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Base.xml
@@ -2,9 +2,9 @@
 <Patch>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[@Name="BasePawn"]/statBases</xpath>
+		<xpath>Defs/ThingDef[@Name="BasePawn"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="BasePawn"]</xpath>
+			<xpath>Defs/ThingDef[@Name="BasePawn"]</xpath>
 			<value>
 				<statBases />
 			</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -425,9 +425,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Boomrat"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Boomrat"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Boomrat"]</xpath>
+			<xpath>Defs/ThingDef[defName="Boomrat"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -73,9 +73,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName="Human"]/comps</xpath>
+		<xpath>Defs/ThingDef[defName="Human"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="Human"]</xpath>
+			<xpath>Defs/ThingDef[defName="Human"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -66,9 +66,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[@Name="BaseMechanoid"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="BaseMechanoid"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="BaseMechanoid"]</xpath>
+			<xpath>Defs/ThingDef[@Name="BaseMechanoid"]</xpath>
 			<value>
 				<comps />
 			</value>

--- a/Patches/Core/TraitDefs/Traits_Spectrum.xml
+++ b/Patches/Core/TraitDefs/Traits_Spectrum.xml
@@ -5,10 +5,10 @@
 		<operations>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracyPawn</xpath>
+				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
+				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
 				<value>
 					<statFactors>
 						<ShootingAccuracyPawn>1.33</ShootingAccuracyPawn>
@@ -18,10 +18,10 @@
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracyPawn</xpath>
+				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
+				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
 				<value>
 					<statFactors>
 						<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
@@ -29,7 +29,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/AimingDelayFactor</xpath>
+				<xpath>Defs/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/AimingDelayFactor</xpath>
 				<value>
 					<AimingDelayFactor>-0.25</AimingDelayFactor>
 				</value>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -318,14 +318,14 @@
   <!-- ========== Add Loadbearing Gear to Imperial Fighters ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/PawnKindDef[@Name="ImperialTrooperBase"]/apparelRequired</xpath>
+    <xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/apparelRequired</xpath>
       <value>
         <li>CE_Apparel_Backpack</li>
       </value>
    </Operation>
  
    <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/PawnKindDef[defName="Empire_Fighter_Champion"]/apparelRequired</xpath>
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]/apparelRequired</xpath>
       <value>
         <li>CE_Apparel_Backpack</li>
       </value>

--- a/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
+++ b/Royalty/Patches/ThingDefs_Buildings/Buildings_Mechanoid.xml
@@ -88,7 +88,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_AutoMiniTurret"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -143,7 +143,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_AutoChargeBlaster"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -198,7 +198,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_AutoInferno"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -278,9 +278,9 @@
 	<!-- Glitter Tech Fix -->
 
 	<Operation Class="PatchOperationConditional">
-    		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
+    		<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]</xpath>
+			<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]</xpath>
 			<value>
 				<statBases>
 					<SightsEfficiency>0.5</SightsEfficiency>
@@ -288,7 +288,7 @@
 			</value>
 		</nomatch>
 		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]/statBases</xpath>
 			<value>
 				<SightsEfficiency>0.5</SightsEfficiency>
 			</value>
@@ -296,7 +296,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]</xpath>
+		<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]</xpath>
 		<value>
 			<comps>
 			  <li Class="CombatExtended.CompProperties_Charges">
@@ -317,14 +317,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]/weaponTags</xpath>
 		<value>
 			<li>TurretGun</li>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName = "Artillery_AutoMortar"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="Artillery_AutoMortar"]/verbs</xpath>
 		<value>
 			<verbs>
 			  <li Class="CombatExtended.VerbPropertiesCE">

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyArmor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyArmor.xml
@@ -154,7 +154,7 @@
 	</Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/verbs</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/verbs</xpath>
         <value>
             <verbs>
                 <li Class="CombatExtended.VerbPropertiesCE">
@@ -182,14 +182,14 @@
     </Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
         <value>
             <ammoDef>Ammo_30x29mmGrenade_HE</ammoDef>
         </value>
     </Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorMarineGrenadier"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
         <value>
             <ammoCountPerCharge>1</ammoCountPerCharge>
         </value>
@@ -245,7 +245,7 @@
 	</Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/verbs</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/verbs</xpath>
         <value>
             <verbs>
                 <li Class="CombatExtended.VerbPropertiesCE">
@@ -273,14 +273,14 @@
     </Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
         <value>
             <ammoDef>Ammo_30x64mmFuel_Incendiary</ammoDef>
         </value>
     </Operation>
 
     <Operation Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+        <xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPhoenix"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
         <value>
             <ammoCountPerCharge>1</ammoCountPerCharge>
         </value>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
@@ -63,9 +63,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSwordBladelink"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSwordBladelink"]</xpath>
 		<value>
 			<weaponTags />
 		</value>
@@ -117,9 +117,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_ZeusHammerBladelink"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_ZeusHammerBladelink"]</xpath>
 		<value>
 			<statBases />
 		</value>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
@@ -63,9 +63,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSwordBladelink"]</xpath>
 		<value>
 			<weaponTags />
 		</value>
@@ -117,9 +117,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_ZeusHammerBladelink"]</xpath>
 		<value>
 			<statBases />
 		</value>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -200,9 +200,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
 			<value>
 				<statBases />
 			</value>
@@ -229,9 +229,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
 			<value>
 				<weaponTags />
 			</value>
@@ -283,9 +283,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]</xpath>
 			<value>
 				<statBases />
 			</value>
@@ -368,9 +368,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]</xpath>
+		<xpath>Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]</xpath>
 			<value>
 				<statBases />
 			</value>

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -200,9 +200,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSword"]</xpath>
 			<value>
 				<statBases />
 			</value>
@@ -229,9 +229,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]/weaponTags</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSword"]/weaponTags</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_MonoSword"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_MonoSword"]</xpath>
 			<value>
 				<weaponTags />
 			</value>
@@ -283,9 +283,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Zeushammer"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_Zeushammer"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Zeushammer"]</xpath>
 			<value>
 				<statBases />
 			</value>
@@ -368,9 +368,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_PlasmaSword"]/statBases</xpath>
 		<nomatch Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "MeleeWeapon_PlasmaSword"]</xpath>
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_PlasmaSword"]</xpath>
 			<value>
 				<statBases />
 			</value>


### PR DESCRIPTION
## Changes

- What it says on the tin, looking for `Defs` is faster than `/Defs` while patching which improves loading time.
- Removed some whitespaces in patch directories.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
