### PR TITLE
Patch VRE-Hussar

### DIFF
--- a/Patches/Vanilla Races Expanded - Hussar/GeneDefs/GeneDefs_Misc.xml
+++ b/Patches/Vanilla Races Expanded - Hussar/GeneDefs/GeneDefs_Misc.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+		<li>Vanilla Races Expanded - Hussar</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/GeneDef[defName="VREH_BulletproofSkin"]</xpath>
+					<value>
+						<statOffsets>
+							<ArmorRating_Sharp>4.0</ArmorRating_Sharp>
+						</statOffsets>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -436,6 +436,7 @@ Vanilla Ideology Expanded - Hats and Rags |
 Vanilla Ideology Expanded - Memes and Structures    |
 Vanilla Genetics Expanded   |
 Vanilla Psycasts Expanded   |
+Vanilla Races Expanded - Hussar  |
 Vanilla Races Expanded - Saurid  |
 Vanilla Skills Expanded  |
 Vanilla Vehicles Expanded	|


### PR DESCRIPTION
## Changes

- Patched the Bulletproof Skin gene to provide 4mm of sharp armor.

## Reasoning

- 4mm is the normal AP value of pistol calibers and the gene protects from attacks with under 20% AP which is roughly all the pistol caliber guns in vanilla, the M16 and minigun aside that is, it currently only protects from attacks with 0.2mm sharp armor penetration.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (working as intended)
