### PR TITLE
Fix some ammo texture directories

### DIFF
--- a/Patches/MiscTurrets/Patch_Ammo.xml
+++ b/Patches/MiscTurrets/Patch_Ammo.xml
@@ -50,7 +50,7 @@
           <defName>Ammo_NanobotsMicroTurret</defName>
           <label>Nanobots (MT) cartridge</label>
           <graphicData>
-            <texPath>Things/Ammo/Charged/Regular</texPath>
+            <texPath>Things/Ammo/Charged/MediumRegular</texPath>
             <graphicClass>Graphic_StackCount</graphicClass>
           </graphicData>
           <statBases>

--- a/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Ammo.xml
+++ b/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Ammo.xml
@@ -39,7 +39,7 @@
 					<defName>Ammo_PlasmaGasCartridge</defName>
 					<label>Plasma Gas Cartridges</label>
 					<graphicData>
-					  <texPath>Things/Ammo/Charged/Concentrated</texPath>
+					  <texPath>Things/Ammo/PlasmaCell/Rifle</texPath>
 					  <graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
@@ -53,7 +53,7 @@
 					<defName>Ammo_PlasmaGasCartridge_AP</defName>
 					<label>Plasma Gas Cartridges (Imp)</label>
 					<graphicData>
-					  <texPath>Things/Ammo/Charged/Regular</texPath>
+					  <texPath>Things/Ammo/PlasmaCell/Rifle</texPath>
 					  <graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>
@@ -67,7 +67,7 @@
 					<defName>Ammo_PlasmaGasCartridge_Ion</defName>
 					<label>Plasma Gas Cartridges (Stun)</label>
 					<graphicData>
-					  <texPath>Things/Ammo/Charged/Ion</texPath>
+					  <texPath>Things/Ammo/PlasmaCell/Rifle</texPath>
 					  <graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>

--- a/Patches/SYR Naga/Patch_Ammo_44Magnum_Naga.xml
+++ b/Patches/SYR Naga/Patch_Ammo_44Magnum_Naga.xml
@@ -32,7 +32,7 @@
 						  <!-- ==================== Ammo ========================== -->
 
 						  <ThingDef Class="CombatExtended.AmmoDef" Name="44MagnumChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
-							<description>Charged shot ammo used by advanced assault rifle designs.</description>
+							<description>Charged shot ammo used by low velocity, high power charge weapons.</description>
 							<statBases>
 							  <Mass>0.023</Mass>
 							  <Bulk>0.02</Bulk>
@@ -51,7 +51,7 @@
 							<defName>Ammo_44MagnumCharged</defName>
 							<label>.44 Magnum Charged cartridge</label>
 							<graphicData>
-							  <texPath>Things/Ammo/Charged/Regular</texPath>
+							  <texPath>Things/Ammo/Charged/SmallRegular</texPath>
 							  <graphicClass>Graphic_StackCount</graphicClass>
 							</graphicData>
 							<statBases>

--- a/Patches/Star Wars - Factions/PlasmaGasCartridge.xml
+++ b/Patches/Star Wars - Factions/PlasmaGasCartridge.xml
@@ -72,7 +72,7 @@
 			<!-- ==================== Ammo ========================== -->
 
 		  <ThingDef Class="CombatExtended.AmmoDef" Name="SWPlasmaGasCartridgeBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
-			<description>Charged shot ammo used by advanced assault rifle designs.</description>
+			<description>Plasma gas cartridge ammo used by advanced assault rifle designs.</description>
 			<statBases>
 			  <Mass>0.01</Mass>
 			  <Bulk>0.03</Bulk>
@@ -91,7 +91,7 @@
 			<defName>Ammo_SWPlasmaGasCartridge</defName>
 			<label>Plasma Gas Cartridges</label>
 			<graphicData>
-			  <texPath>Things/Ammo/Charged/Concentrated</texPath>
+			  <texPath>Things/Ammo/PlasmaCell/Heavy</texPath>
 			  <graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>
@@ -105,7 +105,7 @@
 			<defName>Ammo_SWPlasmaGasCartridge_AP</defName>
 			<label>Plasma Gas Cartridges (Imp)</label>
 			<graphicData>
-			  <texPath>Things/Ammo/Charged/Regular</texPath>
+			  <texPath>Things/Ammo/PlasmaCell/Heavy</texPath>
 			  <graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>
@@ -119,7 +119,7 @@
 			<defName>Ammo_SWPlasmaGasCartridge_Ion</defName>
 			<label>Plasma Gas Cartridges (Stun)</label>
 			<graphicData>
-			  <texPath>Things/Ammo/Charged/Ion</texPath>
+			  <texPath>Things/Ammo/PlasmaCell/Heavy</texPath>
 			  <graphicClass>Graphic_StackCount</graphicClass>
 			</graphicData>
 			<statBases>


### PR DESCRIPTION
## Changes

- Fixed some ammo texture directories that were still directing towards the old charge ammo textures.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
