### PR TITLE
Readjust the Tough trait

### DIFF
--- a/Patches/Core/TraitDefs/Traits_Singular.xml
+++ b/Patches/Core/TraitDefs/Traits_Singular.xml
@@ -25,7 +25,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/TraitDef[defName="Tough"]/degreeDatas/li/statFactors/IncomingDamageFactor</xpath>
 		<value>
-			<IncomingDamageFactor>0.75</IncomingDamageFactor>
+			<IncomingDamageFactor>0.66</IncomingDamageFactor>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Changed the incoming damage factor of the Tough trait from x0.75 to x0.66.

## Reasoning

- Since it is intended for the Tough trait to be stronger than the Robust gene, changing the bonus to x0.66 would be a bit more balanced while keeping it not absurd like its original value.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
