### PR TITLE
Allow bunker buster projectiles to spawn gas 

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_BunkerBuster.cs
@@ -39,7 +39,8 @@ namespace CombatExtended
                                            applyDamageToExplosionCellsNeighbors: props.applyDamageToExplosionCellsNeighbors,
                                            preExplosionSpawnThingDef: props.preExplosionSpawnThingDef,
                                            preExplosionSpawnChance: props.preExplosionSpawnChance,
-                                           preExplosionSpawnThingCount: props.preExplosionSpawnThingCount
+                                           preExplosionSpawnThingCount: props.preExplosionSpawnThingCount,
+                                           postExplosionGasType: props.postExplosionGasType
                                           );
 
                 if (this.TryGetComp<CompFragments>() != null)


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Added a property to bunker buster projectiles' explosion, so that they can spawn the new GasType added in 1.4

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
