### PR TITLE
Rebalance the VFE-Security Military and Sentry turret

### DIFF
--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -364,20 +364,17 @@
 			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
-			  <warmupTime>2.3</warmupTime>
+			  <warmupTime>2.1</warmupTime>
 			  <range>62</range>
-			  <burstShotCount>50</burstShotCount>
+			  <burstShotCount>25</burstShotCount>
 			  <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 			  <soundCast>Shot_Minigun</soundCast>
 			  <soundCastTail>GunTail_Medium</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			  <recoilPattern>Mounted</recoilPattern>
-			  <targetParams>
-				<canTargetLocations>True</canTargetLocations>
-			  </targetParams>
 			</Properties>
 			<AmmoUser>
-			  <magazineSize>500</magazineSize>
+			  <magazineSize>250</magazineSize>
 			  <reloadTime>9.2</reloadTime>
 			  <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 			</AmmoUser>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -213,14 +213,14 @@
 			  <warmupTime>1.3</warmupTime>
 			  <range>54</range>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-			  <burstShotCount>20</burstShotCount>
+			  <burstShotCount>12</burstShotCount>
 			  <soundCast>GunShotA</soundCast>
 			  <soundCastTail>GunTail_Light</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			  <recoilPattern>Mounted</recoilPattern>
 			</Properties>
 			<AmmoUser>
-			  <magazineSize>200</magazineSize>
+			  <magazineSize>120</magazineSize>
 			  <reloadTime>7.8</reloadTime>
 			  <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 			</AmmoUser>
@@ -248,14 +248,14 @@
 			  <warmupTime>1.3</warmupTime>
 			  <range>54</range>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-			  <burstShotCount>20</burstShotCount>
+			  <burstShotCount>12</burstShotCount>
 			  <soundCast>GunShotA</soundCast>
 			  <soundCastTail>GunTail_Light</soundCastTail>
 			  <muzzleFlashScale>9</muzzleFlashScale>
 			  <recoilPattern>Mounted</recoilPattern>
 			</Properties>
 			<AmmoUser>
-			  <magazineSize>200</magazineSize>
+			  <magazineSize>120</magazineSize>
 			  <reloadTime>7.8</reloadTime>
 			  <ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 			</AmmoUser>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -211,7 +211,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
-			  <range>54</range>
+			  <range>48</range>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 			  <burstShotCount>12</burstShotCount>
 			  <soundCast>GunShotA</soundCast>
@@ -246,7 +246,7 @@
 			  <hasStandardCommand>true</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 			  <warmupTime>1.3</warmupTime>
-			  <range>54</range>
+			  <range>48</range>
 			  <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
 			  <burstShotCount>12</burstShotCount>
 			  <soundCast>GunShotA</soundCast>
@@ -365,7 +365,7 @@
 			  <hasStandardCommand>True</hasStandardCommand>
 			  <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 			  <warmupTime>2.1</warmupTime>
-			  <range>62</range>
+			  <range>54</range>
 			  <burstShotCount>25</burstShotCount>
 			  <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
 			  <soundCast>Shot_Minigun</soundCast>


### PR DESCRIPTION
## Changes

- Adjusted the military turret's range,burst shot count from 20 to 12, and its magazine capacity from 200 to 120.
- Adjusted the sentry turret's burst shot count from 50 to 25, and its magazine capacity from 500 to 250.

## Reasoning

- The changes are made to make the military turret which is a double mini-turret to be consistent with autocannon vs double autocannon. And the sentry turret is changed to resemble the handheld minigun.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors