### PR TITLE
Fix .277 Fury's projectile mass

### DIFF
--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -144,9 +144,9 @@
 		<defName>Bullet_277Fury_FMJ</defName>
 		<label>.277 Fury bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>7.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>74.52</armorPenetrationBlunt>
+			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -156,7 +156,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
-			<armorPenetrationBlunt>74.52</armorPenetrationBlunt>
+			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -166,7 +166,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
-			<armorPenetrationBlunt>74.52</armorPenetrationBlunt>
+			<armorPenetrationBlunt>72.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -176,7 +176,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
 		  <armorPenetrationSharp>15</armorPenetrationSharp>
-		  <armorPenetrationBlunt>74.52</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>72.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
 			  <def>Flame_Secondary</def>
@@ -190,9 +190,9 @@
 		<defName>Bullet_277Fury_HE</defName>
 		<label>.277 Fury bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		  <damageAmountBase>20</damageAmountBase>
+		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
-		  <armorPenetrationBlunt>74.52</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>72.46</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
 			  <def>Bomb_Secondary</def>
@@ -208,7 +208,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>26.25</armorPenetrationSharp>
-		  <armorPenetrationBlunt>95.76</armorPenetrationBlunt>
+		  <armorPenetrationBlunt>93.16</armorPenetrationBlunt>
 		  <speed>273</speed>
 		</projectile>
 	  </ThingDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, it should be 135 grains not ~139 grains.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
