### PR TITLE
VE Psycasts Staticlord Bolt ability tweak

### DIFF
--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -44,7 +44,7 @@
                 <li Class="PatchOperationAdd">
                     <xpath>Defs/ThingDef[defName="VPE_Bolt"]/projectile</xpath>
                     <value>
-                        <damageAmountBase>8</damageAmountBase>
+                        <damageAmountBase>10</damageAmountBase>
                     </value>
                 </li>
 

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -48,13 +48,6 @@
                     </value>
                 </li>
 
-                <li Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="VPE_ChainBolt"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]</xpath>
-                    <value>
-                        <damageAmountBase>7</damageAmountBase>
-                    </value>
-                </li>
-
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="VPE_BallLightning"]/projectile/speed</xpath>
                     <value>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs/Projectile_Tweaks.xml
@@ -41,6 +41,20 @@
 
                 <!-- ===== Staticlord ===== -->
 
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="VPE_Bolt"]/projectile</xpath>
+                    <value>
+                        <damageAmountBase>8</damageAmountBase>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="VPE_ChainBolt"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]</xpath>
+                    <value>
+                        <damageAmountBase>7</damageAmountBase>
+                    </value>
+                </li>
+
                 <li Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="VPE_BallLightning"]/projectile/speed</xpath>
                     <value>


### PR DESCRIPTION
## Changes

- Tweaked the damage amount of Bolt ability of the Staticlord tree.

## Reasoning

- Since the aforementioned ability is using the default damage values of the damage type used, it is dealing the default 50 damage of EMP damage type which resulted in it being very overpowered in CE.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
