### PR TITLE
Update and fix RH2 Rangers apparel patch

### DIFF
--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -11,14 +11,14 @@
         <!-- ========== In-built Shield Patch ========== -->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/comps/li[@Class="JetPacks.CompProperties_ShieldBelt"]/EnergyShieldRechargeRate</xpath>
+            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/statBases/EnergyShieldRechargeRate</xpath>
             <value>
                 <EnergyShieldRechargeRate>0.075</EnergyShieldRechargeRate>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/comps/li[@Class="JetPacks.CompProperties_ShieldBelt"]/EnergyShieldEnergyMax</xpath>
+            <xpath>/Defs/ThingDef[defName="RHApparel_PowerArmor_Ranger"]/statBases/EnergyShieldEnergyMax</xpath>
             <value>
                 <EnergyShieldEnergyMax>0.75</EnergyShieldEnergyMax>
             </value>
@@ -27,54 +27,32 @@
         <!-- ========== Ranger Helmet ========== -->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/recipeMaker/researchPrerequisite</xpath>
-            <value>
-                <researchPrerequisite>ReconArmor</researchPrerequisite> 
-            </value>
-        </li>
-
-         <li Class="PatchOperationReplace">
-              <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
-              <value>
-              <ArmorRating_Sharp>14</ArmorRating_Sharp>
-              </value>
-          </li>
-
-
-        <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Mass</xpath>
             <value>
-            <Mass>3.0</Mass><Bulk>4</Bulk>
-            <WornBulk>1</WornBulk>
-            <NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel> 
+              <Mass>5.0</Mass><Bulk>4</Bulk>
+              <WornBulk>1</WornBulk>
+              <NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel> 
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Flammability</xpath>
             <value>
-            <Flammability>0.25</Flammability>
-            </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/MaxHitPoints</xpath>
-            <value>
-            <MaxHitPoints>190</MaxHitPoints>
+              <Flammability>0</Flammability>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
             <value>
-            <ArmorRating_Sharp>14</ArmorRating_Sharp>
+              <ArmorRating_Sharp>16</ArmorRating_Sharp>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
             <value>
-            <ArmorRating_Blunt>26</ArmorRating_Blunt>
+              <ArmorRating_Blunt>36</ArmorRating_Blunt>
             </value>
         </li>
 
@@ -93,8 +71,8 @@
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/costList/Plasteel</xpath>
             <value>
-            <Plasteel>50</Plasteel>
-            <DevilstrandCloth>15</DevilstrandCloth>
+            <Plasteel>60</Plasteel>
+            <DevilstrandCloth>20</DevilstrandCloth>
             </value>
         </li>
 
@@ -106,49 +84,82 @@
             </value>
         </li>
 
+	  <li Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
+		<value>
+		  <li Class="CombatExtended.PartialArmorExt">
+			<stats>
+				<li>
+					<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+					<parts>
+						<li>Eye</li>
+					</parts>
+				</li>
+				<li>
+					<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+					<parts>
+						<li>Eye</li>
+					</parts>
+				</li>
+				<li>
+					<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+					<parts>
+						<li>Nose</li>
+					</parts>
+				</li>
+				<li>
+					<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+					<parts>
+						<li>Nose</li>
+					</parts>
+				</li>
+			</stats>
+		  </li>
+		</value>
+	  </li>
+
         <!-- ========== Ranger armor ========== -->
-
-         <li Class="PatchOperationReplace">
-              <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
-              <value>
-                  <ArmorRating_Sharp>14</ArmorRating_Sharp>
-              </value>
-          </li>
-
 
         <li Class="PatchOperationAdd">
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases</xpath>
             <value>
-                <Bulk>80</Bulk>
-                <WornBulk>12</WornBulk>
+                <Bulk>90</Bulk>
+                <WornBulk>13</WornBulk>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Mass</xpath>
             <value>
-                <Mass>19</Mass>
+                <Mass>40</Mass>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Flammability</xpath>
             <value>
-                <Flammability>0.2</Flammability>
+                <Flammability>0</Flammability>
+            </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/MaxHitPoints</xpath>
+            <value>
+                <MaxHitPoints>450</MaxHitPoints>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
             <value>
-                <ArmorRating_Sharp>14</ArmorRating_Sharp>
+                <ArmorRating_Sharp>19</ArmorRating_Sharp>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
             <value>
-                <ArmorRating_Blunt>24</ArmorRating_Blunt>
+                <ArmorRating_Blunt>42</ArmorRating_Blunt>
             </value>
         </li>
 
@@ -163,12 +174,73 @@
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
             <value>
             <equippedStatOffsets>
-                <CarryWeight>25</CarryWeight>
+                <CarryWeight>70</CarryWeight>
+                <CarryBulk>10</CarryBulk>
+                <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
                 <ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
-                <MoveSpeed>0.4</MoveSpeed>
             </equippedStatOffsets>
             </value>
         </li>
+
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>160</Plasteel>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>20</Uranium>
+		</value>
+	</li>
+
+	<li Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
+		<value>
+		  <li Class="CombatExtended.PartialArmorExt">
+			  <stats>
+				  <li>
+					<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+					<parts>
+						<li>Neck</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+					<parts>
+						<li>Neck</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+					<parts>
+						<li>Arm</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+					<parts>
+						<li>Arm</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+					<parts>
+						<li>Hand</li>
+					</parts>
+				  </li>
+				  <li>
+					<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+					<parts>
+						<li>Hand</li>
+					</parts>
+				  </li>
+			  </stats>
+		  </li>
+		</value>
+	</li>
 
         <!-- Poncho & Duster-->
            <li Class="PatchOperationReplace">


### PR DESCRIPTION
## Changes

- What it says on the tin. Fixed an error and updated armor values.

## Reasoning

- The ranger armor set is based on Marine gear not Recon.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Working as intended)
