### PR TITLE
Tweak the AA's Herald poison bolt ability

### DIFF
--- a/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
+++ b/Patches/Alpha Animals/AA_VPE/AbilityDefs/AbilityDefs_Patch.xml
@@ -37,7 +37,8 @@
 										<projectile>
 											<flyOverhead>false</flyOverhead>
 											<damageDef>AA_ToxicBolt</damageDef>
-											<damageAmountBase>12</damageAmountBase>
+											<damageAmountBase>10</damageAmountBase>
+											<armorPenetrationBase>2.5</armorPenetrationBase>
 											<speed>50</speed>
 										</projectile>
 									</ThingDef>


### PR DESCRIPTION
## Changes

- Made the necessary tweaks to make the projectile launched by the ability to be consistent with the one launched by the Black Hive insectoids.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (It is properly penetrating armor)
