### PR TITLE
Relabel HE ammo to AP-HE

### DIFF
--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo127x108mmBase">
     <defName>Ammo_127x108mm_HE</defName>
-    <label>12.7x108mm cartridge (HE)</label>
+    <label>12.7x108mm cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
 
   <ThingDef ParentName="Base127x108mmBullet">
     <defName>Bullet_127x108mm_HE</defName>
-    <label>12.7x108mm bullet (HE)</label>
+    <label>12.7x108mm bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
       <armorPenetrationSharp>15</armorPenetrationSharp>
@@ -280,9 +280,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_127x108mm_HE</defName>
-    <label>make 12.7x108mm (HE) cartridge x200</label>
-    <description>Craft 200 12.7x108mm (HE) cartridges.</description>
-    <jobString>Making 12.7x108mm (HE) cartridges.</jobString>
+    <label>make 12.7x108mm (AP-HE) cartridge x200</label>
+    <description>Craft 200 12.7x108mm (AP-HE) cartridges.</description>
+    <jobString>Making 12.7x108mm (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo132x92mmSRTuFBase">
 		<defName>Ammo_132x92mmSRTuF_HE</defName>
-		<label>13.2x92mmSR TuF cartridge (HE)</label>
+		<label>13.2x92mmSR TuF cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
 	<ThingDef ParentName="Base132x92mmSRTuFBullet">
 		<defName>Bullet_132x92mmSRTuF_HE</defName>
-		<label>13.2x92mmSR TuF bullet (HE)</label>
+		<label>13.2x92mmSR TuF bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_132x92mmSRTuF_HE</defName>
-		<label>make 13.2x92mmSR TuF (HE) cartridge x200</label>
-		<description>Craft 200 13.2x92mmSR TuF (HE) cartridges.</description>
-		<jobString>Making 13.2x92mmSR TuF (HE) cartridges.</jobString>
+		<label>make 13.2x92mmSR TuF (AP-HE) cartridge x200</label>
+		<description>Craft 200 13.2x92mmSR TuF (AP-HE) cartridges.</description>
+		<jobString>Making 13.2x92mmSR TuF (AP-HE) cartridges.</jobString>
 		<ingredients>
 		<li>
 			<filter>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">
     <defName>Ammo_145x114mm_HE</defName>
-    <label>14.5x114mm cartridge (HE)</label>
+    <label>14.5x114mm cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
 
   <ThingDef ParentName="Base145x114mmBullet">
     <defName>Bullet_145x114mm_HE</defName>
-    <label>14.5x114mm bullet (HE)</label>
+    <label>14.5x114mm bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>53</damageAmountBase>
       <armorPenetrationSharp>18</armorPenetrationSharp>
@@ -280,9 +280,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_145x114mm_HE</defName>
-    <label>make 14.5x114mm (HE) cartridge x200</label>
-    <description>Craft 200 14.5x114mm (HE) cartridges.</description>
-    <jobString>Making 14.5x114mm (HE) cartridges.</jobString>
+    <label>make 14.5x114mm (AP-HE) cartridge x200</label>
+    <description>Craft 200 14.5x114mm (AP-HE) cartridges.</description>
+    <jobString>Making 14.5x114mm (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo2BoreBase">
     <defName>Ammo_2Bore_HE</defName>
-    <label>2-Bore cartridge (HE)</label>
+    <label>2-Bore cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
   
   <ThingDef ParentName="Base2BoreBullet">
     <defName>Bullet_2Bore_HE</defName>
-    <label>2-Bore bullet (HE)</label>
+    <label>2-Bore bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>57</damageAmountBase>
       <armorPenetrationSharp>12</armorPenetrationSharp>
@@ -280,9 +280,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_2Bore_HE</defName>
-    <label>make 2-Bore (HE) cartridge x200</label>
-    <description>Craft 200 2-Bore (HE) cartridges.</description>
-    <jobString>Making 2-Bore (HE) cartridges.</jobString>
+    <label>make 2-Bore (AP-HE) cartridge x200</label>
+    <description>Craft 200 2-Bore (AP-HE) cartridges.</description>
+    <jobString>Making 2-Bore (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x102mmNATOBase">
 		<defName>Ammo_20x102mmNATO_HE</defName>
-		<label>20x102mm NATO cartridge (HE)</label>
+		<label>20x102mm NATO cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base20x102mmNATOBullet">
 		<defName>Bullet_20x102mmNATO_HE</defName>
-		<label>20x102mm NATO bullet (HE)</label>
+		<label>20x102mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
 			<armorPenetrationSharp>15</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x102mmNATO_HE</defName>
-		<label>make 20x102mm NATO (HE) cartridge x200</label>
-		<description>Craft 200 20x102mm NATO (HE) cartridges.</description>
-		<jobString>Making 20x102mm NATO (HE) cartridges.</jobString>
+		<label>make 20x102mm NATO (AP-HE) cartridge x200</label>
+		<description>Craft 200 20x102mm NATO (AP-HE) cartridges.</description>
+		<jobString>Making 20x102mm NATO (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -70,7 +70,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x110mmHispanoBase">
     <defName>Ammo_20x110mmHispano_HE</defName>
-    <label>20x110mm Hispano cartridge (HE)</label>
+    <label>20x110mm Hispano cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
   <ThingDef ParentName="Base20x110mmHispanoBullet">
     <defName>Bullet_20x110mmHispano_HE</defName>
-    <label>20mm Hispano bullet (HE)</label>
+    <label>20mm Hispano bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>66</damageAmountBase>
       <armorPenetrationSharp>14</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_20x110mmHispano_HE</defName>
-    <label>make 20x110mm Hispano (HE) cartridge x200</label>
-    <description>Craft 200 20x110mm Hispano (HE) cartridges.</description>
-    <jobString>Making 20x110mm Hispano (HE) cartridges.</jobString>
+    <label>make 20x110mm Hispano (AP-HE) cartridge x200</label>
+    <description>Craft 200 20x110mm Hispano (AP-HE) cartridges.</description>
+    <jobString>Making 20x110mm Hispano (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x128mmOerlikonBase">
 		<defName>Ammo_20x128mmOerlikon_HE</defName>
-		<label>20x128mm Oerlikon cartridge (HE)</label>
+		<label>20x128mm Oerlikon cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base20x128mmOerlikonBullet">
 		<defName>Bullet_20x128mmOerlikon_HE</defName>
-		<label>20mm Oerlikon bullet (HE)</label>
+		<label>20mm Oerlikon bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>75</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x128mmOerlikon_HE</defName>
-		<label>make 20x128mm Oerlikon (HE) cartridge x200</label>
-		<description>Craft 200 20x128mm Oerlikon (HE) cartridges.</description>
-		<jobString>Making 20x128mm Oerlikon (HE) cartridges.</jobString>
+		<label>make 20x128mm Oerlikon (AP-HE) cartridge x200</label>
+		<description>Craft 200 20x128mm Oerlikon (AP-HE) cartridges.</description>
+		<jobString>Making 20x128mm Oerlikon (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x138mmBBase">
 		<defName>Ammo_20x138mmB_HE</defName>
-		<label>20x138mmB cartridge (HE)</label>
+		<label>20x138mmB cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -129,7 +129,7 @@
 
  	<ThingDef ParentName="Base145x114mmBullet">
 		<defName>Bullet_20x138mmB_HE</defName>
-		<label>20x138mmB bullet (HE)</label>
+		<label>20x138mmB bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>68</damageAmountBase>
 			<armorPenetrationSharp>17</armorPenetrationSharp>
@@ -220,9 +220,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_20x138mmB_HE</defName>
-		<label>make 20x138mmB (HE) cartridge x200</label>
-		<description>Craft 200 20x138mmB (HE) cartridges.</description>
-		<jobString>Making 20x138mmB (HE) cartridges.</jobString>
+		<label>make 20x138mmB (AP-HE) cartridge x200</label>
+		<description>Craft 200 20x138mmB (AP-HE) cartridges.</description>
+		<jobString>Making 20x138mmB (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -70,7 +70,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x82mmMauserBase">
     <defName>Ammo_20x82mmMauser_HE</defName>
-    <label>20x82mm Mauser cartridge (HE)</label>
+    <label>20x82mm Mauser cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
   
   <ThingDef ParentName="Base20x82mmMauserBullet">
     <defName>Bullet_20x82mmMauser_HE</defName>
-    <label>20mm Mauser bullet (HE)</label>
+    <label>20mm Mauser bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>57</damageAmountBase>
       <armorPenetrationSharp>12</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_20x82mmMauser_HE</defName>
-    <label>make 20x82mm Mauser (HE) cartridge x200</label>
-    <description>Craft 200 20x82mm Mauser (HE) cartridges.</description>
-    <jobString>Making 20x82mm Mauser (HE) cartridges.</jobString>
+    <label>make 20x82mm Mauser (AP-HE) cartridge x200</label>
+    <description>Craft 200 20x82mm Mauser (AP-HE) cartridges.</description>
+    <jobString>Making 20x82mm Mauser (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -70,7 +70,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo20x99mmRShVAKBase">
     <defName>Ammo_20x99mmRShVAK_HE</defName>
-    <label>20x99mmR ShVAK cartridge (HE)</label>
+    <label>20x99mmR ShVAK cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
   <ThingDef ParentName="Base20x99mmRShVAKBullet">
     <defName>Bullet_20x99mmRShVAK_HE</defName>
-    <label>20mmR ShVAK bullet (HE)</label>
+    <label>20mmR ShVAK bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>56</damageAmountBase>
       <armorPenetrationSharp>13</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_20x99mmRShVAK_HE</defName>
-    <label>make 20x99mmR ShVAK (HE) cartridge x200</label>
-    <description>Craft 200 20x99mmR ShVAK (HE) cartridges.</description>
-    <jobString>Making 20x99mmR ShVAK (HE) cartridges.</jobString>
+    <label>make 20x99mmR ShVAK (AP-HE) cartridge x200</label>
+    <description>Craft 200 20x99mmR ShVAK (AP-HE) cartridges.</description>
+    <jobString>Making 20x99mmR ShVAK (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo25x137mmNATOBase">
 		<defName>Ammo_25x137mmNATO_HE</defName>
-		<label>25x137mm NATO cartridge (HE)</label>
+		<label>25x137mm NATO cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base25x137mmNATOBullet">
 		<defName>Bullet_25x137mmNATO_HE</defName>
-		<label>25x137mm NATO bullet (HE)</label>
+		<label>25x137mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>98</damageAmountBase>
 			<armorPenetrationSharp>29</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_25x137mmNATO_HE</defName>
-		<label>make 25x137mm NATO (HE) cartridge x200</label>
-		<description>Craft 200 .25x137mm NATO (HE) cartridges.</description>
-		<jobString>Making .25x137mm NATO (HE) cartridges.</jobString>
+		<label>make 25x137mm NATO (AP-HE) cartridge x200</label>
+		<description>Craft 200 .25x137mm NATO (AP-HE) cartridges.</description>
+		<jobString>Making .25x137mm NATO (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo300WinchesterMagnumBase">
 		<defName>Ammo_300WinchesterMagnum_HE</defName>
-		<label>.300 Winchester Magnum cartridge (HE)</label>
+		<label>.300 Winchester Magnum cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
   <ThingDef ParentName="Base300WinchesterMagnumBullet">
     <defName>Bullet_300WinchesterMagnum_HE</defName>
-    <label>.300 Winchester Magnum bullet (HE)</label>
+    <label>.300 Winchester Magnum bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>23</damageAmountBase>
       <armorPenetrationSharp>10</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_300WinchesterMagnum_HE</defName>
-    <label>make .300 Winchester Magnum (HE) cartridge x200</label>
-    <description>Craft 200 .300 Winchester Magnum (HE) cartridges.</description>
-    <jobString>Making .300 Winchester Magnum (HE) cartridges.</jobString>
+    <label>make .300 Winchester Magnum (AP-HE) cartridge x200</label>
+    <description>Craft 200 .300 Winchester Magnum (AP-HE) cartridges.</description>
+    <jobString>Making .300 Winchester Magnum (AP-HE) cartridges.</jobString>
     <ingredients>
     <li>
       <filter>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x113mmBBase">
 		<defName>Ammo_30x113mmB_HE</defName>
-		<label>30x113mmB cartridge (HE)</label>
+		<label>30x113mmB cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base30x113mmBBullet">
 		<defName>Bullet_30x113mmB_HE</defName>
-		<label>30x113mmB bullet (HE)</label>
+		<label>30x113mmB bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>94</damageAmountBase>
 			<armorPenetrationSharp>20</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x113mmB_HE</defName>
-		<label>make 30x113mmB (HE) cartridge x100</label>
-		<description>Craft 100 .30x113mmB (HE) cartridges.</description>
-		<jobString>Making .30x113mmB (HE) cartridges.</jobString>
+		<label>make 30x113mmB (AP-HE) cartridge x100</label>
+		<description>Craft 100 .30x113mmB (AP-HE) cartridges.</description>
+		<jobString>Making .30x113mmB (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x173mmNATOBase">
 		<defName>Ammo_30x173mmNATO_HE</defName>
-		<label>30x173mm NATO cartridge (HE)</label>
+		<label>30x173mm NATO cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base30x173mmNATOBullet">
 		<defName>Bullet_30x173mmNATO_HE</defName>
-		<label>30x173mm NATO bullet (HE)</label>
+		<label>30x173mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>127</damageAmountBase>
 			<armorPenetrationSharp>35</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x173mmNATO_HE</defName>
-		<label>make 30x173mm NATO (HE) cartridge x200</label>
-		<description>Craft 200 .30x173mm NATO (HE) cartridges.</description>
-		<jobString>Making .30x173mm NATO (HE) cartridges.</jobString>
+		<label>make 30x173mm NATO (AP-HE) cartridge x200</label>
+		<description>Craft 200 .30x173mm NATO (AP-HE) cartridges.</description>
+		<jobString>Making .30x173mm NATO (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -84,7 +84,7 @@
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338LapuaBase">
     <defName>Ammo_338Lapua_HE</defName>
-    <label>.338 Lapua Magnum cartridge (HE)</label>
+    <label>.338 Lapua Magnum cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
   
   <ThingDef ParentName="Base338LapuaBullet">
     <defName>Bullet_338Lapua_HE</defName>
-    <label>.338 Lapua Magnum bullet (HE)</label>
+    <label>.338 Lapua Magnum bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
       <armorPenetrationSharp>11</armorPenetrationSharp>
@@ -279,9 +279,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_338Lapua_HE</defName>
-    <label>make .338 Lapua Magnum (HE) cartridge x200</label>
-    <description>Craft 200 .338 Lapua Magnum (HE) cartridges.</description>
-    <jobString>Making .338 Lapua Magnum (HE) cartridges.</jobString>
+    <label>make .338 Lapua Magnum (AP-HE) cartridge x200</label>
+    <description>Craft 200 .338 Lapua Magnum (AP-HE) cartridges.</description>
+    <jobString>Making .338 Lapua Magnum (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -84,7 +84,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo338NormaBase">
     <defName>Ammo_338Norma_HE</defName>
-    <label>.338 Norma Magnum cartridge (HE)</label>
+    <label>.338 Norma Magnum cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
   <ThingDef ParentName="Base338NormaBullet">
     <defName>Bullet_338Norma_HE</defName>
-    <label>.338 Norma Magnum bullet (HE)</label>
+    <label>.338 Norma Magnum bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>25</damageAmountBase>
       <armorPenetrationSharp>11</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_338Norma_HE</defName>
-    <label>make .338 Norma Magnum (HE) cartridge x200</label>
-    <description>Craft 200 .338 Norma Magnum (HE) cartridges.</description>
-    <jobString>Making .338 Norma Magnum (HE) cartridges.</jobString>
+    <label>make .338 Norma Magnum (AP-HE) cartridge x200</label>
+    <description>Craft 200 .338 Norma Magnum (AP-HE) cartridges.</description>
+    <jobString>Making .338 Norma Magnum (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo408CheyenneTacticalBase">
 		<defName>Ammo_408CheyenneTactical_HE</defName>
-		<label>.408 Cheyenne Tactical cartridge (HE)</label>
+		<label>.408 Cheyenne Tactical cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
   <ThingDef ParentName="Base408CheyenneTacticalBullet">
     <defName>Bullet_408CheyenneTactical_HE</defName>
-    <label>.408 Cheyenne Tactical bullet (HE)</label>
+    <label>.408 Cheyenne Tactical bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>23</damageAmountBase>
       <armorPenetrationSharp>12</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_408CheyenneTactical_HE</defName>
-    <label>make .408 Cheyenne Tactical (HE) cartridge x200</label>
-    <description>Craft 200 .408 Cheyenne Tactical (HE) cartridges.</description>
-    <jobString>Making .408 Cheyenne Tactical (HE) cartridges.</jobString>
+    <label>make .408 Cheyenne Tactical (AP-HE) cartridge x200</label>
+    <description>Craft 200 .408 Cheyenne Tactical (AP-HE) cartridges.</description>
+    <jobString>Making .408 Cheyenne Tactical (AP-HE) cartridges.</jobString>
     <ingredients>
     <li>
       <filter>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -70,7 +70,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo40x311mmRBase">
 		<defName>Ammo_40x311mmR_HE</defName>
-		<label>40x311mmR cartridge (HE)</label>
+		<label>40x311mmR cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/Bofors/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="Base40x311mmRBullet">
 		<defName>Bullet_40x311mmR_HE</defName>
-		<label>40x311mmR bullet (HE)</label>
+		<label>40x311mmR bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>168</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
@@ -229,9 +229,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_40x311mmR_HE</defName>
-		<label>make 40x311mmR (HE) cartridge x50</label>
-		<description>Craft 50 40x311mmR (HE) cartridges.</description>
-		<jobString>Making 40x311mmR (HE) cartridges.</jobString>
+		<label>make 40x311mmR (AP-HE) cartridge x50</label>
+		<description>Craft 50 40x311mmR (AP-HE) cartridges.</description>
+		<jobString>Making 40x311mmR (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -84,7 +84,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo470NitroExpressBase">
     <defName>Ammo_470NitroExpress_HE</defName>
-    <label>.470 Nitro Express cartridge (HE)</label>
+    <label>.470 Nitro Express cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 	  
 	  <ThingDef ParentName="Base470NitroExpressBullet">
 		<defName>Bullet_470NitroExpress_HE</defName>
-		<label>.470 Nitro Express bullet (HE)</label>
+		<label>.470 Nitro Express bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>29</damageAmountBase>
 		  <armorPenetrationSharp>11</armorPenetrationSharp>
@@ -279,9 +279,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_470NitroExpress_HE</defName>
-    <label>make .470 Nitro Express (HE) cartridge x200</label>
-    <description>Craft 200 .470 Nitro Express (HE) cartridges.</description>
-    <jobString>Making .470 Nitro Express (HE) cartridges.</jobString>
+    <label>make .470 Nitro Express (AP-HE) cartridge x200</label>
+    <description>Craft 200 .470 Nitro Express (AP-HE) cartridges.</description>
+    <jobString>Making .470 Nitro Express (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">
     <defName>Ammo_50BMG_HE</defName>
-    <label>.50 BMG cartridge (HE)</label>
+    <label>.50 BMG cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
   
   <ThingDef ParentName="Base50BMGBullet">
     <defName>Bullet_50BMG_HE</defName>
-    <label>.50 BMG bullet (HE)</label>
+    <label>.50 BMG bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
       <armorPenetrationSharp>15.5</armorPenetrationSharp>
@@ -280,9 +280,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_50BMG_HE</defName>
-    <label>make .50 BMG (HE) cartridge x200</label>
-    <description>Craft 200 .50 BMG (HE) cartridges.</description>
-    <jobString>Making .50 BMG (HE) cartridges.</jobString>
+    <label>make .50 BMG (AP-HE) cartridge x200</label>
+    <description>Craft 200 .50 BMG (AP-HE) cartridges.</description>
+    <jobString>Making .50 BMG (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo55BoysBase">
 		<defName>Ammo_55Boys_HE</defName>
-		<label>.55 Boys cartridge (HE)</label>
+		<label>.55 Boys cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 	
 	<ThingDef ParentName="Base55BoysBullet">
 		<defName>Bullet_55Boys_HE</defName>
-		<label>.55 Boys bullet (HE)</label>
+		<label>.55 Boys bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>48</damageAmountBase>
 			<armorPenetrationSharp>19</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_55Boys_HE</defName>
-		<label>make .55 Boys (HE) cartridge x200</label>
-		<description>Craft 200 .55 Boys (HE) cartridges.</description>
-		<jobString>Making .55 Boys (HE) cartridges.</jobString>
+		<label>make .55 Boys (AP-HE) cartridge x200</label>
+		<description>Craft 200 .55 Boys (AP-HE) cartridges.</description>
+		<jobString>Making .55 Boys (AP-HE) cartridges.</jobString>
 		<ingredients>
 		<li>
 			<filter>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo600NitroExpressBase">
 		<defName>Ammo_600NitroExpress_HE</defName>
-		<label>.600 Nitro Express cartridge (HE)</label>
+		<label>.600 Nitro Express cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
   <ThingDef ParentName="Base600NitroExpressBullet">
     <defName>Bullet_600NitroExpress_HE</defName>
-    <label>.600 Nitro Express bullet (HE)</label>
+    <label>.600 Nitro Express bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>38</damageAmountBase>
       <armorPenetrationSharp>11</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_600NitroExpress_HE</defName>
-    <label>make .600 Nitro Express (HE) cartridge x200</label>
-    <description>Craft 200 .600 Nitro Express (HE) cartridges.</description>
-    <jobString>Making .600 Nitro Express (HE) cartridges.</jobString>
+    <label>make .600 Nitro Express (AP-HE) cartridge x200</label>
+    <description>Craft 200 .600 Nitro Express (AP-HE) cartridges.</description>
+    <jobString>Making .600 Nitro Express (AP-HE) cartridges.</jobString>
     <ingredients>
     <li>
       <filter>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -85,7 +85,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo792x94mmPatronenBase">
     <defName>Ammo_792x94mmPatronen_HE</defName>
-    <label>7.92x94mm Patronen cartridge (HE)</label>
+    <label>7.92x94mm Patronen cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -164,7 +164,7 @@
 
   <ThingDef ParentName="Base792x94mmPatronenBullet">
     <defName>Bullet_792x94mmPatronen_HE</defName>
-    <label>7.92x94mm Patronen bullet (HE)</label>
+    <label>7.92x94mm Patronen bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>30</damageAmountBase>
       <armorPenetrationSharp>22</armorPenetrationSharp>
@@ -280,9 +280,9 @@
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_792x94mmPatronen_HE</defName>
-    <label>make 7.92x94mm Patronen (HE) cartridge x200</label>
-    <description>Craft 200 7.92x94mm Patronen (HE) cartridges.</description>
-    <jobString>Making 7.92x94mm Patronen (HE) cartridges.</jobString>
+    <label>make 7.92x94mm Patronen (AP-HE) cartridge x200</label>
+    <description>Craft 200 7.92x94mm Patronen (AP-HE) cartridges.</description>
+    <jobString>Making 7.92x94mm Patronen (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -84,7 +84,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo950JDJBase">
 		<defName>Ammo_50JDJ_HE</defName>
-		<label>.950 JDJ cartridge (HE)</label>
+		<label>.950 JDJ cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/HighCaliber/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -163,7 +163,7 @@
 
 	<ThingDef ParentName="Base950JDJBullet">
 		<defName>Bullet_50JDJ_HE</defName>
-		<label>.950 JDJ bullet (HE)</label>
+		<label>.950 JDJ bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>75</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
@@ -279,9 +279,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_50JDJ_HE</defName>
-		<label>make .950 JDJ (HE) cartridge x200</label>
-		<description>Craft 200 .950 JDJ (HE) cartridges.</description>
-		<jobString>Making .950 JDJ (HE) cartridges.</jobString>
+		<label>make .950 JDJ (AP-HE) cartridge x200</label>
+		<description>Craft 200 .950 JDJ (AP-HE) cartridges.</description>
+		<jobString>Making .950 JDJ (AP-HE) cartridges.</jobString>
 		<ingredients>
 		<li>
 		<filter>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -100,7 +100,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="127x55mmBase">
 		<defName>Ammo_127x55mm_HE</defName>
-		<label>12.7x55mm cartridge (HE)</label>
+		<label>12.7x55mm cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -189,7 +189,7 @@
 	
 	<ThingDef ParentName="Base75x54mmFrenchBullet">
 		<defName>Bullet_127x55mm_HE</defName>
-		<label>12.7mm bullet (HE)</label>
+		<label>12.7mm bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
 			<secondaryDamage>
@@ -331,9 +331,9 @@
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_127x55mm_HE</defName>
-		<label>make 12.7x55mm cartridge (HE) cartridge x200</label>
-		<description>Craft 200 12.7x55mm cartridge (HE) cartridge.</description>
-		<jobString>Making 12.7x55mm cartridge (HE) cartridges.</jobString>
+		<label>make 12.7x55mm cartridge (AP-HE) cartridge x200</label>
+		<description>Craft 200 12.7x55mm cartridge (AP-HE) cartridge.</description>
+		<jobString>Making 12.7x55mm cartridge (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="277FuryBase">
 		<defName>Ammo_277Fury_HE</defName>
-		<label>.277 Fury cartridge (HE)</label>
+		<label>.277 Fury cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base277FuryBullet">
 		<defName>Bullet_277Fury_HE</defName>
-		<label>.277 Fury bullet (HE)</label>
+		<label>.277 Fury bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_277Fury_HE</defName>
-    <label>make .277 Fury (HE) cartridge x500</label>
-    <description>Craft 500 .277 Fury (HE) cartridges.</description>
-    <jobString>Making .277 Fury (HE) cartridges.</jobString>
+    <label>make .277 Fury (AP-HE) cartridge x500</label>
+    <description>Craft 500 .277 Fury (AP-HE) cartridges.</description>
+    <jobString>Making .277 Fury (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3006SpringfieldBase">
 		<defName>Ammo_3006Springfield_HE</defName>
-		<label>.30-06 Springfield cartridge (HE)</label>
+		<label>.30-06 Springfield cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base3006SpringfieldBullet">
 		<defName>Bullet_3006Springfield_HE</defName>
-		<label>.30-06 Springfield bullet (HE)</label>
+		<label>.30-06 Springfield bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>21</damageAmountBase>
 		  <armorPenetrationSharp>8</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_3006Springfield_HE</defName>
-    <label>make .30-06 Springfield (HE) cartridge x500</label>
-    <description>Craft 500 .30-06 Springfield (HE) cartridges.</description>
-    <jobString>Making .30-06 Springfield (HE) cartridges.</jobString>
+    <label>make .30-06 Springfield (AP-HE) cartridge x500</label>
+    <description>Craft 500 .30-06 Springfield (AP-HE) cartridges.</description>
+    <jobString>Making .30-06 Springfield (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="300AACBlackoutBase">
 		<defName>Ammo_300AACBlackout_HE</defName>
-		<label>.300 AAC Blackout cartridge (HE)</label>
+		<label>.300 AAC Blackout cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base300AACBlackoutBullet">
 		<defName>Bullet_300AACBlackout_HE</defName>
-		<label>.300 AAC Blackout bullet (HE)</label>
+		<label>.300 AAC Blackout bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>16</damageAmountBase>
 		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_300AACBlackout_HE</defName>
-    <label>make .300 AAC Blackout (HE) cartridge x500</label>
-    <description>Craft 500 .300 AAC Blackout (HE) cartridges.</description>
-    <jobString>Making .300 AAC Blackout (HE) cartridges.</jobString>
+    <label>make .300 AAC Blackout (AP-HE) cartridge x500</label>
+    <description>Craft 500 .300 AAC Blackout (AP-HE) cartridges.</description>
+    <jobString>Making .300 AAC Blackout (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
 		<defName>Ammo_303British_HE</defName>
-		<label>.303 British cartridge (HE)</label>
+		<label>.303 British cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base303BritishBullet">
 		<defName>Bullet_303British_HE</defName>
-		<label>.303 British bullet (HE)</label>
+		<label>.303 British bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationSharp>6.5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_303British_HE</defName>
-    <label>make .303 British (HE) cartridge x500</label>
-    <description>Craft 500 .303 British (HE) cartridges.</description>
-    <jobString>Making .303 British (HE) cartridges.</jobString>
+    <label>make .303 British (AP-HE) cartridge x500</label>
+    <description>Craft 500 .303 British (AP-HE) cartridges.</description>
+    <jobString>Making .303 British (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="30CarbineBase">
     <defName>Ammo_30Carbine_HE</defName>
-    <label>.30 Carbine cartridge (HE)</label>
+    <label>.30 Carbine cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base30CarbineBullet">
 		<defName>Bullet_30Carbine_HE</defName>
-		<label>.30 Carbine bullet (HE)</label>
+		<label>.30 Carbine bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_30Carbine_HE</defName>
-    <label>make .30 Carbine  (HE) cartridge x500</label>
-    <description>Craft 500 .30 Carbine  (HE) cartridges.</description>
-    <jobString>Making .30 Carbine  (HE) cartridges.</jobString>
+    <label>make .30 Carbine  (AP-HE) cartridge x500</label>
+    <description>Craft 500 .30 Carbine  (AP-HE) cartridges.</description>
+    <jobString>Making .30 Carbine  (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -100,7 +100,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="44-40WinchesterBase">
     <defName>Ammo_44-40Winchester_HE</defName>
-    <label>.44-40 Winchester cartridge (HE)</label>
+    <label>.44-40 Winchester cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -190,7 +190,7 @@
 	  
 	  <ThingDef ParentName="Base44-40WinchesterBullet">
 		<defName>Bullet_44-40Winchester_HE</defName>
-		<label>.44-40 Winchester bullet (HE)</label>
+		<label>.44-40 Winchester bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -333,9 +333,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_44-40Winchester_HE</defName>
-    <label>make .44-40 Winchester  (HE) cartridge x500</label>
-    <description>Craft 500 .44-40 Winchester  (HE) cartridges.</description>
-    <jobString>Making .44-40 Winchester  (HE) cartridges.</jobString>
+    <label>make .44-40 Winchester  (AP-HE) cartridge x500</label>
+    <description>Craft 500 .44-40 Winchester  (AP-HE) cartridges.</description>
+    <jobString>Making .44-40 Winchester  (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="4570GovBase">
 		<defName>Ammo_4570Gov_HE</defName>
-		<label>.45-70 Government cartridge (HE)</label>
+		<label>.45-70 Government cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base4570GovBullet">
 		<defName>Bullet_4570Gov_HE</defName>
-		<label>.45-70 bullet (HE)</label>
+		<label>.45-70 bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>24</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_4570Gov_HE</defName>
-    <label>make .45-70 Government (HE) cartridge x500</label>
-    <description>Craft 500 .45-70 Government (HE) cartridges.</description>
-    <jobString>Making .45-70 Government (HE) cartridges.</jobString>
+    <label>make .45-70 Government (AP-HE) cartridge x500</label>
+    <description>Craft 500 .45-70 Government (AP-HE) cartridges.</description>
+    <jobString>Making .45-70 Government (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="473x33mmCaselessBase">
 		<defName>Ammo_473x33mmCaseless_HE</defName>
-		<label>4.73x33mm Caseless cartridge (HE)</label>
+		<label>4.73x33mm Caseless cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
 	  
 	  <ThingDef ParentName="Base473x33mmCaselessBullet">
 		<defName>Bullet_473x33mmCaseless_HE</defName>
-		<label>4.73mm Caseless bullet (HE)</label>
+		<label>4.73mm Caseless bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -329,9 +329,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_473x33mmCaseless_HE</defName>
-    <label>make 4.73x33mm Caseless (HE) cartridge x500</label>
-    <description>Craft 500 4.73x33mm Caseless (HE) cartridges.</description>
-    <jobString>Making 4.73x33mm Caseless (HE) cartridges.</jobString>
+    <label>make 4.73x33mm Caseless (AP-HE) cartridge x500</label>
+    <description>Craft 500 4.73x33mm Caseless (AP-HE) cartridges.</description>
+    <jobString>Making 4.73x33mm Caseless (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
 		<defName>Ammo_545x39mmSoviet_HE</defName>
-		<label>5.45x39mm Soviet cartridge (HE)</label>
+		<label>5.45x39mm Soviet cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base545x39mmSovietBullet">
 		<defName>Bullet_545x39mmSoviet_HE</defName>
-		<label>5.45mm Soviet bullet (HE)</label>
+		<label>5.45mm Soviet bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_545x39mmSoviet_HE</defName>
-    <label>make 5.45x39mm Soviet (HE) cartridge x500</label>
-    <description>Craft 500 5.45x39mm Soviet (HE) cartridges.</description>
-    <jobString>Making 5.45x39mm Soviet (HE) cartridges.</jobString>
+    <label>make 5.45x39mm Soviet (AP-HE) cartridge x500</label>
+    <description>Craft 500 5.45x39mm Soviet (AP-HE) cartridges.</description>
+    <jobString>Making 5.45x39mm Soviet (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -113,7 +113,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
 		<defName>Ammo_556x45mmNATO_HE</defName>
-		<label>5.56x45mm NATO cartridge (HE)</label>
+		<label>5.56x45mm NATO cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -202,7 +202,7 @@
 	  
 	  <ThingDef ParentName="Base556x45mmNATOBullet">
 		<defName>Bullet_556x45mmNATO_HE</defName>
-		<label>5.56mm NATO bullet (HE)</label>
+		<label>5.56mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -281,7 +281,7 @@
 		
 		<ThingDef ParentName="Base556x45mmNATOBullet">
 			<defName>Bullet_556x45mmNATO_HE_SB</defName>
-			<label>5.56mm NATO bullet (HE)</label>
+			<label>5.56mm NATO bullet (AP-HE)</label>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationSharp>5</armorPenetrationSharp>
@@ -424,9 +424,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_HE</defName>
-    <label>make 5.56x45mm NATO (HE) cartridge x500</label>
-    <description>Craft 500 5.56x45mm NATO (HE) cartridges.</description>
-    <jobString>Making 5.56x45mm NATO (HE) cartridges.</jobString>
+    <label>make 5.56x45mm NATO (AP-HE) cartridge x500</label>
+    <description>Craft 500 5.56x45mm NATO (AP-HE) cartridges.</description>
+    <jobString>Making 5.56x45mm NATO (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="5656SpencerBase">
     <defName>Ammo_5656Spencer_HE</defName>
-    <label>.56-56 Spencer cartridge (HE)</label>
+    <label>.56-56 Spencer cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base5656SpencerBullet">
 		<defName>Bullet_5656Spencer_HE</defName>
-		<label>.56-56 Spencer bullet (HE)</label>
+		<label>.56-56 Spencer bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>18</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_5656Spencer_HE</defName>
-    <label>make .56-56 Spencer (HE) cartridge x500</label>
-    <description>Craft 500 .56-56 Spencer (HE) cartridges.</description>
-    <jobString>Making .56-56 Spencer (HE) cartridges.</jobString>
+    <label>make .56-56 Spencer (AP-HE) cartridge x500</label>
+    <description>Craft 500 .56-56 Spencer (AP-HE) cartridges.</description>
+    <jobString>Making .56-56 Spencer (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="58x42mmDBP10Base">
     <defName>Ammo_58x42mmDBP10_HE</defName>
-    <label>5.8x42mm DBP10 cartridge (HE)</label>
+    <label>5.8x42mm DBP10 cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base58x42mmDBP10Bullet">
 		<defName>Bullet_58x42mmDBP10_HE</defName>
-		<label>5.8mm DBP10 bullet (HE)</label>
+		<label>5.8mm DBP10 bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_58x42mmDBP10_HE</defName>
-    <label>make 5.8x42mm DBP10 (HE) cartridge x500</label>
-    <description>Craft 500 5.8x42mm DBP10 (HE) cartridges.</description>
-    <jobString>Making 5.8x42mm DBP10 (HE) cartridges.</jobString>
+    <label>make 5.8x42mm DBP10 (AP-HE) cartridge x500</label>
+    <description>Craft 500 5.8x42mm DBP10 (AP-HE) cartridges.</description>
+    <jobString>Making 5.8x42mm DBP10 (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
 		<defName>Ammo_65x48mmBlackout_HE</defName>
-		<label>6.5mm Creedmoor cartridge (HE)</label>
+		<label>6.5mm Creedmoor cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base65x48mmBlackoutBullet">
 		<defName>Bullet_65x48mmBlackout_HE</defName>
-		<label>6.5mm Creedmoor bullet (HE)</label>
+		<label>6.5mm Creedmoor bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_65x48mmBlackout_HE</defName>
-    <label>make 6.5mm Creedmoor (HE) cartridge x500</label>
-    <description>Craft 500 6.5mm Creedmoor (HE) cartridges.</description>
-    <jobString>Making 6.5mm Creedmoor (HE) cartridges.</jobString>
+    <label>make 6.5mm Creedmoor (AP-HE) cartridge x500</label>
+    <description>Craft 500 6.5mm Creedmoor (AP-HE) cartridges.</description>
+    <jobString>Making 6.5mm Creedmoor (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="65x52mmCarcanoBase">
     <defName>Ammo_65x52mmCarcano_HE</defName>
-    <label>6.5x52mm Carcano cartridge (HE)</label>
+    <label>6.5x52mm Carcano cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	
 	<ThingDef ParentName="Base65x52mmCarcanoBullet">
 	<defName>Bullet_65x52mmCarcano_HE</defName>
-	<label>6.5x52mm Carcano bullet (HE)</label>
+	<label>6.5x52mm Carcano bullet (AP-HE)</label>
 	<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<damageAmountBase>17</damageAmountBase>
 		<armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_65x52mmCarcano_HE</defName>
-    <label>make 6.5x52mm Carcano (HE) cartridge x500</label>
-    <description>Craft 500 6.5x52mm Carcano (HE) cartridges.</description>
-    <jobString>Making 6.5x52mm Carcano (HE) cartridges.</jobString>
+    <label>make 6.5x52mm Carcano (AP-HE) cartridge x500</label>
+    <description>Craft 500 6.5x52mm Carcano (AP-HE) cartridges.</description>
+    <jobString>Making 6.5x52mm Carcano (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x50mmSRArisakaBase">
 		<defName>Ammo_65x50mmSRArisaka_HE</defName>
-		<label>6.5x50mmSR cartridge (HE)</label>
+		<label>6.5x50mmSR cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base65x50mmSRArisakaBullet">
 		<defName>Bullet_65x50mmSRArisaka_HE</defName>
-		<label>6.5mmSR Arisaka bullet (HE)</label>
+		<label>6.5mmSR Arisaka bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>17</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_65x50mmSRArisaka_HE</defName>
-    <label>make 6.5x50mmSR (HE) cartridge x500</label>
-    <description>Craft 500 6.5x50mmSR (HE) cartridges.</description>
-    <jobString>Making 6.5x50mmSR (HE) cartridges.</jobString>
+    <label>make 6.5x50mmSR (AP-HE) cartridge x500</label>
+    <description>Craft 500 6.5x50mmSR (AP-HE) cartridges.</description>
+    <jobString>Making 6.5x50mmSR (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="792x57mmMauserBase">
     <defName>Ammo_792x57mmMauser_HE</defName>
-    <label>7.92x57mm Mauser cartridge (HE)</label>
+    <label>7.92x57mm Mauser cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base792x57mmMauserBullet">
 		<defName>Bullet_792x57mmMauser_HE</defName>
-		<label>7.92x57mm Mauser bullet (HE)</label>
+		<label>7.92x57mm Mauser bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>21</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_792x57mmMauser_HE</defName>
-    <label>make 7.92x57mm Mauser (HE) cartridge x500</label>
-    <description>Craft 500 7.92x57mm Mauser (HE) cartridges.</description>
-    <jobString>Making 7.92x57mm Mauser (HE) cartridges.</jobString>
+    <label>make 7.92x57mm Mauser (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.92x57mm Mauser (AP-HE) cartridges.</description>
+    <jobString>Making 7.92x57mm Mauser (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="75x54mmFrenchBase">
     <defName>Ammo_75x54mmFrench_HE</defName>
-    <label>7.5x54mm French cartridge (HE)</label>
+    <label>7.5x54mm French cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base75x54mmFrenchBullet">
 		<defName>Bullet_75x54mmFrench_HE</defName>
-		<label>7.5mm French bullet (HE)</label>
+		<label>7.5mm French bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_75x54mmFrench_HE</defName>
-    <label>make 7.5x54mm French (HE) cartridge x500</label>
-    <description>Craft 500 7.5x54mm French (HE) cartridges.</description>
-    <jobString>Making 7.5x54mm French (HE) cartridges.</jobString>
+    <label>make 7.5x54mm French (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.5x54mm French (AP-HE) cartridges.</description>
+    <jobString>Making 7.5x54mm French (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
 		<defName>Ammo_762x39mmSoviet_HE</defName>
-		<label>7.62x39mm Soviet cartridge (HE)</label>
+		<label>7.62x39mm Soviet cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base762x39mmSovietBullet">
 		<defName>Bullet_762x39mmSoviet_HE</defName>
-		<label>7.62mm Soviet bullet (HE)</label>
+		<label>7.62mm Soviet bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>17</damageAmountBase>
 		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_762x39mmSoviet_HE</defName>
-    <label>make 7.62x39mm Soviet (HE) cartridge x500</label>
-    <description>Craft 500 7.62x39mm Soviet (HE) cartridges.</description>
-    <jobString>Making 7.62x39mm Soviet (HE) cartridges.</jobString>
+    <label>make 7.62x39mm Soviet (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.62x39mm Soviet (AP-HE) cartridges.</description>
+    <jobString>Making 7.62x39mm Soviet (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
 		<defName>Ammo_762x51mmNATO_HE</defName>
-		<label>7.62x51mm NATO cartridge (HE)</label>
+		<label>7.62x51mm NATO cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base762x51mmNATOBullet">
 		<defName>Bullet_762x51mmNATO_HE</defName>
-		<label>7.62mm NATO bullet (HE)</label>
+		<label>7.62mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationSharp>7</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_762x51mmNATO_HE</defName>
-    <label>make 7.62x51mm NATO (HE) cartridge x500</label>
-    <description>Craft 500 7.62x51mm NATO (HE) cartridges.</description>
-    <jobString>Making 7.62x51mm NATO (HE) cartridges.</jobString>
+    <label>make 7.62x51mm NATO (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.62x51mm NATO (AP-HE) cartridges.</description>
+    <jobString>Making 7.62x51mm NATO (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
 		<defName>Ammo_762x54mmR_HE</defName>
-		<label>7.62x54mmR cartridge (HE)</label>
+		<label>7.62x54mmR cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
   
   <ThingDef ParentName="Base762x54mmRBullet">
     <defName>Bullet_762x54mmR_HE</defName>
-    <label>7.62mmR bullet (HE)</label>
+    <label>7.62mmR bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>20</damageAmountBase>
       <armorPenetrationSharp>7</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_762x54mmR_HE</defName>
-    <label>make 7.62x54mmR (HE) cartridge x500</label>
-    <description>Craft 500 7.62x54mmR (HE) cartridges.</description>
-    <jobString>Making 7.62x54mmR (HE) cartridges.</jobString>
+    <label>make 7.62x54mmR (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.62x54mmR (AP-HE) cartridges.</description>
+    <jobString>Making 7.62x54mmR (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="77x58mmArisakaBase">
 		<defName>Ammo_77x58mmArisaka_HE</defName>
-		<label>7.7x58mm Arisaka cartridge (HE)</label>
+		<label>7.7x58mm Arisaka cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -189,7 +189,7 @@
 	  
 	  <ThingDef ParentName="Base75x54mmFrenchBullet">
 		<defName>Bullet_77x58mmArisaka_HE</defName>
-		<label>7.7x58mm Arisaka bullet (HE)</label>
+		<label>7.7x58mm Arisaka bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationSharp>6</armorPenetrationSharp>
@@ -332,9 +332,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_77x58mmArisaka_HE</defName>
-    <label>make 7.7x58mm Arisaka (HE) cartridge x500</label>
-    <description>Craft 500 7.7x58mm Arisaka (HE) cartridges.</description>
-    <jobString>Making 7.7x58mm Arisaka (HE) cartridges.</jobString>
+    <label>make 7.7x58mm Arisaka (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.7x58mm Arisaka (AP-HE) cartridges.</description>
+    <jobString>Making 7.7x58mm Arisaka (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="792x33mmKurzBase">
 		<defName>Ammo_792x33mmKurz_HE</defName>
-		<label>7.92x33mm Kurz cartridge (HE)</label>
+		<label>7.92x33mm Kurz cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base792x33mmKurzBullet">
 		<defName>Bullet_792x33mmKurz_HE</defName>
-		<label>7.92mm Kurz bullet (HE)</label>
+		<label>7.92mm Kurz bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>16</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_792x33mmKurz_HE</defName>
-    <label>make 7.92x33mm Kurz (HE) cartridge x500</label>
-    <description>Craft 500 7.92x33mm Kurz (HE) cartridges.</description>
-    <jobString>Making 7.92x33mm Kurz (HE) cartridges.</jobString>
+    <label>make 7.92x33mm Kurz (AP-HE) cartridge x500</label>
+    <description>Craft 500 7.92x33mm Kurz (AP-HE) cartridges.</description>
+    <jobString>Making 7.92x33mm Kurz (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -99,7 +99,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="86x43mmBlackoutBase">
 		<defName>Ammo_86x43mmBlackout_HE</defName>
-		<label>8.6mm Blackout cartridge (HE)</label>
+		<label>8.6mm Blackout cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base86x43mmBlackoutBullet">
 		<defName>Bullet_86x43mmBlackout_HE</defName>
-		<label>8.6mm Blackout bullet (HE)</label>
+		<label>8.6mm Blackout bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>21</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_86x43mmBlackout_HE</defName>
-    <label>make 8.6mm Blackout (HE) cartridge x500</label>
-    <description>Craft 500 8.6mm Blackout (HE) cartridges.</description>
-    <jobString>Making 8.6mm Blackout (HE) cartridges.</jobString>
+    <label>make 8.6mm Blackout (AP-HE) cartridge x500</label>
+    <description>Craft 500 8.6mm Blackout (AP-HE) cartridges.</description>
+    <jobString>Making 8.6mm Blackout (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRLebelBase">
     <defName>Ammo_8x50mmRLebel_HE</defName>
-    <label>8x50mmR Lebel cartridge (HE)</label>
+    <label>8x50mmR Lebel cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -188,7 +188,7 @@
 	  
 	  <ThingDef ParentName="Base8x50mmRLebelBullet">
 		<defName>Bullet_8x50mmRLebel_HE</defName>
-		<label>8mmR Lebel bullet (HE)</label>
+		<label>8mmR Lebel bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationSharp>5</armorPenetrationSharp>
@@ -330,9 +330,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_8x50mmRLebel_HE</defName>
-    <label>make 8x50mmR Lebel (HE) cartridge x500</label>
-    <description>Craft 500 8x50mmR Lebel (HE) cartridges.</description>
-    <jobString>Making 8x50mmR Lebel (HE) cartridges.</jobString>
+    <label>make 8x50mmR Lebel (AP-HE) cartridge x500</label>
+    <description>Craft 500 8x50mmR Lebel (AP-HE) cartridges.</description>
+    <jobString>Making 8x50mmR Lebel (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -99,7 +99,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="9x39mmSovietBase">
     <defName>Ammo_9x39mmSoviet_HE</defName>
-    <label>9x39mm Soviet cartridge (HE)</label>
+    <label>9x39mm Soviet cartridge (AP-HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
 	  
 	  <ThingDef ParentName="Base9x39mmSovietBullet">
 		<defName>Bullet_9x39mmSoviet_HE</defName>
-		<label>9mm Soviet bullet (HE)</label>
+		<label>9mm Soviet bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>4</armorPenetrationSharp>
@@ -328,9 +328,9 @@
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
     <defName>MakeAmmo_9x39mmSoviet_HE</defName>
-    <label>make 9x39mm Soviet (HE) cartridge x500</label>
-    <description>Craft 500 9x39mm Soviet (HE) cartridges.</description>
-    <jobString>Making 9x39mm Soviet (HE) cartridges.</jobString>
+    <label>make 9x39mm Soviet (AP-HE) cartridge x500</label>
+    <description>Craft 500 9x39mm Soviet (AP-HE) cartridges.</description>
+    <jobString>Making 9x39mm Soviet (AP-HE) cartridges.</jobString>
     <ingredients>
       <li>
         <filter>


### PR DESCRIPTION
## Changes

- What it says on the tin.

_Will not change the defNames as it will break people's saves and cause other minor issues, it's fine as is._

## Reasoning

- The ammo type we use as the "HE" ammo type is actually called AP-HE irl so it was finally time we fixed the minor inconsistency to avoid the unnecessary confusion.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors