### PR TITLE
Nerf/rebalance the VOID bois

### DIFF
--- a/Patches/RH2 Faction - VOID/Monsters/Races.xml
+++ b/Patches/RH2 Faction - VOID/Monsters/Races.xml
@@ -99,21 +99,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Mother"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Mother"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_Mother"]/combatPower</xpath>
 					<value>
-						<combatPower>500</combatPower>
+						<combatPower>600</combatPower>
 					</value>
 				</li>
 
@@ -196,21 +196,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Titan"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+						<ArmorRating_Sharp>9</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Titan"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_Titan"]/combatPower</xpath>
 					<value>
-						<combatPower>500</combatPower>
+						<combatPower>600</combatPower>
 					</value>
 				</li>
 
@@ -296,21 +296,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Wraith"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+						<ArmorRating_Sharp>7</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Wraith"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>26</ArmorRating_Blunt>
+						<ArmorRating_Blunt>13</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_Wraith"]/combatPower</xpath>
 					<value>
-						<combatPower>450</combatPower>
+						<combatPower>540</combatPower>
 					</value>
 				</li>
 
@@ -404,21 +404,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_GiantSpider"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+						<ArmorRating_Sharp>7</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_GiantSpider"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>26</ArmorRating_Blunt>
+						<ArmorRating_Blunt>13</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DFGiantSpider"]/combatPower</xpath>
 					<value>
-						<combatPower>500</combatPower>
+						<combatPower>600</combatPower>
 					</value>
 				</li>
 
@@ -504,21 +504,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_Stalker"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_Stalker"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF2_Stalker"]/combatPower</xpath>
 					<value>
-						<combatPower>500</combatPower>
+						<combatPower>600</combatPower>
 					</value>
 				</li>
 

--- a/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
+++ b/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
@@ -90,21 +90,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_EvolvedRumbler"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>18</ArmorRating_Sharp>
+						<ArmorRating_Sharp>9</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_EvolvedRumbler"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>36</ArmorRating_Blunt>
+						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_EvolvedRumbler"]/combatPower</xpath>
 					<value>
-						<combatPower>185</combatPower>
+						<combatPower>225</combatPower>
 					</value>
 				</li>
 
@@ -190,21 +190,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_EvolvedLongArms"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_EvolvedLongArms"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_EvolvedLongArms"]/combatPower</xpath>
 					<value>
-						<combatPower>185</combatPower>
+						<combatPower>225</combatPower>
 					</value>
 				</li>
 
@@ -290,21 +290,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_IrridiatedLongArms"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>16</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_IrridiatedLongArms"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_IrridiatedLongArms"]/combatPower</xpath>
 					<value>
-						<combatPower>700</combatPower>
+						<combatPower>900</combatPower>
 					</value>
 				</li>
 
@@ -389,21 +389,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_VolatileLeaper"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>30</ArmorRating_Sharp>
+						<ArmorRating_Sharp>15</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_VolatileLeaper"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>45</ArmorRating_Blunt>
+						<ArmorRating_Blunt>22</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_VolatileLeaper"]/combatPower</xpath>
 					<value>
-						<combatPower>1000</combatPower>
+						<combatPower>2100</combatPower>
 					</value>
 				</li>
 
@@ -486,21 +486,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackTitan"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>28</ArmorRating_Sharp>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackTitan"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>42</ArmorRating_Blunt>
+						<ArmorRating_Blunt>21</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_BlackTitan"]/combatPower</xpath>
 					<value>
-						<combatPower>800</combatPower>
+						<combatPower>1200</combatPower>
 					</value>
 				</li>
 
@@ -586,14 +586,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackWraith"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>27</ArmorRating_Sharp>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackWraith"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>40</ArmorRating_Blunt>
+						<ArmorRating_Blunt>20</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -686,21 +686,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackLeaper"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>28</ArmorRating_Sharp>
+						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_BlackLeaper"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>42</ArmorRating_Blunt>
+						<ArmorRating_Blunt>21</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_BlackLeaper"]/combatPower</xpath>
 					<value>
-						<combatPower>900</combatPower>
+						<combatPower>1500</combatPower>
 					</value>
 				</li>
 
@@ -786,21 +786,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_DevilHound"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>28</ArmorRating_Sharp>
+						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_DevilHound"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>45</ArmorRating_Blunt>
+						<ArmorRating_Blunt>23</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_DevilHound"]/combatPower</xpath>
 					<value>
-						<combatPower>1200</combatPower>
+						<combatPower>2700</combatPower>
 					</value>
 				</li>
 
@@ -886,21 +886,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Tendril"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>12</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Tendril"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_Tendril"]/combatPower</xpath>
 					<value>
-						<combatPower>50</combatPower>
+						<combatPower>75</combatPower>
 					</value>
 				</li>
 
@@ -985,14 +985,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Bone"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>14</ArmorRating_Sharp>
+						<ArmorRating_Sharp>7</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Bone"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>20</ArmorRating_Blunt>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -1085,14 +1085,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_RoidHulk"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>17</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_RoidHulk"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>30</ArmorRating_Blunt>
+						<ArmorRating_Blunt>15</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -1186,21 +1186,21 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Reaper"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>17</ArmorRating_Sharp>
+						<ArmorRating_Sharp>8</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Reaper"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>28</ArmorRating_Blunt>
+						<ArmorRating_Blunt>14</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/PawnKindDef[defName="RH_DF_Reaper"]/combatPower</xpath>
 					<value>
-						<combatPower>50</combatPower>
+						<combatPower>100</combatPower>
 					</value>
 				</li>
 

--- a/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
+++ b/Patches/RH2 Faction - VOID/Monsters/Races_Evolved.xml
@@ -886,14 +886,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Tendril"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>6</ArmorRating_Sharp>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Tendril"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+						<ArmorRating_Blunt>7</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -985,14 +985,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Bone"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>7</ArmorRating_Sharp>
+						<ArmorRating_Sharp>5</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Bone"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+						<ArmorRating_Blunt>8</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -1085,14 +1085,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_RoidHulk"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF2_RoidHulk"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>15</ArmorRating_Blunt>
+						<ArmorRating_Blunt>10</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -1186,14 +1186,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Reaper"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>8</ArmorRating_Sharp>
+						<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="RH_DF_Reaper"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>14</ArmorRating_Blunt>
+						<ArmorRating_Blunt>9</ArmorRating_Blunt>
 					</value>
 				</li>
 

--- a/Patches/RH2 Faction - VOID/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/RH2 Faction - VOID/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -33,6 +33,85 @@
 					</value>
 				</li>
 
+				<!-- ========== CombatPower Patches ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Undying"]/combatPower</xpath>
+					<value>
+						<combatPower>900</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Collaborator"]/combatPower</xpath>
+					<value>
+						<combatPower>270</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[@Name="RH_VOIDAdvMemberBase"]/combatPower</xpath>
+					<value>
+						<combatPower>300</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Associate"]/combatPower</xpath>
+					<value>
+						<combatPower>300</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Destroyer"]/combatPower</xpath>
+					<value>
+						<combatPower>360</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Grinder"]/combatPower</xpath>
+					<value>
+						<combatPower>360</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[@Name="RH_VOIDEliteBase"]/combatPower</xpath>
+					<value>
+						<combatPower>600</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[@Name="RH_VOIDEliteCloakedBase"]/combatPower</xpath>
+					<value>
+						<combatPower>600</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Boss"]/combatPower</xpath>
+					<value>
+						<combatPower>750</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Negotiator"]/combatPower</xpath>
+					<value>
+						<combatPower>240</combatPower>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="RH_VOID_Bodyguard"]/combatPower</xpath>
+					<value>
+						<combatPower>240</combatPower>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- Decreased the armor value of the monsters by 50% and adjusted their CombatPower.
- Patched and tripled the CombatPower of the VOID PawnKinds.

## Reasoning

- The mod is supposed to be absurd but not unbeatable, made adjustments to tone stuff down for CE ecosystem as especially the CombatPower of pawns from the mod was very very low.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
