### PR TITLE
Patch Rimatomics' DamageDef

### DIFF
--- a/Patches/Dubs Rimatomics/Damages_LocalInjury.xml
+++ b/Patches/Dubs Rimatomics/Damages_LocalInjury.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Dubs Rimatomics</li>
+		</mods>
+			
+			<match Class="PatchOperationSequence">
+				<operations>       
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/DamageDef[@Name="EnergyWepBurnBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.DamageDefExtensionCE">
+							<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>
+							<isAmbientDamage>true</isAmbientDamage>
+						</li>
+					</value>
+				</li>
+
+				</operations>
+			</match>
+	</Operation>
+  
+</Patch>

--- a/Patches/Dubs Rimatomics/Damages_LocalInjury.xml
+++ b/Patches/Dubs Rimatomics/Damages_LocalInjury.xml
@@ -10,7 +10,16 @@
 				<operations>       
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/DamageDef[@Name="EnergyWepBurnBase"]</xpath>
+					<xpath>Defs/DamageDef[defName="ArcDischarge"]</xpath>
+					<value>
+						<li Class="CombatExtended.DamageDefExtensionCE">
+							<isAmbientDamage>true</isAmbientDamage>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/DamageDef[defName="LaserDischarge"]</xpath>
 					<value>
 						<li Class="CombatExtended.DamageDefExtensionCE">
 							<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>

--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -8,30 +8,30 @@
 			
 		<match Class="PatchOperationSequence">
 		<operations>
-		
+
 			<!--Sabots : Damage Stuff-->
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultDamage</xpath>
 				<value>
 					<defaultDamage>200</defaultDamage>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_Sabot"]/defaultArmorPenetration</xpath>
 				<value>
 					<defaultArmorPenetration>120000</defaultArmorPenetration>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultDamage</xpath>
 				<value>
 					<defaultDamage>800</defaultDamage>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_DUSabot"]/defaultArmorPenetration</xpath>
 				<value>
@@ -40,96 +40,89 @@
 			</li>
 			
 			<!--Sabots : Projectile Tweaks-->
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Bullet_Sabot"]/projectile/speed</xpath>
 				<value>
-					<speed>700</speed>
+					<speed>500</speed>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Bullet_Sabot_DU"]/projectile/speed</xpath>
 				<value>
-					<speed>650</speed>
+					<speed>500</speed>
 				</value>
 			</li>
-			
+
 			<!--Sabots : Fire Mission Tweaks-->
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
 				<value>
 					<explosionDamage>Bomb_Sabot</explosionDamage>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="DUSabotRoundIncoming"]/skyfaller/explosionDamage</xpath>
 				<value>
 					<explosionDamage>Bomb_DUSabot</explosionDamage>
 				</value>
 			</li>
-			
+
 			<!--Marauder : Damage Stuff-->
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultDamage</xpath>
 				<value>
 					<defaultDamage>70</defaultDamage>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/DamageDef[defName="Bomb_PlasmaToroid"]/defaultArmorPenetration</xpath>
 				<value>
 					<defaultArmorPenetration>80</defaultArmorPenetration>
 				</value>
 			</li>
-			
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/speed</xpath>
-				<value>
-					<speed>800</speed>
-				</value>
-			</li>
-			
+
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/damageAmountBase</xpath>
 			</li>
-			
+
 			<!--Marauder : Range-->
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/verbs/li/range</xpath>
 				<value>
-					<range>90</range>
+					<range>86</range>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Marauder_Railgun"]/EnergyWep/range</xpath>
 				<value>
-					<range>90</range>
+					<range>86</range>
 				</value>
 			</li>
-			
+
 			<!--Turrets : Stats-->
-			
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="PPCMarauder" or defName="PPCRailgun"]/statBases</xpath>
 				<value>
 					<ShootingAccuracyTurret>5</ShootingAccuracyTurret>
 				</value>
 			</li>
-			
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="PPCMarauder"]/specialDisplayRadius</xpath>
 				<value>
-					<specialDisplayRadius>90</specialDisplayRadius>
+					<specialDisplayRadius>86</specialDisplayRadius>
 				</value>
 			</li>
-			
+
 		</operations>
 		</match>	
 	  </li>

--- a/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
+++ b/Patches/Dubs Rimatomics/Turrets_Rimatomics.xml
@@ -87,6 +87,13 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/speed</xpath>
+				<value>
+					<speed>300</speed>
+				</value>
+			</li>
+
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="Bullet_PlasmaToroid"]/projectile/damageAmountBase</xpath>
 			</li>


### PR DESCRIPTION
## Changes

- What it says on the tin, patch the left-out DamageDef in Rimatomics and added the necessary mod extensions to it.
- Made some other minor adjustments to the values in the patches.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
