### PR TITLE
Obsidia Expansion-Mothoids Patch

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -73,5 +73,6 @@
 		<li>VanillaExpanded.VTEXE.SOS2</li>
 		<li>sarg.alphaanimals</li>
 		<li>sarg.magicalmenagerie</li>
+    <li>ObsidiaExpansion.Xenos.Mothoids</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
+++ b/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
@@ -27,24 +27,25 @@
 				
 				<!-- ============== silkshot compatibility ================ -->
 
-				  <li Class="PatchOperationReplace">
+				<li Class="PatchOperationReplace">
 					<xpath>Defs/AbilityDef[defName="OE_Silkshot"]/verbProperties/range</xpath>
 					<value>
 					  <range>11.9</range>
 					</value>
-				  </li>
+			 </li>
 
-				  <li Class="PatchOperationReplace">
+			 <li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="OE_Silkshot_Bullet"]/projectile</xpath>
 					<value>
 					  <projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<damageDef>Stun</damageDef>
-						<speed>95</speed>      
-						<damageAmountBase>18</damageAmountBase>
-						<armorPenetrationBlunt>8</armorPenetrationBlunt>
+					  	<damageDef>Stun</damageDef>
+					  	<speed>95</speed>      
+					  	<damageAmountBase>18</damageAmountBase>
+					  	<armorPenetrationBlunt>8</armorPenetrationBlunt>
 					  </projectile>
 					</value>
-				  </li>
+			 </li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
+++ b/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Obsidia Expansion - Mothoids</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+			
+				<!-- ============== Atlant Pollen ================ -->
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="OE_PollenAtlant"]/verbProperties/range</xpath>
+					<value>
+					  <range>14.9</range>
+					</value>
+				</li>
+				
+				<!-- ============== Flight ================ -->
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="OE_WingsFly"]/verbProperties/range</xpath>
+						<value>
+							<range>27.9</range>
+						</value>
+				</li>			
+				
+				<!-- ============== silkshot compatibility ================ -->
+
+				  <li Class="PatchOperationReplace">
+					<xpath>Defs/AbilityDef[defName="OE_Silkshot"]/verbProperties/range</xpath>
+					<value>
+					  <range>11.9</range>
+					</value>
+				  </li>
+
+				  <li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="OE_Silkshot_Bullet"]/projectile</xpath>
+					<value>
+					  <projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>Stun</damageDef>
+						<speed>95</speed>      
+						<damageAmountBase>18</damageAmountBase>
+						<armorPenetrationBlunt>8</armorPenetrationBlunt>
+					  </projectile>
+					</value>
+				  </li>
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
+++ b/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
@@ -45,6 +45,13 @@
 					  </projectile>
 					</value>
 			 </li>
+        
+       <li Class="PatchOperationAdd">
+					<xpath>Defs/GeneDef[defName="OE_WingsPrime"]/statOffsets</xpath>
+					<value>
+						<CarryWeight>-15</CarryWeight>
+					</value>
+			 </li>
 
 			</operations>
 		</match>

--- a/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
+++ b/Patches/Obsidia Expansion/ThingDefs_Misc/Obsidia_Expansion_CE_Ability.xml
@@ -45,13 +45,6 @@
 					  </projectile>
 					</value>
 			 </li>
-        
-       <li Class="PatchOperationAdd">
-					<xpath>Defs/GeneDef[defName="OE_WingsPrime"]/statOffsets</xpath>
-					<value>
-						<CarryWeight>-15</CarryWeight>
-					</value>
-			 </li>
 
 			</operations>
 		</match>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -310,6 +310,7 @@ Ni'Hal	|
 Nukes   |
 Nyaron Race |
 Not Only Just a Cannon  |
+Obsidia Expansion - Mothoids  |
 ODZ Suits |
 Ogam's Warbanner Mod    |
 Opossum Friends |


### PR DESCRIPTION
This patch changes various ranges of abilities to be in CE standard and also makes silkshot compatible. 

Be warned that Obsidia Expansion-Mothoids *must* be loaded before CE or else silkshot will miss its targets. 