### PR TITLE
Fix for tribal gunners spawning with cheap adv firearms

### DIFF
--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -140,7 +140,7 @@
       <max>290</max>
     </weaponMoney>
     <weaponTags>
-      <li>Gun</li>
+      <li>SimpleGun</li>
     </weaponTags>
     <combatEnhancingDrugsChance>0.3</combatEnhancingDrugsChance>
     <combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -775,7 +775,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="Tribal_ChiefRanged"]/weaponTags/li[.="NeolithicRangedChief"]</xpath>
     <value>
-      <li>Gun</li>
+      <li>SimpleGun</li>
     </value>
   </Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -265,6 +265,7 @@
       <aiAimMode>Snapshot</aiAimMode>
     </FireModes>
     <weaponTags>
+      <li>SimpleGun</li>
       <li>CE_AI_BROOM</li>
     </weaponTags>
     <researchPrerequisite>Gunsmithing</researchPrerequisite>
@@ -379,6 +380,7 @@
       <aiAimMode>AimedShot</aiAimMode>
     </FireModes>
     <weaponTags>
+      <li>SimpleGun</li>
       <li>CE_AI_SR</li>
     </weaponTags>
     <researchPrerequisite>Gunsmithing</researchPrerequisite>


### PR DESCRIPTION
## Additions

- Fix for tribal gunners spawning with cheap adv firearms and in some cases charged guns.

## Changes

- Changes the tag `Gun` to `SimpleGun` for tribal gunners and tribal ranged chiefs.
- Added the `SimpleGun` to vanilla pump-action shotgun and bolt-action rifle.

## Reasoning

- Gunner tribals have the `Gun` weapon tag, any modded gun that inherits from base makeable gun also has the `Gun` tag, when certain advanced guns are cheap to make they have a chance of spawning on tribals.
- Can confirm this happens with the vanilla chain shotgun, my charge KS 23 (charge pump shotgun, sheet makes it cheap) and apparently some advaced industrial guns from other mods.
- Does not happen with all the guns because we usually don't patch crafting costs of other mods and spacer components (for example) make spacer guns too expensive to spawn in tribals.
- Regardless of these inconsistencies is of my opinion that tribal gunners should only have `SimpleGun` guns.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
