### PR TITLE
Make EMP shells require Microelectronics research

### DIFF
--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -270,6 +270,7 @@
     <label>make 10 gauge (EMP) shell x200</label>
     <description>Craft 200 10 gauge (EMP) shells.</description>
     <jobString>Making 10 gauge (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -270,6 +270,7 @@
     <label>make 12 gauge (EMP) shell x200</label>
     <description>Craft 200 12 gauge (EMP) shells.</description>
     <jobString>Making 12 gauge (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Shotgun/16Gauge.xml
+++ b/Defs/Ammo/Shotgun/16Gauge.xml
@@ -270,6 +270,7 @@
     <label>make 16 gauge (EMP) shell x200</label>
     <description>Craft 200 16 gauge (EMP) shells.</description>
     <jobString>Making 16 gauge (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -269,6 +269,7 @@
     <label>make 20 gauge (EMP) shell x200</label>
     <description>Craft 200 20 gauge (EMP) shells.</description>
     <jobString>Making 20 gauge (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -265,6 +265,7 @@
     <label>make 23x75mmR (EMP) shell x200</label>
     <description>Craft 200 23x75mmR (EMP) shells.</description>
     <jobString>Making 23x75mmR (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
     <ingredients>
       <li>
         <filter>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- Anything EMP is locked behind Microelectronics and beyond.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony
