### PR TITLE
Make EMP ammo less common on pawns

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -269,6 +269,10 @@
     <label>make 20x42mm EMP grenades x100</label>
     <description>Craft 100 20x42mm EMP grenades.</description>
     <jobString>Making 20x42mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -20,7 +20,7 @@
 		<Ammo_20x42mmGrenade_Smoke>Bullet_20x42mmGrenade_Smoke</Ammo_20x42mmGrenade_Smoke>	      
     </ammoTypes>
     <similarTo>AmmoSet_LauncherGrenade</similarTo>
-  </CombatExtended.AmmoSetDef> 
+  </CombatExtended.AmmoSetDef>
 	
 	<!-- ==================== Ammo ========================== -->
 
@@ -79,6 +79,7 @@
       <MarketValue>2.8</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_20x42mmGrenade_EMP</detonateProjectile>
   </ThingDef>  
 

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -265,12 +265,15 @@
 	<workAmount>8000</workAmount>
   </RecipeDef>
 
-
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_25x40mmGrenade_EMP</defName>
     <label>make 25x40mm EMP grenades x100</label>
     <description>Craft 100 25x40mm EMP grenades.</description>
     <jobString>Making 25x40mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -80,6 +80,7 @@
       <MarketValue>3.24</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_25x40mmGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -80,6 +80,7 @@
       <MarketValue>3.43</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_25x59mmGrenade_EMP</detonateProjectile>
   </ThingDef>  
 

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -275,6 +275,10 @@
     <label>make 25x59mm EMP grenades x100</label>
     <description>Craft 100 25x59mm EMP grenades.</description>
     <jobString>Making 25x59mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -270,6 +270,10 @@
     <label>make 30x29mm EMP grenades x100</label>
     <description>Craft 100 30x29mm EMP grenades.</description>
     <jobString>Making 30x29mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -80,6 +80,7 @@
       <MarketValue>4.72</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_30x29mmGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -273,6 +273,10 @@
     <label>make 35x32mmSR EMP grenades x100</label>
     <description>Craft 100 35x32mmSR EMP grenades.</description>
     <jobString>Making 35x32mmSR EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -80,6 +80,7 @@
       <MarketValue>3.92</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <detonateProjectile>Bullet_35x32mmSRGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -380,6 +380,10 @@
     <label>make 40x46mm EMP grenades x100</label>
     <description>Craft 100 40x46mm EMP grenades.</description>
     <jobString>Making 40x46mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -95,6 +95,7 @@
       <MarketValue>4.25</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <detonateProjectile>Bullet_40x46mmGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -65,6 +65,7 @@
       <MarketValue>4.61</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_40x47mmGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -188,6 +188,10 @@
     <label>make 40x47mm EMP grenades x100</label>
     <description>Craft 100 40x47mm EMP grenades.</description>
     <jobString>Making 40x47mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -95,6 +95,7 @@
       <MarketValue>4.76</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <detonateProjectile>Bullet_40x53mmGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -354,6 +354,10 @@
     <label>make 40x53mm EMP grenades x100</label>
     <description>Craft 100 40x53mm EMP grenades.</description>
     <jobString>Making 40x53mm EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -270,6 +270,10 @@
     <label>make 40x53mm VOG-25 EMP grenades x100</label>
     <description>Craft 100 40x53mm VOG-25 EMP grenades.</description>
     <jobString>Making 40x53mm VOG-25 EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -80,6 +80,7 @@
       <MarketValue>5.55</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_40x53mmVOG25Grenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -65,6 +65,7 @@
 			<MarketValue>7.03</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
+		<generateAllowChance>0.5</generateAllowChance>
 		<detonateProjectile>Bullet_50mmGS50Grenade_EMP</detonateProjectile>
 	</ThingDef>  
 

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -190,6 +190,10 @@
 		<label>make 50mm EM-50 EMP grenades x50</label>
 		<description>Craft 50 EM-50 50mm EMP grenades.</description>
 		<jobString>Making 50mm EM-50 EMP grenades.</jobString>
+		<researchPrerequisites>
+			<li>MicroelectronicsBasics</li>
+			<li>CE_Launchers</li>
+		</researchPrerequisites>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -245,6 +245,10 @@
     <label>make 83mm PIAT EMP grenades x5</label>
     <description>Craft 5 83mm PIAT EMP grenades.</description>
     <jobString>Making 83mm PIAT EMP grenades.</jobString>
+    <researchPrerequisites>
+      <li>MicroelectronicsBasics</li>
+      <li>CE_Launchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -79,6 +79,7 @@
       <MarketValue>90.7</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
 	<detonateProjectile>Bullet_83mmPIATGrenade_EMP</detonateProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -97,6 +97,7 @@
       <MarketValue>1.5</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <cookOffProjectile>Bullet_10Gauge_ElectroSlug</cookOffProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -97,6 +97,7 @@
       <MarketValue>0.87</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <cookOffProjectile>Bullet_12Gauge_ElectroSlug</cookOffProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/16Gauge.xml
+++ b/Defs/Ammo/Shotgun/16Gauge.xml
@@ -97,6 +97,7 @@
       <MarketValue>0.69</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <cookOffProjectile>Bullet_16Gauge_ElectroSlug</cookOffProjectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -97,6 +97,7 @@
       <MarketValue>0.49</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <cookOffProjectile>Bullet_20Gauge_ElectroSlug</cookOffProjectile>
   </ThingDef>
 	

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -93,10 +93,11 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.03</MarketValue>
       <Mass>0.186</Mass>
+      <MarketValue>3.03</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
     <cookOffProjectile>Bullet_23x75mmR_ElectroSlug</cookOffProjectile>
   </ThingDef>
 	


### PR DESCRIPTION
## Changes

- What it says on the tin.
- Made EMP launched nades require microelectronics same as EMP shotgun shells.

## Reasoning

- EMP shells and launched grenades are effective but tests show that they are spawning on pawns twice as common as other shell types which this PR fixes that.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
