### PR TITLE
Add dual wield to the list of incompat mods

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -39,6 +39,7 @@
 		<li>SteveZero.FullArmorHandsFeet</li>
 		<li>Dingo.GrenadeFixRearmed</li>
 		<li>automatic.gunplay</li>
+    <li>Roolo.DualWield</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>


### PR DESCRIPTION
## Additions

Adds Dual Wield by roolo as incompatible.


## Reasoning

As far as I know/remember it never was, and even roolo said compat wasn't feasible in steam desc.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
