### PR TITLE
Fix various capitalization and trade tag issues

### DIFF
--- a/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
+++ b/Biotech/Patches/PawnKindDefs_Humanlike/PawnKinds_Impid.xml
@@ -6,7 +6,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="Tribal_Archer_Fire"]</xpath>
 		<value>
-			<modExtensions Inherit="false">
+			<modExtensions Inherit="False">
 				<li Class="CombatExtended.LoadoutPropertiesExtension" >
 					<primaryMagazineCount>
 						<min>20</min>
@@ -42,7 +42,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="Tribal_Hunter_Fire"]</xpath>
 		<value>
-			<modExtensions Inherit="false">
+			<modExtensions Inherit="False">
 				<li Class="CombatExtended.LoadoutPropertiesExtension" >
 					<primaryMagazineCount>
 						<min>25</min>

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -23,7 +23,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeChargedBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeChargedBase" ParentName="SpacerAmmoBase" Abstract="True">
     <description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
     <statBases>
 	  <Mass>0.047</Mass>

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MediumAmmoBase">
 		<defName>Ammo_12mmRailgun_Sabot</defName>
 		<label>12mm Railgun cartridge (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for large-caliber railgun weapons.</description>

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="12x64mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="12x64mmChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Mechanoid-built high-caliber charged shot ammo used in heavy weapons.</description>
     <statBases>
       <Mass>0.058</Mass>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -23,7 +23,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="12x72mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="12x72mmChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>High-caliber charged shot ammo used by advanced heavy machine guns and anti-materiel rifles.</description>
     <statBases>
       <Mass>0.058</Mass>

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -21,7 +21,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="15x65mmDiffusingChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="15x65mmDiffusingChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Mechanoid-built cartridge designed to split upon firing.</description>
     <statBases>
 	  <Mass>0.11</Mass>

--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="164x284mmDemoBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="164x284mmDemoBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>A high-caliber, low-velocity mechanoid demolition shell designed to destroy fortifications and structures.</description>
     <statBases>
       <Mass>2.0</Mass>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -23,7 +23,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="20x105mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="20x105mmChargedBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>High-caliber charged shot ammo used by autocannons.</description>
     <statBases>
       <Mass>0.13</Mass>

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -22,7 +22,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="30x64mmFuelBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="30x64mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Container holding fuel for incendiary shot firearms.</description>
     <statBases>
       <Mass>0.08</Mass>

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="60x225mmGammaBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="60x225mmGammaBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Shell containing large amounts of ionising gamma radiation.</description>
     <statBases>
 	  <Mass>5.5</Mass>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="66mmThermalBoltBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="66mmThermalBoltBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Mechanoid-built medium-velocity thermal bolt designed to be fired from a mortar.</description>
     <graphicData>
       <drawSize>0.80</drawSize>

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="70mmMechanoidGrenadeBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="70mmMechanoidGrenadeBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 		<description>Low velocity, large bore grenade fired from mechanoid grenade launchers.</description>
 		<statBases>
 			<Mass>1.58</Mass>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="80x256mmFuelBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Large fuel container for incendiary shot cannons.</description>
     <statBases>
       <Mass>0.85</Mass>

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_8mmRailgun_Sabot</defName>
 		<label>8mm Railgun cartridge (Sabot)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun pistols.</description>

--- a/Defs/Ammo/Advanced/8x40mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x40mmCharged.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="8x40mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="8x40mmChargedBase" ParentName="SpacerAmmoBase" Abstract="True">
     <description>Mechanoid-built high power charged shot ammo used in long range assault weapons.</description>
     <statBases>
       <Mass>0.021</Mass>

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -23,7 +23,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="8x50mmChargedBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="8x50mmChargedBase" ParentName="SpacerAmmoBase" Abstract="True">
     <description>High power charged shot ammo used by advanced battle rifles, machineguns and sniper rifles.</description>
     <statBases>
       <Mass>0.027</Mass>

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerMediumAmmoBase">
 		<defName>Ammo_PlasmaCellHeavy</defName>
 		<label>Plasma Heavy Power Cell</label>
 		<description>Plasma containment power cell optimized for heavy weapons</description>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -51,20 +51,20 @@
 		</statBases>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" Name="NeolithicAmmoBase" ParentName="AmmoBase" Abstract="True">
-      <techLevel>Neolithic</techLevel>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="NeolithicAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<techLevel>Neolithic</techLevel>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" Name="SpacerSmallAmmoBase" ParentName="SmallAmmoBase" Abstract="True">
-      <techLevel>Spacer</techLevel>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="SpacerSmallAmmoBase" ParentName="SmallAmmoBase" Abstract="True">
+		<techLevel>Spacer</techLevel>
+	</ThingDef>
 	
-    <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
-      <tradeTags Inherit="False">
-        <li>CE_AmmoInjector</li>
-        <li>CE_HeavyAmmo</li>
-      </tradeTags>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<tradeTags Inherit="False">
+			<li>CE_AmmoInjector</li>
+			<li>CE_HeavyAmmo</li>
+		</tradeTags>
+	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->
 

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -59,7 +59,7 @@
     </ThingDef>
 	
     <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
-      <tradeTags inherit="false">
+      <tradeTags inherit="False">
         <li>CE_HeavyAmmo</li>
       </tradeTags>
     </ThingDef>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -32,6 +32,7 @@
     <rotatable>false</rotatable>
     <pathCost>15</pathCost>
     <tradeTags>
+      <li>CE_AmmoInjector</li>
       <li>CE_Ammo</li>
     </tradeTags>
     <tradeability>None</tradeability>
@@ -60,6 +61,7 @@
 	
     <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
       <tradeTags Inherit="False">
+        <li>CE_AmmoInjector</li>
         <li>CE_HeavyAmmo</li>
       </tradeTags>
     </ThingDef>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -59,6 +59,18 @@
 		<techLevel>Spacer</techLevel>
 	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" Name="SpacerAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<techLevel>Spacer</techLevel>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="SpacerMediumAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<techLevel>Spacer</techLevel>
+		<tradeTags Inherit="False">
+			<li>CE_AmmoInjector</li>
+			<li>CE_MediumAmmo</li>
+		</tradeTags>
+	</ThingDef>
+
 	<ThingDef Class="CombatExtended.AmmoDef" Name="MediumAmmoBase" ParentName="AmmoBase" Abstract="True">
 		<tradeTags Inherit="False">
 			<li>CE_AmmoInjector</li>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -58,7 +58,14 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="SpacerSmallAmmoBase" ParentName="SmallAmmoBase" Abstract="True">
 		<techLevel>Spacer</techLevel>
 	</ThingDef>
-	
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="MediumAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<tradeTags Inherit="False">
+			<li>CE_AmmoInjector</li>
+			<li>CE_MediumAmmo</li>
+		</tradeTags>
+	</ThingDef>
+
 	<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
 		<tradeTags Inherit="False">
 			<li>CE_AmmoInjector</li>

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -59,7 +59,7 @@
     </ThingDef>
 	
     <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
-      <tradeTags inherit="False">
+      <tradeTags Inherit="False">
         <li>CE_HeavyAmmo</li>
       </tradeTags>
     </ThingDef>

--- a/Defs/Ammo/GENERIC/AntiMateriel.xml
+++ b/Defs/Ammo/GENERIC/AntiMateriel.xml
@@ -26,7 +26,7 @@
   
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAntiMaterielBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAntiMaterielBase" ParentName="MediumAmmoBase" Abstract="True">
         <description>Large caliber bullet used by heavy machine guns and anti-materiel rifles.</description>
 		<statBases>
             <Mass>0.140</Mass>

--- a/Defs/Ammo/GENERIC/Autocannon.xml
+++ b/Defs/Ammo/GENERIC/Autocannon.xml
@@ -25,7 +25,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAutocannonShellBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAutocannonShellBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
     <statBases>
     <Mass>0.257</Mass>

--- a/Defs/Ammo/GENERIC/Charged.xml
+++ b/Defs/Ammo/GENERIC/Charged.xml
@@ -179,7 +179,7 @@
 
 <!-- Heavy Charged -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyChargeAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyChargeAmmo" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>High-caliber charged shot ammo used by advanced heavy machine guns and anti-materiel rifles.</description>
     <statBases>
       <Mass>0.054</Mass>
@@ -229,7 +229,7 @@
 
   <!-- Charge Shotgun -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="ChargeShotgunAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="ChargeShotgunAmmo" ParentName="SpacerAmmoBase" Abstract="True">
     <description>Multi-pellet charge shot cartridge designed for shotgun-type weapons.</description>
     <statBases>
 	  <Mass>0.034</Mass>

--- a/Defs/Ammo/GENERIC/LauncherGrenade.xml
+++ b/Defs/Ammo/GENERIC/LauncherGrenade.xml
@@ -18,14 +18,14 @@
       <Ammo_LauncherGrenade_HE>Bullet_40x53mmGrenade_HE</Ammo_LauncherGrenade_HE>
       <Ammo_LauncherGrenade_HEDP>Bullet_40x53mmGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
       <Ammo_LauncherGrenade_EMP>Bullet_40x53mmGrenade_EMP</Ammo_LauncherGrenade_EMP>
-			<Ammo_LauncherGrenade_Smoke>Bullet_40x53mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>	        
+      <Ammo_LauncherGrenade_Smoke>Bullet_40x53mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>	        
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoLauncherGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoLauncherGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Low velocity grenade fired from various grenade launchers</description>
     <statBases>
       <Mass>0.26</Mass>

--- a/Defs/Ammo/GENERIC/Mech.xml
+++ b/Defs/Ammo/GENERIC/Mech.xml
@@ -41,7 +41,7 @@
 
   <!-- Mech Charged -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="MechChargedAmmo" ParentName="SpacerAmmoBase" Abstract="True">
     <description>Charged shot ammo used by mechanoid weaponry.</description>
     <statBases>
       <Mass>0.013</Mass>
@@ -69,7 +69,7 @@
 
   <!-- Mech Shell -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="MechShellAmmo" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="MechShellAmmo" ParentName="SpacerMediumAmmoBase" Abstract="True">
     <description>Large shell used by mechanoid cannons and heavy weapons.</description>
     <statBases>
       <Mass>0.85</Mass>

--- a/Defs/Ammo/GENERIC/PistolMagnum.xml
+++ b/Defs/Ammo/GENERIC/PistolMagnum.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoPistomMagnum" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoPistomMagnum" ParentName="AmmoBase" Abstract="True">
 		<description>Powerful pistol cartridge designed primarily for revolvers.</description>
 		<statBases>
 			<Mass>0.023</Mass>

--- a/Defs/Ammo/GENERIC/RifleMagnum.xml
+++ b/Defs/Ammo/GENERIC/RifleMagnum.xml
@@ -27,7 +27,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleMagnumBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleMagnumBase" ParentName="AmmoBase" Abstract="True">
         <description>High power rifle ammunition, used mainly by long range sniper rifles.</description>
 		<statBases>
 			<Mass>0.05</Mass>

--- a/Defs/Ammo/GENERIC/ShotgunShell.xml
+++ b/Defs/Ammo/GENERIC/ShotgunShell.xml
@@ -25,7 +25,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoShotgunBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoShotgunBase" ParentName="AmmoBase" Abstract="True">
     <description>Extremely common shotgun caliber used in almost every application, from hunting and riot control to military firearms.</description>
     <statBases>
       <Mass>0.023</Mass>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -24,7 +24,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="20x42mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="20x42mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Specialized grenade developed for use in shoulder-fired grenade launchers.</description>
     <statBases>
 	  <Mass>0.125</Mass>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -24,7 +24,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="25x40mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="25x40mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Specialized grenade developed for use in shoulder-fired grenade launchers.</description>
     <statBases>
       <Mass>0.144</Mass>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -24,7 +24,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="25x59mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="25x59mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Specialized high-velocity grenade developed anti-materiel purposes.</description>
     <statBases>
 	  <Mass>0.29</Mass>

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -24,7 +24,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="30x29mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="30x29mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Relatively small, low velocity grenade for use in grenade launchers.</description>
     <statBases>
       <Mass>0.36</Mass>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -24,7 +24,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="35x32mmSRGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="35x32mmSRGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>High velocity grenade fired from handheld grenade launchers.</description>
     <statBases>
 	  <Mass>0.25</Mass>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -25,7 +25,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40x46mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40x46mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Low velocity grenade fired from handheld grenade launchers.</description>
     <statBases>
       <Mass>0.239</Mass>

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -23,7 +23,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40x47mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40x47mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Low velocity grenade fired from handheld grenade launchers.</description>
     <statBases>
 	  <Mass>0.26</Mass>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -25,7 +25,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40x53mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40x53mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>High velocity grenade fired from mounted and crew-served grenade launchers.</description>
     <statBases>
 	  <Mass>0.375</Mass>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -24,7 +24,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40x53mmVOG25GrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40x53mmVOG25GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Low velocity caseless grenade fired from handheld grenade launchers.</description>
     <statBases>
 	  <Mass>0.25</Mass>

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -23,7 +23,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="50mmGS50GrenadeBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="50mmGS50GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Specialized high-velocity grenades with polymer casing and stabilizing fins.</description>
 		<statBases>
 			<Mass>0.44</Mass>

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -22,7 +22,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="83mmPIATGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="83mmPIATGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large spigot grenade designed to be fired at tanks.</description>
     <statBases>
 	  <Mass>3.176</Mass>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -25,7 +25,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo127x108mmBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo127x108mmBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber bullet used by many heavy machine guns and anti-materiel rifles.</description>
     <statBases>
     <Mass>0.133</Mass>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -25,7 +25,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo132x92mmSRTuFBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo132x92mmSRTuFBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Outdated large caliber bullet used in anti-materiel rifles.</description>
 		<statBases>
 			<Mass>0.142</Mass>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -25,7 +25,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo145x114mmBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo145x114mmBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Old-school anti-tank cartridge originally designed for AT rifles, it is also used by a number of heavy machine guns.</description>
     <statBases>
       <Mass>0.186</Mass>

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -21,7 +21,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo152x169mmBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo152x169mmBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Prototype smoothbore cartridge designed for anti-material use.</description>
     <statBases>
 	  <Mass>0.15</Mass>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -25,7 +25,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo2BoreBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo2BoreBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>An extremely large caliber sporting cartridge, almost impractical for any purpose, but capable of bringing down large targets like elephants or rhinoceroses.</description>
 		<statBases>
 			<Mass>0.477</Mass>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x102mmNATOBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x102mmNATOBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
 			<Mass>0.254</Mass>

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -24,7 +24,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x110mmHispanoBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x110mmHispanoBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
     <statBases>
     <Mass>0.257</Mass>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x128mmOerlikonBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x128mmOerlikonBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
 		<statBases>
 			<Mass>0.353</Mass>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x138mmBBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x138mmBBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>A medium caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
 		<statBases>
 			<Mass>0.3</Mass>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -24,7 +24,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x82mmMauserBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x82mmMauserBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
     <statBases>
     <Mass>0.175</Mass>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -24,7 +24,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x99mmRShVAKBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo20x99mmRShVAKBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
     <statBases>
     <Mass>0.216</Mass>

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo25x137mmNATOBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo25x137mmNATOBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
 			<Mass>0.501</Mass>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x113mmBBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x113mmBBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
 			<Mass>0.49</Mass>

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x173mmNATOBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x173mmNATOBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
 			<Mass>0.837</Mass>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -24,7 +24,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo40x311mmRBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo40x311mmRBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
 			<Mass>2.15</Mass>

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -25,7 +25,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo50BMGBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo50BMGBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber bullet used by many heavy machine guns and anti-materiel rifles.</description>
     <statBases>
       <Mass>0.118</Mass>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -25,7 +25,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo55BoysBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo55BoysBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Outdated large caliber bullet used in anti-materiel rifles.</description>
 		<statBases>
 			<Mass>0.133</Mass>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -25,7 +25,7 @@
   
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo600NitroExpressBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo600NitroExpressBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large and powerful cartridge designed to be fired at large game, like elephants or rhinoceroses.</description>
     <statBases>
       <Mass>0.108</Mass>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -25,7 +25,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo792x94mmPatronenBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo792x94mmPatronenBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Old-school anti-tank cartridge originally designed for AT rifles.</description>
     <statBases>
       <Mass>0.125</Mass>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -25,7 +25,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo950JDJBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo950JDJBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>A ridiculously large and powerful caliber sporting cartridge.</description>
 		<statBases>
 		<Mass>0.319</Mass>

--- a/Defs/Ammo/Medieval/Catapult.xml
+++ b/Defs/Ammo/Medieval/Catapult.xml
@@ -28,7 +28,7 @@
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
-	<ThingDef Class="CombatExtended.AmmoDef" Name="CatapultShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="CatapultShellBase" ParentName="MediumAmmoBase" Abstract="True">
 		<thingCategories>
 			<li>AmmoCatapult</li>
 		</thingCategories>

--- a/Defs/Ammo/Medieval/Catapult.xml
+++ b/Defs/Ammo/Medieval/Catapult.xml
@@ -115,7 +115,7 @@
 			<li>StoneChunks</li>
 			</categories>
 		</fixedIngredientFilter>
-		<recipeUsers Inherit="false">
+		<recipeUsers Inherit="False">
 			<li>TableStonecutter</li>
 		</recipeUsers>		  
 		<products>

--- a/Defs/Ammo/Pistols/13mmGyrojet.xml
+++ b/Defs/Ammo/Pistols/13mmGyrojet.xml
@@ -23,7 +23,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="13mmGyrojetBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="13mmGyrojetBase" ParentName="AmmoBase" Abstract="True">
 		<description>Rare pistol rocket that utilizes miniature rockets for propulsion instead of gunpowder.</description>
 		<statBases>
 			<Mass>0.014</Mass>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -26,7 +26,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="545x39mmSovietBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="545x39mmSovietBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Small, high-velocity rifle bullet used in a variety of assault rifles.</description>
 		<statBases>
 			<Mass>0.011</Mass>

--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -30,7 +30,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="5x100mmCaselessBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="5x100mmCaselessBase" ParentName="AmmoBase" Abstract="True">
 		<description>A long caseless cartridge with a solid propellant enveloping the slim projectile.</description>
 		<statBases>
 			<Bulk>0.03</Bulk>

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -26,7 +26,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="9x39mmSovietBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="9x39mmSovietBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Small, high-velocity rifle bullet used in a variety of assault rifles.</description>
 		<statBases>
 			<Mass>0.027</Mass>

--- a/Defs/Ammo/Rocket/130mmType63.xml
+++ b/Defs/Ammo/Rocket/130mmType63.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="130mmType63Base" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="130mmType63Base" ParentName="MediumAmmoBase" Abstract="True">
 		<description>130mm heavy rocket typically used in multi-barrel rocket artillery launchers.</description>
 		<statBases>
 			<MaxHitPoints>300</MaxHitPoints>

--- a/Defs/Ammo/Rocket/132mmM13.xml
+++ b/Defs/Ammo/Rocket/132mmM13.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="132mmM13Base" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="132mmM13Base" ParentName="MediumAmmoBase" Abstract="True">
 		<description>13.2cm rocket typically used in multi-railed rocket artillery launchers.</description>
 		<statBases>
 			<MaxHitPoints>280</MaxHitPoints>

--- a/Defs/Ammo/Rocket/20mmFliegerfaust.xml
+++ b/Defs/Ammo/Rocket/20mmFliegerfaust.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="20mmFliegerfaustBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="20mmFliegerfaustBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Outdated 20mm rocket designed to be fired in volleys at airplanes.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/50mmRocket.xml
+++ b/Defs/Ammo/Rocket/50mmRocket.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="50mmRocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="50mmRocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>An unguided rocket equipped with an explosive warhead and a contact fuse.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/70mmAPKWS.xml
+++ b/Defs/Ammo/Rocket/70mmAPKWS.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="70mmAPKWSBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="70mmAPKWSBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>70mm laser-guided munition known as the Advanced Precision Kill Weapon System (APKWS), based on Hydra 70 unguided rockets.</description>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -22,7 +22,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="83mmSMAWBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="83mmSMAWBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>83mm rocket designed for the Shoulder-Launched Multipurpose Assault Weapon (SMAW). After being fired a rocket motor kicks in to propel the warhead further.</description>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -21,7 +21,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="84x246mmRBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="84x246mmRBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Recoilless cartridge designed for use with the Carl Gustav rifle.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/88mmRPzB.xml
+++ b/Defs/Ammo/Rocket/88mmRPzB.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="88mmRPzBRocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="88mmRPzBRocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Outdated 88mm rocket.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -21,7 +21,7 @@
 
   <!-- ==================== Ammo ==================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Base90mmRecoillessAmmo" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Base90mmRecoillessAmmo" ParentName="MediumAmmoBase" Abstract="True">
     <description>Rocket-propelled ammunition desinged for use with the M67 recoilless rifle</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/M6.xml
+++ b/Defs/Ammo/Rocket/M6.xml
@@ -23,7 +23,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="M6RocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="M6RocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Outdated 60mm rocket-propelled grenade designed for the M1 Bazooka.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/M6A1.xml
+++ b/Defs/Ammo/Rocket/M6A1.xml
@@ -12,7 +12,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="M6A1RocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="M6A1RocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Outdated 60mm rocket-propelled grenade designed for the M1A1 Bazooka.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -12,7 +12,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="M6A3RocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="M6A3RocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Outdated 60mm rocket-propelled grenade designed for the M9 Bazooka.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/M74.xml
+++ b/Defs/Ammo/Rocket/M74.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="M74Base" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="M74Base" ParentName="MediumAmmoBase" Abstract="True">
     <description>66mm incendiary rocket based upon the rocket used in the M72 LAW, for use in the quadruple-tubed M202 FLASH.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/PG15V.xml
+++ b/Defs/Ammo/Rocket/PG15V.xml
@@ -23,7 +23,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="PG15VRocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="PG15VRocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Tube launched rocket-propelled grenade used by SPG-9 recoilless launcher and the BMP-1's 2A28 Grom cannon. After being fired, a rocket motor kicks in to propel the grenade further.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/RPG32.xml
+++ b/Defs/Ammo/Rocket/RPG32.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="RPG32RocketBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="RPG32RocketBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Rocket-propelled grenade designed for the RPG-32 launcher. After being fired, a rocket motor kicks in to propel the grenade further.</description>
 		<statBases>
 			<MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -22,7 +22,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG7GrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG7GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Rocket-propelled grenade designed for the RPG-7 launcher. After being fired a rocket motor kicks in to propel the grenade further.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -21,7 +21,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="SPG9GrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="SPG9GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Rocket-assisted projectile for use with the SPG-9 launcher.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Defs/Ammo/Rocket/TomahawkLAM.xml
+++ b/Defs/Ammo/Rocket/TomahawkLAM.xml
@@ -15,7 +15,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="TomahawkLAMBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="TomahawkLAMBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Long-range, all-weather, jet-powered, surface-launched subsonic cruise missile designed to attack land targets.</description>
 		<statBases>
 			<MaxHitPoints>500</MaxHitPoints>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -24,7 +24,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="10GaugeBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="10GaugeBase" ParentName="AmmoBase" Abstract="True">
     <description>Very common shotgun caliber used mostly for big game hunting.</description>
     <statBases>
       <Mass>0.087</Mass>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -24,7 +24,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="12GaugeBase" ParentName="AmmoBase" Abstract="True">
     <description>Extremely common shotgun caliber used in almost every application, from hunting over riot control to military firearms.</description>
     <statBases>
       <Mass>0.051</Mass>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -24,7 +24,7 @@
 	
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="23x75mmRBase" ParentName="AmmoBase" Abstract="True">
     <description>Large 6.27 gauge shotgun caliber designed to be fired by the KS-23 shotgun.</description>
     <statBases>
 	  <Mass>0.095</Mass>

--- a/Defs/PawnKindDefs/PawnKinds_CE.xml
+++ b/Defs/PawnKindDefs/PawnKinds_CE.xml
@@ -5,7 +5,7 @@
     <defName>MercenaryMachineGunner</defName>
     <label>mercenary machine gunner</label>
     <combatPower>110</combatPower>
-    <weaponTags Inherit="false">
+    <weaponTags Inherit="False">
       <li>CE_MachineGun</li>
     </weaponTags>
     <weaponMoney>450~600</weaponMoney>

--- a/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Defs/RecipeDefs/Recipes_Production.xml
@@ -105,7 +105,7 @@
 			<Plasteel>2</Plasteel>
 			<Steel>2</Steel>
 		</products>
-		<recipeUsers Inherit="false">
+		<recipeUsers Inherit="False">
 			<li>ElectricSmelter</li>
 		</recipeUsers>	
 	</RecipeDef>
@@ -145,7 +145,7 @@
 			<Plasteel>5</Plasteel>
 			<Steel>20</Steel>
 		</products>
-		<recipeUsers Inherit="false">
+		<recipeUsers Inherit="False">
 			<li>FabricationBench</li>
 		</recipeUsers>	
 	</RecipeDef>
@@ -187,7 +187,7 @@
 			<FSX>1</FSX>
 			<Prometheum>1</Prometheum>
 		</products>
-		<recipeUsers Inherit="false">
+		<recipeUsers Inherit="False">
 			<li>FabricationBench</li>
 		</recipeUsers>	
 	</RecipeDef>

--- a/Defs/ThingDefs_Items/Items_Unfinished.xml
+++ b/Defs/ThingDefs_Items/Items_Unfinished.xml
@@ -8,7 +8,7 @@
       <texPath>Things/Item/Unfinished/UnfinishedComponent</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <stuffCategories Inherit="false" />
+    <stuffCategories Inherit="False" />
   </ThingDef>
 
   <ThingDef ParentName="UnfinishedBase">
@@ -27,7 +27,7 @@
       <texPath>Things/Item/Unfinished/UnfinishedGun</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <stuffCategories Inherit="false">
+    <stuffCategories Inherit="False">
       <li>Metallic</li>
     </stuffCategories>
   </ThingDef>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -194,11 +194,11 @@
     <costStuffCount>20</costStuffCount>
     <apparel>
       <developmentalStageFilter>Child</developmentalStageFilter>
-      <tags inherit="False">
+      <tags Inherit="False">
         <li>IndustrialBasic</li>
       </tags>
       <wornGraphicPath>Things/Apparel/KidBackpack/CE_KidBackpack</wornGraphicPath>
-      <wornGraphicData inherit="False">
+      <wornGraphicData Inherit="False">
       <renderUtilityAsPack>true</renderUtilityAsPack>
         <east>
           <offset>(0.1,-0)</offset>

--- a/Defs/ThingDefs_Misc/Apparel_Carrying.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Carrying.xml
@@ -194,11 +194,11 @@
     <costStuffCount>20</costStuffCount>
     <apparel>
       <developmentalStageFilter>Child</developmentalStageFilter>
-      <tags inherit="false">
+      <tags inherit="False">
         <li>IndustrialBasic</li>
       </tags>
       <wornGraphicPath>Things/Apparel/KidBackpack/CE_KidBackpack</wornGraphicPath>
-      <wornGraphicData inherit="false">
+      <wornGraphicData inherit="False">
       <renderUtilityAsPack>true</renderUtilityAsPack>
         <east>
           <offset>(0.1,-0)</offset>

--- a/Defs/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Headgear.xml
@@ -262,7 +262,7 @@
                 <HideBeard>false</HideBeard>
             </li>
         </modExtensions>
-        <thingCategories Inherit="false">
+        <thingCategories Inherit="False">
             <li>Headgear</li>
         </thingCategories>
         <tradeTags>
@@ -324,7 +324,7 @@
                 <HideBeard>false</HideBeard>
             </li>
         </modExtensions>
-        <thingCategories Inherit="false">
+        <thingCategories Inherit="False">
             <li>Headgear</li>
         </thingCategories>
         <tradeTags>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -9,24 +9,27 @@
     <thingClass>ThingWithComps</thingClass>
     <category>Item</category>
     <useHitPoints>true</useHitPoints>
+    <pathCost>14</pathCost>
     <selectable>true</selectable>
+    <drawerType>MapMeshOnly</drawerType>
     <drawGUIOverlay>true</drawGUIOverlay>
+    <alwaysHaulable>true</alwaysHaulable>
+    <tickerType>Never</tickerType>
+    <altitudeLayer>Item</altitudeLayer>
+    <description>Equipment lacks desc.</description>
     <statBases>
       <MaxHitPoints>100</MaxHitPoints>
       <Flammability>1.0</Flammability>
       <DeteriorationRate>2</DeteriorationRate>
-      <SellPriceFactor>0.5</SellPriceFactor>
+      <Beauty>-3</Beauty>
+      <SellPriceFactor>0.20</SellPriceFactor>
     </statBases>
-    <altitudeLayer>Item</altitudeLayer>
-    <description>Equipment lacks desc.</description>
     <comps>
       <li Class="CompProperties_Forbiddable"/>
       <li>
         <compClass>CompEquippable</compClass>
       </li>
     </comps>
-    <alwaysHaulable>true</alwaysHaulable>
-    <tickerType>Never</tickerType>
     <tools>
       <li Class="CombatExtended.ToolCE">
         <label>Body</label>
@@ -39,6 +42,10 @@
         <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
       </li>
     </tools>
+    <tradeTags>
+      <li>CE_MediumAmmo</li>
+    </tradeTags>
+    <allowedArchonexusCount>5</allowedArchonexusCount>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="BaseGrenadeEquipment" ParentName="BaseEquipment" Abstract="True">

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -3,7 +3,7 @@
 
   <!-- ==================== Grenade Launcher ==================== -->
 
-  <ThingDef ParentName="BaseMakeableGun">
+  <ThingDef ParentName="BaseHumanMakeableGun">
     <defName>CE_GrenadeLauncher</defName>
     <label>grenade launcher</label>
     <description>A simple, locally produced break-action grenade launcher, capable of firing a variety of different projectiles.</description>
@@ -29,7 +29,7 @@
       <ComponentIndustrial>1</ComponentIndustrial>
       <WoodLog>10</WoodLog>
     </costList>
-    <weaponTags>
+    <weaponTags Inherit="False">
       <li>GunGrenadeLauncher</li>
       <li>GunHeavy</li>
       <li>GrenadeEMP</li>

--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -121,6 +121,7 @@
     <tickerType>Normal</tickerType>
     <resourceReadoutPriority>First</resourceReadoutPriority>
     <techLevel>Industrial</techLevel>
+    <stackLimit>25</stackLimit>
     <statBases>
       <MarketValue>91</MarketValue>
       <SightsEfficiency>1.0</SightsEfficiency>
@@ -158,7 +159,6 @@
         <aiAimMode>AimedShot</aiAimMode>
       </li>
     </comps>
-    <stackLimit>25</stackLimit>
     <tools>
       <li Class="CombatExtended.ToolCE">
         <label>stock</label>
@@ -198,6 +198,9 @@
         <DrawOffset>-0.3,0.0</DrawOffset>
       </li>
     </modExtensions>
+    <tradeTags Inherit="False">
+      <li>CE_HeavyAmmo</li>
+    </tradeTags>
   </ThingDef>
 
    <RecipeDef ParentName="GrenadeRecipeBase">

--- a/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
+++ b/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
@@ -26,7 +26,7 @@
 
 						<!-- ==================== Ammo ========================== -->
 
-						<ThingDef Class="CombatExtended.AmmoDef" Name="MastiffShotgunShellBase" ParentName="AmmoBase" Abstract="True">
+						<ThingDef Class="CombatExtended.AmmoDef" Name="MastiffShotgunShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 							<description>Very large caliber buckshot shell designed specifically for the mech-operated Mastiff Shotgun.</description>
 							<statBases>
 								<Mass>2.128</Mass>

--- a/Patches/Android Tiers/Ammo/X5Pistol.xml
+++ b/Patches/Android Tiers/Ammo/X5Pistol.xml
@@ -26,7 +26,7 @@
 
 						<!-- ==================== Ammo ========================== -->
 
-						<ThingDef Class="CombatExtended.AmmoDef" Name="AndroidTiersX5PistolBase" ParentName="AmmoBase" Abstract="True">
+						<ThingDef Class="CombatExtended.AmmoDef" Name="AndroidTiersX5PistolBase" ParentName="MediumAmmoBase" Abstract="True">
 							<description>Large-caliber handgun round designed specifically for use with the mech-operated X-5 Pistol.</description>
 							<statBases>
 								<Mass>0.138</Mass>

--- a/Patches/Android Tiers/Andro_Trader.xml
+++ b/Patches/Android Tiers/Andro_Trader.xml
@@ -42,8 +42,8 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>70</max>
+          <min>30</min>
+          <max>100</max>
         </countRange>
         <thingDefCountRange>
           <min>5</min>
@@ -127,12 +127,12 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
-          <max>20</max>
+          <min>20</min>
+          <max>40</max>
         </countRange>
         <thingDefCountRange>
           <min>2</min>
-          <max>5</max>
+          <max>6</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -210,13 +210,13 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>40</max>
+          <min>30</min>
+          <max>60</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
           <min>3</min>
-          <max>5</max>
+          <max>6</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">

--- a/Patches/Android Tiers/Andro_Trader.xml
+++ b/Patches/Android Tiers/Andro_Trader.xml
@@ -40,13 +40,24 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
+        <tradeTag>CE_MediumAmmo</tradeTag>
+        <countRange>
+          <min>20</min>
+          <max>70</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>5</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
         <tradeTag>CE_HeavyAmmo</tradeTag>
         <countRange>
           <min>10</min>
-          <max>100</max>
+          <max>50</max>
         </countRange>
         <thingDefCountRange>
-          <min>3</min>
+          <min>4</min>
           <max>6</max>
         </thingDefCountRange>
       </li>      
@@ -114,14 +125,25 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>5</min>
+          <min>10</min>
           <max>20</max>
         </countRange>
         <thingDefCountRange>
-          <min>1</min>
-          <max>3</max>
+          <min>2</min>
+          <max>5</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>5</min>
+          <max>10</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>4</max>
         </thingDefCountRange>
       </li>         
       <li Class="StockGenerator_Category">
@@ -186,17 +208,29 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
-          <max>50</max>
+          <min>20</min>
+          <max>40</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
-          <min>2</min>
+          <min>3</min>
           <max>5</max>
         </thingDefCountRange>
-      </li>      
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>15</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>4</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>

--- a/Patches/Astoriel Legacy/Traders_Astoriel.xml
+++ b/Patches/Astoriel Legacy/Traders_Astoriel.xml
@@ -74,13 +74,13 @@
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>15</min>
-							<max>20</max>
+							<min>20</min>
+							<max>30</max>
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
-							<min>1</min>
-							<max>3</max>
+							<min>2</min>
+							<max>4</max>
 						</thingDefCountRange>
       				</li>
 					<li Class="StockGenerator_Tag">

--- a/Patches/Astoriel Legacy/Traders_Astoriel.xml
+++ b/Patches/Astoriel Legacy/Traders_Astoriel.xml
@@ -72,17 +72,29 @@
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>15</min>
+							<max>20</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>1</min>
+							<max>3</max>
+						</thingDefCountRange>
+      				</li>
+					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_HeavyAmmo</tradeTag>
 						<countRange>
 							<min>10</min>
-							<max>20</max>
+							<max>15</max>
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
 							<min>0</min>
 							<max>3</max>
 						</thingDefCountRange>
-      					</li>        
+      				</li>
 				</value>
 			</li>
 

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_BfgCell.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_BfgCell.xml
@@ -24,7 +24,7 @@
 
 					<!-- ==================== Ammo ========================== -->
 
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 						<defName>Ammo_Doom2016BfgCell</defName>
 						<label>UAC BFG Cell</label>
 						<description>Plasma containment power cell developed by the Union Aerospace Corporation for the BFG 9000, utilizing the compression of Argent energy</description>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_Rocket.xml
@@ -29,7 +29,7 @@
 
 					<!-- ==================== Ammo ========================== -->
 
-					<ThingDef Class="CombatExtended.AmmoDef" Name="Doom2016RocketBase" ParentName="AmmoBase" Abstract="True">
+					<ThingDef Class="CombatExtended.AmmoDef" Name="Doom2016RocketBase" ParentName="MediumAmmoBase" Abstract="True">
 						<description>Compact 60mm rocket developed by the Union Aerospace Corporation for infantry rocket launchers.</description>
 						<statBases>
 							<MaxHitPoints>150</MaxHitPoints>

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_KitClassic_CE_Patch_Ammo_ClassicRocket.xml
@@ -30,7 +30,7 @@
 
 					<!-- ==================== Ammo ========================== -->
 
-					<ThingDef Class="CombatExtended.AmmoDef" Name="DoomClassicRocketBase" ParentName="AmmoBase" Abstract="True">
+					<ThingDef Class="CombatExtended.AmmoDef" Name="DoomClassicRocketBase" ParentName="MediumAmmoBase" Abstract="True">
 						<description>Compact 60mm rocket developed by the Union Aerospace Corporation for infantry rocket launchers.</description>
 						<statBases>
 							<MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Censored Armory/30mm Rifle Grenade.xml
+++ b/Patches/Censored Armory/30mm Rifle Grenade.xml
@@ -30,7 +30,7 @@
 
         <!-- ==================== Ammo ========================== -->
 
-        <ThingDef Class="CombatExtended.AmmoDef" Name="30mmRifleGrenadeBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="30mmRifleGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
           <description>A small, low velocity rifle grenade propelled with a blank cartridge.</description>
           <statBases>
             <Mass>0.36</Mass>

--- a/Patches/Censored Armory/37x249mmR.xml
+++ b/Patches/Censored Armory/37x249mmR.xml
@@ -30,7 +30,7 @@
 
 				<!-- ==================== Ammo ========================== -->
 
-				<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo37x249mmRBase" ParentName="SmallAmmoBase" Abstract="True">
+				<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo37x249mmRBase" ParentName="MediumAmmoBase" Abstract="True">
 					<description>Medium caliber cannon shell used by light, quick-firing anti-tank guns.</description>
 					<statBases>
 						<Mass>1.305</Mass>

--- a/Patches/Censored Armory/75cm leIG18.xml
+++ b/Patches/Censored Armory/75cm leIG18.xml
@@ -30,7 +30,7 @@
 
 				<!-- ==================== Ammo ========================== -->
 
-				<ThingDef Class="CombatExtended.AmmoDef" Name="75cmleIG18CannonShellBase" ParentName="AmmoBase" Abstract="True">
+				<ThingDef Class="CombatExtended.AmmoDef" Name="75cmleIG18CannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 					<description>Light cannon shell used in field guns.</description>
 					<thingCategories>
 						<li>Ammo75cmleIG18CannonShells</li>

--- a/Patches/Censored Armory/75x714mmR.xml
+++ b/Patches/Censored Armory/75x714mmR.xml
@@ -30,7 +30,7 @@
 
         <!-- ==================== Ammo ========================== -->
 
-        <ThingDef Class="CombatExtended.AmmoDef" Name="75x714mmRShellBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="75x714mmRShellBase" ParentName="HeavyAmmoBase" Abstract="True">
           <description>A relatively powerful, high-velocity shell designed to destroy heavily armored targets.</description>
           <thingCategories>
             <li>Ammo75x714mmRShells</li>

--- a/Patches/Censored Armory/Recipes_Grenades.xml
+++ b/Patches/Censored Armory/Recipes_Grenades.xml
@@ -17,7 +17,7 @@
 							<description>Craft 10 M24 grenades.</description>
 							<jobString>Making M24 grenades.</jobString>
 							<workAmount>3400</workAmount>
-							<recipeUsers Inherit="false">
+							<recipeUsers Inherit="False">
 								<li>TableRA</li>
 							</recipeUsers>
 							<ingredients>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -6,31 +6,11 @@
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]</xpath>
 		<attribute>ParentName</attribute>
-		<value>BaseWeapon</value>
+		<value>BaseGrenadeEquipment</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]/recipeMaker</xpath>
-	</Operation>
-
-	<!-- ========== Melee tools ========== -->
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]</xpath>
-		<value>
-			<tools>
-			  <li Class="CombatExtended.ToolCE">
-				<label>Body</label>
-				<capacities>
-				  <li>Blunt</li>
-				</capacities>
-				<power>2</power>
-				<cooldownTime>1.75</cooldownTime>
-				<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
-			  </li>
-			</tools>
-		</value>
 	</Operation>
 
 	<!-- ========== Base Grenade Projectile ========== -->
@@ -138,21 +118,6 @@
 				<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
 			</graphicData>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]</xpath>
-		<value>
-			<thingClass>CombatExtended.AmmoThing</thingClass>
-			<stackLimit>75</stackLimit>
-			<resourceReadoutPriority>First</resourceReadoutPriority>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]</xpath>
-		<attribute>Class</attribute>
-		<value>CombatExtended.AmmoDef</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -269,16 +234,8 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeMolotov"]</xpath>
 		<value>
-			<thingClass>CombatExtended.AmmoThing</thingClass>
 			<stackLimit>50</stackLimit>
-			<resourceReadoutPriority>First</resourceReadoutPriority>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeMolotov"]</xpath>
-		<attribute>Class</attribute>
-		<value>CombatExtended.AmmoDef</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -381,21 +338,6 @@
 				<onGroundRandomRotateAngle>0</onGroundRandomRotateAngle>
 			</graphicData>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]</xpath>
-		<value>
-			<thingClass>CombatExtended.AmmoThing</thingClass>
-			<stackLimit>75</stackLimit>
-			<resourceReadoutPriority>First</resourceReadoutPriority>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAttributeSet">
-		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]</xpath>
-		<attribute>Class</attribute>
-		<value>CombatExtended.AmmoDef</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -6,11 +6,35 @@
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]</xpath>
 		<attribute>ParentName</attribute>
-		<value>BaseGrenadeEquipment</value>
+		<value>BaseWeapon</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]/recipeMaker</xpath>
+	</Operation>
+
+	<!-- ========== Melee tools ========== -->
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag" or defName="Weapon_GrenadeMolotov" or defName="Weapon_GrenadeEMP"]</xpath>
+		<value>
+			<tools>
+			  <li Class="CombatExtended.ToolCE">
+				<label>Body</label>
+				<capacities>
+				  <li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.75</cooldownTime>
+				<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
+			  </li>
+			</tools>
+			<tradeTags Inherit="False">
+			  <li>CE_MediumAmmo</li>
+			</tradeTags>
+			<allowedArchonexusCount>5</allowedArchonexusCount>
+		</value>
 	</Operation>
 
 	<!-- ========== Base Grenade Projectile ========== -->
@@ -120,6 +144,21 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]</xpath>
+		<value>
+			<thingClass>CombatExtended.AmmoThing</thingClass>
+			<stackLimit>75</stackLimit>
+			<resourceReadoutPriority>First</resourceReadoutPriority>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeFrag"]/comps</xpath>
 		<value>
@@ -172,6 +211,7 @@
 			<ai_AvoidFriendlyFireRadius>7</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
+			<li>CE_AI_Grenade</li>
 			<li>CE_AI_AOE</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
@@ -234,8 +274,16 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeMolotov"]</xpath>
 		<value>
+			<thingClass>CombatExtended.AmmoThing</thingClass>
 			<stackLimit>50</stackLimit>
+			<resourceReadoutPriority>First</resourceReadoutPriority>
 		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeMolotov"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -281,6 +329,7 @@
 			<ai_AvoidFriendlyFireRadius>2</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
+			<li>CE_AI_Grenade</li>
 			<li>CE_AI_AOE</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
@@ -340,6 +389,21 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]</xpath>
+		<value>
+			<thingClass>CombatExtended.AmmoThing</thingClass>
+			<stackLimit>75</stackLimit>
+			<resourceReadoutPriority>First</resourceReadoutPriority>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]</xpath>
+		<attribute>Class</attribute>
+		<value>CombatExtended.AmmoDef</value>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Weapon_GrenadeEMP"]/smeltable</xpath>
 		<value>
@@ -388,6 +452,7 @@
 			<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
 		</Properties>
 		<weaponTags>
+			<li>CE_AI_Grenade</li>
 			<li>CE_AI_EMP</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -247,16 +247,27 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
+          <min>20</min>
           <max>100</max>
         </countRange>
         <thingDefCountRange>
-          <min>3</min>
+          <min>5</min>
+          <max>7</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>4</min>
           <max>6</max>
         </thingDefCountRange>
-      </li>      
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -320,16 +320,27 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>5</min>
+          <min>10</min>
           <max>20</max>
         </countRange>
         <thingDefCountRange>
-          <min>1</min>
-          <max>3</max>
+          <min>2</min>
+          <max>5</max>
         </thingDefCountRange>
-      </li>         
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>5</min>
+          <max>10</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -392,17 +403,29 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
-          <max>50</max>
+          <min>20</min>
+          <max>40</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
-          <min>2</min>
+          <min>3</min>
           <max>5</max>
         </thingDefCountRange>
-      </li>      
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>15</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>4</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -466,16 +489,27 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>15</min>
+          <min>50</min>
           <max>100</max>
         </countRange>
         <thingDefCountRange>
-          <min>1</min>
-          <max>3</max>
+          <min>4</min>
+          <max>6</max>
         </thingDefCountRange>
-      </li>            
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>15</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>4</max>
+        </thingDefCountRange>
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -538,17 +572,29 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>100</min>
-          <max>500</max>
+          <min>150</min>
+          <max>400</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
-          <min>3</min>
+          <min>5</min>
+          <max>9</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>100</min>
+          <max>250</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>4</min>
           <max>8</max>
         </thingDefCountRange>
-      </li>       
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -594,4 +640,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -249,12 +249,12 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>100</max>
+          <min>30</min>
+          <max>120</max>
         </countRange>
         <thingDefCountRange>
           <min>5</min>
-          <max>7</max>
+          <max>8</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -326,19 +326,19 @@
           <max>400</max>
         </countRange>
         <thingDefCountRange>
-          <min>1</min>
+          <min>2</min>
           <max>4</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
-          <max>20</max>
+          <min>20</min>
+          <max>40</max>
         </countRange>
         <thingDefCountRange>
           <min>2</min>
-          <max>5</max>
+          <max>6</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -416,13 +416,13 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>40</max>
+          <min>30</min>
+          <max>60</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
           <min>3</min>
-          <max>5</max>
+          <max>6</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -495,19 +495,19 @@
           <max>1000</max>
         </countRange>
         <thingDefCountRange>
-          <min>1</min>
+          <min>2</min>
           <max>4</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>50</min>
-          <max>100</max>
+          <min>60</min>
+          <max>120</max>
         </countRange>
         <thingDefCountRange>
           <min>4</min>
-          <max>6</max>
+          <max>7</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -578,20 +578,20 @@
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
-          <min>5</min>
+          <min>6</min>
           <max>12</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>150</min>
-          <max>400</max>
+          <min>175</min>
+          <max>500</max>
         </countRange>
         <price>Cheap</price>
         <thingDefCountRange>
           <min>5</min>
-          <max>9</max>
+          <max>10</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">

--- a/Patches/Dubs Rimatomics/Atomics_Trader.xml
+++ b/Patches/Dubs Rimatomics/Atomics_Trader.xml
@@ -36,14 +36,25 @@
             </thingDefCountRange>
           </li>
           <li Class="StockGenerator_Tag">
+            <tradeTag>CE_MediumAmmo</tradeTag>
+            <countRange>
+              <min>50</min>
+              <max>200</max>
+            </countRange>
+            <thingDefCountRange>
+              <min>5</min>
+              <max>9</max>
+            </thingDefCountRange>
+          </li>  
+          <li Class="StockGenerator_Tag">
             <tradeTag>CE_HeavyAmmo</tradeTag>
             <countRange>
               <min>20</min>
-              <max>250</max>
+              <max>120</max>
             </countRange>
             <thingDefCountRange>
-              <min>4</min>
-              <max>7</max>
+              <min>5</min>
+              <max>8</max>
             </thingDefCountRange>
           </li>      
           <li Class="StockGenerator_Category">

--- a/Patches/Dubs Rimatomics/Atomics_Trader.xml
+++ b/Patches/Dubs Rimatomics/Atomics_Trader.xml
@@ -38,12 +38,12 @@
           <li Class="StockGenerator_Tag">
             <tradeTag>CE_MediumAmmo</tradeTag>
             <countRange>
-              <min>50</min>
-              <max>200</max>
+              <min>70</min>
+              <max>250</max>
             </countRange>
             <thingDefCountRange>
               <min>5</min>
-              <max>9</max>
+              <max>10</max>
             </thingDefCountRange>
           </li>  
           <li Class="StockGenerator_Tag">

--- a/Patches/Faction - Mafia/Traders_Mafia.xml
+++ b/Patches/Faction - Mafia/Traders_Mafia.xml
@@ -30,7 +30,7 @@
 					<tradeTag>CE_Ammo</tradeTag>
 					<countRange>
 						<min>200</min>
-						<max>00</max>
+						<max>1000</max>
 					</countRange>
 					<thingDefCountRange>
 						<min>1</min>
@@ -40,12 +40,12 @@
 				<li Class="StockGenerator_Tag">
 					<tradeTag>CE_MediumAmmo</tradeTag>
 					<countRange>
-						<min>20</min>
-						<max>40</max>
+						<min>30</min>
+						<max>60</max>
 					</countRange>
 					<thingDefCountRange>
 						<min>1</min>
-						<max>2</max>
+						<max>3</max>
 					</thingDefCountRange>
 				</li> 
 				<li Class="StockGenerator_Tag">

--- a/Patches/Faction - Mafia/Traders_Mafia.xml
+++ b/Patches/Faction - Mafia/Traders_Mafia.xml
@@ -38,10 +38,21 @@
 					</thingDefCountRange>
 				</li>
 				<li Class="StockGenerator_Tag">
+					<tradeTag>CE_MediumAmmo</tradeTag>
+					<countRange>
+						<min>20</min>
+						<max>40</max>
+					</countRange>
+					<thingDefCountRange>
+						<min>1</min>
+						<max>2</max>
+					</thingDefCountRange>
+				</li> 
+				<li Class="StockGenerator_Tag">
 					<tradeTag>CE_HeavyAmmo</tradeTag>
 					<countRange>
 						<min>10</min>
-						<max>50</max>
+						<max>25</max>
 					</countRange>
 					<thingDefCountRange>
 						<min>0</min>

--- a/Patches/Fortifications - Industrial/FT_Security.xml
+++ b/Patches/Fortifications - Industrial/FT_Security.xml
@@ -292,7 +292,7 @@
 					<aimedBurstShotCount>3</aimedBurstShotCount>
 					<noSingleShot>true</noSingleShot>
 				</FireModes>
-        <weaponTags Inherit="false">
+        <weaponTags Inherit="False">
           <li>TurretGun</li>
         </weaponTags>
       </li>

--- a/Patches/Frontline Collection/Frontline - Trenches/FrontlineTrenches_AmmoPatch.xml
+++ b/Patches/Frontline Collection/Frontline - Trenches/FrontlineTrenches_AmmoPatch.xml
@@ -25,7 +25,7 @@
         </CombatExtended.AmmoSetDef>
 
         <!-- ==================== Ammo ========================== -->
-        <ThingDef Class="CombatExtended.AmmoDef" Name="TRMortarGrenadesBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="TRMortarGrenadesBase" ParentName="MediumAmmoBase" Abstract="True">
           <description>Grenades for your Mortar.</description>
           <thingCategories>
             <li>AmmoTRMortarGrenades</li>
@@ -169,7 +169,7 @@
         </CombatExtended.AmmoSetDef>
 
         <!-- ==================== Ammo ========================== -->
-        <ThingDef Class="CombatExtended.AmmoDef" Name="TRHowitzerShellsBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="TRHowitzerShellsBase" ParentName="HeavyAmmoBase" Abstract="True">
           <description>Shells for your Howitzer.</description>
           <thingCategories>
             <li>AmmoTRHowitzerShells</li>
@@ -317,7 +317,7 @@
         </CombatExtended.AmmoSetDef>
 
         <!-- ==================== Ammo ========================== -->
-        <ThingDef Class="CombatExtended.AmmoDef" Name="TRPAKShellsBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="TRPAKShellsBase" ParentName="HeavyAmmoBase" Abstract="True">
           <description>Shell for your PAK.</description>
           <thingCategories>
             <li>AmmoTRPAKShells</li>

--- a/Patches/Gas Traps and Shells/Patch_PawnKinds_CE.xml
+++ b/Patches/Gas Traps and Shells/Patch_PawnKinds_CE.xml
@@ -17,7 +17,7 @@
 				<label>mercenary chemical grenadier</label>
 				<combatPower>60</combatPower>
 				<canBeSapper>true</canBeSapper>
-				<weaponTags Inherit="false">
+				<weaponTags Inherit="False">
 					<li>GrenadeSmoke</li>
 				</weaponTags>
 				<initialResistanceRange>10~20</initialResistanceRange>

--- a/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/105mmShapedCharge.xml
+++ b/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/105mmShapedCharge.xml
@@ -28,7 +28,7 @@
         </CombatExtended.AmmoSetDef>
 
         <!-- === Ammo === -->
-        <ThingDef Class="CombatExtended.AmmoDef" Name="105ShapedChargeBase" ParentName="AmmoBase" Abstract="True">
+        <ThingDef Class="CombatExtended.AmmoDef" Name="105ShapedChargeBase" ParentName="MediumAmmoBase" Abstract="True">
           <description>Rocket-propelled grenade designed for the Charge Launcher.</description>
           <statBases>
             <MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
+++ b/Patches/Halo - UNSC Armoury/Weapons_Laser.xml
@@ -120,7 +120,7 @@
 
 							<!-- ==================== Ammo ========================== -->
 
-							<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyLaserChargePackBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+							<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyLaserChargePackBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 								<description>A battery pack for a heavy laser weapon.</description>
 								<statBases>
 									<Mass>0.5</Mass>

--- a/Patches/Halo Ammo/12.7x99mm.xml
+++ b/Patches/Halo Ammo/12.7x99mm.xml
@@ -33,7 +33,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo127x99mmBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo127x99mmBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Large caliber bullet used by many UNSC heavy machine guns.</description>
     <statBases>
       <Mass>0.115</Mass>

--- a/Patches/Halo Ammo/14.5x114mmUNSC.xml
+++ b/Patches/Halo Ammo/14.5x114mmUNSC.xml
@@ -33,7 +33,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo145x114mmUNSCBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo145x114mmUNSCBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Old-school anti-tank cartridge originally designed for AT rifles, it is now used by UNSC heavy sniper rifles.</description>
     <statBases>
       <Mass>0.186</Mass>

--- a/Patches/Halo Ammo/16x65mm.xml
+++ b/Patches/Halo Ammo/16x65mm.xml
@@ -30,7 +30,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo16x65mmBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo16x65mmBase" ParentName="SpacerAmmoBase" Abstract="True">
     <description>The M645 Ferric-Tungsten Projectile - High Explosive is a 16x65mm slug round used by Acheron Security's ARC-920 railgun.</description>
     <statBases>
 	  <Mass>0.12</Mass>

--- a/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
+++ b/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
@@ -26,7 +26,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Medium velocity grenade fired from handheld grenade launchers. This one features a heat warhead.</description>
     <statBases>
       <Mass>0.2</Mass>

--- a/Patches/Halo Ammo/8 Gauge.xml
+++ b/Patches/Halo Ammo/8 Gauge.xml
@@ -33,7 +33,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="8GaugeBase" ParentName="SmallAmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="8GaugeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>An uncommon, oversized shotgun shell used primarily in military application.</description>
     <statBases>
       <Mass>0.04</Mass>

--- a/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
+++ b/Patches/Halo UNSC Weapon Pack/UNSC_CE.xml
@@ -222,7 +222,7 @@
 
 			<!-- ==================== Ammo ========================== -->
 
-			<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyLaserChargePackBase" ParentName="SpacerSmallAmmoBase" Abstract="True">
+			<ThingDef Class="CombatExtended.AmmoDef" Name="HeavyLaserChargePackBase" ParentName="SpacerMediumAmmoBase" Abstract="True">
 				<description>A battery pack for a heavy laser weapon.</description>
 				<statBases>
 					<Mass>0.5</Mass>

--- a/Patches/Infinity Rim Ariadna/Ammo/MicroMissile.xml
+++ b/Patches/Infinity Rim Ariadna/Ammo/MicroMissile.xml
@@ -27,7 +27,7 @@
 							</ammoTypes>
 						</CombatExtended.AmmoSetDef>
 
-						<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAriadnanMicroMissileBase" ParentName="AmmoBase" Abstract="True">
+						<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAriadnanMicroMissileBase" ParentName="MediumAmmoBase" Abstract="True">
 							<description>Ariadnan micro missiles that is small enough to be carried by the missile launcher.</description>
 							<statBases>
 								<MaxHitPoints>150</MaxHitPoints>

--- a/Patches/JDS Castle Walls/ThingDefs_Tower.xml
+++ b/Patches/JDS Castle Walls/ThingDefs_Tower.xml
@@ -59,7 +59,7 @@
         <reloadTime>10</reloadTime>
         <ammoSet>AmmoSet_GreatArrow</ammoSet>
       </AmmoUser>
-      <weaponTags Inherit="false">
+      <weaponTags Inherit="False">
         <li>TurretGun</li>
       </weaponTags>
       <FireModes>

--- a/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
+++ b/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
@@ -32,7 +32,7 @@
             <!-- ===================== Rocket Ammo ===================== -->
 
             <!-- ======= Type 74mm Rocket ======= -->
-            <ThingDef Class="CombatExtended.AmmoDef" Name="K4GType74mmRocketBase" ParentName="AmmoBase" Abstract="True">
+            <ThingDef Class="CombatExtended.AmmoDef" Name="K4GType74mmRocketBase" ParentName="MediumAmmoBase" Abstract="True">
                <description>Outdated 74mm rocket-propelled grenade designed for the Type-4 74mm Rocket Launcher.</description>
                <statBases>
                   <MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Kaiser Armory/105x155mmR.xml
+++ b/Patches/Kaiser Armory/105x155mmR.xml
@@ -29,7 +29,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="105x155mmRCannonShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="105x155mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Light howitzer shell used in field guns.</description>
 		<thingCategories>
 			<li>Ammo105x155mmRCannonShells</li>

--- a/Patches/Kaiser Armory/77x230mmR.xml
+++ b/Patches/Kaiser Armory/77x230mmR.xml
@@ -30,7 +30,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="77x230mmRCannonShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="77x230mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Light shell used in field guns.</description>
 		<thingCategories>
 			<li>Ammo77x230mmRCannonShells</li>

--- a/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_GrenadeRecipe.xml
@@ -18,7 +18,7 @@
 				<description>Craft 10 M1915 grenades.</description>
 				<jobString>Making M1915 grenades.</jobString>
 				<workAmount>3400</workAmount>
-				<recipeUsers Inherit="false">
+				<recipeUsers Inherit="False">
 					<li>TableKA</li>
 				</recipeUsers>					
 				<ingredients>

--- a/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Security.xml
+++ b/Patches/Kit's Gunpowder Weapons/KitsGunpowder_Security.xml
@@ -121,7 +121,7 @@
 		    <aimedBurstShotCount>5</aimedBurstShotCount>
 		    <aiAimMode>SuppressFire</aiAimMode>
 		  </FireModes>
-		  <weaponTags Inherit="false">
+		  <weaponTags Inherit="False">
 		    <li>TurretGun</li>
 		  </weaponTags>
 		</li>

--- a/Patches/LF Red Dawn/RPG16.xml
+++ b/Patches/LF Red Dawn/RPG16.xml
@@ -29,7 +29,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG16GrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG16GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Rocket-propelled grenade designed for the RPG-16 launcher. After being fired a rocket motor kicks in to propel the grenade further.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
+++ b/Patches/Mass Effect - Playable Geth/Ammo_ME.xml
@@ -107,7 +107,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG7GrenadeBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="RPG7GrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Rocket-propelled missile designed for the ML-77. After being fired a rocket motor kicks in to propel the grenade further.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
+++ b/Patches/Miho Race/ThingDefs_Misc/Miho_Apparel_Special.xml
@@ -104,7 +104,7 @@
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="Miho_Apparel_Special_Shield"]</xpath>
 			<value>
-				<thingClass Inherit="false">CombatExtended.Apparel_Shield</thingClass>
+				<thingClass Inherit="False">CombatExtended.Apparel_Shield</thingClass>
 			</value>
 		</li>
 		

--- a/Patches/MiningCo. Spaceship/Mining_Trader.xml
+++ b/Patches/MiningCo. Spaceship/Mining_Trader.xml
@@ -38,13 +38,24 @@
 						</thingDefCountRange>
 					</li>
      				<li Class="StockGenerator_Tag">
-        					<tradeTag>CE_HeavyAmmo</tradeTag>
+        					<tradeTag>CE_MediumAmmo</tradeTag>
         					<countRange>
-          						<min>10</min>
+          						<min>15</min>
           						<max>20</max>
         					</countRange>
         					<thingDefCountRange>
-          						<min>1</min>
+          						<min>2</min>
+          						<max>4</max>
+        					</thingDefCountRange>
+      				</li>  
+     				<li Class="StockGenerator_Tag">
+        					<tradeTag>CE_HeavyAmmo</tradeTag>
+        					<countRange>
+          						<min>10</min>
+          						<max>15</max>
+        					</countRange>
+        					<thingDefCountRange>
+          						<min>2</min>
           						<max>3</max>
         					</thingDefCountRange>
       				</li>      
@@ -81,14 +92,26 @@
 				</thingDefCountRange>
 				</li>
      			<li Class="StockGenerator_Tag">
-        				<tradeTag>CE_HeavyAmmo</tradeTag>
+        				<tradeTag>CE_MediumAmmo</tradeTag>
         				<countRange>
-          					<min>10</min>
-          					<max>40</max>
+          					<min>25</min>
+          					<max>50</max>
         				</countRange>
 				<price>Cheap</price>
         				<thingDefCountRange>
-          					<min>2</min>
+          					<min>3</min>
+          					<max>6</max>
+        				</thingDefCountRange>
+      			</li> 
+     			<li Class="StockGenerator_Tag">
+        				<tradeTag>CE_HeavyAmmo</tradeTag>
+        				<countRange>
+          					<min>10</min>
+          					<max>30</max>
+        				</countRange>
+				<price>Cheap</price>
+        				<thingDefCountRange>
+          					<min>3</min>
           					<max>5</max>
         				</thingDefCountRange>
       			</li>      

--- a/Patches/MiningCo. Spaceship/Mining_Trader.xml
+++ b/Patches/MiningCo. Spaceship/Mining_Trader.xml
@@ -40,12 +40,12 @@
      				<li Class="StockGenerator_Tag">
         					<tradeTag>CE_MediumAmmo</tradeTag>
         					<countRange>
-          						<min>15</min>
-          						<max>20</max>
+          						<min>20</min>
+          						<max>30</max>
         					</countRange>
         					<thingDefCountRange>
           						<min>2</min>
-          						<max>4</max>
+          						<max>5</max>
         					</thingDefCountRange>
       				</li>  
      				<li Class="StockGenerator_Tag">
@@ -94,13 +94,13 @@
      			<li Class="StockGenerator_Tag">
         				<tradeTag>CE_MediumAmmo</tradeTag>
         				<countRange>
-          					<min>25</min>
-          					<max>50</max>
+          					<min>30</min>
+          					<max>60</max>
         				</countRange>
 				<price>Cheap</price>
         				<thingDefCountRange>
           					<min>3</min>
-          					<max>6</max>
+          					<max>7</max>
         				</thingDefCountRange>
       			</li> 
      			<li Class="StockGenerator_Tag">

--- a/Patches/Morgante WW2 Italian Weapons/Patch_Ammo.xml
+++ b/Patches/Morgante WW2 Italian Weapons/Patch_Ammo.xml
@@ -31,7 +31,7 @@
 		
 		<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="60mmGrenadeBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="60mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large spigot grenade designed to be fired at tanks.</description>
 		<statBases>
 		<Mass>2.176</Mass>

--- a/Patches/Moyo from the depth/Ammo/Ammo_Moyo.xml
+++ b/Patches/Moyo from the depth/Ammo/Ammo_Moyo.xml
@@ -32,7 +32,7 @@
 
 					<!-- ==================== Ammo ========================== -->
 
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 						<defName>Ammo_MoyoBallista</defName>
 						<label>Moyo charge bolt</label>
 						<description>High power ion charge bolt for use against heavy targets such as mechanoids or power armor.</description>

--- a/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
+++ b/Patches/NewRatkinPlus/Ammo/RKCannonShell.xml
@@ -29,7 +29,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 	
-   <ThingDef Name="AmmoRKCannonBall" ParentName="AmmoBase" Abstract="True">
+   <ThingDef Name="AmmoRKCannonBall" ParentName="HeavyAmmoBase" Abstract="True">
     <description>Simple solid shot, designed for ratkin cannons.</description>
     <statBases>
       <Mass>13.6</Mass>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_RangedWeapons.xml
@@ -108,7 +108,7 @@
 			<FireModes>
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 				<li>RK_1TierRange</li>
 				<li>RK_Crossbow</li>
 				<li>RK_Weapon</li>
@@ -145,7 +145,7 @@
 			<FireModes>
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 				<li>RK_1TierRange</li>
 				<li>RK_Crossbow</li>
 				<li>RK_Weapon</li>
@@ -183,7 +183,7 @@
 			<FireModes>
 			  <aiAimMode>AimedShot</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 				<li>RK_1TierRange</li>
 				<li>RK_Crossbow</li>
 				<li>RK_Weapon</li>

--- a/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
+++ b/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
@@ -759,7 +759,7 @@
 					<li>StoneChunks</li>
 				</categories>
 				</fixedIngredientFilter>
-				<recipeUsers Inherit="false">
+				<recipeUsers Inherit="False">
 				<li>TableStonecutter</li>
 				</recipeUsers>		  
 				<products>
@@ -786,7 +786,7 @@
 					<li>StoneChunks</li>
 				</categories>
 				</fixedIngredientFilter>
-				<recipeUsers Inherit="false">
+				<recipeUsers Inherit="False">
 				<li>TableStonecutter</li>
 				</recipeUsers>		  
 				<products>

--- a/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
+++ b/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
@@ -31,7 +31,7 @@
 			</CombatExtended.AmmoSetDef>
 
 
-			<ThingDef Class="CombatExtended.AmmoDef" Name="164mmCannonShellBase" ParentName="AmmoBase" Abstract="True">
+			<ThingDef Class="CombatExtended.AmmoDef" Name="164mmCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 			<description>A round shell designed to be fired from a cannon.</description>
 			<thingCategories>
 				<li>Ammo164mmCannonShells</li>
@@ -344,7 +344,7 @@
 			<isMortarAmmoSet>true</isMortarAmmoSet>
 			</CombatExtended.AmmoSetDef>
 
-			<ThingDef Class="CombatExtended.AmmoDef" Name="164mmCannonShellBaseChamber" ParentName="AmmoBase" Abstract="True">
+			<ThingDef Class="CombatExtended.AmmoDef" Name="164mmCannonShellBaseChamber" ParentName="HeavyAmmoBase" Abstract="True">
 			<description>A metal projectile and powder charge loaded in a mug-shaped chamber to be loaded into a cannon.</description>
 			<thingCategories>
 				<li>Ammo164mmCannonShellsChamber</li>

--- a/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
+++ b/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
@@ -315,7 +315,7 @@
 					  <MarketValue>1.69</MarketValue>
 					</statBases>
 					<ammoClass>GrenadeHE</ammoClass>
-					<thingCategories inherit="False">
+					<thingCategories Inherit="False">
 					  <li>AmmoAdvanced</li>
 					</thingCategories>
 					<detonateProjectile>Bullet_NyaronFlakGrenade_HE</detonateProjectile>

--- a/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
+++ b/Patches/Nyaron/Ammo/Ammo_Nyaron.xml
@@ -315,7 +315,7 @@
 					  <MarketValue>1.69</MarketValue>
 					</statBases>
 					<ammoClass>GrenadeHE</ammoClass>
-					<thingCategories inherit="false">
+					<thingCategories inherit="False">
 					  <li>AmmoAdvanced</li>
 					</thingCategories>
 					<detonateProjectile>Bullet_NyaronFlakGrenade_HE</detonateProjectile>

--- a/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Ammo.xml
+++ b/Patches/O21 Outer Rim Galaxies/Patch_OuterRim_Ammo.xml
@@ -115,7 +115,7 @@
 						<li>O21_OR_ComponentHypertech</li>
 					  </thingDefs>
 					</fixedIngredientFilter>
-					<recipeUsers Inherit="false">
+					<recipeUsers Inherit="False">
 						<li>O21_OR_WeaponsFabricator</li>
 					  </recipeUsers>
 					<products>
@@ -162,7 +162,7 @@
 						<li>O21_OR_ComponentHypertech</li>
 					  </thingDefs>
 					</fixedIngredientFilter>
-					<recipeUsers Inherit="false">
+					<recipeUsers Inherit="False">
 						<li>O21_OR_WeaponsFabricator</li>
 					  </recipeUsers>
 					<products>
@@ -210,7 +210,7 @@
 						<li>O21_OR_ComponentHypertech</li>
 					  </thingDefs>
 					</fixedIngredientFilter>
-					<recipeUsers Inherit="false">
+					<recipeUsers Inherit="False">
 						<li>O21_OR_WeaponsFabricator</li>
 					  </recipeUsers>
 					<products>

--- a/Patches/Orassans/Ammo/10mmRailgunOE.xml
+++ b/Patches/Orassans/Ammo/10mmRailgunOE.xml
@@ -28,7 +28,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_10mmRailgun_SabotOE</defName>
 		<label>10mm Railgun cartridge (Sabot:OE)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for long-range railgun weapons.</description>

--- a/Patches/Orassans/Ammo/12mm-autoRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-autoRailgunOE.xml
@@ -28,7 +28,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_12mmautoRailgun_SabotOE</defName>
 		<label>12mm auto Railgun cartridge (Sabot:OE)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for high calibar handguns.</description>

--- a/Patches/Orassans/Ammo/12mm-longRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-longRailgunOE.xml
@@ -28,7 +28,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerMediumAmmoBase">
 		<defName>Ammo_12mmRailgun_SabotOE</defName>
 		<label>12mm Railgun cartridge (Sabot:OE)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for large-caliber railgun weapons.</description>

--- a/Patches/Orassans/Ammo/12mm-subsonicRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-subsonicRailgunOE.xml
@@ -28,7 +28,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_12mmsubsonicRailgun_SabotOE</defName>
 		<label>12mm subsonic Railgun cartridge (Sabot:OE)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for high calibar subsonic railguns.</description>

--- a/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
+++ b/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
@@ -31,7 +31,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="40x90mmGrenadeBaseOE" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="40x90mmGrenadeBaseOE" ParentName="MediumAmmoBase" Abstract="True">
     <description>Low velocity caseless grenade fired from handheld railgun grenade launchers.</description>
     <statBases>
       <Mass>0.320</Mass>

--- a/Patches/Orassans/Ammo/8mmRailgunOE.xml
+++ b/Patches/Orassans/Ammo/8mmRailgunOE.xml
@@ -28,7 +28,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerSmallAmmoBase">
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="SpacerAmmoBase">
 		<defName>Ammo_8mmRailgun_SabotOE</defName>
 		<label>8mm Railgun cartridge (Sabot:OE)</label>
 		<description>Fin-stabilized tungsten carbide penetrator with discarding sabot, designed for railgun rifles.</description>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -70,7 +70,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -89,7 +89,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -108,7 +108,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -126,7 +126,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -145,7 +145,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -164,7 +164,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -183,7 +183,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						  <li>CE_AutoEnableTrade_Sellable</li>
@@ -203,7 +203,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="False">
+						<tradeTags Inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -539,7 +539,7 @@
 						<description>Craft 2 Paniel HE Howitzer shells.</description>
 						<jobString>Making Paniel HE Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -587,7 +587,7 @@
 						<description>Craft 2 Paniel Incendiary Howitzer shells.</description>
 						<jobString>Making Paniel Incendiary Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -635,7 +635,7 @@
 						<description>Craft 2 Paniel EMP Howitzer shells.</description>
 						<jobString>Making Paniel EMP Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -683,7 +683,7 @@
 						<description>Craft 2 Paniel Smoke Howitzer shells.</description>
 						<jobString>Making Paniel Smoke Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -731,7 +731,7 @@
 						<description>Craft 2 Paniel firefoam Howitzer shells.</description>
 						<jobString>Making Paniel firefoam Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -779,7 +779,7 @@
 						<description>Craft Paniel antigrain Howitzer shell.</description>
 						<jobString>Making Paniel antigrain Howitzer shell.</jobString>
 						<workAmount>1200</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -818,7 +818,7 @@
 						<description>Craft 2 Paniel ap Howitzer shells.</description>
 						<jobString>Making Paniel ap Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -866,7 +866,7 @@
 						<description>Craft Paniel Railgun Shell.</description>
 						<jobString>Making Paniel Railgun Shell.</jobString>
 						<workAmount>16000</workAmount>
-						<recipeUsers inherit="False">
+						<recipeUsers Inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite Inherit="False">PNRP_Railgun</researchPrerequisite>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -70,7 +70,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -89,7 +89,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -108,7 +108,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -126,7 +126,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -145,7 +145,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -164,7 +164,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -183,7 +183,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						  <li>CE_AutoEnableTrade_Sellable</li>
@@ -203,7 +203,7 @@
 							<graphicClass>Graphic_StackCount</graphicClass>
 							<drawSize>0.90</drawSize>
 						</graphicData>
-						<tradeTags inherit="false">
+						<tradeTags inherit="False">
 						  <li>CE_HeavyAmmo</li>
 						  <li>CE_AutoEnableTrade</li>
 						</tradeTags>
@@ -539,7 +539,7 @@
 						<description>Craft 2 Paniel HE Howitzer shells.</description>
 						<jobString>Making Paniel HE Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -587,7 +587,7 @@
 						<description>Craft 2 Paniel Incendiary Howitzer shells.</description>
 						<jobString>Making Paniel Incendiary Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -635,7 +635,7 @@
 						<description>Craft 2 Paniel EMP Howitzer shells.</description>
 						<jobString>Making Paniel EMP Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -683,7 +683,7 @@
 						<description>Craft 2 Paniel Smoke Howitzer shells.</description>
 						<jobString>Making Paniel Smoke Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -731,7 +731,7 @@
 						<description>Craft 2 Paniel firefoam Howitzer shells.</description>
 						<jobString>Making Paniel firefoam Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -779,7 +779,7 @@
 						<description>Craft Paniel antigrain Howitzer shell.</description>
 						<jobString>Making Paniel antigrain Howitzer shell.</jobString>
 						<workAmount>1200</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -818,7 +818,7 @@
 						<description>Craft 2 Paniel ap Howitzer shells.</description>
 						<jobString>Making Paniel ap Howitzer shells.</jobString>
 						<workAmount>11600</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
 						<researchPrerequisite>PNRP_AutoArtillery</researchPrerequisite>
@@ -866,10 +866,10 @@
 						<description>Craft Paniel Railgun Shell.</description>
 						<jobString>Making Paniel Railgun Shell.</jobString>
 						<workAmount>16000</workAmount>
-						<recipeUsers inherit="false">
+						<recipeUsers inherit="False">
 							<li>PN_AutomatonBench</li>
 						</recipeUsers>
-						<researchPrerequisite Inherit="false">PNRP_Railgun</researchPrerequisite>
+						<researchPrerequisite Inherit="False">PNRP_Railgun</researchPrerequisite>
 						<ingredients>
 							<li>
 								<filter>

--- a/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
@@ -38,16 +38,27 @@
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
-						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
 							<min>10</min>
-							<max>50</max>
+							<max>40</max>
 						</countRange>
 						<thingDefCountRange>
-							<min>3</min>
+							<min>4</min>
+							<max>7</max>
+						</thingDefCountRange>
+					</li>  
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
+							<max>20</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>4</min>
 							<max>6</max>
 						</thingDefCountRange>
-						</li>        
+					</li>        
 				</value>
 			</li>
 
@@ -81,9 +92,21 @@
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
-						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
 							<min>10</min>
+							<max>30</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>5</max>
+						</thingDefCountRange>
+					</li> 
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
 							<max>20</max>
 						</countRange>
 						<price>Cheap</price>
@@ -124,6 +147,17 @@
 							<max>2</max>
 						</thingDefCountRange>
 					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
+							<max>10</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li> 
 						<li Class="StockGenerator_Tag">
 						<tradeTag>CE_HeavyAmmo</tradeTag>
 						<countRange>

--- a/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Asari_Trader.xml
@@ -40,12 +40,12 @@
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>10</min>
-							<max>40</max>
+							<min>20</min>
+							<max>80</max>
 						</countRange>
 						<thingDefCountRange>
 							<min>4</min>
-							<max>7</max>
+							<max>8</max>
 						</thingDefCountRange>
 					</li>  
 					<li Class="StockGenerator_Tag">
@@ -87,20 +87,20 @@
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
-							<min>1</min>
-							<max>3</max>
+							<min>2</min>
+							<max>4</max>
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>10</min>
-							<max>30</max>
+							<min>20</min>
+							<max>60</max>
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
 							<min>3</min>
-							<max>5</max>
+							<max>6</max>
 						</thingDefCountRange>
 					</li> 
 					<li Class="StockGenerator_Tag">
@@ -150,8 +150,8 @@
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>5</min>
-							<max>10</max>
+							<min>10</min>
+							<max>20</max>
 						</countRange>
 						<thingDefCountRange>
 							<min>2</min>

--- a/Patches/Rim-Effect Core/ME_Trader.xml
+++ b/Patches/Rim-Effect Core/ME_Trader.xml
@@ -33,15 +33,15 @@
 							<max>1800</max>
 						</countRange>
 						<thingDefCountRange>
-							<min>1</min>
+							<min>2</min>
 							<max>4</max>
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>10</min>
-							<max>40</max>
+							<min>20</min>
+							<max>80</max>
 						</countRange>
 						<thingDefCountRange>
 							<min>4</min>
@@ -87,20 +87,20 @@
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
-							<min>1</min>
-							<max>3</max>
+							<min>2</min>
+							<max>4</max>
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>10</min>
-							<max>30</max>
+							<min>20</min>
+							<max>60</max>
 						</countRange>
 						<price>Cheap</price>
 						<thingDefCountRange>
 							<min>3</min>
-							<max>5</max>
+							<max>6</max>
 						</thingDefCountRange>
 					</li> 
 					<li Class="StockGenerator_Tag">
@@ -144,18 +144,18 @@
 						</countRange>
 						<thingDefCountRange>
 							<min>1</min>
-							<max>2</max>
+							<max>3</max>
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
 						<tradeTag>CE_MediumAmmo</tradeTag>
 						<countRange>
-							<min>5</min>
-							<max>10</max>
+							<min>10</min>
+							<max>20</max>
 						</countRange>
 						<thingDefCountRange>
 							<min>2</min>
-							<max>4</max>
+							<max>5</max>
 						</thingDefCountRange>
 					</li> 
      					<li Class="StockGenerator_Tag">

--- a/Patches/Rim-Effect Core/ME_Trader.xml
+++ b/Patches/Rim-Effect Core/ME_Trader.xml
@@ -38,13 +38,24 @@
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>40</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>4</min>
+							<max>7</max>
+						</thingDefCountRange>
+					</li>  
+					<li Class="StockGenerator_Tag">
         						<tradeTag>CE_HeavyAmmo</tradeTag>
         						<countRange>
-          							<min>10</min>
-          							<max>50</max>
+          							<min>5</min>
+          							<max>20</max>
         						</countRange>
         						<thingDefCountRange>
-        							 <min>3</min>
+        							 <min>4</min>
           							<max>6</max>
         						</thingDefCountRange>
       					</li>        
@@ -81,9 +92,21 @@
 						</thingDefCountRange>
 					</li>
 					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>30</max>
+						</countRange>
+						<price>Cheap</price>
+						<thingDefCountRange>
+							<min>3</min>
+							<max>5</max>
+						</thingDefCountRange>
+					</li> 
+					<li Class="StockGenerator_Tag">
         						<tradeTag>CE_HeavyAmmo</tradeTag>
         						<countRange>
-          							<min>10</min>
+          							<min>5</min>
           							<max>20</max>
         						</countRange>
 						<price>Cheap</price>
@@ -124,6 +147,17 @@
 							<max>2</max>
 						</thingDefCountRange>
 					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
+							<max>10</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li> 
      					<li Class="StockGenerator_Tag">
         						<tradeTag>CE_HeavyAmmo</tradeTag>
         						<countRange>

--- a/Patches/Rim-Effect Drell/Apparel_Drell.xml
+++ b/Patches/Rim-Effect Drell/Apparel_Drell.xml
@@ -11,7 +11,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="RE_AssassinsHood"]/apparel/layers</xpath>
 				<value>
-					<layers Inherit="false">
+					<layers Inherit="False">
 						<li>OnHead</li>
 						<li>Overhead</li>
 					</layers>

--- a/Patches/Rim-Effect Extended Cut/Headgear_ExtendedCut.xml
+++ b/Patches/Rim-Effect Extended Cut/Headgear_ExtendedCut.xml
@@ -59,7 +59,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_CapacitorHelmet"]/apparel</xpath>
 					<value>
-					<layers Inherit="false">
+					<layers Inherit="False">
 						<li>Overhead</li>
 						<li>StrappedHead</li>
 					</layers>
@@ -86,7 +86,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>/Defs/ThingDef[defName="RE_Apparel_ArchonVisor"]/apparel</xpath>
 					<value>
-					<layers Inherit="false">
+					<layers Inherit="False">
 						<li>StrappedHead</li>
 					</layers>
 					</value>

--- a/Patches/Rimsenal Collection/Core/Ammo_JI.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_JI.xml
@@ -51,7 +51,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="88mmRPzBRocketBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="88mmRPzBRocketBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Bulky siege rockets, fired by the heaviest of Jotun Interstellar weaponry. An outer casing of high explosives around a shaped-charge core makes it capable of engaging both hard and soft targets.</description>
     <statBases>
       <MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -16,7 +16,7 @@
 			defName="Feral_DMG"				
 			]</xpath>
 			<value>
-			  <tools inherit="False">
+			  <tools Inherit="False">
 				<li Class="CombatExtended.ToolCE">
 				  <label>stock</label>
 				  <capacities>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -16,7 +16,7 @@
 			defName="Feral_DMG"				
 			]</xpath>
 			<value>
-			  <tools inherit="false">
+			  <tools inherit="False">
 				<li Class="CombatExtended.ToolCE">
 				  <label>stock</label>
 				  <capacities>

--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -52,7 +52,7 @@
 
 		<!-- ==================== Ammo ========================== -->
 
-		<ThingDef Class="CombatExtended.AmmoDef" Name="MoltenShellBase" ParentName="AmmoBase" Abstract="True">
+		<ThingDef Class="CombatExtended.AmmoDef" Name="MoltenShellBase" ParentName="MediumAmmoBase" Abstract="True">
 			<description>Relatively small diameter cannon shell, fired at high velocity to defeat heavy armor.</description>
 			<thingCategories>
 			<li>AmmoMoltenShells</li>
@@ -186,7 +186,7 @@
 
 		<!-- ==================== Ammo ========================== -->
 
-		<ThingDef Class="CombatExtended.AmmoDef" Name="ATGMBase" ParentName="AmmoBase" Abstract="True">
+		<ThingDef Class="CombatExtended.AmmoDef" Name="ATGMBase" ParentName="HeavyAmmoBase" Abstract="True">
 			<description>Equipped with a large warhead and originally designed to penetrate the thick armor of tanks with a shaped charge, this missile is fired from a specialized launcher and guided by wire to the target.</description>
 			<statBases>
 			<MaxHitPoints>150</MaxHitPoints>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -48,7 +48,7 @@
                         </statBases>
                         <!--equippedAngleOffset>30</equippedAngleOffset-->
                         <stackLimit>25</stackLimit>
-                        <weaponTags Inherit="false">
+                        <weaponTags Inherit="False">
                             <!--li>NeolithicRangedHeavy</li>
                             <li>CE_Pila</li--> <!-- tribal tags -->
                             <li>CE_OneHandedWeapon</li>
@@ -115,7 +115,7 @@
                             <Mass>2.00</Mass>
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
-                        <verbs Inherit="false">
+                        <verbs Inherit="False">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
                                 <hasStandardCommand>true</hasStandardCommand>
@@ -148,7 +148,7 @@
                             <Mass>2.00</Mass>
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
-                        <verbs Inherit="false">
+                        <verbs Inherit="False">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
                                 <hasStandardCommand>true</hasStandardCommand>
@@ -182,7 +182,7 @@
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
 						<generateAllowChance>0</generateAllowChance>
-                        <verbs Inherit="false">
+                        <verbs Inherit="False">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
                                 <hasStandardCommand>true</hasStandardCommand>
@@ -216,7 +216,7 @@
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
 						<generateAllowChance>0</generateAllowChance>
-                        <verbs Inherit="false">
+                        <verbs Inherit="False">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
                                 <hasStandardCommand>true</hasStandardCommand>
@@ -250,7 +250,7 @@
                             <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                         </statBases>
 						<generateAllowChance>0.1</generateAllowChance> <!-- carried over from base mod, generate commonality 0.1 -->
-                        <verbs Inherit="false">
+                        <verbs Inherit="False">
                             <li Class="CombatExtended.VerbPropertiesCE">
                                 <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
                                 <hasStandardCommand>true</hasStandardCommand>

--- a/Patches/Thog's Guns - More Brukka Pack/Gun_Turrets.xml
+++ b/Patches/Thog's Guns - More Brukka Pack/Gun_Turrets.xml
@@ -89,7 +89,7 @@
 				<aimedBurstShotCount>5</aimedBurstShotCount>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -126,7 +126,7 @@
 			<FireModes>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -164,7 +164,7 @@
 				<aimedBurstShotCount>15</aimedBurstShotCount>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -202,7 +202,7 @@
 				<aimedBurstShotCount>20</aimedBurstShotCount>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -240,7 +240,7 @@
 				<aimedBurstShotCount>8</aimedBurstShotCount>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -279,7 +279,7 @@
 				<aimedBurstShotCount>10</aimedBurstShotCount>
 				<aiAimMode>SuppressFire</aiAimMode>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			<li>TurretGun</li>
 			</weaponTags>
 		</li>

--- a/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
@@ -162,7 +162,7 @@
 		<reloadTime>9.2</reloadTime>
 		<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 	      </AmmoUser>
-	      <weaponTags Inherit="false">
+	      <weaponTags Inherit="False">
 		<li>TurretGun</li>
 	      </weaponTags>
 	      <FireModes>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -86,7 +86,7 @@
           <reloadTime>10</reloadTime>
           <ammoSet>AmmoSet_12x72mmCharged</ammoSet>
         </AmmoUser>
-        <weaponTags Inherit="false">
+        <weaponTags Inherit="False">
           <li>TurretGun</li>
         </weaponTags>
           <FireModes>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -114,7 +114,7 @@
 		    <aimedBurstShotCount>5</aimedBurstShotCount>
 		    <aiAimMode>SuppressFire</aiAimMode>
 		  </FireModes>
-		  <weaponTags Inherit="false">
+		  <weaponTags Inherit="False">
 		    <li>TurretGun</li>
 		  </weaponTags>
 		</li>
@@ -154,7 +154,7 @@
 		    <aimedBurstShotCount>5</aimedBurstShotCount>
 		    <aiAimMode>SuppressFire</aiAimMode>
 		  </FireModes>
-		  <weaponTags Inherit="false">
+		  <weaponTags Inherit="False">
 		    <li>TurretGun</li>
 		  </weaponTags>
 		</li>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -191,7 +191,7 @@
 			  <aimedBurstShotCount>10</aimedBurstShotCount>
 			  <aiAimMode>SuppressFire</aiAimMode>				
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -300,7 +300,7 @@
 			  <noSnapshot>true</noSnapshot>
 			  <noSingleShot>true</noSingleShot>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -338,7 +338,7 @@
 			  <noSnapshot>true</noSnapshot>
 			  <noSingleShot>true</noSingleShot>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -383,7 +383,7 @@
 			  <noSnapshot>true</noSnapshot>
 			  <noSingleShot>true</noSingleShot>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -416,7 +416,7 @@
 			  <noSnapshot>true</noSnapshot>
 			  <noSingleShot>true</noSingleShot>
 			</FireModes>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 		</li>
@@ -451,7 +451,7 @@
 			  <reloadTime>10</reloadTime>
 			  <ammoSet>AmmoSet_12mmRailgun</ammoSet>
 			</AmmoUser>
-			<weaponTags Inherit="false">
+			<weaponTags Inherit="False">
 			  <li>TurretGun</li>
 			</weaponTags>
 			<FireModes>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
@@ -28,7 +28,7 @@
 
         <!-- === Ammo === -->
 
-        <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoBase">
+        <ThingDef Class="CombatExtended.AmmoDef" ParentName="MediumAmmoBase">
           <defName>Ammo_M73_HE</defName>
           <label>M73 Rocket (HE)</label>
           <description>66mm high explosive rocket based upon the rocket used in the M72 LAW, used by the Swarm Missile Launcher.</description>

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -176,7 +176,7 @@
 						<ammoSet>AmmoSet_StreamlinedArrow</ammoSet>
 					</AmmoUser>
 					<FireModes />
-					<weaponTags Inherit="false">
+					<weaponTags Inherit="False">
 						<li>CE_Bow</li>
 					</weaponTags>
 				</li>
@@ -802,7 +802,7 @@
 						<ammoSet>AmmoSet_VWE_Extinguisher</ammoSet>
 					</AmmoUser>
 					<FireModes />
-					<weaponTags Inherit="false">
+					<weaponTags Inherit="False">
 						<li>ToolDecent</li>
 					</weaponTags>
 				</li>

--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
@@ -31,7 +31,7 @@
 
 		<!-- ==================== Ammo ========================== -->
 
-		<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoBolter998Base" ParentName="SmallAmmoBase" Abstract="True">
+		<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoBolter998Base" ParentName="AmmoBase" Abstract="True">
 			<description>A .998 caliber, gryojet-stabilized projectile with an explosive charge and hardened tip, fired from most patterns of Astartes heavy bolters.</description>
 			<statBases>
 				<Mass>0.385</Mass>

--- a/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
+++ b/Royalty/Defs/ThingDefs_Buildings/Weapons_Turrets.xml
@@ -91,7 +91,7 @@
         <aiAimMode>AimedShot</aiAimMode>
       </li>   
     </comps>
-	<tools Inherit="false" />
+	<tools Inherit="False" />
   </ThingDef>
 
   <!-- ================== Auto Inferno Cannon ================== -->
@@ -129,7 +129,7 @@
       </li>
     </verbs>	
     <comps>
-    <li Class="CombatExtended.CompProperties_AmmoUser" Inherit="false">
+    <li Class="CombatExtended.CompProperties_AmmoUser" Inherit="False">
       <magazineSize>5</magazineSize>
       <reloadTime>9.8</reloadTime>
       <ammoSet>AmmoSet_80x256mmFuel</ammoSet>
@@ -138,7 +138,7 @@
       <aiAimMode>AimedShot</aiAimMode>
     </li>         
     </comps>	
-	<tools Inherit="false" />
+	<tools Inherit="False" />
   </ThingDef>
 
 </Defs>

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_RoyaltyHeadgear.xml
@@ -103,7 +103,7 @@
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/apparel</xpath>
     <value>
-    <layers Inherit="false">
+    <layers Inherit="False">
       <li>StrappedHead</li>
     </layers>  
     </value>

--- a/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
+++ b/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
@@ -27,19 +27,19 @@
           <max>2000</max>
         </countRange>
         <thingDefCountRange>
-          <min>3</min>
-          <max>6</max>
+          <min>4</min>
+          <max>7</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>100</max>
+          <min>30</min>
+          <max>120</max>
         </countRange>
         <thingDefCountRange>
           <min>5</min>
-          <max>7</max>
+          <max>8</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -123,12 +123,12 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
-          <max>20</max>
+          <min>20</min>
+          <max>40</max>
         </countRange>
         <thingDefCountRange>
-          <min>2</min>
-          <max>5</max>
+          <min>3</min>
+          <max>6</max>
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
@@ -157,7 +157,7 @@
           <max>2000</max>
         </countRange>
         <thingDefCountRange>
-          <min>2</min>
+          <min>3</min>
           <max>6</max>
         </thingDefCountRange>
       </li>
@@ -171,8 +171,8 @@
       <li Class="StockGenerator_Tag">
         <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>20</min>
-          <max>80</max>
+          <min>30</min>
+          <max>100</max>
         </countRange>
         <thingDefCountRange>
           <min>5</min>

--- a/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
+++ b/Royalty/Patches/TraderKindDefs/TraderKinds_Royalty.xml
@@ -32,16 +32,27 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
+          <min>20</min>
           <max>100</max>
         </countRange>
         <thingDefCountRange>
-          <min>2</min>
-          <max>5</max>
+          <min>5</min>
+          <max>7</max>
         </thingDefCountRange>
-      </li>       
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -110,16 +121,27 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
+        <tradeTag>CE_MediumAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>20</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>5</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
         <tradeTag>CE_HeavyAmmo</tradeTag>
         <countRange>
           <min>5</min>
-          <max>60</max>
+          <max>10</max>
         </countRange>
         <thingDefCountRange>
           <min>0</min>
-          <max>2</max>
+          <max>3</max>
         </thingDefCountRange>
-      </li>       
+      </li>      
 		</value>
 	</Operation>
 
@@ -147,19 +169,28 @@
         </thingDefCountRange>
       </li>
       <li Class="StockGenerator_Tag">
-        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <tradeTag>CE_MediumAmmo</tradeTag>
         <countRange>
-          <min>10</min>
+          <min>20</min>
           <max>80</max>
         </countRange>
         <thingDefCountRange>
-          <min>3</min>
+          <min>5</min>
+          <max>7</max>
+        </thingDefCountRange>
+      </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>40</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>4</min>
           <max>6</max>
         </thingDefCountRange>
       </li>       
 		</value>
 	</Operation>
 
-
 </Patch>
-

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -23,7 +23,7 @@ namespace CombatExtended
     {
         public static readonly FieldInfo _allRecipesCached = typeof(ThingDef).GetField("allRecipesCached", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        public const string destroyWithAmmoDisabledTag = "CE_Ammo";               // The trade tag which automatically deleted this ammo with the ammo system disabled
+        public const string destroyWithAmmoDisabledTag = "CE_AmmoInjector";               // The trade tag which automatically deleted this ammo with the ammo system disabled
         private const string enableTradeTag = "CE_AutoEnableTrade";             // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
         private const string enableCraftingTag = "CE_AutoEnableCrafting";        // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
         // these ammo classes are disabled when simplified ammo is turned on


### PR DESCRIPTION
## Changes

- Made the `false` and `inherit` in inherit="false"` have a first capital letter.
- Added a `CE_AmmoInjector` trade tag to normal and heavy ammo types in CE.
- Added a `CE_MediumAmmo` trade tag and inserted in into various trader stocks.
- Added normal and medium spacer ammo categories to be used in the appropriate places.
- Reduced the amount of Heavy Ammo in trader stocks but increased their type variation in return.
- Changed launched grenades and high caliber ammo to a medium size ammo type with its appropriate trade tag.

## References

- Closes https://github.com/CombatExtended-Continued/CombatExtended/issues/2162

## Reasoning

- The `inherit` in Inherit="false"` should have a capital I, otherwise the whole node won't fire properly in some cases as mentioned in the linked issue.
- The new trade tag is only added to be used by the Ammo Injector to do its thing when the ammo system is disabled. The new tag is not used by the trader stock generator.
- Grenades in vanilla are considered weapons with the specific weapon trade tag and CE grenades same as the M72 LAW don't even have a trade tag, gave grenades the medium ammo tag and the M72 the heavy tag so that they show up in trader stocks in decent numbers.
- Launched grenades were considered normal-sized ammo which would take up the space of normal ammo in trader stocks and be useless most of the time due to them being in large numbers, the new medium category balances it out.
- Heavy ammo still showed up in relatively large numbers and low variations in trader stocks which leads to severely over-encumbered animals and useless ammo being offered for trade so their numbers was reduced and variations increased.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Stuff is working as intended with and without the ammo system disabled,)
