### PR TITLE
Prevent busted mod assemblies from breaking CE on load

### DIFF
--- a/Source/CombatExtended/Compatibility/Patches.cs
+++ b/Source/CombatExtended/Compatibility/Patches.cs
@@ -1,7 +1,8 @@
 using Verse;
 using System.Collections.Generic;
 using System;
-using System.Linq;
+using System.Reflection;
+using System.Text;
 
 namespace CombatExtended.Compatibility
 {
@@ -12,11 +13,45 @@ namespace CombatExtended.Compatibility
         {
             patches = new List<IPatch>();
             Type iPatch = typeof(IPatch);
-            foreach (Type patchType in AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
-                    .Where(x => iPatch.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract))
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                IPatch patch = ((IPatch)patchType.GetConstructor(new Type[] { }).Invoke(new object[] { }));
-                patches.Add(patch);
+                try
+                {
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        if (iPatch.IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract)
+                        {
+                            IPatch patch = ((IPatch)type.GetConstructor(new Type[] { }).Invoke(new object[] { }));
+                            patches.Add(patch);
+                        }
+                    }
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    // Report any errors encountered while looking for compatibility patches in an assembly and prevent such errors
+                    // from breaking the CE initialization process and cause exceptions at runtime.
+                    // Since we're scanning all loaded assemblies, most of the time, type load errors here will be from some unrelated broken mod
+                    // that vanilla itself has already excluded from loading via ModAssemblyHandler,
+                    // so only log a message if development mode is enabled to reduce logspam.
+                    if (Prefs.DevMode)
+                    {
+                        var errorStringBuilder = new StringBuilder();
+                        errorStringBuilder.AppendLine($"[CE] ReflectionTypeLoadException while looking for compat patches in assembly {assembly.GetName().Name}: {e}");
+                        errorStringBuilder.AppendLine();
+                        errorStringBuilder.AppendLine("Loader exceptions:");
+
+                        if (e.LoaderExceptions != null)
+                        {
+                            foreach (var loaderException in e.LoaderExceptions)
+                            {
+                                errorStringBuilder.AppendLine("   => " + loaderException.ToString());
+                            }
+                        }
+
+                        Log.Warning(errorStringBuilder.ToString());
+                    }
+                }
             }
         }
 


### PR DESCRIPTION



## Changes
If the active mod list contains mod assemblies incompatible with the game (i.e. they throw a ReflectionTypeLoadException when their types are fetched), vanilla's ModAssemblyHandler logs an error and skips over those assemblies. However, we try to process all loaded assemblies as part of the initialization stage where we're looking for compatibility patches, so if such a broken mod is present in the modlist, it will break CE initialization and lead to various NREs in-game.

As a fix, harden the loading process to catch type load errors from assemblies. Since these errors are likely to be from some unrelated, broken mod, only log a message if development mode is active to reduce user confusion and logspam.

## Reasoning
This should help reduce user confusion as people won't be seeing CE-related errors in logs when a completely unrelated mod is causing issues. This way, it should be easier for them to narrow down the issue or find the right place to report it.

Example manifestation of user confusion: https://discord.com/channels/278818534069501953/994681225262415902/1050702484198404126

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony 
