### PR TITLE
VFE-Production fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -234,7 +234,6 @@ namespace CombatExtended
                                         if (benchNameVFE != null)
                                         {
                                             benchVFE = DefDatabase<ThingDef>.GetNamed(benchNameVFE, false);
-
                                             if (benchVFE == null) 
                                             {
                                                 Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no VFE crafting bench with defName=" + benchNameVFE + " could be found for tag " + curTag);

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -234,7 +234,7 @@ namespace CombatExtended
                                         if (benchNameVFE != null)
                                         {
                                             benchVFE = DefDatabase<ThingDef>.GetNamed(benchNameVFE, false);
-                                            if (benchVFE == null) 
+                                            if (benchVFE == null)
                                             {
                                                 Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no VFE crafting bench with defName=" + benchNameVFE + " could be found for tag " + curTag);
                                                 continue;

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -218,21 +218,26 @@ namespace CombatExtended
                                     }
                                     if (ModLister.HasActiveModWithName("Vanilla Furniture Expanded - Production"))
                                     {
-                                        if (curTag != "CE_AutoEnableCrafting_FabricationBench" && curTag != "CE_AutoEnableCrafting_CraftingSpot")
+                                        string benchNameVFE = null;
+                                        if (curTag == "CE_AutoEnableCrafting_ElectricSmithy" || curTag == "CE_AutoEnableCrafting_FueledSmithy")
                                         {
-                                            var benchNameVFE = "VFE_" + curTag.Remove(0, enableCraftingTag.Length + 1) + "Large";
-                                            if (curTag == "CE_AutoEnableCrafting_ElectricSmithy" || curTag == "CE_AutoEnableCrafting_FueledSmithy")
-                                            {
-                                                benchNameVFE = "VFE_TableSmithyLarge";
-                                            }
-                                            if (curTag == "CE_AutoEnableCrafting_DrugLab")
-                                            {
-                                                benchNameVFE = "VFE_TableDrugLabElectric";
-                                            }
+                                            benchNameVFE = "VFE_TableSmithyLarge";
+                                        }
+                                        if (curTag == "CE_AutoEnableCrafting_DrugLab")
+                                        {
+                                            benchNameVFE = "VFE_TableDrugLabElectric";
+                                        }
+                                        if(curTag == "CE_AutoEnableCrafting_TableMachining")
+                                        {
+                                            benchNameVFE = "VFE_TableMachiningLarge";
+                                        }
+                                        if (benchNameVFE != null)
+                                        {
                                             benchVFE = DefDatabase<ThingDef>.GetNamed(benchNameVFE, false);
-                                            if (benchVFE == null)
+
+                                            if (benchVFE == null) 
                                             {
-                                                Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no crafting bench with defName=" + benchNameVFE + " could be found for tag " + curTag);
+                                                Log.Error("Combat Extended :: AmmoInjector trying to inject " + ammoDef.ToString() + " but no VFE crafting bench with defName=" + benchNameVFE + " could be found for tag " + curTag);
                                                 continue;
                                             }
                                         }

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -227,7 +227,7 @@ namespace CombatExtended
                                         {
                                             benchNameVFE = "VFE_TableDrugLabElectric";
                                         }
-                                        if(curTag == "CE_AutoEnableCrafting_TableMachining")
+                                        if (curTag == "CE_AutoEnableCrafting_TableMachining")
                                         {
                                             benchNameVFE = "VFE_TableMachiningLarge";
                                         }


### PR DESCRIPTION
## Changes
changed from var to string and limit only to VFE-Production Benches so other benches are not touched

Was looking at error logs and wondered why MO was having this issue. This should fix it.  Placed the benchVFE check inside the benchNameVFE check to avoid false errors since I initialized benchVFE as null.

## Reasoning
Fixes my edits when other tags are introduced because new benches are available. Also limits to only the VFE-Production benches that matters

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
