### PR TITLE
Fix/Update the buildable mechs' patch

### DIFF
--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -9,6 +9,26 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="BaseVFEMachine"]/comps</xpath>
+		<value>
+			<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			</li>
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
+		</value>
+	</li>
+
+    <li Class="PatchOperationReplace">
+      <xpath>/Defs/ThingDef[@Name="BaseVFEMachine"]/statBases/ArmorRating_Heat</xpath>
+      <value>
+        <ArmorRating_Heat>0</ArmorRating_Heat>
+        <SmokeSensitivity>0</SmokeSensitivity>
+      </value>
+    </li>
+
     <li Class="PatchOperationReplace">
       <xpath>Defs/ThingDef[
         defName="VFE_Mechanoids_Autocleaner" or


### PR DESCRIPTION
## Changes

- What it says on the tin, there were some parent def and inheritance issues that are fixed. _This PR has to be merged after VFE-Mechs is updated on steam._

## References

- As per this PR, we have to update our patches to accommodate for the changes:
https://github.com/Vanilla-Expanded/VanillaFactionsExpanded-Mechanoid/pull/1

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Working as intended)
