### PR TITLE
Warhammer 40k - Genes and Psycasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ Assembly-CSharp.dll
 UnityEngine.dll 
 
 .idea/
-/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Assembly-CSharp.dll
 UnityEngine.dll 
 
 .idea/
+/.vs

--- a/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Warhammer 40k - Genes and Psycasts</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- Ossmodula -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Ossmodula"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>6</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Ossmodula"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+          </value>
+        </li>
+
+        <!-- Biscopea -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Biscopea"]/statOffsets/CarryingCapacity</xpath>
+          <value>
+            <CarryWeight>100</CarryWeight>
+          </value>
+        </li>
+
+        <!-- Sinew Coil -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_SinewCoil"]/statOffsets</xpath>
+          <value>
+            <statOffsets>
+              <CarryWeight>100</CarryWeight>
+            </statOffsets>
+          </value>
+        </li>
+
+        <!-- Custodes -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>24.5</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/CarryingCapacity</xpath>
+          <value>
+            <CarryWeight>200</CarryWeight>
+          </value>
+        </li>
+
+        <!-- Primarch -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>33.75</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>9</ArmorRating_Sharp>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/CarryingCapacity</xpath>
+          <value>
+            <CarryWeight>250</CarryWeight>
+          </value>
+        </li>
+
+        <!-- Mark of Nurgle -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_NurgleMark"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>12</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_NurgleMark"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>3.25</ArmorRating_Sharp>
+          </value>
+        </li>
+
+        <!-- Mark of Chaos -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_UndividedMark"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>3</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_UndividedMark"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>1</ArmorRating_Sharp>
+          </value>
+        </li>
+
+        <!-- Daemon Hide -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_DaemonHide"]/statOffsets/ArmorRating_Blunt</xpath>
+          <value>
+            <ArmorRating_Blunt>17</ArmorRating_Blunt>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_DaemonHide"]/statOffsets/ArmorRating_Sharp</xpath>
+          <value>
+            <ArmorRating_Sharp>4.5</ArmorRating_Sharp>
+          </value>
+        </li>
+
+        <!-- Daemon Wings -->
+
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/GeneDef[defName="BEWH_DaemonHide"]/statOffsets</xpath>
+          <value>
+            <statOffsets>
+              <CarryWeight>100</CarryWeight>
+            </statOffsets>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
@@ -132,7 +132,7 @@
         <!-- Daemon Wings -->
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/GeneDef[defName="BEWH_DaemonHide"]/statOffsets</xpath>
+          <xpath>Defs/GeneDef[defName="BEWH_DaemonWings"]/statOffsets</xpath>
           <value>
             <statOffsets>
               <CarryWeight>100</CarryWeight>


### PR DESCRIPTION
## Additions
https://steamcommunity.com/sharedfiles/filedetails/?id=2880152795
Describe new functionality added by your code, e.g.
- Patched all genes, hopefully, that have to deal with sharp, blunt and carry capacity. Left bulk alone as I have no clue on balancing, OP as it is anyway. 

## Changes

Describe adjustments to existing features made in this merge, e.g.
- I reduced some carry weights as 1200 weight seems excessive on Primarch and Custodes. 

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- I calculated the sharp and blunt values using (sharp of vanilla flak pants/sharp from gene)*sharp of flak pants in CE respectively.
- Left maxhitpoints alone, don't know how to balance that and carry bulk. 
- Also didn't patch some of the genes that have weapons, such as horns, tail, etc. Tried copying from other patches but didn't seem to fit or make sense. 
## Alternatives

Describe alternative implementations you have considered, e.g.
Help with balancing is definitely necessary.


## Testing
Everything works so far, though Primarch and Custode genes don't display the values in xenotype editor, only on pawn description screen. 
Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
