### PR TITLE
Port the Gunpowder tech into main CE

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -287,6 +287,7 @@
 		<label>make round shot cannon balls x5</label>
 		<description>Craft 5 round shot cannon balls.</description>
 		<jobString>Making round shot cannon balls.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<workAmount>6600</workAmount>
 		<ingredients>
 		<li>
@@ -313,6 +314,7 @@
 		<label>make bursting shells cannon balls x5</label>
 		<description>Craft 5 bursting shells cannon balls.</description>
 		<jobString>Making bursting shells cannon balls.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
 		<li>
 			<filter>
@@ -348,6 +350,7 @@
 		<label>make incendiary shells cannon balls x5</label>
 		<description>Craft 5 incendiary shells cannon balls.</description>
 		<jobString>Making incendiary shells cannon balls.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<ingredients>
 		<li>
 			<filter>
@@ -383,6 +386,7 @@
 		<label>Make grape shot cannon shells x5</label>
 		<description>Craft 5 grape shot cannon shells.</description>
 		<jobString>Making grape shot cannon shells.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 		<workAmount>8600</workAmount>
 		<ingredients>
 		<li>

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -88,6 +88,7 @@
 	<label>Make Mortar Grenade x6</label>
 	<description>Craft 6 Mortar Grenades</description>
 	<jobString>Making Mortar Grenades</jobString>
+	<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
 	<ingredients>
 		<li>
 		<filter>

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -37,7 +37,7 @@
 		<Bulk>0.12</Bulk>
 		</statBases>
 		<tradeTags>
-      		  <li>CE_PreIndustrialAmmo</li>
+		  <li>CE_PreIndustrialAmmo</li>
 		  <li>CE_AutoEnableTrade</li>
 		  <li>CE_AutoEnableCrafting_FueledSmithy</li>
 		  <li>CE_AutoEnableCrafting_ElectricSmithy</li>
@@ -107,6 +107,7 @@
 		<label>make musket ball x100</label>
 		<description>Craft 100 musket balls.</description>
 		<jobString>Making musket balls.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
     	<workAmount>2000</workAmount>		
 		<ingredients>
 			<li>

--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -4,7 +4,7 @@
   <ResearchProjectDef>
     <defName>CE_Gunpowder</defName>
     <label>gunpowder</label>
-    <description>Allows crafting flintlock weapons at the smithy bench.</description>
+    <description>Learn the fundamentals of firearm manufacturing  the production of basic gunpowder weapons.</description>
     <baseCost>500</baseCost>
     <techLevel>Medieval</techLevel>
     <prerequisites>
@@ -17,7 +17,7 @@
   <ResearchProjectDef>
     <defName>CE_Launchers</defName>
     <label>simple launchers</label>
-    <description>Allows production of basic grenade and rocket launchers.</description>
+    <description>Allows for the production of basic grenade and rocket launchers.</description>
     <baseCost>1000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -30,7 +30,7 @@
   <ResearchProjectDef>
     <defName>CE_AdvancedLaunchers</defName>
     <label>advanced launchers</label>
-    <description>Allows production of more advanced launchers and munitions like the incendiary, triple rocket, or doomsday launcher and time-fuzed explosives.</description>
+    <description>Allows for the production of more advanced launchers and munitions like the incendiary, triple rocket, or doomsday launcher and time-fuzed explosives.</description>
     <baseCost>1000</baseCost>
     <techLevel>Spacer</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -48,7 +48,7 @@
   <ResearchProjectDef>
     <defName>CE_AdvancedAmmo</defName>
     <label>advanced ammunition</label>
-    <description>Allows production of advanced ammunition for small arms and light weapons systems like armor-piercing incendiary, sabot, and high-explosive rounds.</description>
+    <description>Allows for the production of advanced ammunition for small arms and light weapons systems like armor-piercing incendiary, sabot, and high-explosive rounds.</description>
     <baseCost>1200</baseCost>
     <techLevel>Industrial</techLevel>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>    

--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -4,7 +4,7 @@
   <ResearchProjectDef>
     <defName>CE_Gunpowder</defName>
     <label>gunpowder</label>
-    <description>Learn the fundamentals of firearm manufacturing  the production of basic gunpowder weapons.</description>
+    <description>Craft early muzzle loading weapons and black powder ammunition.</description>
     <baseCost>500</baseCost>
     <techLevel>Medieval</techLevel>
     <prerequisites>

--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -2,6 +2,19 @@
 <Defs>
 
   <ResearchProjectDef>
+    <defName>CE_Gunpowder</defName>
+    <label>gunpowder</label>
+    <description>Allows crafting flintlock weapons at the smithy bench.</description>
+    <baseCost>500</baseCost>
+    <techLevel>Medieval</techLevel>
+    <prerequisites>
+      <li>Smithing</li>
+    </prerequisites>
+    <researchViewX>2</researchViewX>
+    <researchViewY>4.25</researchViewY>
+  </ResearchProjectDef>
+
+  <ResearchProjectDef>
     <defName>CE_Launchers</defName>
     <label>simple launchers</label>
     <description>Allows production of basic grenade and rocket launchers.</description>

--- a/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
+++ b/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
@@ -2,11 +2,18 @@
 <Patch>
 
     <Operation Class="PatchOperationAdd">
-        <xpath>/Defs/ResearchProjectDef[defName="Gunsmithing"]</xpath>
+        <xpath>Defs/ResearchProjectDef[defName="Gunsmithing"]</xpath>
         <value>
           <hiddenPrerequisites>
             <li>CE_Gunpowder</li>
           </hiddenPrerequisites>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ResearchProjectDef[defName="Gunsmithing"]/description</xpath>
+        <value>
+          <description>Craft simple manually-operated guns like revolvers, pump shotguns, bolt-action and lever-action rifles.</description>
         </value>
     </Operation>
 

--- a/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
+++ b/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/ResearchProjectDef[defName="Gunsmithing"]</xpath>
+        <value>
+          <hiddenPrerequisites>
+            <li>CE_Gunpowder</li>
+          </hiddenPrerequisites>
+        </value>
+    </Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/researchViewX</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Similar to https://github.com/CombatExtended-Continued/CombatExtendedGuns/pull/68
- Changed the Gunsmithing's description to reflect allowing for making lever-action rifles and not incendiary launchers.
- Made medieval ammo that would use gunpowder have the appropriate Gunpowder research project as a prerequisite.

## Reasoning

- Our submods need the research project and it's good to have on hand to be used when patching other mods.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
