### PR TITLE
Fix DD's Focusing Tome's melee tools

### DIFF
--- a/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
+++ b/Patches/Dragons Descent/ThingDefs_Misc/Weapons/MeleeDD.xml
@@ -192,11 +192,9 @@
 								<capacities>
 									<li>Blunt</li>
 								</capacities>
-								<power>24</power>
-								<cooldownTime>1.93</cooldownTime>
-								<armorPenetrationBlunt>3.8</armorPenetrationBlunt>
-								<armorPenetrationSharp>20</armorPenetrationSharp>
-								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+								<power>3</power>
+								<cooldownTime>2.0</cooldownTime>
+								<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 							</li>
 						</tools>
 					</value>


### PR DESCRIPTION
## Changes

- What it says on the tin, it had pasted-over stats from another weapon by mistake.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors