### PR TITLE
Rimsenal Core xpath Update

### DIFF
--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -918,7 +918,7 @@
 			</li>
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="Apparel_Dropsuit"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_Dropsuit"]/verbs</xpath>
 				<match Class="PatchOperationSequence">
 				<operations>
 					<li Class="PatchOperationReplace">
@@ -1317,12 +1317,12 @@
 			</li>
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
 				<match Class="PatchOperationSequence">
 				<operations>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1350,14 +1350,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
 					<value>
 						<ammoDef>Ammo_30x29mmGrenade_EMP</ammoDef>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
 					<value>
 						<ammoCountPerCharge>1</ammoCountPerCharge>
 					</value>
@@ -1663,12 +1663,12 @@
 			</li>
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
 				<match Class="PatchOperationSequence">
 				<operations>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1696,14 +1696,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
 					<value>
 						<ammoDef>Ammo_JI_Alloy</ammoDef>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_Korp"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
 					<value>
 						<ammoCountPerCharge>80</ammoCountPerCharge>
 					</value>

--- a/Patches/Rimsenal Collection/Core/Rimsenal_DamageDefs.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_DamageDefs.xml
@@ -6,7 +6,7 @@
 		<li>Rimsenal - Core</li>
     </mods>
 		<match Class="PatchOperationAddModExtension">
-		<xpath>/Defs/DamageDef[defName="Microwave"]</xpath>
+		<xpath>Defs/DamageDef[defName="Microwave"]</xpath>
 			<value>
 				<li Class="CombatExtended.DamageDefExtensionCE">
 					<isAmbientDamage>true</isAmbientDamage>

--- a/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
+++ b/Patches/Rimsenal Collection/Core/Rimsenal_Melee.xml
@@ -194,15 +194,17 @@
 				<nomatch Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="YP_BingJu"]</xpath>
 					<value>
-						<weaponTags />
+						<weaponTags>
+							<li>CE_OneHandedWeapon</li> 
+						</weaponTags>
 					</value>
 				</nomatch>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
-				<value>
-					<li>CE_OneHandedWeapon</li> 
-				</value>
+				<match Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="YP_BingJu"]/weaponTags</xpath>
+					<value>
+						<li>CE_OneHandedWeapon</li> 
+					</value>
+				</match>
 			</li>
 
 			<!-- JI Assault Hammer -->			

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -11,7 +11,7 @@
 
 			<!-- Pistols -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/tools</xpath>
 				<value>
 				  <tools>
 					<li Class="CombatExtended.ToolCE">
@@ -41,7 +41,7 @@
 			
 			<!-- Long guns-->			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeoLi" or
+				<xpath>Defs/ThingDef[defName="YP_SeoLi" or
 				defName="YP_SagPung" or
 				defName="YP_SangAe"	or
 				defName="YP_VectorShot"				
@@ -85,7 +85,7 @@
 			
 			<!-- Heavy Weapons -->			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_GeugGwang"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="YP_GeugGwang"]/tools</xpath>
 				<value>
 				  <tools>
 					<li Class="CombatExtended.ToolCE">
@@ -104,7 +104,7 @@
 		
 			<!-- ==========  YP Shard Rifle =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeoLi"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeoLi"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>48500</WorkToMake>
@@ -118,7 +118,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeoLi"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeoLi"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">					
@@ -138,7 +138,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_SeoLi"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeoLi"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
@@ -157,7 +157,7 @@
 			
 			<!-- ==========  YP Swarmer =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SagPung"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SagPung"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>42500</WorkToMake>
@@ -171,7 +171,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SagPung"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SagPung"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">					
@@ -192,7 +192,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_SagPung"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SagPung"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
@@ -211,7 +211,7 @@
 		
 			<!-- ==========  YP Spike Rifle =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SangAe"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SangAe"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>55500</WorkToMake>
@@ -225,7 +225,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SangAe"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SangAe"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">
@@ -245,7 +245,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_SangAe"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SangAe"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
@@ -264,7 +264,7 @@
 			
 			<!-- ==========  YP Dual Wield Shard Pistols =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>50500</WorkToMake>
@@ -278,7 +278,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">
@@ -299,7 +299,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
@@ -317,16 +317,16 @@
 			</li>
 			
 			<li Class="PatchOperationConditional">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>Defs/thingDef[defName="YP_SeolHwa"]</xpath>
+					<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
 					<value>
 						<weaponTags />
 					</value>
 				</nomatch>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
 				<value>
 				    <li>CE_Sidearm</li>
 					<li>CE_AI_Pistol</li>
@@ -335,7 +335,7 @@
 
 			<!-- ==========  YP Microwave Emmiter =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_GeugGwang"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_GeugGwang"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>42500</WorkToMake>
@@ -349,7 +349,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_GeugGwang"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_GeugGwang"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">					
@@ -368,7 +368,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_GeugGwang"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_GeugGwang"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_FireModes" />						
@@ -378,7 +378,7 @@
 					
 			<!-- ==========  YP Vector Shot =========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_VectorShot"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="YP_VectorShot"]/statBases</xpath>
 				<value>
 					<statBases>
 						<WorkToMake>58500</WorkToMake>
@@ -392,7 +392,7 @@
 				</value>
 			</li>				
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="YP_VectorShot"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="YP_VectorShot"]/verbs</xpath>
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">					
@@ -417,7 +417,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="YP_VectorShot"]</xpath>
+				<xpath>Defs/ThingDef[defName="YP_VectorShot"]</xpath>
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				

--- a/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_YP_CE.xml
@@ -321,16 +321,19 @@
 				<nomatch Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="YP_SeolHwa"]</xpath>
 					<value>
-						<weaponTags />
+						<weaponTags>
+							<li>CE_Sidearm</li>
+							<li>CE_AI_Pistol</li>
+						</weaponTags>
 					</value>
 				</nomatch>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
-				<value>
-				    <li>CE_Sidearm</li>
-					<li>CE_AI_Pistol</li>
-				</value>
+				<match Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="YP_SeolHwa"]/weaponTags</xpath>
+					<value>
+						<li>CE_Sidearm</li>
+						<li>CE_AI_Pistol</li>
+					</value>
+				</match>
 			</li>
 
 			<!-- ==========  YP Microwave Emmiter =========== -->


### PR DESCRIPTION
## Changes

thingDef -> ThingDef
Merged the few weaponTag PatchoperationAdds to the PatchOperationConditional's match/nomatch class.
Removed the starting '/' from Defs

## Reasoning

Fixes Defs from Rimsenal Core
Using both functions for the PatchOperationalConditional where it could be used.
'/' is not needed in front of Defs.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
