### PR TITLE
Mo missing races

### DIFF
--- a/Patches/Medieval Overhaul/MO_Races.xml
+++ b/Patches/Medieval Overhaul/MO_Races.xml
@@ -848,6 +848,67 @@
                   </li>
                </value>
             </li>
+			
+			<!-- deathstinger - used Megascarab as reference -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
+					<value>
+						<MoveSpeed>5.1</MoveSpeed>
+						<MeleeDodgeChance>0.22</MeleeDodgeChance>
+						<MeleeCritChance>0.03</MeleeCritChance>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>mandibles</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>1.5</cooldownTime>
+								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.24</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>0.5</baseHealthScale>
+					</value>
+				</li>
 
          </operations>
       </match>

--- a/Patches/Medieval Overhaul/MO_Races.xml
+++ b/Patches/Medieval Overhaul/MO_Races.xml
@@ -603,6 +603,15 @@
                   </tools>
                </value>
             </li>
+			
+			<li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
 
             <!-- === Schrat === -->
             <li Class="PatchOperationAdd">

--- a/Patches/Medieval Overhaul/MO_Races.xml
+++ b/Patches/Medieval Overhaul/MO_Races.xml
@@ -1,949 +1,997 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Medieval Overhaul</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<operations>
-				<!-- ======= Farm Animal ======= -->
-				<!-- Hampshire, Gloucestershire -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.07</MeleeDodgeChance>
-						<MeleeCritChance>0.06</MeleeCritChance>
-						<MeleeParryChance>0.08</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>1.5</cooldownTime>
-								<chanceFactor>0.7</chanceFactor>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.04</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>2.12</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>2</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+
+   <Operation Class="PatchOperationFindMod">
+      <mods>
+         <li>Medieval Overhaul</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+         <operations>
+
+            <!-- ======= Farm Animal ======= -->
+            <!-- Hampshire, Gloucestershire -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.07</MeleeDodgeChance>
+                  <MeleeCritChance>0.06</MeleeCritChance>
+                  <MeleeParryChance>0.08</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>1.5</cooldownTime>
+                        <chanceFactor>0.7</chanceFactor>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.04</armorPenetrationSharp>
+                        <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>2.12</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>2</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- Ravelder, Angus -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.08</MeleeDodgeChance>
+                  <MeleeCritChance>0.13</MeleeCritChance>
+                  <MeleeParryChance>0.22</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>4</power>
+                        <cooldownTime>1</cooldownTime>
+                        <chanceFactor>0.7</chanceFactor>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>16</power>
+                        <cooldownTime>2.12</cooldownTime>
+                        <chanceFactor>0.2</chanceFactor>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>horns</label>
+                        <capacities>
+                           <li>Stab</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2.0</cooldownTime>
+                        <chanceFactor>0.65</chanceFactor>
+                        <restrictedGender>Male</restrictedGender>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.25</armorPenetrationSharp>
+                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- === Rox === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.06</MeleeDodgeChance>
+                  <MeleeCritChance>0.41</MeleeCritChance>
+                  <MeleeParryChance>0.48</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>horn</label>
+                        <capacities>
+                           <li>Stab</li>
+                        </capacities>
+                        <power>30</power>
+                        <cooldownTime>2.52</cooldownTime>
+                        <chanceFactor>0.4</chanceFactor>
+                        <linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>1.5</armorPenetrationSharp>
+                        <armorPenetrationBlunt>15</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left foot</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>22</power>
+                        <cooldownTime>2.13</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right foot</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>22</power>
+                        <cooldownTime>2.13</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>19</power>
+                        <cooldownTime>1.62</cooldownTime>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.09</armorPenetrationSharp>
+                        <armorPenetrationBlunt>2.016</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>11</power>
+                        <cooldownTime>2.52</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/PawnKindDef[defName="DankPyon_Rox"]/combatPower</xpath>
+               <value>
+                  <combatPower>375</combatPower>
+               </value>
+            </li>
+
+            <!-- === Direwolf === -->
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases/MoveSpeed</xpath>
+               <value>
+                  <MoveSpeed>7</MoveSpeed>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases</xpath>
+               <value>
+                  <ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+                  <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+                  <MeleeDodgeChance>0.21</MeleeDodgeChance>
+                  <MeleeCritChance>0.20</MeleeCritChance>
+                  <MeleeParryChance>0.09</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>11</power>
+                        <cooldownTime>1.19</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.75</armorPenetrationSharp>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>11</power>
+                        <cooldownTime>1.19</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.75</armorPenetrationSharp>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>24</power>
+                        <cooldownTime>1.46</cooldownTime>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <chanceFactor>2</chanceFactor>
+                        <armorPenetrationSharp>1.6</armorPenetrationSharp>
+                        <armorPenetrationBlunt>8.863</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>4</power>
+                        <cooldownTime>3.2</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>1.225</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/PawnKindDef[defName="DankPyon_Direwolf"]/combatPower</xpath>
+               <value>
+                  <combatPower>140</combatPower>
+               </value>
+            </li>
+
+            <!-- === Hyena === -->
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/statBases/MoveSpeed</xpath>
+               <value>
+                  <MoveSpeed>6.25</MoveSpeed>
+                  <MeleeDodgeChance>0.26</MeleeDodgeChance>
+                  <MeleeCritChance>0.09</MeleeCritChance>
+                  <MeleeParryChance>0.05</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>0.8</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.07</armorPenetrationSharp>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>0.8</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+                        <armorPenetrationSharp>0.07</armorPenetrationSharp>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>1.73</cooldownTime>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>20</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationSharp>0.55</armorPenetrationSharp>
+                        <armorPenetrationBlunt>4.225</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>1</power>
+                        <cooldownTime>1.26</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/PawnKindDef[defName="DankPyon_Hyena"]/combatPower</xpath>
+               <value>
+                  <combatPower>80</combatPower>
+               </value>
+            </li>
+
+            <!-- === Daer === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.14</MeleeDodgeChance>
+                  <MeleeCritChance>0.27</MeleeCritChance>
+                  <MeleeParryChance>0.3</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>30</power>
+                        <cooldownTime>2.6</cooldownTime>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <chanceFactor>0.5</chanceFactor>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>14</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationSharp>1.8</armorPenetrationSharp>
+                        <armorPenetrationBlunt>12</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>7</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationSharp>0.45</armorPenetrationSharp>
+                        <armorPenetrationBlunt>7</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>7</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationSharp>0.45</armorPenetrationSharp>
+                        <armorPenetrationBlunt>7</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>18</power>
+                        <cooldownTime>2.44</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/PawnKindDef[defName="DankPyon_Daer"]/combatPower</xpath>
+               <value>
+                  <combatPower>300</combatPower>
+               </value>
+            </li>
+
+            <!-- === Dire Boar === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.12</MeleeDodgeChance>
+                  <MeleeCritChance>0.33</MeleeCritChance>
+                  <MeleeParryChance>0.34</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>tusk</label>
+                        <capacities>
+                           <li>Scratch</li>
+                           <li>Stab</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2.6</cooldownTime>
+                        <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.01</armorPenetrationSharp>
+                        <armorPenetrationBlunt>1.250</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>20</power>
+                        <cooldownTime>2.6</cooldownTime>
+                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+                        <chanceFactor>0.5</chanceFactor>
+                        <armorPenetrationSharp>0.02</armorPenetrationSharp>
+                        <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>14</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left hoof</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Poke</li>
+                        </capacities>
+                        <power>5</power>
+                        <cooldownTime>1</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right hoof</label>
+                        <capacities>
+                           <li>Blunt</li>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>5</power>
+                        <cooldownTime>1</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>6</power>
+                        <cooldownTime>0.92</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+			
+			<li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Quadruped</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- === Schrat === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.12</MeleeDodgeChance>
+                  <MeleeCritChance>0.14</MeleeCritChance>
+                  <MeleeParryChance>0.22</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left fist</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>4</armorPenetrationBlunt>
+                        <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right fist</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>21</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                        <armorPenetrationBlunt>4</armorPenetrationBlunt>
+                        <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Humanoid</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- ======= Snakes ======= -->
+            <!-- === Large Cobra === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.19</MeleeDodgeChance>
+                  <MeleeCritChance>0.18</MeleeCritChance>
+                  <MeleeParryChance>0.17</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>venom-fangs</label>
+                        <capacities>
+                           <li>ToxicBite</li>
+                        </capacities>
+                        <power>14</power>
+                        <cooldownTime>1.8</cooldownTime>
+                        <armorPenetrationSharp>0.25</armorPenetrationSharp>
+                        <armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>14</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>3</power>
+                        <cooldownTime>2</cooldownTime>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Serpentine</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- === Giant Constrictor === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.23</MeleeDodgeChance>
+                  <MeleeCritChance>0.12</MeleeCritChance>
+                  <MeleeParryChance>0.15</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>24</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>2.26</armorPenetrationSharp>
+                        <armorPenetrationBlunt>1.49</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>7</power>
+                        <cooldownTime>0.92</cooldownTime>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Serpentine</bodyShape>
+                  </li>
+               </value>
+            </li>
+
+            <!-- === Lindwurm === -->
+            <li Class="PatchOperationAdd">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/statBases</xpath>
+               <value>
+                  <MeleeDodgeChance>0.20</MeleeDodgeChance>
+                  <MeleeCritChance>0.25</MeleeCritChance>
+                  <MeleeParryChance>0.08</MeleeParryChance>
+               </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/tools</xpath>
+               <value>
+                  <tools>
+                     <li Class="CombatExtended.ToolCE">
+                        <capacities>
+                           <li>Bite</li>
+                        </capacities>
+                        <power>32</power>
+                        <cooldownTime>2.6</cooldownTime>
+                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.5</armorPenetrationSharp>
+                        <armorPenetrationBlunt>2.7</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>head</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>4</power>
+                        <cooldownTime>0.97</cooldownTime>
+                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                        <chanceFactor>0.2</chanceFactor>
+                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>left claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>23</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.18</armorPenetrationSharp>
+                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>right claw</label>
+                        <capacities>
+                           <li>Scratch</li>
+                        </capacities>
+                        <power>23</power>
+                        <cooldownTime>2</cooldownTime>
+                        <linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
+                        <armorPenetrationSharp>0.18</armorPenetrationSharp>
+                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+                     </li>
+                     <li Class="CombatExtended.ToolCE">
+                        <label>tail</label>
+                        <capacities>
+                           <li>Blunt</li>
+                        </capacities>
+                        <power>28</power>
+                        <cooldownTime>4</cooldownTime>
+                        <linkedBodyPartsGroup>DankPyon_TailAttackTool</linkedBodyPartsGroup>
+                        <surpriseAttack>
+                           <extraMeleeDamages>
+                              <li>
+                                 <def>Stun</def>
+                                 <amount>14</amount>
+                              </li>
+                           </extraMeleeDamages>
+                        </surpriseAttack>
+                        <armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+                     </li>
+                  </tools>
+               </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]</xpath>
+               <value>
+                  <li Class="CombatExtended.RacePropertiesExtensionCE">
+                     <bodyShape>Birdlike</bodyShape>
+                  </li>
+               </value>
+            </li>
+			
+			<!-- deathstinger - used Megascarab as reference -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>5.1</MoveSpeed>
+					<MeleeDodgeChance>0.22</MeleeDodgeChance>
+					<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>mandibles</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.24</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<!-- Ravelder, Angus -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.08</MeleeDodgeChance>
-						<MeleeCritChance>0.13</MeleeCritChance>
-						<MeleeParryChance>0.22</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>4</power>
-								<cooldownTime>1</cooldownTime>
-								<chanceFactor>0.7</chanceFactor>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>16</power>
-								<cooldownTime>2.12</cooldownTime>
-								<chanceFactor>0.2</chanceFactor>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>6</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>horns</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2.0</cooldownTime>
-								<chanceFactor>0.65</chanceFactor>
-								<restrictedGender>Male</restrictedGender>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.25</armorPenetrationSharp>
-								<armorPenetrationBlunt>6</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<!-- === Rox === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.06</MeleeDodgeChance>
-						<MeleeCritChance>0.41</MeleeCritChance>
-						<MeleeParryChance>0.48</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>horn</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>30</power>
-								<cooldownTime>2.52</cooldownTime>
-								<chanceFactor>0.4</chanceFactor>
-								<linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
-								<armorPenetrationSharp>1.5</armorPenetrationSharp>
-								<armorPenetrationBlunt>15</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>left foot</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>22</power>
-								<cooldownTime>2.13</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right foot</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>22</power>
-								<cooldownTime>2.13</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>19</power>
-								<cooldownTime>1.62</cooldownTime>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.09</armorPenetrationSharp>
-								<armorPenetrationBlunt>2.016</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>11</power>
-								<cooldownTime>2.52</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>6</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>0.5</baseHealthScale>
+				</value>
+			</li>
+				
+			<!-- northern boar - used wildboar as reference -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.14</MeleeCritChance>
+					<MeleeParryChance>0.14</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.89</cooldownTime>
+							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="DankPyon_Rox"]/combatPower</xpath>
-					<value>
-						<combatPower>375</combatPower>
-					</value>
-				</li>
-				<!-- === Direwolf === -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.41</cooldownTime>
+							<chanceFactor>0.65</chanceFactor>
+							<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases/MoveSpeed</xpath>
-					<value>
-						<MoveSpeed>7</MoveSpeed>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases</xpath>
-					<value>
-						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-						<MeleeDodgeChance>0.21</MeleeDodgeChance>
-						<MeleeCritChance>0.20</MeleeCritChance>
-						<MeleeParryChance>0.09</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>left claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>11</power>
-								<cooldownTime>1.19</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.75</armorPenetrationSharp>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>11</power>
-								<cooldownTime>1.19</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.75</armorPenetrationSharp>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>24</power>
-								<cooldownTime>1.46</cooldownTime>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<chanceFactor>2</chanceFactor>
-								<armorPenetrationSharp>1.6</armorPenetrationSharp>
-								<armorPenetrationBlunt>8.863</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>4</power>
-								<cooldownTime>3.2</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>1.225</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="DankPyon_Direwolf"]/combatPower</xpath>
-					<value>
-						<combatPower>140</combatPower>
-					</value>
-				</li>
-				<!-- === Hyena === -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>8.7</power>
+							<cooldownTime>1.57</cooldownTime>
+							<chanceFactor>0.6</chanceFactor>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>					
+							<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/statBases/MoveSpeed</xpath>
-					<value>
-						<MoveSpeed>6.25</MoveSpeed>
-						<MeleeDodgeChance>0.26</MeleeDodgeChance>
-						<MeleeCritChance>0.09</MeleeCritChance>
-						<MeleeParryChance>0.05</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>left claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>0.8</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.07</armorPenetrationSharp>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>0.8</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-								<armorPenetrationSharp>0.07</armorPenetrationSharp>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>1.73</cooldownTime>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>20</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationSharp>0.55</armorPenetrationSharp>
-								<armorPenetrationBlunt>4.225</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>1</power>
-								<cooldownTime>1.26</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="DankPyon_Hyena"]/combatPower</xpath>
-					<value>
-						<combatPower>80</combatPower>
-					</value>
-				</li>
-				<!-- === Daer === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.14</MeleeDodgeChance>
-						<MeleeCritChance>0.27</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>30</power>
-								<cooldownTime>2.6</cooldownTime>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<chanceFactor>0.5</chanceFactor>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>14</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationSharp>1.8</armorPenetrationSharp>
-								<armorPenetrationBlunt>12</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>left claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>7</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationSharp>0.45</armorPenetrationSharp>
-								<armorPenetrationBlunt>7</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>7</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationSharp>0.45</armorPenetrationSharp>
-								<armorPenetrationBlunt>7</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>18</power>
-								<cooldownTime>2.44</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>2.12</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
 						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/PawnKindDef[defName="DankPyon_Daer"]/combatPower</xpath>
-					<value>
-						<combatPower>300</combatPower>
-					</value>
-				</li>
-				<!-- === Dire Boar === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.12</MeleeDodgeChance>
-						<MeleeCritChance>0.33</MeleeCritChance>
-						<MeleeParryChance>0.34</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>tusk</label>
-								<capacities>
-									<li>Scratch</li>
-									<li>Stab</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2.6</cooldownTime>
-								<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.01</armorPenetrationSharp>
-								<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>20</power>
-								<cooldownTime>2.6</cooldownTime>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<chanceFactor>0.5</chanceFactor>
-								<armorPenetrationSharp>0.02</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>14</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>left hoof</label>
-								<capacities>
-									<li>Blunt</li>
-									<li>Poke</li>
-								</capacities>
-								<power>5</power>
-								<cooldownTime>1</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right hoof</label>
-								<capacities>
-									<li>Blunt</li>
-									<li>Blunt</li>
-								</capacities>
-								<power>5</power>
-								<cooldownTime>1</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>0.92</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
-						</li>
-					</value>
-				</li>
-				<!-- === Schrat === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.12</MeleeDodgeChance>
-						<MeleeCritChance>0.14</MeleeCritChance>
-						<MeleeParryChance>0.22</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>left fist</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>4</armorPenetrationBlunt>
-								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right fist</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>21</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>4</armorPenetrationBlunt>
-								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Humanoid</bodyShape>
-						</li>
-					</value>
-				</li>
-				<!-- ======= Snakes ======= -->
-				<!-- === Large Cobra === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.19</MeleeDodgeChance>
-						<MeleeCritChance>0.18</MeleeCritChance>
-						<MeleeParryChance>0.17</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>venom-fangs</label>
-								<capacities>
-									<li>ToxicBite</li>
-								</capacities>
-								<power>14</power>
-								<cooldownTime>1.8</cooldownTime>
-								<armorPenetrationSharp>0.25</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.20</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>14</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>3</power>
-								<cooldownTime>2</cooldownTime>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Serpentine</bodyShape>
-						</li>
-					</value>
-				</li>
-				<!-- === Giant Constrictor === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.23</MeleeDodgeChance>
-						<MeleeCritChance>0.12</MeleeCritChance>
-						<MeleeParryChance>0.15</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>24</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>2.26</armorPenetrationSharp>
-								<armorPenetrationBlunt>1.49</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>7</power>
-								<cooldownTime>0.92</cooldownTime>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Serpentine</bodyShape>
-						</li>
-					</value>
-				</li>
-				<!-- === Lindwurm === -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.20</MeleeDodgeChance>
-						<MeleeCritChance>0.25</MeleeCritChance>
-						<MeleeParryChance>0.08</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>32</power>
-								<cooldownTime>2.6</cooldownTime>
-								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.5</armorPenetrationSharp>
-								<armorPenetrationBlunt>2.7</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>4</power>
-								<cooldownTime>0.97</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>left claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>23</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.18</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>right claw</label>
-								<capacities>
-									<li>Scratch</li>
-								</capacities>
-								<power>23</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.18</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>tail</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>28</power>
-								<cooldownTime>4</cooldownTime>
-								<linkedBodyPartsGroup>DankPyon_TailAttackTool</linkedBodyPartsGroup>
-								<surpriseAttack>
-									<extraMeleeDamages>
-										<li>
-											<def>Stun</def>
-											<amount>14</amount>
-										</li>
-									</extraMeleeDamages>
-								</surpriseAttack>
-								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Birdlike</bodyShape>
-						</li>
-					</value>
-				</li>
-				<!-- deathstinger - used Megascarab as reference -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
-					<value>
-						<MoveSpeed>5.1</MoveSpeed>
-						<MeleeDodgeChance>0.22</MeleeDodgeChance>
-						<MeleeCritChance>0.03</MeleeCritChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>mandibles</label>
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>9</power>
-								<cooldownTime>1.5</cooldownTime>
-								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.24</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>1</power>
-								<cooldownTime>1.26</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>0.5</baseHealthScale>
-					</value>
-				</li>
-				<!-- northern boar - used wildboar as reference -->
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
-						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/statBases</xpath>
-					<value>
-						<MeleeDodgeChance>0.15</MeleeDodgeChance>
-						<MeleeCritChance>0.14</MeleeCritChance>
-						<MeleeParryChance>0.14</MeleeParryChance>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>tusk</label>
-								<capacities>
-									<li>Cut</li>
-								</capacities>
-								<power>11</power>
-								<cooldownTime>1.89</cooldownTime>
-								<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.1</armorPenetrationSharp>
-								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>tusk</label>
-								<capacities>
-									<li>Stab</li>
-								</capacities>
-								<power>7</power>
-								<cooldownTime>1.41</cooldownTime>
-								<chanceFactor>0.65</chanceFactor>
-								<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.2</armorPenetrationSharp>
-								<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>8.7</power>
-								<cooldownTime>1.57</cooldownTime>
-								<chanceFactor>0.6</chanceFactor>
-								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.08</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>6</power>
-								<cooldownTime>2.12</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>2</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
-			</operations>
-		</match>
-	</Operation>
+					</tools>
+				</value>
+			</li>
+         </operations>
+      </match>
+   </Operation>
+
 </Patch>

--- a/Patches/Medieval Overhaul/MO_Races.xml
+++ b/Patches/Medieval Overhaul/MO_Races.xml
@@ -1,997 +1,949 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-
-   <Operation Class="PatchOperationFindMod">
-      <mods>
-         <li>Medieval Overhaul</li>
-      </mods>
-      <match Class="PatchOperationSequence">
-         <operations>
-
-            <!-- ======= Farm Animal ======= -->
-            <!-- Hampshire, Gloucestershire -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.07</MeleeDodgeChance>
-                  <MeleeCritChance>0.06</MeleeCritChance>
-                  <MeleeParryChance>0.08</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>6</power>
-                        <cooldownTime>1.5</cooldownTime>
-                        <chanceFactor>0.7</chanceFactor>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.04</armorPenetrationSharp>
-                        <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>6</power>
-                        <cooldownTime>2.12</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>2</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- Ravelder, Angus -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.08</MeleeDodgeChance>
-                  <MeleeCritChance>0.13</MeleeCritChance>
-                  <MeleeParryChance>0.22</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>4</power>
-                        <cooldownTime>1</cooldownTime>
-                        <chanceFactor>0.7</chanceFactor>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>16</power>
-                        <cooldownTime>2.12</cooldownTime>
-                        <chanceFactor>0.2</chanceFactor>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>horns</label>
-                        <capacities>
-                           <li>Stab</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2.0</cooldownTime>
-                        <chanceFactor>0.65</chanceFactor>
-                        <restrictedGender>Male</restrictedGender>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.25</armorPenetrationSharp>
-                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- === Rox === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.06</MeleeDodgeChance>
-                  <MeleeCritChance>0.41</MeleeCritChance>
-                  <MeleeParryChance>0.48</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>horn</label>
-                        <capacities>
-                           <li>Stab</li>
-                        </capacities>
-                        <power>30</power>
-                        <cooldownTime>2.52</cooldownTime>
-                        <chanceFactor>0.4</chanceFactor>
-                        <linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>1.5</armorPenetrationSharp>
-                        <armorPenetrationBlunt>15</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left foot</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>22</power>
-                        <cooldownTime>2.13</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>14.640</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right foot</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>22</power>
-                        <cooldownTime>2.13</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>14.640</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>19</power>
-                        <cooldownTime>1.62</cooldownTime>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.09</armorPenetrationSharp>
-                        <armorPenetrationBlunt>2.016</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>11</power>
-                        <cooldownTime>2.52</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>6</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Rox"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName="DankPyon_Rox"]/combatPower</xpath>
-               <value>
-                  <combatPower>375</combatPower>
-               </value>
-            </li>
-
-            <!-- === Direwolf === -->
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases/MoveSpeed</xpath>
-               <value>
-                  <MoveSpeed>7</MoveSpeed>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases</xpath>
-               <value>
-                  <ArmorRating_Blunt>0.075</ArmorRating_Blunt>
-                  <ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-                  <MeleeDodgeChance>0.21</MeleeDodgeChance>
-                  <MeleeCritChance>0.20</MeleeCritChance>
-                  <MeleeParryChance>0.09</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>11</power>
-                        <cooldownTime>1.19</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-                        <armorPenetrationSharp>0.75</armorPenetrationSharp>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>11</power>
-                        <cooldownTime>1.19</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-                        <armorPenetrationSharp>0.75</armorPenetrationSharp>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>24</power>
-                        <cooldownTime>1.46</cooldownTime>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <chanceFactor>2</chanceFactor>
-                        <armorPenetrationSharp>1.6</armorPenetrationSharp>
-                        <armorPenetrationBlunt>8.863</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>4</power>
-                        <cooldownTime>3.2</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>1.225</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName="DankPyon_Direwolf"]/combatPower</xpath>
-               <value>
-                  <combatPower>140</combatPower>
-               </value>
-            </li>
-
-            <!-- === Hyena === -->
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/statBases/MoveSpeed</xpath>
-               <value>
-                  <MoveSpeed>6.25</MoveSpeed>
-                  <MeleeDodgeChance>0.26</MeleeDodgeChance>
-                  <MeleeCritChance>0.09</MeleeCritChance>
-                  <MeleeParryChance>0.05</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>6</power>
-                        <cooldownTime>0.8</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-                        <armorPenetrationSharp>0.07</armorPenetrationSharp>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>6</power>
-                        <cooldownTime>0.8</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationBlunt>0.450</armorPenetrationBlunt>
-                        <armorPenetrationSharp>0.07</armorPenetrationSharp>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>1.73</cooldownTime>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>20</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationSharp>0.55</armorPenetrationSharp>
-                        <armorPenetrationBlunt>4.225</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>1</power>
-                        <cooldownTime>1.26</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName="DankPyon_Hyena"]/combatPower</xpath>
-               <value>
-                  <combatPower>80</combatPower>
-               </value>
-            </li>
-
-            <!-- === Daer === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.14</MeleeDodgeChance>
-                  <MeleeCritChance>0.27</MeleeCritChance>
-                  <MeleeParryChance>0.3</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>30</power>
-                        <cooldownTime>2.6</cooldownTime>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <chanceFactor>0.5</chanceFactor>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>14</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationSharp>1.8</armorPenetrationSharp>
-                        <armorPenetrationBlunt>12</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>7</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationSharp>0.45</armorPenetrationSharp>
-                        <armorPenetrationBlunt>7</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>7</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationSharp>0.45</armorPenetrationSharp>
-                        <armorPenetrationBlunt>7</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>18</power>
-                        <cooldownTime>2.44</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Daer"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/PawnKindDef[defName="DankPyon_Daer"]/combatPower</xpath>
-               <value>
-                  <combatPower>300</combatPower>
-               </value>
-            </li>
-
-            <!-- === Dire Boar === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.12</MeleeDodgeChance>
-                  <MeleeCritChance>0.33</MeleeCritChance>
-                  <MeleeParryChance>0.34</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>tusk</label>
-                        <capacities>
-                           <li>Scratch</li>
-                           <li>Stab</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2.6</cooldownTime>
-                        <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.01</armorPenetrationSharp>
-                        <armorPenetrationBlunt>1.250</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>20</power>
-                        <cooldownTime>2.6</cooldownTime>
-                        <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-                        <chanceFactor>0.5</chanceFactor>
-                        <armorPenetrationSharp>0.02</armorPenetrationSharp>
-                        <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>14</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left hoof</label>
-                        <capacities>
-                           <li>Blunt</li>
-                           <li>Poke</li>
-                        </capacities>
-                        <power>5</power>
-                        <cooldownTime>1</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right hoof</label>
-                        <capacities>
-                           <li>Blunt</li>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>5</power>
-                        <cooldownTime>1</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>2.250</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>6</power>
-                        <cooldownTime>0.92</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>2.5</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-			
-			<li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Quadruped</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- === Schrat === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.12</MeleeDodgeChance>
-                  <MeleeCritChance>0.14</MeleeCritChance>
-                  <MeleeParryChance>0.22</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left fist</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>4</armorPenetrationBlunt>
-                        <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right fist</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>21</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-                        <armorPenetrationBlunt>4</armorPenetrationBlunt>
-                        <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Schrat"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Humanoid</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- ======= Snakes ======= -->
-            <!-- === Large Cobra === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.19</MeleeDodgeChance>
-                  <MeleeCritChance>0.18</MeleeCritChance>
-                  <MeleeParryChance>0.17</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>venom-fangs</label>
-                        <capacities>
-                           <li>ToxicBite</li>
-                        </capacities>
-                        <power>14</power>
-                        <cooldownTime>1.8</cooldownTime>
-                        <armorPenetrationSharp>0.25</armorPenetrationSharp>
-                        <armorPenetrationBlunt>0.20</armorPenetrationBlunt>
-                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>14</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>3</power>
-                        <cooldownTime>2</cooldownTime>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>0.2</armorPenetrationBlunt>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Serpentine</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- === Giant Constrictor === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.23</MeleeDodgeChance>
-                  <MeleeCritChance>0.12</MeleeCritChance>
-                  <MeleeParryChance>0.15</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>24</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>2.26</armorPenetrationSharp>
-                        <armorPenetrationBlunt>1.49</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>7</power>
-                        <cooldownTime>0.92</cooldownTime>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>0.3</armorPenetrationBlunt>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Serpentine</bodyShape>
-                  </li>
-               </value>
-            </li>
-
-            <!-- === Lindwurm === -->
-            <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/statBases</xpath>
-               <value>
-                  <MeleeDodgeChance>0.20</MeleeDodgeChance>
-                  <MeleeCritChance>0.25</MeleeCritChance>
-                  <MeleeParryChance>0.08</MeleeParryChance>
-               </value>
-            </li>
-
-            <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/tools</xpath>
-               <value>
-                  <tools>
-                     <li Class="CombatExtended.ToolCE">
-                        <capacities>
-                           <li>Bite</li>
-                        </capacities>
-                        <power>32</power>
-                        <cooldownTime>2.6</cooldownTime>
-                        <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.5</armorPenetrationSharp>
-                        <armorPenetrationBlunt>2.7</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>head</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>4</power>
-                        <cooldownTime>0.97</cooldownTime>
-                        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                        <chanceFactor>0.2</chanceFactor>
-                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>left claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>23</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.18</armorPenetrationSharp>
-                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>right claw</label>
-                        <capacities>
-                           <li>Scratch</li>
-                        </capacities>
-                        <power>23</power>
-                        <cooldownTime>2</cooldownTime>
-                        <linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
-                        <armorPenetrationSharp>0.18</armorPenetrationSharp>
-                        <armorPenetrationBlunt>0.823</armorPenetrationBlunt>
-                     </li>
-                     <li Class="CombatExtended.ToolCE">
-                        <label>tail</label>
-                        <capacities>
-                           <li>Blunt</li>
-                        </capacities>
-                        <power>28</power>
-                        <cooldownTime>4</cooldownTime>
-                        <linkedBodyPartsGroup>DankPyon_TailAttackTool</linkedBodyPartsGroup>
-                        <surpriseAttack>
-                           <extraMeleeDamages>
-                              <li>
-                                 <def>Stun</def>
-                                 <amount>14</amount>
-                              </li>
-                           </extraMeleeDamages>
-                        </surpriseAttack>
-                        <armorPenetrationBlunt>0.9</armorPenetrationBlunt>
-                     </li>
-                  </tools>
-               </value>
-            </li>
-
-            <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]</xpath>
-               <value>
-                  <li Class="CombatExtended.RacePropertiesExtensionCE">
-                     <bodyShape>Birdlike</bodyShape>
-                  </li>
-               </value>
-            </li>
-			
-			<!-- deathstinger - used Megascarab as reference -->
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
-				<value>
-					<MoveSpeed>5.1</MoveSpeed>
-					<MeleeDodgeChance>0.22</MeleeDodgeChance>
-					<MeleeCritChance>0.03</MeleeCritChance>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>mandibles</label>
-							<capacities>
-								<li>Bite</li>
-							</capacities>
-							<power>9</power>
-							<cooldownTime>1.5</cooldownTime>
-							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.24</armorPenetrationSharp>
-							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medieval Overhaul</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ======= Farm Animal ======= -->
+				<!-- Hampshire, Gloucestershire -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.07</MeleeDodgeChance>
+						<MeleeCritChance>0.06</MeleeCritChance>
+						<MeleeParryChance>0.08</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>1.5</cooldownTime>
+								<chanceFactor>0.7</chanceFactor>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.04</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>2.12</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>1</power>
-							<cooldownTime>1.26</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+					</value>
+				</li>
+				<!-- Ravelder, Angus -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.08</MeleeDodgeChance>
+						<MeleeCritChance>0.13</MeleeCritChance>
+						<MeleeParryChance>0.22</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>1</cooldownTime>
+								<chanceFactor>0.7</chanceFactor>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>16</power>
+								<cooldownTime>2.12</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>horns</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2.0</cooldownTime>
+								<chanceFactor>0.65</chanceFactor>
+								<restrictedGender>Male</restrictedGender>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.25</armorPenetrationSharp>
+								<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Ravelder" or defName="DankPyon_Angus"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-					</tools>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
-				<value>
-					<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
-				<value>
-					<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
-				<value>
-					<baseHealthScale>0.5</baseHealthScale>
-				</value>
-			</li>
-				
-			<!-- northern boar - used wildboar as reference -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.15</MeleeDodgeChance>
-					<MeleeCritChance>0.14</MeleeCritChance>
-					<MeleeParryChance>0.14</MeleeParryChance>
-				</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<label>tusk</label>
-							<capacities>
-								<li>Cut</li>
-							</capacities>
-							<power>11</power>
-							<cooldownTime>1.89</cooldownTime>
-							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.1</armorPenetrationSharp>
-							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					</value>
+				</li>
+				<!-- === Rox === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.06</MeleeDodgeChance>
+						<MeleeCritChance>0.41</MeleeCritChance>
+						<MeleeParryChance>0.48</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>horn</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>30</power>
+								<cooldownTime>2.52</cooldownTime>
+								<chanceFactor>0.4</chanceFactor>
+								<linkedBodyPartsGroup>HornAttackTool_2</linkedBodyPartsGroup>
+								<armorPenetrationSharp>1.5</armorPenetrationSharp>
+								<armorPenetrationBlunt>15</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left foot</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right foot</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>22</power>
+								<cooldownTime>2.13</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>14.640</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>19</power>
+								<cooldownTime>1.62</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.09</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.016</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>2.52</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>6</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Rox"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>tusk</label>
-							<capacities>
-								<li>Stab</li>
-							</capacities>
-							<power>7</power>
-							<cooldownTime>1.41</cooldownTime>
-							<chanceFactor>0.65</chanceFactor>
-							<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.2</armorPenetrationSharp>
-							<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Rox"]/combatPower</xpath>
+					<value>
+						<combatPower>375</combatPower>
+					</value>
+				</li>
+				<!-- === Direwolf === -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<capacities>
-								<li>Bite</li>
-							</capacities>
-							<power>8.7</power>
-							<cooldownTime>1.57</cooldownTime>
-							<chanceFactor>0.6</chanceFactor>
-							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.08</armorPenetrationSharp>					
-							<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases/MoveSpeed</xpath>
+					<value>
+						<MoveSpeed>7</MoveSpeed>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/statBases</xpath>
+					<value>
+						<ArmorRating_Blunt>0.075</ArmorRating_Blunt>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<MeleeDodgeChance>0.21</MeleeDodgeChance>
+						<MeleeCritChance>0.20</MeleeCritChance>
+						<MeleeParryChance>0.09</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Direwolf"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>1.19</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>1.19</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.75</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>1.46</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<chanceFactor>2</chanceFactor>
+								<armorPenetrationSharp>1.6</armorPenetrationSharp>
+								<armorPenetrationBlunt>8.863</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>3.2</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>1.225</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Direwolf"]/combatPower</xpath>
+					<value>
+						<combatPower>140</combatPower>
+					</value>
+				</li>
+				<!-- === Hyena === -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-						<li Class="CombatExtended.ToolCE">
-							<label>head</label>
-							<capacities>
-								<li>Blunt</li>
-							</capacities>
-							<power>6</power>
-							<cooldownTime>2.12</cooldownTime>
-							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-							<chanceFactor>0.2</chanceFactor>
-							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/statBases/MoveSpeed</xpath>
+					<value>
+						<MoveSpeed>6.25</MoveSpeed>
+						<MeleeDodgeChance>0.26</MeleeDodgeChance>
+						<MeleeCritChance>0.09</MeleeCritChance>
+						<MeleeParryChance>0.05</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Hyena"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>0.8</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.07</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>0.8</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.450</armorPenetrationBlunt>
+								<armorPenetrationSharp>0.07</armorPenetrationSharp>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>1.73</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>20</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationSharp>0.55</armorPenetrationSharp>
+								<armorPenetrationBlunt>4.225</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Hyena"]/combatPower</xpath>
+					<value>
+						<combatPower>80</combatPower>
+					</value>
+				</li>
+				<!-- === Daer === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.14</MeleeDodgeChance>
+						<MeleeCritChance>0.27</MeleeCritChance>
+						<MeleeParryChance>0.3</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>30</power>
+								<cooldownTime>2.6</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<chanceFactor>0.5</chanceFactor>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>14</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationSharp>1.8</armorPenetrationSharp>
+								<armorPenetrationBlunt>12</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>7</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationSharp>0.45</armorPenetrationSharp>
+								<armorPenetrationBlunt>7</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>7</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationSharp>0.45</armorPenetrationSharp>
+								<armorPenetrationBlunt>7</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>18</power>
+								<cooldownTime>2.44</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Daer"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
 						</li>
-					</tools>
-				</value>
-			</li>
-         </operations>
-      </match>
-   </Operation>
-
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/PawnKindDef[defName="DankPyon_Daer"]/combatPower</xpath>
+					<value>
+						<combatPower>300</combatPower>
+					</value>
+				</li>
+				<!-- === Dire Boar === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.12</MeleeDodgeChance>
+						<MeleeCritChance>0.33</MeleeCritChance>
+						<MeleeParryChance>0.34</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>tusk</label>
+								<capacities>
+									<li>Scratch</li>
+									<li>Stab</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2.6</cooldownTime>
+								<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.01</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.250</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>20</power>
+								<cooldownTime>2.6</cooldownTime>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<chanceFactor>0.5</chanceFactor>
+								<armorPenetrationSharp>0.02</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>14</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left hoof</label>
+								<capacities>
+									<li>Blunt</li>
+									<li>Poke</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right hoof</label>
+								<capacities>
+									<li>Blunt</li>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>1</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>2.250</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>0.92</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_DireBoar"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+				<!-- === Schrat === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.12</MeleeDodgeChance>
+						<MeleeCritChance>0.14</MeleeCritChance>
+						<MeleeParryChance>0.22</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>left fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right fist</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+								<armorPenetrationBlunt>4</armorPenetrationBlunt>
+								<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_Schrat"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Humanoid</bodyShape>
+						</li>
+					</value>
+				</li>
+				<!-- ======= Snakes ======= -->
+				<!-- === Large Cobra === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.19</MeleeDodgeChance>
+						<MeleeCritChance>0.18</MeleeCritChance>
+						<MeleeParryChance>0.17</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>venom-fangs</label>
+								<capacities>
+									<li>ToxicBite</li>
+								</capacities>
+								<power>14</power>
+								<cooldownTime>1.8</cooldownTime>
+								<armorPenetrationSharp>0.25</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.20</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>14</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>3</power>
+								<cooldownTime>2</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LargeCobraBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Serpentine</bodyShape>
+						</li>
+					</value>
+				</li>
+				<!-- === Giant Constrictor === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.23</MeleeDodgeChance>
+						<MeleeCritChance>0.12</MeleeCritChance>
+						<MeleeParryChance>0.15</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>24</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>2.26</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.49</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>0.92</cooldownTime>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[@Name="DankPyon_GiantConstrictorBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Serpentine</bodyShape>
+						</li>
+					</value>
+				</li>
+				<!-- === Lindwurm === -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.20</MeleeDodgeChance>
+						<MeleeCritChance>0.25</MeleeCritChance>
+						<MeleeParryChance>0.08</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>32</power>
+								<cooldownTime>2.6</cooldownTime>
+								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.7</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>4</power>
+								<cooldownTime>0.97</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>left claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>23</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.18</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>right claw</label>
+								<capacities>
+									<li>Scratch</li>
+								</capacities>
+								<power>23</power>
+								<cooldownTime>2</cooldownTime>
+								<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.18</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.823</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>tail</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>28</power>
+								<cooldownTime>4</cooldownTime>
+								<linkedBodyPartsGroup>DankPyon_TailAttackTool</linkedBodyPartsGroup>
+								<surpriseAttack>
+									<extraMeleeDamages>
+										<li>
+											<def>Stun</def>
+											<amount>14</amount>
+										</li>
+									</extraMeleeDamages>
+								</surpriseAttack>
+								<armorPenetrationBlunt>0.9</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[@Name="DankPyon_LindwurmBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Birdlike</bodyShape>
+						</li>
+					</value>
+				</li>
+				<!-- deathstinger - used Megascarab as reference -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
+					<value>
+						<MoveSpeed>5.1</MoveSpeed>
+						<MeleeDodgeChance>0.22</MeleeDodgeChance>
+						<MeleeCritChance>0.03</MeleeCritChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>mandibles</label>
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>9</power>
+								<cooldownTime>1.5</cooldownTime>
+								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.24</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>1</power>
+								<cooldownTime>1.26</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>0.5</baseHealthScale>
+					</value>
+				</li>
+				<!-- northern boar - used wildboar as reference -->
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]</xpath>
+					<value>
+						<li Class="CombatExtended.RacePropertiesExtensionCE">
+							<bodyShape>Quadruped</bodyShape>
+						</li>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/statBases</xpath>
+					<value>
+						<MeleeDodgeChance>0.15</MeleeDodgeChance>
+						<MeleeCritChance>0.14</MeleeCritChance>
+						<MeleeParryChance>0.14</MeleeParryChance>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>tusk</label>
+								<capacities>
+									<li>Cut</li>
+								</capacities>
+								<power>11</power>
+								<cooldownTime>1.89</cooldownTime>
+								<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.1</armorPenetrationSharp>
+								<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>tusk</label>
+								<capacities>
+									<li>Stab</li>
+								</capacities>
+								<power>7</power>
+								<cooldownTime>1.41</cooldownTime>
+								<chanceFactor>0.65</chanceFactor>
+								<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.2</armorPenetrationSharp>
+								<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<capacities>
+									<li>Bite</li>
+								</capacities>
+								<power>8.7</power>
+								<cooldownTime>1.57</cooldownTime>
+								<chanceFactor>0.6</chanceFactor>
+								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+								<armorPenetrationSharp>0.08</armorPenetrationSharp>
+								<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>head</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>6</power>
+								<cooldownTime>2.12</cooldownTime>
+								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+								<chanceFactor>0.2</chanceFactor>
+								<armorPenetrationBlunt>2</armorPenetrationBlunt>
+							</li>
+						</tools>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 </Patch>

--- a/Patches/Medieval Overhaul/MO_Races.xml
+++ b/Patches/Medieval Overhaul/MO_Races.xml
@@ -9,9 +9,9 @@
          <operations>
 
             <!-- ======= Farm Animal ======= -->
-            <!-- Hampshire, Gloucestershire, Northern Boar -->
+            <!-- Hampshire, Gloucestershire -->
             <li Class="PatchOperationAdd">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/statBases</xpath>
                <value>
                   <MeleeDodgeChance>0.07</MeleeDodgeChance>
                   <MeleeCritChance>0.06</MeleeCritChance>
@@ -20,7 +20,7 @@
             </li>
 
             <li Class="PatchOperationReplace">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]/tools</xpath>
                <value>
                   <tools>
                      <li Class="CombatExtended.ToolCE">
@@ -50,7 +50,7 @@
             </li>
 
             <li Class="PatchOperationAddModExtension">
-               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire" or defName="DankPyon_Gloucestershire"]</xpath>
+               <xpath>Defs/ThingDef[defName="DankPyon_Hampshire" or defName="DankPyon_Gloucestershire"]</xpath>
                <value>
                   <li Class="CombatExtended.RacePropertiesExtensionCE">
                      <bodyShape>Quadruped</bodyShape>
@@ -850,66 +850,137 @@
             </li>
 			
 			<!-- deathstinger - used Megascarab as reference -->
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
-					<value>
-						<MoveSpeed>5.1</MoveSpeed>
-						<MeleeDodgeChance>0.22</MeleeDodgeChance>
-						<MeleeCritChance>0.03</MeleeCritChance>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>5.1</MoveSpeed>
+					<MeleeDodgeChance>0.22</MeleeDodgeChance>
+					<MeleeCritChance>0.03</MeleeCritChance>
+				</value>
+			</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>mandibles</label>
-								<capacities>
-									<li>Bite</li>
-								</capacities>
-								<power>9</power>
-								<cooldownTime>1.5</cooldownTime>
-								<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-								<armorPenetrationSharp>0.24</armorPenetrationSharp>
-								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-							</li>
-							<li Class="CombatExtended.ToolCE">
-								<label>head</label>
-								<capacities>
-									<li>Blunt</li>
-								</capacities>
-								<power>1</power>
-								<cooldownTime>1.26</cooldownTime>
-								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
-							</li>
-						</tools>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>mandibles</label>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>9</power>
+							<cooldownTime>1.5</cooldownTime>
+							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.24</armorPenetrationSharp>
+							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>1</power>
+							<cooldownTime>1.26</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
-					<value>
-						<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+				</value>
+			</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
-					<value>
-						<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.7</ArmorRating_Sharp>
+				</value>
+			</li>
 
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
-					<value>
-						<baseHealthScale>0.5</baseHealthScale>
-					</value>
-				</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_Deathstinger"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>0.5</baseHealthScale>
+				</value>
+			</li>
+				
+			<!-- northern boar - used wildboar as reference -->
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]</xpath>
+				<value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+						<bodyShape>Quadruped</bodyShape>
+					</li>
+				</value>
+			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.14</MeleeCritChance>
+					<MeleeParryChance>0.14</MeleeParryChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DankPyon_NorthernBoar"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Cut</li>
+							</capacities>
+							<power>11</power>
+							<cooldownTime>1.89</cooldownTime>
+							<linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.1</armorPenetrationSharp>
+							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>tusk</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>7</power>
+							<cooldownTime>1.41</cooldownTime>
+							<chanceFactor>0.65</chanceFactor>
+							<linkedBodyPartsGroup>TuskAttackTool_2</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.2</armorPenetrationSharp>
+							<armorPenetrationBlunt>2.940</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<power>8.7</power>
+							<cooldownTime>1.57</cooldownTime>
+							<chanceFactor>0.6</chanceFactor>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<armorPenetrationSharp>0.08</armorPenetrationSharp>					
+							<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>Blunt</li>
+							</capacities>
+							<power>6</power>
+							<cooldownTime>2.12</cooldownTime>
+							<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+							<chanceFactor>0.2</chanceFactor>
+							<armorPenetrationBlunt>2</armorPenetrationBlunt>
+						</li>
+					</tools>
+				</value>
+			</li>
          </operations>
       </match>
    </Operation>


### PR DESCRIPTION
## Additions

Added Deathstinger, and Northern Boar support for MO
Added Missing ModExtension for DireBoar


## Reasoning
DeathStinger values were compared to a Megascarab because it looked like it was copy pasted in vanilla.
Northern Boar values were compared to a wild boar because it looked like it was copy pasted in vanilla.
DireBoar is a Quadruped animal.
This is to properly patch the animals so the autopatcher doesn't do it.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
