### PR TITLE
Wild boar patch operation change

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -424,8 +424,8 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="WildBoar"]/statBases/MoveSpeed</xpath>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="WildBoar"]/statBases</xpath>
 		<value>
 			<MeleeDodgeChance>0.16</MeleeDodgeChance>
 			<MeleeCritChance>0.09</MeleeCritChance>


### PR DESCRIPTION
## Changes

Changed the Patch Operation from replace to add

## Reasoning

Movespeed isn't being modified like the previous animals.

## Alternatives

Add a movespeed value to override vanilla

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
