### PR TITLE
Fix ThingsNearSegment, make average projectiles apply suppression around travel path

### DIFF
--- a/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
+++ b/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
@@ -167,26 +167,26 @@ namespace CombatExtended.Utilities
         public IEnumerable<Thing> ThingsNearSegment(IntVec3 origin, IntVec3 destination, float range, bool behind)
         {
             float rangeSq = range * range;
-            float minX;
-            float maxX;
+            int minX;
+            int maxX;
             // Find the band of cells (1-D) the line segment spans.  The band is widened on both sides by range.
             // ...<--range---x_min-----x_max---range-->...
             // ...minX-----------------------------maxX...
             if (origin.x > destination.x)
             {
-                minX = destination.x - range;
-                maxX = origin.x + range;
+                minX = destination.x - Mathf.RoundToInt(range);
+                maxX = origin.x + Mathf.RoundToInt(range);
             }
             else
             {
-                minX = origin.x - range;
-                maxX = destination.x + range;
+                minX = origin.x - Mathf.RoundToInt(range);
+                maxX = destination.x + Mathf.RoundToInt(range);
             }
 
             int bottom = 0;
             int index;
             int top = count;
-            int mid = (top + bottom) / 2;
+            int mid = 0;
             int limiter = 0;
             IntVec3 midPosition;
             IntVec3 direction = destination - origin;
@@ -236,7 +236,7 @@ namespace CombatExtended.Utilities
                 Thing t = sortedThings[index++].thing;
                 IntVec3 curPosition = t.Position;
                 // if we're outside the range of interest, we're done checking to the right.
-                if (curPosition.x + range < minX || curPosition.x - range > maxX)
+                if (curPosition.x < minX || curPosition.x > maxX)
                 {
                     break;
                 }
@@ -280,12 +280,12 @@ namespace CombatExtended.Utilities
                 }
             }
             index = mid - 1;
-            while (index >= 0) // Same as above, but moving right.
+            while (index >= 0) // Same as above, but moving left.
             {
                 Thing t = sortedThings[index--].thing;
                 IntVec3 curPosition = t.Position;
                 // if we're outside the range of interest, we're done checking to the right.
-                if (curPosition.x + range < minX || curPosition.x - range > maxX)
+                if (curPosition.x < minX || curPosition.x > maxX)
                 {
                     break;
                 }


### PR DESCRIPTION
## Changes
1. Fixed ThingsNearSegment by stopping later, with minor modifications;
2. Made average projectiles use RayCastSuppression;
3. Made non-explosive projectiles apply suppression upon impact.

## Reasoning
1. With how currently ThingsNearSegment works, it uses a cache of pawns sorted by their position X axis to quickly find which pawns may be within the area of a segment. It limited itself a bit too much within the X axis when checking pawn positions that it cut its checking area off.
2. Projectiles would apply suppression to pawns in a radius around its current position, therefore slow projectiles could apply more suppression to a single pawn. Now they apply suppression in a range around a segment between the old position and new position.
3. With how I modified which area RayCastSuppression checks, applying suppression on impact was necessary to fully cover the area around the projectile's travel path.

## Alternatives
2., 3. Keep the old suppression within a radius
  - (+) More likely to give better performance;
  - (+) With #2123, the issue of slow projectiles giving more suppression may be remedied;
  - (-) Fast enough projectiles may still skip applying suppression to some tiles;
  - (-) #2123 requires a lot of XML modification.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony.

## Possible issues
- The change nerfs slow projectile suppression while buffing fast projectile suppression, therefore some rebalancing may be required;
- I didn't test many cases, therefore the game may throw exceptions.