### PR TITLE
Better log for animal autopatcher

### DIFF
--- a/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
@@ -102,8 +102,11 @@ namespace CombatExtended.Compatibility
                 patchCount++;
                 patchedanimals += animal.ToString() + "\n";
             }
-
-            Log.Message("CE successfully patched " + patchCount.ToString() + " animals.\nThese are the Defs:" + patchedanimals);
+            // Don't show log if no animals being patched in autopatcher.
+            if (patchCount > 0)
+            {
+                Log.Message("CE successfully patched " + patchCount.ToString() + " animals.\nAnimal Defs autopatched:" + patchedanimals);
+            }
             //Log.Message(patchedanimals);
 
             #endregion

--- a/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
@@ -102,7 +102,7 @@ namespace CombatExtended.Compatibility
                 patchCount++;
                 patchedanimals += animal.ToString() + "\n";
             }
-            // Don't show log if no animals being patched in autopatcher.
+            // Don't show log if there are no animals being patched by autopatcher.
             if (patchCount > 0)
             {
                 Log.Message("CE successfully patched " + patchCount.ToString() + " animals.\nAnimal Defs autopatched:" + patchedanimals);

--- a/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/RaceAutoPatchers/RaceAutoPatcher.cs
@@ -26,6 +26,7 @@ namespace CombatExtended.Compatibility
                                                                       );
 
             int patchCount = 0;
+            string patchedanimals = "";
             foreach (ThingDef animal in animalsUnpatched)
             {
                 if (animal.modExtensions == null)
@@ -99,9 +100,11 @@ namespace CombatExtended.Compatibility
                 }
 
                 patchCount++;
+                patchedanimals += animal.ToString() + "\n";
             }
 
-            Log.Message("CE successfully patched " + patchCount.ToString() + " animals");
+            Log.Message("CE successfully patched " + patchCount.ToString() + " animals.\nThese are the Defs:" + patchedanimals);
+            //Log.Message(patchedanimals);
 
             #endregion
 


### PR DESCRIPTION
## Additions

Adds which defs are being patched by autopatcher.
Stops log from showing if no animals are autopatched.

## Reasoning

For patch contribs to know which animal(s) they forgot to patch or if a mod added more animals.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
