### PR TITLE
Patch Steamworld Uniforms.

### DIFF
--- a/Patches/Steamworld Uniforms/Apparel_Various.xml
+++ b/Patches/Steamworld Uniforms/Apparel_Various.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Steamworld Uniforms</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Headgear -->
+		<!-- Caps -->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_Caps_Base"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>				
+			</value>
+		</li>
+
+		<!-- Helmets (Slightly more protection than vanilla simple helmet.) -->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="Steamworld_Helmet_Base"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<Bulk>3.5</Bulk>
+				<WornBulk>1</WornBulk>
+				<StuffEffectMultiplierArmor>4.25</StuffEffectMultiplierArmor>				
+			</value>
+		</li>
+
+		<!-- Pith Helmets (Armor based upon roughly material thickness in cloth/wood.)-->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_PithHelm"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<Bulk>3.5</Bulk>
+				<WornBulk>1</WornBulk>
+				<ArmorRating_Sharp>0.95</ArmorRating_Sharp>				
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_PithHelm"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>1.25</ArmorRating_Blunt>				
+			</value>
+		</li>
+
+		<!-- Jackets -->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_UniformJacketBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<Bulk>5</Bulk>
+				<WornBulk>1</WornBulk>
+				<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>				
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="SteamworldUniforms_ZouaveJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>				
+			</value>
+		</li>
+
+		<!-- Rolled-up Bedroll -->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="SteamworldUniforms_BedRoll"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<Bulk>4</Bulk>
+				<WornBulk>1.5</WornBulk>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>				
+			</value>
+		</li>
+
+		<!-- Decorations -->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_Gold"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<Bulk>0.25</Bulk>
+				<ArmorRating_Sharp>0.05</ArmorRating_Sharp>				
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[@Name="SteamworldUniforms_Gold"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>0.05</ArmorRating_Blunt>				
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Steamworld Uniforms/Apparel_Various.xml
+++ b/Patches/Steamworld Uniforms/Apparel_Various.xml
@@ -17,13 +17,13 @@
 			</value>
 		</li>
 
-		<!-- Helmets (Slightly more protection than vanilla simple helmet.) -->
+		<!-- Helmets -->
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[@Name="Steamworld_Helmet_Base"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<Bulk>3.5</Bulk>
 				<WornBulk>1</WornBulk>
-				<StuffEffectMultiplierArmor>4.25</StuffEffectMultiplierArmor>				
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>				
 			</value>
 		</li>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -390,17 +390,18 @@ Silkiera Race	|
 Simple Ogre Race  |
 Simply More Melee	|
 Slime Rancher	|
+Solark Race |
 Soviet Armory	|
 Space Worms (Continued) |
 Spartan Foundry	|
 Spidercamp's Horses     |
 Stalingrad – Uniforms   |
+Steamworld Uniforms |
 Star Crafters Armory  |
 Star Wars - Droids |
 Star Wars - Factions |
 Star Wars - Factions (Continued) |
 Starship Troopers Aracnids  |
-Solark Race |
 Swords (Continued)  |
 Tactical Extremity Protection [BAL] |
 Textiles+ (continued)   |


### PR DESCRIPTION
## Additions
- Patch Steamworld uniforms. Most of the equipment are stuffable caps or jackets, made equivalent to their vanilla counterparts (the tuque/bowler and the jacket, respectively). Also includes a pith helmet and a pickelhaube (spiked helmet), which have been given appropriate armor/material thicknesses.

## Reasoning
- The pith helmet is made from a combination of wood and cloth, and the material is fairly thick but light. As such, it's strong enough to protect the head from edged attacks reasonably well and has some ability to absorb the energy of blows.
- The vanilla armor value given to the spiked helmets (slightly higher than that of the simple helmet) show that the mod author clearly intends them to be viable combat helmets. This isn't historically accurate (most real helmets were made of felt or leather, and metal examples were about ~1.2mm thick. they provided little protection from shrapnel/gunfire), but is reasonable for their intended purpose in-game. As a compromise, I've given them the same thickness as the simple helmet but kept them as `metallic` rather than making them `steeled`, since many real spiked helmets were intended for ceremonial purposes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
