### PR TITLE
Patch Logistic Mech Mod

### DIFF
--- a/Patches/Logistics_Mechanoid/Bodies_Mechanoid_Heavy.xml
+++ b/Patches/Logistics_Mechanoid/Bodies_Mechanoid_Heavy.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		  <li>Logistics_Mechanoid</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		 <operations>
+
+      <!-- ==================== Logistic Mech ==================== -->
+
+      <!-- ========== Add groups entry if it doesn't exist already ========== -->
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <li Class="PatchOperationConditional">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+        <nomatch Class="PatchOperationAdd">
+          <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]</xpath>
+          <value>
+            <groups />
+          </value>
+        </nomatch>
+      </li>
+
+      <!-- ========== Add armor coverage ========== -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts/li[def="PowerClaw"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/parts/li[def="MechanicalFoot"]/groups</xpath>
+        <value>
+          <li>CoveredByNaturalArmor</li>
+        </value>
+      </li>
+
+      <!-- ========== Modify coverage ========== -->
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/coverage</xpath>
+        <value>
+          <coverage>0.08</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+        <value>
+          <coverage>0.75</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="ArtificialBrain"]/coverage</xpath>
+        <value>
+          <coverage>0.15</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SightSensor"]/coverage</xpath>
+        <value>
+          <coverage>0.15</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="HearingSensor"]/coverage</xpath>
+        <value>
+          <coverage>0.05</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def="SmellSensor"]/coverage</xpath>
+        <value>
+          <coverage>0.05</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/coverage</xpath>
+        <value>
+          <coverage>0.15</coverage>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/coverage</xpath>
+        <value>
+          <coverage>0.1</coverage>
+        </value>
+      </li>
+
+      <!-- ========== Remove unwanted vanilla body parts ========== -->
+
+      <li Class="PatchOperationRemove">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="Reactor"]</xpath>
+      </li>
+
+      <li Class="PatchOperationRemove">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="FluidReprocessor"]</xpath>
+      </li>
+
+      <!-- ========== Add new body parts ========== -->
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts</xpath>
+        <value>
+          <li>
+            <def>MechanicalPowerCore</def>
+            <coverage>0.12</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalCapacitor</def>
+            <coverage>0.02</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalCapacitor</def>
+            <coverage>0.02</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalHeatSink</def>
+            <coverage>0.03</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalHeatSink</def>
+            <coverage>0.03</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalCoolantTank</def>
+            <coverage>0.06</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalRollerBearing</def>
+            <coverage>0.06</coverage>
+            <depth>Inside</depth>
+          </li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalShoulder"]/parts/li[def="MechanicalArm"]/parts</xpath>
+        <value>
+          <li>
+            <def>MechanicalUpperActuator</def>
+            <coverage>0.15</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalUpperPiston</def>
+            <coverage>0.25</coverage>
+            <depth>Inside</depth>
+          </li>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/BodyDef[defName="Mech_Logistic"]/corePart/parts/li[def="MechanicalLeg"]/parts</xpath>
+        <value>
+          <li>
+            <def>MechanicalLowerActuator</def>
+            <coverage>0.15</coverage>
+            <depth>Inside</depth>
+          </li>
+          <li>
+            <def>MechanicalLowerPiston</def>
+            <coverage>0.25</coverage>
+            <depth>Inside</depth>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>			  

--- a/Patches/Logistics_Mechanoid/MeleeMechanoid.xml
+++ b/Patches/Logistics_Mechanoid/MeleeMechanoid.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		  <li>Logistics_Mechanoid</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		  <operations>
+
+      <!-- Hydraulic Claws -->
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName = "MeleeWeapon_HydraulicClaw"]/statBases</xpath>
+        <value>
+          <MeleeCounterParryBonus>0.28</MeleeCounterParryBonus>
+          <Bulk>0</Bulk>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="MeleeWeapon_HydraulicClaw"]/tools</xpath>
+        <value>
+          <tools>
+            <li Class="CombatExtended.ToolCE">
+              <label>base</label>
+              <capacities>
+                <li>Poke</li>
+              </capacities>
+              <power>28</power>
+              <cooldownTime>3.51</cooldownTime>
+              <armorPenetrationBlunt>13</armorPenetrationBlunt>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+              <label>pincer</label>
+              <labelUsedInLogging>false</labelUsedInLogging>
+              <capacities>
+                <li>Blunt</li>
+              </capacities>
+              <power>28</power>
+              <cooldownTime>3.51</cooldownTime>
+              <armorPenetrationBlunt>13</armorPenetrationBlunt>
+            </li>            
+          </tools>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>	

--- a/Patches/Logistics_Mechanoid/Races_Mechanoids_Heavy.xml
+++ b/Patches/Logistics_Mechanoid/Races_Mechanoids_Heavy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+		<li>Logistics_Mechanoid</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+		 <operations>
+
+		<!-- ========== Logistics ========== -->
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Mech_Logistic"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>QuadrupedLow</bodyShape>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Mech_Logistic"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>12</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Mech_Logistic"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>8</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="Mech_Logistic"]/statBases</xpath>
+			<value>
+				<CarryWeight>250</CarryWeight>
+				<CarryBulk>60</CarryBulk>			
+				<MeleeDodgeChance>0.09</MeleeDodgeChance>
+				<MeleeCritChance>0.21</MeleeCritChance>
+				<MeleeParryChance>0.44</MeleeParryChance>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Mech_Logistic"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>2.51</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>	

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -256,6 +256,7 @@ Lemolim Race    |
 Let's Have a Cat!	|
 Littluna Race |
 Logann Race	|
+Logistics_Mechanoid |
 Magical Menagerie	|
 Magic Wands |
 Makeshift Melee Weapons |


### PR DESCRIPTION
## Additions
- Patches the new mech added by the Logistics Mech mod. Patches the new body (which is virtually identical to the Tunneler body) and the logi mech's melee weapon, which was made as a separate weapon for some reason.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
