### PR TITLE
Tweaks - Medieval Overhaul

### DIFF
--- a/Patches/Medieval Overhaul/MO_Weapons_Melee.xml
+++ b/Patches/Medieval Overhaul/MO_Weapons_Melee.xml
@@ -62,6 +62,7 @@
 -->
 
 <Patch>
+
    <Operation Class="PatchOperationFindMod">
       <mods>
          <li>Medieval Overhaul</li>
@@ -2413,10 +2414,10 @@
                         <capacities>
                            <li>Poke</li>
                         </capacities>
-                        <power>5</power>
+                        <power>9</power>
                         <cooldownTime>1.69</cooldownTime>
                         <chanceFactor>0.05</chanceFactor>
-                        <armorPenetrationBlunt>0.8</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2424,11 +2425,11 @@
                         <capacities>
                            <li>Stab</li>
                         </capacities>
-                        <power>30</power>
+                        <power>49</power>
                         <cooldownTime>1.98</cooldownTime>
                         <chanceFactor>0.50</chanceFactor>
-                        <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
-                        <armorPenetrationSharp>2.375</armorPenetrationSharp>
+                        <armorPenetrationBlunt>1.95</armorPenetrationBlunt>
+                        <armorPenetrationSharp>4.64</armorPenetrationSharp>
                         <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2436,11 +2437,11 @@
                         <capacities>
                            <li>Cut</li>
                         </capacities>
-                        <power>54</power>
+                        <power>99</power>
                         <cooldownTime>2.86</cooldownTime>
                         <chanceFactor>0.45</chanceFactor>
-                        <armorPenetrationBlunt>4.392</armorPenetrationBlunt>
-                        <armorPenetrationSharp>0.60</armorPenetrationSharp>
+                        <armorPenetrationBlunt>8.75</armorPenetrationBlunt>
+                        <armorPenetrationSharp>1.41</armorPenetrationSharp>
                         <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                      </li>
                   </tools>
@@ -2476,10 +2477,10 @@
                         <capacities>
                            <li>Poke</li>
                         </capacities>
-                        <power>3</power>
+                        <power>4</power>
                         <cooldownTime>1.59</cooldownTime>
                         <chanceFactor>0.10</chanceFactor>
-                        <armorPenetrationBlunt>0.785</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2487,10 +2488,10 @@
                         <capacities>
                            <li>Blunt</li>
                         </capacities>
-                        <power>33</power>
+                        <power>45</power>
                         <cooldownTime>3.30</cooldownTime>
                         <chanceFactor>0.90</chanceFactor>
-                        <armorPenetrationBlunt>17.785</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>32.28</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                      </li>
                   </tools>
@@ -2526,7 +2527,7 @@
                         <capacities>
                            <li>Poke</li>
                         </capacities>
-                        <power>4</power>
+                        <power>6</power>
                         <cooldownTime>1.3</cooldownTime>
                         <chanceFactor>0.05</chanceFactor>
                         <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
@@ -2537,10 +2538,10 @@
                         <capacities>
                            <li>Blunt</li>
                         </capacities>
-                        <power>18</power>
+                        <power>28</power>
                         <cooldownTime>2.18</cooldownTime>
                         <chanceFactor>0.25</chanceFactor>
-                        <armorPenetrationBlunt>12</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>23.4</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2548,11 +2549,11 @@
                         <capacities>
                            <li>Cut</li>
                         </capacities>
-                        <power>46</power>
+                        <power>76</power>
                         <cooldownTime>2.18</cooldownTime>
                         <chanceFactor>0.70</chanceFactor>
-                        <armorPenetrationBlunt>12</armorPenetrationBlunt>
-                        <armorPenetrationSharp>1.18</armorPenetrationSharp>
+                        <armorPenetrationBlunt>23.4</armorPenetrationBlunt>
+                        <armorPenetrationSharp>2.31</armorPenetrationSharp>
                         <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                      </li>
                   </tools>
@@ -2588,10 +2589,10 @@
                         <capacities>
                            <li>Poke</li>
                         </capacities>
-                        <power>3</power>
+                        <power>4</power>
                         <cooldownTime>1.59</cooldownTime>
                         <chanceFactor>0.05</chanceFactor>
-                        <armorPenetrationBlunt>0.785</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2599,10 +2600,10 @@
                         <capacities>
                            <li>Blunt</li>
                         </capacities>
-                        <power>30</power>
+                        <power>45</power>
                         <cooldownTime>2.86</cooldownTime>
                         <chanceFactor>0.95</chanceFactor>
-                        <armorPenetrationBlunt>16.525</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>32.28</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                      </li>
                   </tools>
@@ -2638,9 +2639,9 @@
                         <capacities>
                            <li>Blunt</li>
                         </capacities>
-                        <power>7</power>
+                        <power>11</power>
                         <cooldownTime>1.31</cooldownTime>
-                        <armorPenetrationBlunt>2.525</armorPenetrationBlunt>
+                        <armorPenetrationBlunt>4.94</armorPenetrationBlunt>
                         <linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2648,11 +2649,11 @@
                         <capacities>
                            <li>Cut</li>
                         </capacities>
-                        <power>59</power>
+                        <power>97</power>
                         <cooldownTime>2.9</cooldownTime>
                         <chanceFactor>1.165</chanceFactor>
-                        <armorPenetrationBlunt>10.125</armorPenetrationBlunt>
-                        <armorPenetrationSharp>2.025</armorPenetrationSharp>
+                        <armorPenetrationBlunt>19.75</armorPenetrationBlunt>
+                        <armorPenetrationSharp>3.95</armorPenetrationSharp>
                         <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
                      </li>
                      <li Class="CombatExtended.ToolCE">
@@ -2660,11 +2661,11 @@
                         <capacities>
                            <li>Stab</li>
                         </capacities>
-                        <power>50</power>
+                        <power>82</power>
                         <cooldownTime>1.16</cooldownTime>
                         <chanceFactor>1.165</chanceFactor>
-                        <armorPenetrationBlunt>2.525</armorPenetrationBlunt>
-                        <armorPenetrationSharp>2.535</armorPenetrationSharp>
+                        <armorPenetrationBlunt>4.95</armorPenetrationBlunt>
+                        <armorPenetrationSharp>4.94</armorPenetrationSharp>
                         <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
                      </li>
                   </tools>
@@ -2674,4 +2675,5 @@
          </operations>
       </match>
    </Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- adjusted base damage, sharp and blunt penetration value for Named Melee Weapons

## Reasoning

Why did you choose to implement things this way, e.g.
- The original mod author implied that Named is an equivalent of their Legendary quality Plasteel counterpart
- their value is so low that it's _Nameless_ weapon now

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
