### PR TITLE
Reduce Sniper and Autocannon Power Consumption and HP

### DIFF
--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -125,7 +125,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>1500</basePowerConsumption>
+				<basePowerConsumption>450</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>
@@ -192,7 +192,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>1250</basePowerConsumption>
+				<basePowerConsumption>450</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>
@@ -200,7 +200,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="AutocannonTurret"]/statBases/MaxHitPoints</xpath>
 		<value>
-			<MaxHitPoints>750</MaxHitPoints>
+			<MaxHitPoints>500</MaxHitPoints>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -125,7 +125,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>600</basePowerConsumption>
+				<basePowerConsumption>500</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>
@@ -192,7 +192,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>600</basePowerConsumption>
+				<basePowerConsumption>500</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -125,7 +125,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>450</basePowerConsumption>
+				<basePowerConsumption>600</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>
@@ -192,7 +192,7 @@
 		<value>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>450</basePowerConsumption>
+				<basePowerConsumption>600</basePowerConsumption>
 			</li>	
 		</value>
 	</Operation>


### PR DESCRIPTION
## Changes
- Reduce autocannon & sniper turret power consumption from 1250 to 500 Watts.
- Decrease the autocannon & sniper hitpoints from 750 to 500.

## Reasoning
Given their effectiveness, it's not desirable to let the player easily operate a large number of higher quality turrets like the sniper and autocannon turrets. The being said, having each turret consume 1250 Watts is quite excessive. A well-established colony with a reliable source of power should be able to practically support 4 - 6 advanced turrets (which is a reasonable number to spread across a larger perimeter to supplement other defenses) without needing to heavily invest in whole new power grid to support them. Yes, a player can reduce this burden with effective power management (e.g turning turrets of when not in use), but that's besides the point.

Currently, 4 - 6 turrets would require 5000 - 7500 W, meaning the turrets _alone_ would require power output equivalent to 2 - 3 geothermal generators. And that's before other necessary colony power consumers like lighting and production facilities. 

Adjusted to 500 W, these turrets still consume far more than in vanilla (150 W), but are much less of a burden on a colony's power grid. Given that they're quite resistant to gunfire already and no longer explode on destruction, I've decreased their max HP to compensate for the fact it's now practical for the player to have a few more.

It may be worth discussing what other military-grade turrets from mods and CE should have their power consumption tweaked in line with these changes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
