### PR TITLE
Various CE turret adjustments

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -16,7 +16,7 @@
     <techLevel>Industrial</techLevel>
     <statBases>
       <MaxHitPoints>100</MaxHitPoints>
-      <Flammability>0.1</Flammability>
+      <Flammability>0.7</Flammability>
       <WorkToMake>10000</WorkToMake>
       <Beauty>-60</Beauty>
     </statBases>
@@ -120,13 +120,13 @@
     <comps>
       <li Class="CompProperties_Power">
         <compClass>CompPowerTrader</compClass>
-        <basePowerConsumption>950</basePowerConsumption>
+        <basePowerConsumption>400</basePowerConsumption>
       </li>
     </comps>
     <description>Automatic turret equipped with a charge blaster.</description>
     <costList>
-      <Steel>65</Steel>
-      <Plasteel>30</Plasteel>
+      <Steel>125</Steel>
+      <Plasteel>40</Plasteel>
       <ComponentIndustrial>12</ComponentIndustrial>
     </costList>
     <building>
@@ -160,7 +160,7 @@
     <statBases>
       <WorkToBuild>80000</WorkToBuild>
       <MaxHitPoints>350</MaxHitPoints>
-      <Flammability>0.05</Flammability>
+      <Flammability>0.5</Flammability>
       <Mass>60</Mass>
       <Bulk>80</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
@@ -184,7 +184,7 @@
     <comps>
       <li Class="CompProperties_Power">
         <compClass>CompPowerTrader</compClass>
-        <basePowerConsumption>700</basePowerConsumption>
+        <basePowerConsumption>300</basePowerConsumption>
       </li>
     </comps>
     <minifiedDef>MinifiedThing</minifiedDef>
@@ -210,7 +210,7 @@
     <statBases>
       <WorkToBuild>40000</WorkToBuild>
       <MaxHitPoints>200</MaxHitPoints>
-      <Flammability>0.5</Flammability>
+      <Flammability>0.6</Flammability>
       <Mass>30</Mass>
       <Bulk>40</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
@@ -219,7 +219,7 @@
     <techLevel>Industrial</techLevel>
     <description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
     <costList>
-      <Steel>125</Steel>
+      <Steel>150</Steel>
       <ComponentIndustrial>8</ComponentIndustrial>
     </costList>
     <building>
@@ -233,7 +233,7 @@
     <comps>
       <li Class="CompProperties_Power">
         <compClass>CompPowerTrader</compClass>
-        <basePowerConsumption>300</basePowerConsumption>
+        <basePowerConsumption>150</basePowerConsumption>
       </li>
     </comps>
     <minifiedDef>MinifiedThing</minifiedDef>
@@ -263,7 +263,7 @@
     <description>KPV heavy machine gun mounted on a tripod.</description>
     <costList>
       <Steel>275</Steel>
-      <ComponentIndustrial>4</ComponentIndustrial>
+      <ComponentIndustrial>6</ComponentIndustrial>
     </costList>
     <building>
       <turretGunDef>Gun_KPV</turretGunDef>
@@ -294,15 +294,14 @@
     </graphicData>
     <uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
     <statBases>
-      <Flammability>1.0</Flammability>
       <WorkToBuild>31500</WorkToBuild>
       <Mass>16.5</Mass>
       <Bulk>20</Bulk>
     </statBases>
     <description>M240B medium machine gun mounted on a tripod.</description>
     <costList>
-      <Steel>125</Steel>
-      <ComponentIndustrial>4</ComponentIndustrial>
+      <Steel>150</Steel>
+      <ComponentIndustrial>6</ComponentIndustrial>
     </costList>
     <building>
       <turretGunDef>Gun_M240B</turretGunDef>
@@ -373,6 +372,7 @@
     <uiIconPath>UI/Icons/Turrets/FlakTurret_uiIcon</uiIconPath>
     <statBases>
       <MaxHitPoints>500</MaxHitPoints>
+      <Flammability>0.4</Flammability>
       <WorkToBuild>79500</WorkToBuild>
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -110,7 +110,7 @@
     <uiIconPath>UI/Icons/Turrets/ChargeBlaster_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>48000</WorkToBuild>
-      <MaxHitPoints>250</MaxHitPoints>
+      <MaxHitPoints>150</MaxHitPoints>
       <Mass>20</Mass>
       <Bulk>25</Bulk>
       <AimingAccuracy>0.75</AimingAccuracy>
@@ -159,7 +159,7 @@
     <uiIconPath>UI/Icons/Turrets/HeavyAutoTurret_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>80000</WorkToBuild>
-      <MaxHitPoints>550</MaxHitPoints>
+      <MaxHitPoints>350</MaxHitPoints>
       <Flammability>0.05</Flammability>
       <Mass>60</Mass>
       <Bulk>80</Bulk>
@@ -209,7 +209,7 @@
     <uiIconPath>UI/Icons/Turrets/MediumAutoTurret_uiIcon</uiIconPath>
     <statBases>
       <WorkToBuild>40000</WorkToBuild>
-      <MaxHitPoints>300</MaxHitPoints>
+      <MaxHitPoints>200</MaxHitPoints>
       <Flammability>0.5</Flammability>
       <Mass>30</Mass>
       <Bulk>40</Bulk>
@@ -219,8 +219,8 @@
     <techLevel>Industrial</techLevel>
     <description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
     <costList>
-      <Steel>175</Steel>
-      <ComponentIndustrial>6</ComponentIndustrial>
+      <Steel>125</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
     </costList>
     <building>
       <ai_combatDangerous>true</ai_combatDangerous>
@@ -239,43 +239,6 @@
     <minifiedDef>MinifiedThing</minifiedDef>
     <researchPrerequisites>
       <li>GunTurrets</li>
-      <li>PrecisionRifling</li>
-    </researchPrerequisites>
-  </ThingDef>
-
-  <!--=============== M240B ===============-->
-
-  <ThingDef ParentName="TurretMannedBuildableBase">
-    <defName>Turret_M240B</defName>
-    <label>M240B</label>
-    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-    <graphicData>
-      <texPath>Things/Building/Turrets/M240_base</texPath>
-      <drawSize>(2,2)</drawSize>
-    </graphicData>
-    <uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
-    <statBases>
-      <Flammability>1.0</Flammability>
-      <WorkToBuild>31500</WorkToBuild>
-      <Mass>16.5</Mass>
-      <Bulk>20</Bulk>
-    </statBases>
-    <description>M240B medium machine gun mounted on a tripod.</description>
-    <costList>
-      <Steel>125</Steel>
-      <ComponentIndustrial>4</ComponentIndustrial>
-    </costList>
-    <building>
-      <turretGunDef>Gun_M240B</turretGunDef>
-      <ai_combatDangerous>true</ai_combatDangerous>
-      <turretBurstCooldownTime>0.36</turretBurstCooldownTime>
-    </building>
-    <placeWorkers>
-      <li>PlaceWorker_TurretTop</li>
-      <li>PlaceWorker_ShowTurretRadius</li>
-    </placeWorkers>
-    <minifiedDef>MinifiedThing</minifiedDef>
-    <researchPrerequisites>
       <li>PrecisionRifling</li>
     </researchPrerequisites>
   </ThingDef>
@@ -317,6 +280,43 @@
       <li>PrecisionRifling</li>
     </researchPrerequisites>
     <minifiedDef>MinifiedThing</minifiedDef>
+  </ThingDef>
+
+  <!--=============== M240B ===============-->
+
+  <ThingDef ParentName="TurretMannedBuildableBase">
+    <defName>Turret_M240B</defName>
+    <label>M240B</label>
+    <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+    <graphicData>
+      <texPath>Things/Building/Turrets/M240_base</texPath>
+      <drawSize>(2,2)</drawSize>
+    </graphicData>
+    <uiIconPath>UI/Icons/Turrets/M240B_uiIcon</uiIconPath>
+    <statBases>
+      <Flammability>1.0</Flammability>
+      <WorkToBuild>31500</WorkToBuild>
+      <Mass>16.5</Mass>
+      <Bulk>20</Bulk>
+    </statBases>
+    <description>M240B medium machine gun mounted on a tripod.</description>
+    <costList>
+      <Steel>125</Steel>
+      <ComponentIndustrial>4</ComponentIndustrial>
+    </costList>
+    <building>
+      <turretGunDef>Gun_M240B</turretGunDef>
+      <ai_combatDangerous>true</ai_combatDangerous>
+      <turretBurstCooldownTime>0.36</turretBurstCooldownTime>
+    </building>
+    <placeWorkers>
+      <li>PlaceWorker_TurretTop</li>
+      <li>PlaceWorker_ShowTurretRadius</li>
+    </placeWorkers>
+    <minifiedDef>MinifiedThing</minifiedDef>
+    <researchPrerequisites>
+      <li>PrecisionRifling</li>
+    </researchPrerequisites>
   </ThingDef>
 
   <!--=============== AGS-30 ===============-->

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -137,14 +137,14 @@
 		</value>
 	</Operation>
 
-    <Operation Class="PatchOperationReplace">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</value>
-    </Operation>
+	</Operation>
 
-    <Operation Class="PatchOperationReplace">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Sniper"]/costList</xpath>
 		<value>
 			<costList>
@@ -152,9 +152,9 @@
 				<Plasteel>30</Plasteel>
 				<Uranium>60</Uranium>
 				<ComponentIndustrial>10</ComponentIndustrial>
-			</costList>    
+			</costList>
 		</value>
-    </Operation>
+	</Operation>
 
 	<!-- ========== Autocannon turret ========== -->
 
@@ -205,29 +205,36 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AutocannonTurret"]/statBases/Flammability</xpath>
+		<value>
+			<Flammability>0.4</Flammability>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/statBases/ShootingAccuracyTurret</xpath>
 		<value>
 			<ShootingAccuracyTurret>1.25</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 
-    <Operation Class="PatchOperationReplace">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 		</value>
-    </Operation>
+	</Operation>
 
-    <Operation Class="PatchOperationReplace">
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Turret_Autocannon"]/costList</xpath>
 		<value>
-		<costList>
-			<Steel>425</Steel>
-			<Plasteel>40</Plasteel>
-			<ComponentIndustrial>9</ComponentIndustrial>
-		</costList>  
+			<costList>
+				<Steel>425</Steel>
+				<Plasteel>40</Plasteel>
+				<ComponentIndustrial>9</ComponentIndustrial>
+			</costList>
 		</value>
-    </Operation>
+	</Operation>
 
 	<!-- ========== Foam Turret ========== -->
 
@@ -274,11 +281,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/costList/Chemfuel</xpath>
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/placeWorkers/li[.="PlaceWorker_ShowTurretRadius"]</xpath>
 	</Operation>
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/placeWorkers/li[.="PlaceWorker_ShowTurretRadius"]</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>300</MaxHitPoints>
+		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
@@ -299,6 +309,17 @@
 		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>4.2</turretBurstCooldownTime>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Turret_RocketswarmLauncher"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>300</Steel>
+				<Plasteel>30</Plasteel>
+				<ComponentIndustrial>5</ComponentIndustrial>
+			</costList>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Decreased the base CE auto turrets' HP to be in line with the changes made in #2208 
- Tweaked the medium turret's cost list to be a M240B with the extra components for the automation purposes.
- Tweaked CE and base game turret flammability.
- Tweaked the Rocketswarm turret's cost list to be more in line with the other 2x2 ones.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
