### PR TITLE
Patch the Alpha Genes' Crab Claw

### DIFF
--- a/Patches/Alpha Genes/HediffDefs/Hediffs_Attacks.xml
+++ b/Patches/Alpha Genes/HediffDefs/Hediffs_Attacks.xml
@@ -36,10 +36,28 @@
 									<capacities>
 										<li>Cut</li>
 									</capacities>
-									<power>26</power>
-									<cooldownTime>1.5</cooldownTime>
+									<power>13</power>
+									<cooldownTime>1.0</cooldownTime>
 									<armorPenetrationSharp>0.5</armorPenetrationSharp>
 									<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+								</li>
+							</tools>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/HediffDef[defName="AG_CrabClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+						<value>
+							<tools>
+								<li Class="CombatExtended.ToolCE">
+									<label>claw</label>
+									<capacities>
+										<li>Cut</li>
+									</capacities>
+									<power>26</power>
+									<cooldownTime>2.0</cooldownTime>
+									<armorPenetrationSharp>0.5</armorPenetrationSharp>
+									<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 								</li>
 							</tools>
 						</value>


### PR DESCRIPTION
## Changes

- What it says on the tin, it's a new hediff attached to a gene.
- Tweaked the chainsaw hands to attack x2 faster but deal half damage.

## Reasoning

- Chainsaw go vroom vroom.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
