### PR TITLE
Ignore optimized .dds textures from Rimpy / png2dds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,8 @@ _ReSharper*/
 Assembly-CSharp.dll 
 UnityEngine.dll 
 
+# Exclude optimized .dds textures from RimPy / png2dds
+*.dds
+
+
 .idea/


### PR DESCRIPTION


## Reasoning

This makes life easier for people like me that install and work on CE using Git but also use png2dds to optimize textures.


