### PR TITLE
Second attempt at #2201

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -598,8 +598,12 @@ namespace CombatExtended
 
         private void RayCastSuppression(IntVec3 muzzle, IntVec3 destination, Map map = null)
         {
+            if (muzzle == destination)
+            {
+                return;
+            }
             map ??= base.Map;
-            foreach (Pawn pawn in muzzle.PawnsNearSegment(destination, map, SuppressionRadius, false, false).Union(destination.PawnsInRange(map, SuppressionRadius)).Except(muzzle.PawnsInRange(map, SuppressionRadius)))
+            foreach (Pawn pawn in muzzle.PawnsNearSegment(destination, map, SuppressionRadius, false, true).Except(muzzle.PawnsInRange(map, SuppressionRadius)))
             {
                 ApplySuppression(pawn);
             }

--- a/Source/CombatExtended/Utilities/GenClosest.cs
+++ b/Source/CombatExtended/Utilities/GenClosest.cs
@@ -83,10 +83,10 @@ namespace CombatExtended.Utilities
             return ThingsReachableFrom(thing.Map, tracker.SimilarInRangeOf(thing, range), thing, pathEndMode, traverseMode, danger);
         }
 
-        public static IEnumerable<Thing> PawnsNearSegment(this IntVec3 origin, IntVec3 destination, Map map, float range, bool behind = false)
+        public static IEnumerable<Thing> PawnsNearSegment(this IntVec3 origin, IntVec3 destination, Map map, float range, bool behind = false, bool infront = true)
         {
             ThingsTracker tracker = map.GetThingTracker();
-            return tracker.ThingsNearSegment(TrackedThingsRequestCategory.Pawns, origin, destination, range, behind).Select(t => t as Pawn);
+            return tracker.ThingsNearSegment(TrackedThingsRequestCategory.Pawns, origin, destination, range, behind, infront).Select(t => t as Pawn);
         }
 
         public static IEnumerable<Thing> ThingsByDefInRange(this IntVec3 cell, Map map, ThingDef thingDef, float range, PathEndMode pathEndMode = PathEndMode.None, TraverseMode traverseMode = TraverseMode.ByPawn, Danger danger = Danger.Unspecified)

--- a/Source/CombatExtended/Utilities/Tracking/ThingsTracker.cs
+++ b/Source/CombatExtended/Utilities/Tracking/ThingsTracker.cs
@@ -225,10 +225,10 @@ namespace CombatExtended.Utilities
         public IEnumerable<Thing> SimilarInRangeOf(Thing thing, float range) => ThingsInRangeOf(thing.def, thing.Position, range);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IEnumerable<Thing> ThingsNearSegment(TrackedThingsRequestCategory category, IntVec3 origin, IntVec3 destination, float range, bool behind = false)
+        public IEnumerable<Thing> ThingsNearSegment(TrackedThingsRequestCategory category, IntVec3 origin, IntVec3 destination, float range, bool behind = false, bool infront = true)
         {
             ThingsTrackingModel tracker = GetModelFor(category);
-            return tracker.ThingsNearSegment(origin, destination, range, behind);
+            return tracker.ThingsNearSegment(origin, destination, range, behind, infront);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
+++ b/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
@@ -172,7 +172,7 @@ namespace CombatExtended.Utilities
             float lengthSq = direction.x * direction.x + direction.z * direction.z;
             if (lengthSq == 0) // origin and destination cell are the same, so just return all things within range radius of origin.
             {
-                if(infront == false && behind == false) // Let's assume that every point around a point is both infront and behind it
+                if (infront == false && behind == false) // Let's assume that every point around a point is both infront and behind it
                 {
                     yield break;
                 }
@@ -275,7 +275,7 @@ namespace CombatExtended.Utilities
                 // rp_direction_dot ∈ (0, lengthSq), so curPosition is between the origin and destination
                 // Calculate the dot product of the relative (from segment origin) position and the rotated-clockwise direction vector. Used in the division-less distance from segment formula
                 float rp_cwdirection_dot = relativePosition.x * direction.z - relativePosition.z * direction.x;
-                if (rp_cwdirection_dot*rp_cwdirection_dot <= rangeSqLengthSq)
+                if (rp_cwdirection_dot * rp_cwdirection_dot <= rangeSqLengthSq)
                 {
                     yield return t;
                 }
@@ -319,7 +319,7 @@ namespace CombatExtended.Utilities
                 // rp_direction_dot ∈ (0, lengthSq), so curPosition is between the origin and destination
                 // Calculate the dot product of the relative (from segment origin) position and the rotated-clockwise direction vector. Used in the division-less distance from segment check
                 float rp_cwdirection_dot = relativePosition.x * direction.z - relativePosition.z * direction.x;
-                if (rp_cwdirection_dot*rp_cwdirection_dot <= rangeSqLengthSq)
+                if (rp_cwdirection_dot * rp_cwdirection_dot <= rangeSqLengthSq)
                 {
                     yield return t;
                 }

--- a/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
+++ b/Source/CombatExtended/Utilities/Tracking/ThingsTrackingModel.cs
@@ -167,26 +167,26 @@ namespace CombatExtended.Utilities
         public IEnumerable<Thing> ThingsNearSegment(IntVec3 origin, IntVec3 destination, float range, bool behind)
         {
             float rangeSq = range * range;
-            float minX;
-            float maxX;
+            int minX;
+            int maxX;
             // Find the band of cells (1-D) the line segment spans.  The band is widened on both sides by range.
             // ...<--range---x_min-----x_max---range-->...
             // ...minX-----------------------------maxX...
             if (origin.x > destination.x)
             {
-                minX = destination.x - range;
-                maxX = origin.x + range;
+                minX = destination.x - Mathf.RoundToInt(range);
+                maxX = origin.x + Mathf.RoundToInt(range);
             }
             else
             {
-                minX = origin.x - range;
-                maxX = destination.x + range;
+                minX = origin.x - Mathf.RoundToInt(range);
+                maxX = destination.x + Mathf.RoundToInt(range);
             }
 
             int bottom = 0;
             int index;
             int top = count;
-            int mid = (top + bottom) / 2;
+            int mid = 0;
             int limiter = 0;
             IntVec3 midPosition;
             IntVec3 direction = destination - origin;
@@ -236,7 +236,7 @@ namespace CombatExtended.Utilities
                 Thing t = sortedThings[index++].thing;
                 IntVec3 curPosition = t.Position;
                 // if we're outside the range of interest, we're done checking to the right.
-                if (curPosition.x + range < minX || curPosition.x - range > maxX)
+                if (curPosition.x < minX || curPosition.x > maxX)
                 {
                     break;
                 }
@@ -280,12 +280,12 @@ namespace CombatExtended.Utilities
                 }
             }
             index = mid - 1;
-            while (index >= 0) // Same as above, but moving right.
+            while (index >= 0) // Same as above, but moving left.
             {
                 Thing t = sortedThings[index--].thing;
                 IntVec3 curPosition = t.Position;
                 // if we're outside the range of interest, we're done checking to the right.
-                if (curPosition.x + range < minX || curPosition.x - range > maxX)
+                if (curPosition.x < minX || curPosition.x > maxX)
                 {
                     break;
                 }


### PR DESCRIPTION
#2201 second attempt.

## Changes
1. Modified ThingsNearSegment algorithm to a work;
2. Added new `infront` boolean parameter to ThingsNearSegment;
3. Made ThingsNearSegment yield-break (stop completely) if `behind` and `infront` are set to `false`;
4. Made average projectiles use RayCastSuppression;
5. Modified RayCastSuppression for better performance and consistency with average projectiles.

## Reasoning
1. ThingsNearSegment algorithm didn't seem to work, thus I decided to recreate it from scratch. Fortunately, many things didn't need much change;
2. Implemented it because I could;
3. May be helpful in some cases, can be changed if required;
4. Fixes slow projectiles applying more suppression to a single tile and fast projectiles skipping over some tiles;
5. Slow projectiles will make RayCastSuppression return early if their origin and destination are the same, otherwise it checks in a certain area that ensure no overlap (hopefully).

## Alternatives
4. Keep the old suppression within a radius
  - (+) More likely to give better performance;
  - (+) With #2123, the issue of slow projectiles giving more suppression may be remedied;
  - (-) Fast enough projectiles may still skip applying suppression to some tiles;
  - (-) #2123 requires a lot of XML modification.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] Playtested a colony.

## Possible issues
- The change nerfs slow projectile suppression while buffing fast projectile suppression, therefore some rebalancing may be required;
- I didn't test many cases, therefore the game may throw exceptions.