### PR TITLE
Reduce the performance impact of GetHighestCoverAndSmokeForTarget()

### DIFF
--- a/Source/CombatExtended/CombatExtended/BoundsInjector.cs
+++ b/Source/CombatExtended/CombatExtended/BoundsInjector.cs
@@ -40,19 +40,21 @@ namespace CombatExtended
 
         public static Vector2 BoundMap(Graphic graphic, GraphicType type)
         {
-            if (!boundMap.ContainsKey(graphic.path))
+            if (boundMap.TryGetValue(graphic.path, out var cachedBounds))
             {
-                try
-                {
-                    boundMap[graphic.path] = ExtractBounds(graphic, type);
-                }
-                catch (Exception e)
-                {
-                    throw new Exception("BoundMap(,)", e);
-                }
-
+                return cachedBounds;
             }
-            return boundMap[graphic.path];
+
+            try
+            {
+                var bounds = ExtractBounds(graphic, type);
+                boundMap[graphic.path] = bounds;
+                return bounds;
+            }
+            catch (Exception e)
+            {
+                throw new Exception("BoundMap(,)", e);
+            }
         }
 
         private static Vector2 ExtractBounds(Graphic graphic, GraphicType type, Graphic headGraphic, Vector2 headOffset)

--- a/Source/CombatExtended/CombatExtended/GenSightCE.cs
+++ b/Source/CombatExtended/CombatExtended/GenSightCE.cs
@@ -10,6 +10,8 @@ namespace CombatExtended
 {
     public static class GenSightCE
     {
+        private static List<IntVec3> points = new List<IntVec3>();
+
         /// <summary>
         /// Equivalent of Verse.GenSight.PointsOnLineOfSight, with support for floating-point vectors.
         /// Allows for better precision when calculating cells on a shot line's path (e.g: leaning pawns).
@@ -93,6 +95,18 @@ namespace CombatExtended
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// As <see cref="GenSight.PointsOnLineOfSight(IntVec3, IntVec3)"/>, but optimized for the case
+        /// where the caller will need all points as well as the number of points on the sight line.
+        /// </summary>
+        public static List<IntVec3> AllPointsOnLineOfSight(IntVec3 startPos, IntVec3 dest)
+        {
+            points.Clear();
+            points.AddRange(GenSight.PointsOnLineOfSight(startPos, dest));
+
+            return points;
         }
 
         public static IEnumerable<IntVec3> PartialLineOfSights(this Pawn pawn, LocalTargetInfo targetFacing)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -679,8 +679,8 @@ namespace CombatExtended
             smokeDensity = 0;
 
             // Iterate through all cells on line of sight and check for cover and smoke
-            var cells = GenSight.PointsOnLineOfSight(target.Cell, caster.Position).ToArray();
-            if (cells.Length < 3)
+            var cells = GenSightCE.AllPointsOnLineOfSight(target.Cell, caster.Position);
+            if (cells.Count < 3)
             {
                 cover = null;
                 return false;
@@ -690,7 +690,7 @@ namespace CombatExtended
             {
                 instant = pprop.isInstant;
             }
-            int endCell = instant ? cells.Length : cells.Length / 2;
+            int endCell = instant ? cells.Count : cells.Count / 2;
 
             for (int i = 0; i < endCell; i++)
             {
@@ -715,21 +715,25 @@ namespace CombatExtended
 
 
                 // Check for cover in the second half of LoS
-                if (instant || i <= cells.Length / 2)
+                if (instant || i <= cells.Count / 2)
                 {
                     Pawn pawn = cell.GetFirstPawn(map);
                     Thing newCover = pawn == null ? cell.GetCover(map) : pawn;
-                    float newCoverHeight = new CollisionVertical(newCover).Max;
 
                     // Cover check, if cell has cover compare collision height and get the highest piece of cover, ignore if cover is the target (e.g. solar panels, crashed ship, etc)
                     if (newCover != null
                             && (targetThing == null || !newCover.Equals(targetThing))
-                            && (highestCover == null || highestCoverHeight < newCoverHeight)
                             && newCover.def.Fillage == FillCategory.Partial
                             && !newCover.IsPlant())
                     {
-                        highestCover = newCover;
-                        highestCoverHeight = newCoverHeight;
+                        float newCoverHeight = new CollisionVertical(newCover).Max;
+
+                        if (highestCover == null || highestCoverHeight < newCoverHeight)
+                        {
+                            highestCover = newCover;
+                            highestCoverHeight = newCoverHeight;
+                        }
+
                         if (Controller.settings.DebugDrawTargetCoverChecks)
                         {
                             map.debugDrawer.FlashCell(cell, highestCoverHeight, highestCoverHeight.ToString());


### PR DESCRIPTION
theum

## Changes

GetHighestCoverAndSmokeForTarget() needs to iterate over all cells on the line of sight to the target and also needs the count of cells on the line. It currently does this by converting the cells IEnumerable to an array via ToArray(), which always allocates a new array and can result in considerable memory pressure when many pawns are in combat and looking for targets. Reduce the memory churn by introducing a new helper method for getting a list of cells on a line of sight that uses a preallocated List under the hood to store the cells.

We can further reduce the impact of cover checking in the subsequent iteration by only calculating cover height once we've determined that the cover is not a plant, as the calculation does not consider plants anyways in this particular case.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - tested a 3-way battle with/without the change.
