### PR TITLE
Patch Warcasket Persona Weapons

### DIFF
--- a/Patches/Warcasket Persona Weapons/Weapons_Warcaskets.xml
+++ b/Patches/Warcasket Persona Weapons/Weapons_Warcaskets.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+    	<li>Warcasket Persona Weapons</li>
+    </mods>
+		<match Class="PatchOperationSequence">
+			<operations>			
+
+			<!-- Tool Capacity Def -->	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ToolCapacityDef[
+				defName="BifurcatorCleave" or
+				defName="CrustbreakerSmash"
+				]
+				</xpath>
+				<value>
+					<li Class="CombatExtended.ModExtensionMeleeToolPenetration">
+						<canHitInternal>true</canHitInternal>
+					</li>
+				</value>
+			</li>
+
+			<!-- Kyokatana -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WP_Kyokatana"]/statBases</xpath>
+				<value>
+					<Bulk>35</Bulk>
+					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+					<ToughnessRating>24</ToughnessRating>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WP_Kyokatana"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+				<value>
+					<MeleeCritChance>0.02</MeleeCritChance>
+					<MeleeParryChance>0.47</MeleeParryChance>
+					<MeleeDodgeChance>0.18</MeleeDodgeChance>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WP_Kyokatana"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>point</label>
+							<capacities>
+								<li>Stab</li>
+							</capacities>
+							<power>46</power>
+							<cooldownTime>2</cooldownTime>
+							<armorPenetrationBlunt>9</armorPenetrationBlunt>
+							<armorPenetrationSharp>64</armorPenetrationSharp>
+							<extraMeleeDamages>
+							<li>
+								<def>WP_WhiteHotBurn</def>
+								<amount>10</amount>
+							</li>
+							<li>
+								<def>Flame</def>
+								<amount>10</amount>
+								<chance>0.15</chance>
+							</li>
+							</extraMeleeDamages>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+							<li>Cut</li>
+							</capacities>
+							<power>58</power>
+							<cooldownTime>2.6</cooldownTime>
+							<armorPenetrationBlunt>17</armorPenetrationBlunt>
+							<armorPenetrationSharp>48</armorPenetrationSharp>
+							<extraMeleeDamages>
+							<li>
+								<def>WP_WhiteHotBurn</def>
+								<amount>10</amount>
+							</li>
+							<li>
+								<def>Flame</def>
+								<amount>10</amount>
+								<chance>0.5</chance>
+							</li>
+							</extraMeleeDamages>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- Bifurcator -->	
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WP_Bifurcator"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>BifurcatorCleave</li>
+							</capacities>
+							<power>62</power>
+							<cooldownTime>5.73</cooldownTime>
+							<armorPenetrationSharp>52</armorPenetrationSharp>
+							<armorPenetrationBlunt>580</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WP_Bifurcator"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.8</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WP_Bifurcator"]/statBases</xpath>
+				<value>
+					<Bulk>16</Bulk>
+					<MeleeCounterParryBonus>1.75</MeleeCounterParryBonus>
+					<ToughnessRating>22</ToughnessRating>
+				</value>
+			</li>
+
+			<!-- Voltrender -->	
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="WP_Voltrender"]/statBases</xpath>
+				<value>
+					<Bulk>15</Bulk>
+					<MeleeCounterParryBonus>1</MeleeCounterParryBonus>
+					<ToughnessRating>24</ToughnessRating>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WP_Voltrender"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.02</MeleeCritChance>
+						<MeleeParryChance>0.44</MeleeParryChance>
+						<MeleeDodgeChance>0.22</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="WP_Voltrender"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>blade</label>
+							<capacities>
+								<li>VoltaicSlash</li>
+							</capacities>
+							<power>52</power>
+							<cooldownTime>2.6</cooldownTime>
+							<armorPenetrationBlunt>17</armorPenetrationBlunt>
+							<armorPenetrationSharp>28</armorPenetrationSharp>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<!-- Crustbreaker -->	
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="WP_Crustbreaker"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>head</label>
+							<capacities>
+								<li>CrustbreakerSmash</li>
+							</capacities>
+							<power>92</power>
+							<cooldownTime>5.73</cooldownTime>
+							<armorPenetrationBlunt>580</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WP_Crustbreaker"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.8</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
+						<MeleeDodgeChance>0.18</MeleeDodgeChance>	
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="WP_Crustbreaker"]/statBases</xpath>
+				<value>
+					<Bulk>18</Bulk>
+					<MeleeCounterParryBonus>2</MeleeCounterParryBonus>
+					<ToughnessRating>25</ToughnessRating>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -478,6 +478,7 @@ Vulpine Race Pack	|
 Wall Mounted Turrets (Continued)    |
 WarCasket Expanded  |
 WarCasket Gundam Addon  |
+Warcasket Persona Weapons   |
 Warcaskets: Adeptus Astartes    |
 Weapons+	|
 WWII German Uniforms - V's Edit |


### PR DESCRIPTION
## Additions
- Patch Warcasket Persona Weapons mod. Weapons are on par with other spacer warcasket melee weapons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
