### PR TITLE
Killzone Concept Armor Patch

### DIFF
--- a/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
+++ b/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
@@ -95,12 +95,12 @@
                 </value>
             </li>
 
-            <Operation Class="PatchOperationAdd">
+            <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/equippedStatOffsets</xpath>
                 <value>
                     <SmokeSensitivity>-0.4</SmokeSensitivity>
                 </value>
-            </Operation>
+            </li>
 
             <li Class="PatchOperationReplace">
                 <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/statBases/ArmorRating_Sharp</xpath>

--- a/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
+++ b/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
@@ -98,7 +98,7 @@
             <li Class="PatchOperationAdd">
                 <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/equippedStatOffsets</xpath>
                 <value>
-                    <SmokeSensitivity>-0.4</SmokeSensitivity>
+                    <SmokeSensitivity>-1</SmokeSensitivity>
                 </value>
             </li>
 

--- a/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
+++ b/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
@@ -39,6 +39,14 @@
                 </value>
             </li>
 
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]/apparel/bodyPartGroups</xpath>
+                <value>
+                    <li>Hands</li>
+                    <li>Feet</li>
+                </value>
+            </li>
+
             <li Class="PatchOperationAddModExtension">
                 <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]</xpath>
                 <value>

--- a/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
+++ b/Patches/Killzone Concept Armor Set/Apparel_Armor.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Killzone Concept Armor Set</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+            <!-- === Heavy Trooper Armor === -->
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]/statBases</xpath>
+                <value>
+                    <Bulk>75</Bulk>
+                    <WornBulk>15</WornBulk>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]/statBases/ArmorRating_Sharp</xpath>
+                <value>
+                    <ArmorRating_Sharp>14.7</ArmorRating_Sharp>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]/statBases/ArmorRating_Blunt</xpath>
+                <value>
+                    <ArmorRating_Blunt>28.5</ArmorRating_Blunt>
+                </value>
+            </li>
+
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]/equippedStatOffsets</xpath>
+                <value>
+                    <CarryBulk>20</CarryBulk>
+                    <CarryWeight>25</CarryWeight>
+                </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Armor"]</xpath>
+                <value>
+                <li Class="CombatExtended.PartialArmorExt">
+                    <stats>
+                        <li>
+                            <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                            <parts>
+                                <li>Neck</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                            <parts>
+                                <li>Neck</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+                            <parts>
+                                <li>Arm</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+                            <parts>
+                                <li>Arm</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+                            <parts>
+                                <li>Hand</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+                            <parts>
+                                <li>Hand</li>
+                            </parts>
+                        </li>
+                    </stats>
+                </li>
+                </value>
+            </li>
+
+            <!-- === Heavy Trooper Helmet === -->
+            <li Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/statBases</xpath>
+                <value>
+                    <Bulk>5</Bulk>
+                    <WornBulk>1</WornBulk>
+                    <NightVisionEfficiency_Apparel>0.50</NightVisionEfficiency_Apparel>
+                </value>
+            </li>
+
+            <Operation Class="PatchOperationAdd">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/equippedStatOffsets</xpath>
+                <value>
+                    <SmokeSensitivity>-0.4</SmokeSensitivity>
+                </value>
+            </Operation>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+                <value>
+                    <ArmorRating_Sharp>10.5</ArmorRating_Sharp>
+                </value>
+            </li>
+
+            <li Class="PatchOperationReplace">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+                <value>
+                    <ArmorRating_Blunt>20</ArmorRating_Blunt>
+                </value>
+            </li>
+
+            <li Class="PatchOperationAddModExtension">
+                <xpath>Defs/ThingDef[defName="Bot_Soldier_Helmet"]</xpath>
+                <value>
+                    <li Class="CombatExtended.PartialArmorExt">
+                    <stats>
+                        <li>
+                            <ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+                            <parts>
+                                <li>Eye</li>
+                            </parts>
+                        </li>
+                        <li>
+                            <ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+                            <parts>
+                                <li>Eye</li>
+                            </parts>
+                        </li>
+                    </stats>
+                    </li>
+                </value>
+            </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Killzone Concept Armor Set/Ranged_Industrial.xml
+++ b/Patches/Killzone Concept Armor Set/Ranged_Industrial.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Killzone Concept Armor Set</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+            
+            <!-- === Tools === -->
+            <li Class="PatchOperationReplace">
+                <xpath>
+                    /Defs/ThingDef[
+                        defName = "StA25_SMG" or 
+                        defName = "StA-3_HMG"
+                    ]/tools
+                </xpath>
+                <value>
+                    <tools>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>stock</label>
+                            <capacities>
+                                <li>Blunt</li>
+                            </capacities>
+                            <power>8</power>
+                            <cooldownTime>1.55</cooldownTime>
+                            <chanceFactor>1.5</chanceFactor>
+                            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>barrel</label>
+                            <capacities>
+                                <li>Blunt</li>
+                            </capacities>
+                            <power>5</power>
+                            <cooldownTime>2.02</cooldownTime>
+                            <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+                        </li>
+                        <li Class="CombatExtended.ToolCE">
+                            <label>muzzle</label>
+                            <capacities>
+                                <li>Poke</li>
+                            </capacities>
+                            <power>8</power>
+                            <cooldownTime>1.55</cooldownTime>
+                            <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                            <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+                        </li>
+                    </tools>
+                </value>
+            </li>
+
+            <!-- StA25 Vlug -->
+            <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                <defName>StA25_SMG</defName>
+                <statBases>
+                    <Mass>3.0</Mass>
+                    <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+                    <SightsEfficiency>1.10</SightsEfficiency>
+                    <ShotSpread>0.2</ShotSpread>
+                    <SwayFactor>0.49</SwayFactor>
+                    <Bulk>2.41</Bulk>
+                </statBases>
+                <Properties>
+                    <recoilAmount>1.64</recoilAmount>
+                    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                    <hasStandardCommand>true</hasStandardCommand>
+                    <defaultProjectile>Bullet_46x30mm_FMJ</defaultProjectile>
+                    <warmupTime>0.6</warmupTime>
+                    <range>35</range>
+                    <burstShotCount>5</burstShotCount>
+                    <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+                    <soundCast>Shot_AssaultRifle</soundCast>
+                    <soundCastTail>GunTail_Medium</soundCastTail>
+                    <muzzleFlashScale>9</muzzleFlashScale>
+                </Properties>
+                <AmmoUser>
+                    <magazineSize>30</magazineSize>
+                    <reloadTime>4.0</reloadTime>
+                    <ammoSet>AmmoSet_46x30mm</ammoSet>
+                </AmmoUser>
+                <FireModes>
+                    <aimedBurstShotCount>10</aimedBurstShotCount>
+                    <aiUseBurstMode>FALSE</aiUseBurstMode>
+                </FireModes>
+                <weaponTags>
+                    <li>CE_SMG</li>
+                    <li>CE_AI_AssaultWeapon</li>
+                </weaponTags>
+            </li>
+
+            <!-- StA-3 Light Machine Gun -->
+            <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                <defName>StA-3_HMG</defName>
+                <statBases>
+                    <Mass>8.50</Mass>
+                    <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+                    <SightsEfficiency>1.10</SightsEfficiency>
+                    <ShotSpread>0.07</ShotSpread>
+                    <SwayFactor>1.65</SwayFactor>
+                    <Bulk>11.0</Bulk>
+                </statBases>
+                <Properties>
+                    <recoilAmount>1.25</recoilAmount>
+                    <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                    <hasStandardCommand>true</hasStandardCommand>
+                    <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+                    <warmupTime>1.3</warmupTime>
+                    <range>60</range>
+                    <burstShotCount>10</burstShotCount>
+                    <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+                    <soundCast>Shot_AssaultRifle</soundCast>
+                    <soundCastTail>GunTail_Medium</soundCastTail>
+                    <muzzleFlashScale>9</muzzleFlashScale>
+                </Properties>
+                <AmmoUser>
+                    <magazineSize>100</magazineSize>
+                    <reloadTime>5.2</reloadTime>
+                    <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+                </AmmoUser>
+                <FireModes>
+                    <aimedBurstShotCount>3</aimedBurstShotCount>
+                    <aiUseBurstMode>FALSE</aiUseBurstMode>
+                    <aiAimMode>SuppressFire</aiAimMode>
+                </FireModes>
+                <weaponTags>
+                    <li>CE_MachineGun</li>
+                    <li>CE_AI_Suppressive</li>
+                    <li>Bipod_LMG</li>
+                </weaponTags>
+            </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Killzone Concept Armor Set/Ranged_Industrial.xml
+++ b/Patches/Killzone Concept Armor Set/Ranged_Industrial.xml
@@ -62,10 +62,10 @@
                     <SightsEfficiency>1.10</SightsEfficiency>
                     <ShotSpread>0.2</ShotSpread>
                     <SwayFactor>0.49</SwayFactor>
-                    <Bulk>2.41</Bulk>
+                    <Bulk>7.5</Bulk>
                 </statBases>
                 <Properties>
-                    <recoilAmount>1.64</recoilAmount>
+                    <recoilAmount>1.04</recoilAmount>
                     <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                     <hasStandardCommand>true</hasStandardCommand>
                     <defaultProjectile>Bullet_46x30mm_FMJ</defaultProjectile>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -246,6 +246,7 @@ Kenshi Armory |
 K.L.K - Styles Apparel Pack	|
 Kijin Race 2.0     	|     
 Kill la Kill Styles Pack    |
+Killzone Concept Armor Set  |
 Kit's Gunpowder Weapons |
 Kit's Industrial Weapons |   
 Kit's Roman Weapons |


### PR DESCRIPTION
## Additions
- Patch for the Killzone Concept Armor, which includes a set of armor and two weapons. Original patch from Auggie0808, with some adjustments by me.
  - Added partial armor.
  - Added smoke protection.
  - Switched LMG from 5.56 NATO to 7.51 NATO, as this is what's called out on the Killzone wiki.
  - Reduced the recoil and increased the bulk of the SMG. It looks to be roughly the size of a bullpup rifle like the FAMAS, but enjoys low recoil due to the larger weapon.

## References
Closes #1431 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
