### PR TITLE
Casing fall tweaks

### DIFF
--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -34,6 +34,7 @@
 		<defName>Mote_EmptyCasing</defName>
 		<graphicData>
 			<texPath>Things/Mote/Mote_BulletCasing</texPath>
+      <renderInstanced>true</renderInstanced>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
 		<solidTime>3.0</solidTime>
@@ -47,6 +48,7 @@
 		<graphicData>
 			<texPath>Things/Mote/Mote_ShotgunShell</texPath>
 			<drawSize>(0.5,0.5)</drawSize>
+      <renderInstanced>true</renderInstanced>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
 		<solidTime>3.0</solidTime>
@@ -59,6 +61,7 @@
 		<defName>Mote_BigShell</defName>
 		<graphicData>
 			<texPath>Things/Mote/Mote_BigShell</texPath>
+      <renderInstanced>true</renderInstanced>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
 		<solidTime>3.0</solidTime>
@@ -71,6 +74,7 @@
 		<defName>Mote_GrenadePin</defName>
 		<graphicData>
 			<texPath>Things/Mote/Mote_GrenadePin</texPath>
+      <renderInstanced>true</renderInstanced>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
 		<solidTime>3.0</solidTime>

--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -66,7 +66,7 @@
 		<altitudeLayer>MoteOverhead</altitudeLayer>
 		<solidTime>3.0</solidTime>
 		<fadeOutTime>0.2</fadeOutTime>
-		<landSound>C_Impact_ShotgunCasingImpact</landSound>
+		<landSound>C_Impact_CannonShellCasing</landSound>
 		<collide>true</collide>
 	</FleckDef>
 

--- a/Defs/Effects/Flecks.xml
+++ b/Defs/Effects/Flecks.xml
@@ -36,7 +36,7 @@
 			<texPath>Things/Mote/Mote_BulletCasing</texPath>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
+		<solidTime>3.0</solidTime>
 		<fadeOutTime>0.2</fadeOutTime>
 		<landSound>C_Impact_BulletCasing</landSound>
 		<collide>true</collide>
@@ -49,7 +49,7 @@
 			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
+		<solidTime>3.0</solidTime>
 		<fadeOutTime>0.2</fadeOutTime>
 		<landSound>C_Impact_ShotgunCasingImpact</landSound>
 		<collide>true</collide>
@@ -61,7 +61,7 @@
 			<texPath>Things/Mote/Mote_BigShell</texPath>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
+		<solidTime>3.0</solidTime>
 		<fadeOutTime>0.2</fadeOutTime>
 		<landSound>C_Impact_ShotgunCasingImpact</landSound>
 		<collide>true</collide>
@@ -73,7 +73,7 @@
 			<texPath>Things/Mote/Mote_GrenadePin</texPath>
 		</graphicData>
 		<altitudeLayer>MoteOverhead</altitudeLayer>
-		<solidTime>1.0</solidTime>
+		<solidTime>3.0</solidTime>
 		<fadeOutTime>0.2</fadeOutTime>
 		<landSound>C_Impact_BulletCasing</landSound>
 		<collide>true</collide>

--- a/Defs/SoundDefs/CasingSounds.xml
+++ b/Defs/SoundDefs/CasingSounds.xml
@@ -29,6 +29,35 @@
       </li>
     </subSounds>
   </SoundDef>
+  
+    <SoundDef>
+    <defName>C_Impact_CannonShellCasing</defName>
+    <context>MapOnly</context>
+    <eventNames />
+    <subSounds>
+      <li>
+        <grains>
+          <li Class="AudioGrain_Folder">
+            <clipFolderPath>Impact/Brass</clipFolderPath>
+          </li>
+        </grains>
+        <pitchRange>
+          <min>0.5</min>
+          <max>0.7</max>
+        </pitchRange>
+        <volumeRange>
+          <min>10</min>
+          <max>15</max>
+        </volumeRange>
+        <distRange>
+          <min>0</min>
+          <max>70</max>
+        </distRange>
+        <repeatMode>NeverTwice</repeatMode>
+        <sustainLoop>False</sustainLoop>
+      </li>
+    </subSounds>
+  </SoundDef>
 
   <SoundDef>
     <defName>C_Impact_ShotgunCasingImpact</defName>

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -712,6 +712,7 @@ namespace CombatExtended
             creationData.spawnPosition = loc;
             creationData.velocitySpeed = Rand.Range(0.7f, 0.5f);
             creationData.velocityAngle = Rand.Range(160, 200);
+            creationData.rotationRate = (float)Rand.Range(-300, 300);
             map.flecks.CreateFleck(creationData);
             Rand.PopState();
         }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -706,7 +706,7 @@ namespace CombatExtended
 
             Rand.PushState();
             FleckCreationData creationData = FleckMaker.GetDataStatic(loc, map, casingFleckDef);
-            creationData.airTimeLeft = 60;
+            creationData.airTimeLeft = 1.5f;
             creationData.scale = Rand.Range(0.5f, 0.3f) * size;
             creationData.rotation = Rand.Range(-3f, 4f);
             creationData.spawnPosition = loc;


### PR DESCRIPTION
## Changes

Describe adjustments to existing features made in this merge, e.g.
- Decreased casing air time. They should now fall 1-2 tiles near the pawn.
- Made fleck solid time longer than air time. Allows them to land on the ground before disappearing and stay there for 1.5 seconds.
- Made flying casings spin around themselves purely for aesthetics. 1 line change, shouldn't impact performance.
- Made big shells use a separate, pitched down, brass sound instead of light plastic shotgun shell sound.
- Made all casings flecks render instanced. This is used in vanilla for dust puffs, footprints, various mass-produced flecks that don't need to look unique. 

## Reasoning

Why did you choose to implement things this way, e.g.
- Casing impact sounds existed for years in CE, but never actually showed up in game, because shells never truly landed. They were disappearing before air time ran out.
- I left fleck solidTime low so that they disappear almost immediately after landing. If you make it higher without switching AttitudeLayer, fallen casings will render on top of pawns and will look bad.
- I added a separate sounddef that uses existing sound files for cannons, because shotgun shells sounds didn't sound appropriate for big metallic cases of Flak 88 and 81mm mortar. I used a pitched down sound of normal bullet casings, because I couldn't find a good recording of tank shells falling.  
- Instancing flecks should help a little with performance from what it seems.


## Alternatives

Describe alternative implementations you have considered, e.g.
- Change casing render level from MoteOverhead to MoteLow and increase solidTime to ~20 seconds. Pros: battlefield looks cooler when there's spent casings lying around. Cons: For it to look okay, casings need to render *under* pawns. Thus, you can no longer see them fly out of the gun, only from under the pawn.
- Give cannon shell impact a unique sound recording from a tank or a mortar. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
