### PR TITLE
Minor Fixes

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -82,6 +82,7 @@
     <xpath>Defs/ThingDef[defName="Apparel_AdvancedHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
       <Bulk>4</Bulk>
+      <WornBulk>1</WornBulk>
       <ArmorRating_Heat>0.54</ArmorRating_Heat>
     </value>
   </Operation>

--- a/Patches/Expanded Materials - Metals/Items_Resource_Stuff.xml
+++ b/Patches/Expanded Materials - Metals/Items_Resource_Stuff.xml
@@ -224,6 +224,14 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VMEu_StainlessSteel"]/stuffProps/categories</xpath>
+				<value>
+					<li>Metallic_Weapon</li>
+					<li>Steeled</li>
+				</value>
+			</li>
+
 			<!-- === Titanium === -->
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="VMEu_Titanium"]/statBases</xpath>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -21,53 +21,55 @@
                 <EnergyShieldEnergyMax>0.75</EnergyShieldEnergyMax>
             </value>
         </li>
-    <!-- Add Partial Armor to Helmet -->
-    <li Class="PatchOperationAddModExtension">
-          <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
-    <value>
-      <li Class="CombatExtended.PartialArmorExt">
-		<stats>
-			<li>
-				<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-				<parts>
-					<li>Eye</li>
-				</parts>
-			</li>
-			<li>
-				<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-				<parts>
-					<li>Eye</li>
-				</parts>
-			</li>
-			<li>
-				<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-				<parts>
-					<li>Nose</li>
-				</parts>
-			</li>
-			<li>
-				<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-				<parts>
-					<li>Nose</li>
-				</parts>
-			</li>
-			<li>
-				<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-				<parts>
-					<li>Jaw</li>
-				</parts>
-			</li>
-			<li>
-				<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-				<parts>
-					<li>Jaw</li>
-				</parts>
-			</li>
-		</stats>
-      </li>
-    </value>
-	</li>
-	<!-- Add partial armor to Ranger Armors -->
+ 
+        <!-- Add Partial Armor to Helmet -->
+        <li Class="PatchOperationAddModExtension">
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
+        <value>
+        <li Class="CombatExtended.PartialArmorExt">
+            <stats>
+                <li>
+                    <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                    <parts>
+                        <li>Eye</li>
+                    </parts>
+                </li>
+                <li>
+                    <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                    <parts>
+                        <li>Eye</li>
+                    </parts>
+                </li>
+                <li>
+                    <ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+                    <parts>
+                        <li>Nose</li>
+                    </parts>
+                </li>
+                <li>
+                    <ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+                    <parts>
+                        <li>Nose</li>
+                    </parts>
+                </li>
+                <li>
+                    <ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+                    <parts>
+                        <li>Jaw</li>
+                    </parts>
+                </li>
+                <li>
+                    <ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+                    <parts>
+                        <li>Jaw</li>
+                    </parts>
+                </li>
+            </stats>
+        </li>
+        </value>
+        </li>
+
+	    <!-- Add partial armor to Ranger Armors -->
         <li Class="PatchOperationAddModExtension">
           <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
           <value>
@@ -124,7 +126,8 @@
 			  </stats>
 		  </li>
           </value>
-        </li>	
+        </li>
+
         <!-- ========== Ranger Helmet ========== -->
 
         <li Class="PatchOperationReplace">
@@ -171,8 +174,8 @@
         <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/costList/Plasteel</xpath>
             <value>
-            <Plasteel>60</Plasteel>
-            <DevilstrandCloth>20</DevilstrandCloth>
+                <Plasteel>60</Plasteel>
+                <DevilstrandCloth>20</DevilstrandCloth>
             </value>
         </li>
 
@@ -184,39 +187,39 @@
             </value>
         </li>
 
-	  <li Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
-		<value>
-		  <li Class="CombatExtended.PartialArmorExt">
-			<stats>
-				<li>
-					<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-					<parts>
-						<li>Eye</li>
-					</parts>
-				</li>
-				<li>
-					<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-					<parts>
-						<li>Eye</li>
-					</parts>
-				</li>
-				<li>
-					<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-					<parts>
-						<li>Nose</li>
-					</parts>
-				</li>
-				<li>
-					<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-					<parts>
-						<li>Nose</li>
-					</parts>
-				</li>
-			</stats>
-		  </li>
-		</value>
-	  </li>
+        <li Class="PatchOperationAddModExtension">
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
+            <value>
+            <li Class="CombatExtended.PartialArmorExt">
+                <stats>
+                    <li>
+                        <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                        <parts>
+                            <li>Eye</li>
+                        </parts>
+                    </li>
+                    <li>
+                        <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                        <parts>
+                            <li>Eye</li>
+                        </parts>
+                    </li>
+                    <li>
+                        <ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+                        <parts>
+                            <li>Nose</li>
+                        </parts>
+                    </li>
+                    <li>
+                        <ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+                        <parts>
+                            <li>Nose</li>
+                        </parts>
+                    </li>
+                </stats>
+            </li>
+            </value>
+        </li>
 
         <!-- ========== Ranger armor ========== -->
 
@@ -274,10 +277,6 @@
             <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
             <value>
             <equippedStatOffsets>
-                <CarryWeight>25</CarryWeight>
-                <ToxicResistance>0.50</ToxicResistance>
-                <MoveSpeed>0.4</MoveSpeed>
-
                 <CarryWeight>70</CarryWeight>
                 <CarryBulk>10</CarryBulk>
                 <ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>


### PR DESCRIPTION
## Changes
- Rangers: Removed duplicate set of stat nodes. Looks like a potential merge conflict that wasn't resolved correctly? Very odd.
- Materials Expanded: Give Stainless Steel the appropriate material tags.
- Gave the Advanced Helmet 1 wornbulk, since it previously had 0.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
