### PR TITLE
Royalty weapons minor tweaks

### DIFF
--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
@@ -101,15 +101,15 @@
 					<capacities>
 					<li>Blunt</li>
 					</capacities>
-					<power>49</power>
+					<power>58</power>
 					<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
 						<amount>8</amount>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2.24</cooldownTime>
-					<armorPenetrationBlunt>190.575</armorPenetrationBlunt>
+					<cooldownTime>2.19</cooldownTime>
+					<armorPenetrationBlunt>190</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>	
 			</tools>
@@ -130,7 +130,7 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_ZeusHammerBladelink"]/statBases</xpath>
 		<value>
       		<Bulk>8</Bulk>
-      		<MeleeCounterParryBonus>0.50</MeleeCounterParryBonus>
+      		<MeleeCounterParryBonus>0.7</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -138,8 +138,8 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_ZeusHammerBladelink"]</xpath>
 		<value>
 			<equippedStatOffsets>
-				<MeleeCritChance>1.60</MeleeCritChance>
-				<MeleeParryChance>0.40</MeleeParryChance>
+				<MeleeCritChance>1.1</MeleeCritChance>
+				<MeleeParryChance>0.55</MeleeParryChance>
 				<MeleeDodgeChance>0.40</MeleeDodgeChance>	
 			</equippedStatOffsets>
 		</value>	

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyMelee.xml
@@ -133,7 +133,7 @@
 					</capacities>
 					<power>5</power>
 					<cooldownTime>2.85</cooldownTime>
-					<armorPenetrationBlunt>1.69</armorPenetrationBlunt>
+					<armorPenetrationBlunt>1.54</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>
 			</tools>
@@ -144,15 +144,15 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_PsyfocusStaff"]/statBases</xpath>
 		<value>
 			<Bulk>6</Bulk>
-			<MeleeCounterParryBonus>0.93</MeleeCounterParryBonus>
+			<MeleeCounterParryBonus>1.56</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_PsyfocusStaff"]/equippedStatOffsets</xpath>
 		<value>
-			<MeleeCritChance>1.00</MeleeCritChance>
-			<MeleeParryChance>0.70</MeleeParryChance>
+			<MeleeCritChance>0.6</MeleeCritChance>
+			<MeleeParryChance>1.17</MeleeParryChance>
 			<MeleeDodgeChance>0.47</MeleeDodgeChance>	
 		</value>	
 	</Operation>
@@ -267,15 +267,15 @@
 					<capacities>
 					<li>Blunt</li>
 					</capacities>
-					<power>41</power>
+					<power>49</power>
 					<extraMeleeDamages>
 					<li>
 						<def>EMP</def>
 						<amount>5</amount>
 					</li>
 					</extraMeleeDamages>					
-					<cooldownTime>2.76</cooldownTime>
-					<armorPenetrationBlunt>157.5</armorPenetrationBlunt>
+					<cooldownTime>2.45</cooldownTime>
+					<armorPenetrationBlunt>160</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>				
 			</tools>
@@ -296,7 +296,7 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Zeushammer"]/statBases</xpath>
 		<value>
 			<Bulk>8</Bulk>
-			<MeleeCounterParryBonus>0.40</MeleeCounterParryBonus>
+			<MeleeCounterParryBonus>0.6</MeleeCounterParryBonus>
 		</value>
 	</Operation>
 
@@ -304,8 +304,8 @@
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Zeushammer"]</xpath>
 		<value>
 			<equippedStatOffsets>
-				<MeleeCritChance>1.50</MeleeCritChance>
-				<MeleeParryChance>0.30</MeleeParryChance>
+				<MeleeCritChance>1.0</MeleeCritChance>
+				<MeleeParryChance>0.45</MeleeParryChance>
 				<MeleeDodgeChance>0.30</MeleeDodgeChance>	
 			</equippedStatOffsets>
 		</value>	


### PR DESCRIPTION
## Changes

- Increased the speed of the head attack tool of the Zeushammer and its persona version by 10% and fixed its mass in the spreadsheet.
- Fixed the mass of the Psyfocus staff in the melee spreadsheet.

## References

- https://docs.google.com/spreadsheets/d/11e6FkTQvZiJpq7DpXUk9JSXBSq9enrx0DQhTTJ2xH7c/edit#gid=647442519

## Reasoning

- https://discord.com/channels/278818534069501953/322827713335394304/1058162877426585631

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
