### PR TITLE
Patch Odz's 40k Equipment Mods

### DIFF
--- a/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
@@ -36,14 +36,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>21</ArmorRating_Blunt>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -73,14 +73,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22</ArmorRating_Blunt>
 				</value>
 			</li>
 

--- a/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Astra Militarum Regimentum - Cadia</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Fatigues === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Fatigues"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Fatigues"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Flak Armor === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>21</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>30</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/apparel/layers</xpath>
+				<value>
+					<li>Webbing</li>		
+				</value>
+			</li>
+
+			<!-- === Flak Armor === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases</xpath>
+				<value>
+					<Bulk>15</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>30</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/apparel/layers</xpath>
+				<value>
+					<li>Webbing</li>		
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
@@ -61,6 +61,15 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+						<li>Steeled</li>
+					</stuffCategories>
+				</value>
+			</li>
+
 			<!-- === Heavy Flak Armor === -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases</xpath>
@@ -95,6 +104,15 @@
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/apparel/layers</xpath>
 				<value>
 					<li>Webbing</li>		
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+						<li>Steeled</li>
+					</stuffCategories>
 				</value>
 			</li>
 

--- a/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
@@ -61,7 +61,7 @@
 				</value>
 			</li>
 
-			<!-- === Flak Armor === -->
+			<!-- === Heavy Flak Armor === -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases</xpath>
 				<value>

--- a/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Armor_Industrial.xml
@@ -70,6 +70,28 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+							<parts>
+								<li>Shoulder</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
+							<parts>
+								<li>Shoulder</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
 			<!-- === Heavy Flak Armor === -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]/statBases</xpath>
@@ -113,6 +135,40 @@
 					<stuffCategories>
 						<li>Steeled</li>
 					</stuffCategories>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_FlakArmor"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
 				</value>
 			</li>
 

--- a/Patches/Astra Militarum Regimentum - Cadia/Headgear_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Headgear_Industrial.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Astra Militarum Regimentum - Cadia</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+			<!-- === Officer Gorget === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_OfficerGorget"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>0.5</Bulk>
+					<StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Field Cap === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Fieldcap"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Officer's Cap === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_CrusherCap"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Helmet === -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Helmet"]</xpath>
+				<value>
+					<costList>
+						<Hyperweave>15</Hyperweave> <!-- Hyperweave instead of Devilstrand, since the torso armor already uses it.-->
+					</costList>	
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_Helmet"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<!-- === Kasrkin Helmet === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_Helmet"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_Helmet"]/costList</xpath>
+				<value>
+					<Hyperweave>20</Hyperweave>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_CadianKasrkin_Helmet"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Astra Militarum Regimentum - Cadia/Headgear_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Cadia/Headgear_Industrial.xml
@@ -42,7 +42,7 @@
 				<value>
 					<Bulk>4</Bulk>
 					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>6.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
@@ -69,7 +69,7 @@
 				<value>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>9</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Astra Militarum Regimentum - Krieg Officer Helmet/Headgear_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Krieg Officer Helmet/Headgear_Industrial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Astra Militarum Regimentum - Krieg: Officer Helmet </li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Grenadier Helmet === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40K_IG_DKOK_OFFICER" or defName="ODZ_40K_IG_DKOK_NCO"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40K_IG_DKOK_OFFICER" or defName="ODZ_40K_IG_DKOK_NCO"]</xpath>
+				<value>
+					<costList>
+						<Hyperweave>20</Hyperweave>
+					</costList>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40K_IG_DKOK_OFFICER" or defName="ODZ_40K_IG_DKOK_NCO"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Astra Militarum Regimentum - Krieg/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Krieg/Armor_Industrial.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Astra Militarum Regimentum - Krieg</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Krieg Uniform === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_KriegUniform"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_KriegUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Combat Webbing === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_CombatWebbing"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_CombatWebbing"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Flak Armor === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierArmor"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/stuffCategories</xpath>
+				<value>
+					<stuffCategories>
+						<li>Steeled</li>
+					</stuffCategories>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Astra Militarum Regimentum - Krieg/Armor_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Krieg/Armor_Industrial.xml
@@ -64,11 +64,33 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]/stuffCategories</xpath>
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierArmor"]/stuffCategories</xpath>
 				<value>
 					<stuffCategories>
 						<li>Steeled</li>
 					</stuffCategories>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_Cadian_FlakArmor"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+							<parts>
+								<li>Shoulder</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
+							<parts>
+								<li>Shoulder</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
 				</value>
 			</li>
 

--- a/Patches/Astra Militarum Regimentum - Krieg/Headgear_Industrial.xml
+++ b/Patches/Astra Militarum Regimentum - Krieg/Headgear_Industrial.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Astra Militarum Regimentum - Krieg</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Helmet === -->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_Helmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>6.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_Helmet"]</xpath>
+				<value>
+					<costList>
+						<Hyperweave>15</Hyperweave> <!-- Hyperweave instead of Devilstrand.-->
+					</costList>	
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_Helmet"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<!-- === Grenadier Helmet === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierHelmet"]</xpath>
+				<value>
+					<costList>					
+						<Hyperweave>20</Hyperweave>
+					</costList>						
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierHelmet"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<!-- === Gas Mask === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_Gasmask"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_Gasmask"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<!-- === Grenadier Gas Mask === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierGasmask"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IG_DKOK_GrenadierGasmask"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Ordo Tempestus - Tempestus Scions/Armor_Industrial.xml
+++ b/Patches/Ordo Tempestus - Tempestus Scions/Armor_Industrial.xml
@@ -61,6 +61,40 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Ordo Tempestus - Tempestus Scions/Armor_Industrial.xml
+++ b/Patches/Ordo Tempestus - Tempestus Scions/Armor_Industrial.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Ordo Tempestus - Tempestus Scions</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Fatigues === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Fatigues"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Fatigues"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Carapace Armor === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]/statBases</xpath>
+				<value>
+					<Bulk>20</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]/equippedStatOffsets</xpath>
+				<value>
+					<CarryBulk>30</CarryBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_CarapaceArmor"]/apparel/layers</xpath>
+				<value>
+					<li>Webbing</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Ordo Tempestus - Tempestus Scions/Headgear_Industrial.xml
+++ b/Patches/Ordo Tempestus - Tempestus Scions/Headgear_Industrial.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[1.4] Ordo Tempestus - Tempestus Scions</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Beret === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Beret"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- === Helmet === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>14</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Helmet"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			<!-- === Omni Mask === -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Mask"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<WornBulk>0.5</WornBulk>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ODZ_40k_IM_TempestusScion_Mask"]/stuffCategories/li[.="Metallic"]</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -116,6 +116,7 @@ Argonians of Blackmarsh (Continued) |
 Arrow Please (Continued)    |
 Aspero Race |
 Astoriel Legacy |
+Astra Militarum Regimentum - Cadia  |
 Autocleaner	|
 Auto-Mortars	|
 Bastyon  |

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -117,6 +117,8 @@ Arrow Please (Continued)    |
 Aspero Race |
 Astoriel Legacy |
 Astra Militarum Regimentum - Cadia  |
+Astra Militarum Regimentum - Krieg  |
+Astra Militarum Regimentum - Krieg: Officer Helmet  |
 Autocleaner	|
 Auto-Mortars	|
 Bastyon  |

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -324,6 +324,7 @@ ODZ Suits |
 Ogam's Warbanner Mod    |
 Opossum Friends |
 Orassans	|
+Ordo Tempestus - Tempestus Scions   |
 Outer Rim - Tatooine    |
 Palm Cats   |
 Paniel the Automata |


### PR DESCRIPTION
## Additions
Patches the following mods:
- Ordo Tempestus - Tempestus Scions
- Astra Militarum Regimentum - Krieg
- Astra Militarum Regimentum - Cadia
- Astra Militarum Regimentum - Krieg: Officer Helmet

## References
Closes #2233
Closes #2232
Closes #2231 

## Reasoning
Armor levels for the equipment are generally on part with late industrial gear like the advanced/composite helmet. The body armor is a bit lighter than recon armor, offering protection roughly similar to advanced modern armor. The armor is treated as unpowered (providing no weight capacity bonus) as I couldn't find an indication these types of armor were generally powered in the 40k 'verse. I included partial armor, with the shoulders having a somewhat better proportion of armor (85% vs 60%) than comparable modern vests, since 40k typically uses bulky, hard armor for pauldrons. 

I gave the Tempetus and Cadian armors bulk carrying capacity equal to the Tac Vest and had them occupy the `Webbing` layer. The Cadian armor has equipment pouches and various webbing visible on it. I included it on the Tempetus armor as well because it was in line with the Cadian armor sets, and because it seemed to me that players would probably not want tac vests visually obstructing the armor.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
