### PR TITLE
Warmup nre fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -385,6 +385,10 @@ namespace CombatExtended
             if (AttackVerb.verbProps.warmupTime > 0f)
             {
                 burstWarmupTicksLeft = AttackVerb.verbProps.warmupTime.SecondsToTicks();
+                if (AttackVerb is Verb_ShootCE verb)
+                {
+                    verb.RecalculateWarmupTicks();
+                }
                 return;
             }
             if (canBeginBurstImmediately)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -321,13 +321,13 @@ namespace CombatExtended
             var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);
             var reduction = Mathf.Max(maxReduction, delta / 45f);
             storedShotReduction = reduction;
-            if (reduction < 1.0f && this.WarmupStance != null)
+            if (reduction < 1.0f)
             {
                 if (caster is Building_TurretGunCE turret)
                 {
                     turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
                 }
-                else
+                else if (this.WarmupStance != null)
                 {
                     this.WarmupStance.ticksLeft = (int)(this.WarmupStance.ticksLeft * reduction);
                 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -325,7 +325,7 @@ namespace CombatExtended
             {
                 if (caster is Building_TurretGunCE turret)
                 {
-                    turret.burstWarmupTicksLeft += (int)(turret.burstWarmupTicksLeft * reduction);
+                    turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
                 }
                 else
                 {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -321,7 +321,7 @@ namespace CombatExtended
             var maxReduction = storedShotReduction ?? (CompFireModes?.CurrentAimMode == AimMode.SuppressFire ? 0.1f : 0.25f);
             var reduction = Mathf.Max(maxReduction, delta / 45f);
             storedShotReduction = reduction;
-            if (reduction < 1.0f)
+            if (reduction < 1.0f && this.WarmupStance != null)
             {
                 this.WarmupStance.ticksLeft = (int)(this.WarmupStance.ticksLeft * reduction);
             }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -325,7 +325,11 @@ namespace CombatExtended
             {
                 if (caster is Building_TurretGunCE turret)
                 {
-                    turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
+                    if (!_isAiming && turret.burstWarmupTicksLeft > 0)  //Turrets call beginBurst() when starting to fire a burst, and when starting the final aiming part of an aimed shot.  We only want apply changes to warmup.
+                    {
+                        Log.Message("Reducing warmup from " + turret.burstWarmupTicksLeft + " to " + (int)(turret.burstWarmupTicksLeft * reduction) + " for " + caster.ThingID);
+                        turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
+                    }
                 }
                 else if (this.WarmupStance != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -323,7 +323,14 @@ namespace CombatExtended
             storedShotReduction = reduction;
             if (reduction < 1.0f && this.WarmupStance != null)
             {
-                this.WarmupStance.ticksLeft = (int)(this.WarmupStance.ticksLeft * reduction);
+                if (caster is Building_TurretGunCE turret)
+                {
+                    turret.burstWarmupTicksLeft += (int)(turret.burstWarmupTicksLeft * reduction);
+                }
+                else
+                {
+                    this.WarmupStance.ticksLeft = (int)(this.WarmupStance.ticksLeft * reduction);
+                }
             }
 
         }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -327,7 +327,6 @@ namespace CombatExtended
                 {
                     if (!_isAiming && turret.burstWarmupTicksLeft > 0)  //Turrets call beginBurst() when starting to fire a burst, and when starting the final aiming part of an aimed shot.  We only want apply changes to warmup.
                     {
-                        Log.Message("Reducing warmup from " + turret.burstWarmupTicksLeft + " to " + (int)(turret.burstWarmupTicksLeft * reduction) + " for " + caster.ThingID);
                         turret.burstWarmupTicksLeft = (int)(turret.burstWarmupTicksLeft * reduction);
                     }
                 }


### PR DESCRIPTION
## Changes

- Fix NRE when aiming turret.
- Turrets now benefit from the faster follow-up shot system


## Reasoning

- Checks added to RecalculateWarmupTicks() to prevent affecting aiming time (as opposed to warmup time).  Turret code calls beginBurst() which ultimately calls RecalculateWarmupTicks() when starting to fire, and starting to aim.

## Alternatives

- Revamp turret code

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
