### PR TITLE
Adjust Human Body Coverage

### DIFF
--- a/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
+++ b/Patches/Ancient Blade Cyborg/Cyborg_CoveredByNaturalArmor.xml
@@ -11,7 +11,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="Cyborg"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 
@@ -119,13 +119,6 @@
 						<coverage>0.15</coverage>
 					</value>
 				</li>
-
-  <li Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Cyborg"]/corePart/parts/li[def = "CyborgLeg"]/coverage</xpath>
-    <value>
-      <coverage>0.1</coverage>
-    </value>
-  </li>
 
   <!-- ========== Add armor coverage ========== -->
 

--- a/Patches/Antinium/Bodies/Ant_Bodies.xml
+++ b/Patches/Antinium/Bodies/Ant_Bodies.xml
@@ -176,12 +176,6 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
 					<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
@@ -191,12 +185,6 @@
 					<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/BodyDef[defName="Antinium"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
 					</value>
 				</li>
 			</operations>

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -136,7 +136,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/coverage</xpath>
     <value>
-      <coverage>0.05</coverage>
+      <coverage>0.055</coverage>
     </value>
   </Operation>
 

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -87,7 +87,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
     <value>
-      <coverage>0.012</coverage>
+      <coverage>0.07</coverage>
     </value>
   </Operation>
 
@@ -136,7 +136,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Neck"]/coverage</xpath>
     <value>
-      <coverage>0.055</coverage>
+      <coverage>0.05</coverage>
     </value>
   </Operation>
 
@@ -197,13 +197,6 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-    <value>
-      <coverage>0.1</coverage>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
     <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
@@ -214,13 +207,6 @@
     <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Tibia"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
-    <xpath>Defs/BodyDef[defName="Human"]/corePart/parts/li[def="Leg"]/parts/li[def="Foot"]/coverage</xpath>
-    <value>
-      <coverage>0.1</coverage>
     </value>
   </Operation>
 

--- a/Patches/Moyo from the depth/Bodies/Moyo_Bodytype.xml
+++ b/Patches/Moyo from the depth/Bodies/Moyo_Bodytype.xml
@@ -146,7 +146,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -237,12 +237,6 @@
 					<xpath>/Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="Moyo"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/NewRatkinPlus/Bodies/Bodies_Ratkin.xml
+++ b/Patches/NewRatkinPlus/Bodies/Bodies_Ratkin.xml
@@ -41,7 +41,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
 				<value>
-					<coverage>0.012</coverage>
+					<coverage>0.07</coverage>
 				</value>
 			</li>
 
@@ -151,13 +151,6 @@
 		  </li>
 
 		  <li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
-				<value>
-				  <coverage>0.1</coverage>
-				</value>
-		  </li>
-
-		  <li Class="PatchOperationReplace">
 				<xpath>/Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Leg"]/parts/li[def="Femur"]/coverage</xpath>
 				<value>
 				  <coverage>0.15</coverage>
@@ -170,13 +163,6 @@
 				  <coverage>0.15</coverage>
 				</value>
 		  </li>
-
-		  <li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Leg"]/parts/li[def="Foot"]/coverage</xpath>
-				<value>
-				  <coverage>0.1</coverage>
-				</value>
-		  </li>  
 
 		  <li Class="PatchOperationReplace">
 				<xpath>/Defs/BodyDef[defName = "Ratkin"]/corePart/parts/li[def = "Neck"]/parts/li[def = "Head"]/parts/li[customLabel="left ear"]/coverage</xpath>

--- a/Patches/Nyaron/Bodies/Nyaron_Bodytype.xml
+++ b/Patches/Nyaron/Bodies/Nyaron_Bodytype.xml
@@ -15,7 +15,7 @@
 			<li Class="PatchOperationReplace">
 			<xpath>/Defs/BodyDef[defName = "Nyaron"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
 			<value>
-			  <coverage>0.012</coverage>
+			  <coverage>0.07</coverage>
 			</value>
 			</li>
 
@@ -125,13 +125,6 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/BodyDef[defName = "Nyaron"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
-			<value>
-			  <coverage>0.1</coverage>
-			</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
 			<xpath>/Defs/BodyDef[defName = "Nyaron"]/corePart/parts/li[def = "Leg"]/parts/li[def="Femur"]/coverage</xpath>
 			<value>
 			  <coverage>0.15</coverage>
@@ -142,13 +135,6 @@
 			<xpath>/Defs/BodyDef[defName = "Nyaron"]/corePart/parts/li[def = "Leg"]/parts/li[def="Tibia"]/coverage</xpath>
 			<value>
 			  <coverage>0.15</coverage>
-			</value>
-			</li>
-
-			<li Class="PatchOperationReplace">
-			<xpath>/Defs/BodyDef[defName = "Nyaron"]/corePart/parts/li[def = "Leg"]/parts/li[def="Foot"]/coverage</xpath>
-			<value>
-			  <coverage>0.1</coverage>
 			</value>
 			</li>
 			

--- a/Patches/Poleepkwa Race/Patch_Bodies_Prawny.xml
+++ b/Patches/Poleepkwa Race/Patch_Bodies_Prawny.xml
@@ -13,7 +13,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -104,12 +104,6 @@
 					<xpath>/Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="PoleepkwaBody"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Revia Race/ThingDefs_Bodies/Revia_Bodytype.xml
+++ b/Patches/Revia Race/ThingDefs_Bodies/Revia_Bodytype.xml
@@ -18,7 +18,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -109,12 +109,6 @@
 					<xpath>/Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="ReviaRaceBody"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/Rim-Effect Asari and Reapers/Bodies_Asari.xml
+++ b/Patches/Rim-Effect Asari and Reapers/Bodies_Asari.xml
@@ -10,7 +10,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 				<value>
-					<coverage>0.012</coverage>
+					<coverage>0.07</coverage>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -101,12 +101,6 @@
 				<xpath>/Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 				<value>
 					<coverage>0.15</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="RE_Asari"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-				<value>
-					<coverage>0.1</coverage>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Rim-Hivers!/Patch_Bodies_Hivers.xml
+++ b/Patches/Rim-Hivers!/Patch_Bodies_Hivers.xml
@@ -12,7 +12,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -105,38 +105,6 @@
 						<coverage>0.15</coverage>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="HiverBody"]/corePart/parts/li[def="Leg"]</xpath>
-					<value>
-                  					<parts>
-            						<li>
-              						<def>Femur</def>
-              						<customLabel>right femur</customLabel>
-              						<coverage>0.15</coverage>
-              						<depth>Inside</depth>
-              						<groups>
-                					<li>Legs</li>
-              						</groups>
-            						</li>
-            						<li>
-              						<def>Tibia</def>
-              						<customLabel>right tibia</customLabel>
-              						<coverage>0.15</coverage>
-              						<depth>Inside</depth>
-              						<groups>
-                					<li>Legs</li>
-              						</groups>
-            						</li>
-                  					</parts>
-					</value>
-				</li>
-
 
       <li Class="PatchOperationAdd">
         <xpath>

--- a/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
+++ b/Patches/Rim-Sheks!/Patch_Bodies_Sheks.xml
@@ -12,7 +12,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -106,12 +106,6 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="ShekBody"]/corePart/parts/li[def="Leg"]/parts/li[def="Femur"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
@@ -123,8 +117,6 @@
 						<coverage>0.15</coverage>
 					</value>
 				</li>
-
-
 
       <li Class="PatchOperationAdd">
         <xpath>

--- a/Patches/Rimcraft Collection/Rimcraft/Patch_Bodies_WOW.xml
+++ b/Patches/Rimcraft Collection/Rimcraft/Patch_Bodies_WOW.xml
@@ -11,7 +11,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -102,12 +102,6 @@
 					<xpath>/Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Shoulder"]/parts/li[def="Arm"]/parts/li[def="Radius"]/coverage</xpath>
 					<value>
 						<coverage>0.15</coverage>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/BodyDef[defName="Tauren"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-					<value>
-						<coverage>0.1</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/SYR Harpy/Patch_Bodies_Harpy.xml
+++ b/Patches/SYR Harpy/Patch_Bodies_Harpy.xml
@@ -37,7 +37,7 @@
 			<li Class="PatchOperationReplace">
 			<xpath>/Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 				<value>
-					<coverage>0.012</coverage>
+					<coverage>0.07</coverage>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -134,12 +134,6 @@
 				<xpath>/Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Shoulder"]/parts/li[def="ArmHarpy"]/parts/li[def="Radius"]/coverage</xpath>
 				<value>
 					<coverage>0.15</coverage>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>/Defs/BodyDef[defName="Harpy_Body"]/corePart/parts/li[def="Leg"]/coverage</xpath>
-				<value>
-					<coverage>0.1</coverage>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/SYR Naga/Patch_Bodies_Naga.xml
+++ b/Patches/SYR Naga/Patch_Bodies_Naga.xml
@@ -38,7 +38,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/BodyDef[defName="Naga_Body"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 				<value>
-					<coverage>0.012</coverage>
+					<coverage>0.07</coverage>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Bodies_Thrumkin.xml
@@ -37,7 +37,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/BodyDef[defName="Thrumkin_Body"]/corePart/parts/li[def="Ribcage"]/coverage</xpath>
 					<value>
-						<coverage>0.012</coverage>
+						<coverage>0.07</coverage>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">


### PR DESCRIPTION
# Changes
1. Remove redundant patch for `Foot` coverage from the HumanBodyDef.
2. Remove patches for the `Leg` coverage, restoring to vanilla coverage of 0.14.
3. Increase the coverage of the `Ribcage` from 0.012 to 0.07.

Made these same adjustments to various race mods.

**Rim-Hivers:** Removed the patch that gives them a tibia and fibula. They're an insectoid race and the base mod lacks these, so it may be justifiable that they have an exoskeleton rather than these particular bones. 

## References
Suggested alternative scheme to #2224

## Reasoning
The entire vanilla body only has a total coverage of **85%**, so the rest is just kind of "empty internal space". Even accepting that Rimworld doesn't really concern itself with simulating the intestines and various other organs (and counting that space as "empty"), there's not really that much empty room inside a body. So, I don't really agree with how vanilla sizes the organs overall.

This empty space means that, despite the changes CE makes to body part coverage, none of the changes seem to be arbitrarily shrinking parts to "make room" for enlarging other parts.

So, this PR is a somewhat more modest alternative to #2224. It still accomplishes a lot of the same important things (adjusts the ribcage size)

1. `Foot` coverage is already 0.1 in vanilla. The existing patch is therefore redundant.
2. Scaling between the arm and leg is strange in vanilla, so it's not desirable to go right back to it, but it should still be adjusted a bit. Removing CE's patch to `Shoulder` coverage makes the arm 70% the size of the leg, which feels more appropriate than the 85% we currently use. For comparison, vanilla also uses 85% (albeit at different coverage values).
3. The `Ribcage` is an odd case, as the way it's structured in the .xml is that the ribs exists on the same level as the various internal organs, rather than the organs being contained _within_ the ribcage. It's preferable to adjust coverage rather than majorly restructure the .xml. Increasing the coverage of the ribcage to 0.07 serves to both preserve the vanilla coverage ratio with the pelvis of 1:1.4, and also fills some of the "empty space". 

**Note:** We can _probably_ remove most of the coverage adjustments we make to vanilla animal bodies (as is done in #2224), but I'd like to hold off for this release so I can take the time for a closer look and check for any oddities in the vanilla coverages. For now, let's just adjust the humanoid bodies that need it.

## Alternatives
More sweeping changes in #2224 reverting to vanilla coverage, though coverage has its own oddities and quirks that make it undesirable in some ways.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
