### PR TITLE
Fix the base grenade projectile inheritance issues

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -77,8 +77,14 @@
       <damageAmountBase>80</damageAmountBase>
       <explosionDelay>150</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
+      <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
       <speed>12</speed>
       <screenShakeFactor>0.5</screenShakeFactor>
+      <suppressionFactor>3.0</suppressionFactor>
+      <dangerFactor>2.0</dangerFactor>
+      <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
@@ -156,9 +162,12 @@
       <soundExplode>Explosion_Stun</soundExplode>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
- 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+      <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
       <speed>10</speed>
       <screenShakeFactor>0</screenShakeFactor>
+      <suppressionFactor>2.0</suppressionFactor>
+      <dangerFactor>1.5</dangerFactor>
+      <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
     </projectile>
   </ThingDef>
 
@@ -233,6 +242,9 @@
       <explosionDelay>90</explosionDelay>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <speed>8</speed>
+      <suppressionFactor>3.0</suppressionFactor>
+      <dangerFactor>2.0</dangerFactor>
+      <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
     </projectile>
   </ThingDef>
 
@@ -301,11 +313,13 @@
       <explosionDelay>30</explosionDelay>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
- 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+      <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
       <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>12</speed>
       <screenShakeFactor>0</screenShakeFactor>
+      <suppressionFactor>0</suppressionFactor>
+      <dangerFactor>0</dangerFactor>
     </projectile>
   </ThingDef>
 
@@ -379,11 +393,13 @@
       <explosionDelay>30</explosionDelay>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
- 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
+      <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
       <speed>12</speed>
       <screenShakeFactor>0</screenShakeFactor>
+      <suppressionFactor>0</suppressionFactor>
+      <dangerFactor>0</dangerFactor>
     </projectile>
   </ThingDef>
 

--- a/Patches/Bori Race/ThingDefs_Misc/Bori_Explosives.xml
+++ b/Patches/Bori Race/ThingDefs_Misc/Bori_Explosives.xml
@@ -54,6 +54,9 @@
 				  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 				  <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+				  <suppressionFactor>3.0</suppressionFactor>
+				  <dangerFactor>2.0</dangerFactor>
+				  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 				</projectile>
 			</value>
 		</li>	

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -63,9 +63,6 @@
 		<xpath>Defs/ThingDef[@Name="BaseGrenadeProjectile"]/projectile</xpath>
 		<value>
 			<explosionDamageFalloff>true</explosionDamageFalloff>
-			<suppressionFactor>3.0</suppressionFactor>
-			<dangerFactor>2.0</dangerFactor>
-			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</value>
 	</Operation>
 
@@ -103,6 +100,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>12</speed>
+				<suppressionFactor>3.0</suppressionFactor>
+				<dangerFactor>2.0</dangerFactor>
+				<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -244,6 +244,9 @@
 				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 				<screenShakeFactor>0</screenShakeFactor>
+				<suppressionFactor>3.0</suppressionFactor>
+				<dangerFactor>2.0</dangerFactor>
+				<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 			</projectile>
 		</value>
 	</Operation>
@@ -370,6 +373,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<speed>12</speed>
 				<screenShakeFactor>0</screenShakeFactor>
+				<suppressionFactor>3.0</suppressionFactor>
+				<dangerFactor>2.0</dangerFactor>
+				<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 			</projectile>
 		</value>
 	</Operation>

--- a/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Grenades.xml
+++ b/Patches/K4G Rimworld War 2/ThingDefs_Misc/WW2_Grenades.xml
@@ -33,6 +33,9 @@
                         <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                         <speed>10</speed>
                      </projectile>
                      <comps>
@@ -62,6 +65,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -97,6 +103,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -135,6 +144,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -166,6 +178,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -197,6 +212,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -226,6 +244,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -254,6 +275,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -292,6 +316,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -321,6 +348,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -350,6 +380,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -378,6 +411,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -416,6 +452,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -447,6 +486,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -476,6 +518,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -505,6 +550,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">
@@ -533,6 +581,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -568,6 +619,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -603,6 +657,9 @@
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>9</speed>
                         <gravityFactor>1.5</gravityFactor>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -641,6 +698,9 @@
                         <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
                         <speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
                      </projectile>
                      <comps>
                         <li Class="CombatExtended.CompProperties_Fragments">

--- a/Patches/Kaiser Armory/KaiserArmory_Guns.xml
+++ b/Patches/Kaiser Armory/KaiserArmory_Guns.xml
@@ -574,6 +574,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/LF Red Dawn/RD_Grenade.xml
+++ b/Patches/LF Red Dawn/RD_Grenade.xml
@@ -37,6 +37,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 				</projectile>
 				<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
@@ -64,6 +67,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 				</projectile>
 				<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
@@ -91,6 +97,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 				</projectile>
 				<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
@@ -118,6 +127,9 @@
 				<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<speed>10</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 				</projectile>
 				<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">

--- a/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
+++ b/Patches/Pratt WWII Weapons Pack/PWW2_CE_Patch_Weapons_Grenades.xml
@@ -224,6 +224,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -352,6 +355,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -495,6 +501,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -627,6 +636,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -759,6 +771,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -891,6 +906,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
+++ b/Patches/Red Horse Faction Elite Crew/RH_EliteCrew_CE_Patch_RangedIndustrial_Grenades.xml
@@ -107,6 +107,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>
@@ -208,6 +211,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>6</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Tsar Armory/TsarArmory_Guns.xml
+++ b/Patches/Tsar Armory/TsarArmory_Guns.xml
@@ -277,6 +277,9 @@
 						<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 						<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 						<speed>12</speed>
+						  <suppressionFactor>3.0</suppressionFactor>
+						  <dangerFactor>2.0</dangerFactor>
+						  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 					</projectile>
 				</value>
 			</li>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
@@ -38,6 +38,9 @@
               <armorPenetrationSharp>0</armorPenetrationSharp>
               <armorPenetrationBlunt>0</armorPenetrationBlunt>
               <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			  <suppressionFactor>3.0</suppressionFactor>
+			  <dangerFactor>2.0</dangerFactor>
+			  <airborneSuppressionFactor>0.25</airborneSuppressionFactor>
             </projectile>
           </value>
         </li>


### PR DESCRIPTION
## Changes

- What it says on the tin, the base grenade projectile being patched to include CE specific nodes in #2235 was causing certain projectiles that used the bade projectile as a parent but did not have the CE projectile class to throw errors and not recognize the nodes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
