### PR TITLE
Fix sidearm generation money.

### DIFF
--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -150,7 +150,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>110</speed>
-      <damageAmountBase>14</damageAmountBase>
+      <damageAmountBase>15</damageAmountBase>
       <armorPenetrationSharp>4.5</armorPenetrationSharp>
       <armorPenetrationBlunt>21.36</armorPenetrationBlunt>
     </projectile>

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -161,7 +161,7 @@ namespace CombatExtended
             }
             // Generate weapon - mostly based on PawnWeaponGenerator.TryGenerateWeaponFor()
             // START 1:1 COPY
-            float randomInRange = pawn.kindDef.weaponMoney.RandomInRange;
+            float randomInRange = option.sidearmMoney.RandomInRange;
             for (int i = 0; i < allWeaponPairs.Count; i++)
             {
                 ThingStuffPair w = allWeaponPairs[i];


### PR DESCRIPTION
## Changes

- Sidearm generation now based on money value in SidearmOption, not pawn weapon money.

## References

- Closes #2260

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
