### PR TITLE
Fix the Light Mechanoid gun draw sizes

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -39,6 +39,18 @@
     </value>
   </Operation>
 
+  <!-- ========== Draw Size ========== -->
+
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Gun_MiniShotgun" or defName="Gun_Slugthrower" or defName="Gun_Spiner" or defName="Gun_MiniFlameblaster"]</xpath>
+    <value>
+      <li Class="CombatExtended.GunDrawExtension">
+        <DrawSize>0.65,0.65</DrawSize>
+        <DrawOffset>0.0,0.0</DrawOffset>
+      </li>
+    </value>
+  </Operation>
+
   <!-- ========== Mini-shotgun ========== -->
 
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Weapons_RoyaltyBladelinkMelee.xml
@@ -109,7 +109,7 @@
 					</li>
 					</extraMeleeDamages>					
 					<cooldownTime>2.19</cooldownTime>
-					<armorPenetrationBlunt>190</armorPenetrationBlunt>
+					<armorPenetrationBlunt>200</armorPenetrationBlunt>
 					<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 				</li>	
 			</tools>


### PR DESCRIPTION
## Changes

- What is says on the tin. For whatever reason the vanilla draw size node is not working in CE be it patch op added in or inherited from a parent. This PR fixes that by giving them their appropriate size via CE's gun draw size mod extension

## References

- https://discord.com/channels/278818534069501953/322827713335394304/1059729803751719022

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
