### PR TITLE
Ammo adjustments and additions

### DIFF
--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -29,6 +29,9 @@
 			<Ammo_45ACP_AP>Bullet_45ACP_AP</Ammo_45ACP_AP>
 			<Ammo_45ACP_HP>Bullet_45ACP_HP</Ammo_45ACP_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -22,6 +22,17 @@
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45Colt_HV</defName>
+		<label>.45 Colt</label>
+		<ammoTypes>
+			<Ammo_45Colt_FMJ>Bullet_45Colt_HV_FMJ</Ammo_45Colt_FMJ>
+			<Ammo_45Colt_AP>Bullet_45Colt_HV_AP</Ammo_45Colt_AP>
+			<Ammo_45Colt_HP>Bullet_45Colt_HV_HP</Ammo_45Colt_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_45Colt410Bore</defName>
 		<label>.45 Colt/.410 bore</label>
 		<ammoTypes>
@@ -145,6 +156,41 @@
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.440</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ========= High velocity ========= -->
+
+	<ThingDef ParentName="Base45ColtBullet">
+		<defName>Bullet_45Colt_HV_FMJ</defName>
+		<label>.45 Colt bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>16</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
+			<speed>86</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base45ColtBullet">
+		<defName>Bullet_45Colt_HV_AP</defName>
+		<label>.45 Colt bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
+			<speed>86</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base45ColtBullet">
+		<defName>Bullet_45Colt_HV_HP</defName>
+		<label>.45 Colt bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
+			<speed>86</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -36,10 +36,13 @@
 		<defName>AmmoSet_45Colt410Bore</defName>
 		<label>.45 Colt/.410 bore</label>
 		<ammoTypes>
-			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
-			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
-			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+			<Ammo_45Colt_FMJ>Bullet_45Colt_HV_FMJ</Ammo_45Colt_FMJ>
+			<Ammo_45Colt_AP>Bullet_45Colt_HV_AP</Ammo_45Colt_AP>
+			<Ammo_45Colt_HP>Bullet_45Colt_HV_HP</Ammo_45Colt_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -52,6 +55,9 @@
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -174,7 +174,7 @@
       <damageAmountBase>19</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <empShieldBreakChance>0.2</empShieldBreakChance>
+      <empShieldBreakChance>0.25</empShieldBreakChance>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -172,7 +172,7 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<empShieldBreakChance>0.18</empShieldBreakChance>      
+			<empShieldBreakChance>0.18</empShieldBreakChance>
 			<speed>30</speed>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -170,6 +170,10 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>29</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<empShieldBreakChance>0.5</empShieldBreakChance>
+			<speed>46</speed>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -74,8 +74,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.04</Mass>
-      <MarketValue>0.18</MarketValue>
+      <Mass>0.012</Mass>
+      <MarketValue>0.06</MarketValue>
     </statBases>
     <ammoClass>Slug</ammoClass>
     <cookOffProjectile>Bullet_410Bore_Slug</cookOffProjectile>
@@ -90,8 +90,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.058</Mass>
-      <MarketValue>0.32</MarketValue>
+      <Mass>0.015</Mass>
+      <MarketValue>0.11</MarketValue>
     </statBases>
     <ammoClass>Beanbag</ammoClass>
     <cookOffProjectile>Bullet_410Bore_Beanbag</cookOffProjectile>
@@ -105,8 +105,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.049</Mass>
-      <MarketValue>0.53</MarketValue>
+      <Mass>0.014</Mass>
+      <MarketValue>0.39</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -296,7 +296,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>18</count>
+        <count>6</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -307,7 +307,7 @@
     <products>
       <Ammo_410Bore_Slug>200</Ammo_410Bore_Slug>
     </products>
-    <workAmount>1800</workAmount>
+    <workAmount>600</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -322,7 +322,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>24</count>
+        <count>8</count>
       </li>
       <li>
         <filter>
@@ -330,7 +330,7 @@
             <li>Cloth</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>3</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -342,7 +342,7 @@
     <products>
       <Ammo_410Bore_Beanbag>200</Ammo_410Bore_Beanbag>
     </products>
-    <workAmount>3400</workAmount>
+    <workAmount>1100</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -358,7 +358,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>20</count>
+        <count>6</count>
       </li>
       <li>
         <filter>
@@ -378,7 +378,7 @@
     <products>
       <Ammo_410Bore_ElectroSlug>200</Ammo_410Bore_ElectroSlug>
     </products>
-    <workAmount>3200</workAmount>
+    <workAmount>1800</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -15,6 +15,9 @@
 		<label>.410 bore</label>
 		<ammoTypes>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -24,6 +27,9 @@
 		<label>.410 bore</label>
 		<ammoTypes>
 		  <Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+		  <Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+		  <Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+		  <Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -60,6 +66,53 @@
     <cookOffProjectile>Bullet_410Bore_Buck</cookOffProjectile>
   </ThingDef>
 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="410BoreBase">
+    <defName>Ammo_410Bore_Slug</defName>
+    <label>.410 Bore shell (Slug)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Shotgun/Slug</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <Mass>0.04</Mass>
+      <MarketValue>0.18</MarketValue>
+    </statBases>
+    <ammoClass>Slug</ammoClass>
+    <cookOffProjectile>Bullet_410Bore_Slug</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="410BoreBase">
+    <defName>Ammo_410Bore_Beanbag</defName>
+    <label>.410 Bore shell (Bean)</label>
+    <generateAllowChance>0</generateAllowChance>
+    <graphicData>
+      <texPath>Things/Ammo/Shotgun/Beanbag</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <Mass>0.058</Mass>
+      <MarketValue>0.32</MarketValue>
+    </statBases>
+    <ammoClass>Beanbag</ammoClass>
+    <cookOffProjectile>Bullet_410Bore_Beanbag</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="410BoreBase">
+    <defName>Ammo_410Bore_ElectroSlug</defName>
+    <label>.410 Bore shell (EMP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Shotgun/EMP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <Mass>0.049</Mass>
+      <MarketValue>0.53</MarketValue>
+    </statBases>
+    <ammoClass>ElectroSlug</ammoClass>
+    <generateAllowChance>0.5</generateAllowChance>
+    <cookOffProjectile>Bullet_410Bore_ElectroSlug</cookOffProjectile>
+  </ThingDef>
+
   <!-- ================== Projectiles ================== -->
 
   <ThingDef Name="Base410BoreBullet" ParentName="BaseBullet" Abstract="true">
@@ -69,23 +122,6 @@
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
-    </projectile>
-  </ThingDef>
-
-  <ThingDef ParentName="Base410BoreBullet">
-    <defName>Bullet_410Bore_Buck_SB</defName>
-    <label>buckshot pellet</label>
-    <graphicData>
-      <texPath>Things/Projectile/Shotgun_Pellet</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>49</speed>
-      <damageAmountBase>7</damageAmountBase> 
-      <pelletCount>5</pelletCount>
-      <armorPenetrationSharp>2.3</armorPenetrationSharp>
-      <armorPenetrationBlunt>2.72</armorPenetrationBlunt>
-      <spreadMult>17.8</spreadMult>
     </projectile>
   </ThingDef>
 
@@ -102,6 +138,121 @@
       <armorPenetrationSharp>3</armorPenetrationSharp>
       <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
       <spreadMult>8.9</spreadMult>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Slug</defName>
+    <label>shotgun slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>110</speed>
+      <damageAmountBase>14</damageAmountBase>
+      <armorPenetrationSharp>4.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>21.36</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Beanbag</defName>
+    <label>beanbag</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>18</speed>
+      <damageDef>Beanbag</damageDef>
+      <damageAmountBase>5</damageAmountBase>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0.86</armorPenetrationBlunt>
+      <spreadMult>2</spreadMult>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_ElectroSlug</defName>
+    <label>EMP slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>30</speed>
+      <damageDef>EMP</damageDef>
+      <damageAmountBase>7</damageAmountBase>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <empShieldBreakChance>0.15</empShieldBreakChance>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Buck_SB</defName>
+    <label>buckshot pellet</label>
+    <graphicData>
+      <texPath>Things/Projectile/Shotgun_Pellet</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>49</speed>
+      <damageAmountBase>7</damageAmountBase> 
+      <pelletCount>5</pelletCount>
+      <armorPenetrationSharp>2.1</armorPenetrationSharp>
+      <armorPenetrationBlunt>2.72</armorPenetrationBlunt>
+      <spreadMult>17.8</spreadMult>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Slug_SB</defName>
+    <label>shotgun slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>78</speed>
+      <damageAmountBase>11</damageAmountBase>
+      <armorPenetrationSharp>3.2</armorPenetrationSharp>
+      <armorPenetrationBlunt>10.72</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_Beanbag_SB</defName>
+    <label>beanbag</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>18</speed>
+      <damageDef>Beanbag</damageDef>
+      <damageAmountBase>4</damageAmountBase>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0.44</armorPenetrationBlunt>
+      <spreadMult>2</spreadMult>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base410BoreBullet">
+    <defName>Bullet_410Bore_ElectroSlug_SB</defName>
+    <label>EMP slug</label>
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <speed>21</speed>
+      <damageDef>EMP</damageDef>
+      <damageAmountBase>7</damageAmountBase>
+      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <empShieldBreakChance>0.15</empShieldBreakChance>
     </projectile>
   </ThingDef>
 
@@ -131,6 +282,103 @@
       <Ammo_410Bore_Buck>200</Ammo_410Bore_Buck>
     </products>
     <workAmount>1200</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_410Bore_Slug</defName>
+    <label>make .410 Bore (Slug) shell x200</label>
+    <description>Craft 200 .410 Bore (Slug) shells.</description>
+    <jobString>Making .410 Bore (Slug) shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_410Bore_Slug>200</Ammo_410Bore_Slug>
+    </products>
+    <workAmount>1800</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_410Bore_Beanbag</defName>
+    <label>make .410 Bore (Beanbag) shell x200</label>
+    <description>Craft 200 .410 Bore (Beanbag) shells.</description>
+    <jobString>Making .410 Bore (Beanbag) shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>24</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Cloth</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Cloth</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_410Bore_Beanbag>200</Ammo_410Bore_Beanbag>
+    </products>
+    <workAmount>3400</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_410Bore_ElectroSlug</defName>
+    <label>make .410 Bore (EMP) shell x200</label>
+    <description>Craft 200 .410 Bore (EMP) shells.</description>
+    <jobString>Making .410 Bore (EMP) shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_410Bore_ElectroSlug>200</Ammo_410Bore_ElectroSlug>
+    </products>
+    <workAmount>3200</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -91,7 +91,7 @@
     </graphicData>
     <statBases>
       <Mass>0.015</Mass>
-      <MarketValue>0.11</MarketValue>
+      <MarketValue>0.1</MarketValue>
     </statBases>
     <ammoClass>Beanbag</ammoClass>
     <cookOffProjectile>Bullet_410Bore_Beanbag</cookOffProjectile>
@@ -106,7 +106,7 @@
     </graphicData>
     <statBases>
       <Mass>0.014</Mass>
-      <MarketValue>0.39</MarketValue>
+      <MarketValue>0.33</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -270,7 +270,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>12</count>
+        <count>30</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -279,9 +279,9 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_410Bore_Buck>200</Ammo_410Bore_Buck>
+      <Ammo_410Bore_Buck>500</Ammo_410Bore_Buck>
     </products>
-    <workAmount>1200</workAmount>
+    <workAmount>3000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -296,7 +296,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>6</count>
+        <count>14</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -305,9 +305,9 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_410Bore_Slug>200</Ammo_410Bore_Slug>
+      <Ammo_410Bore_Slug>500</Ammo_410Bore_Slug>
     </products>
-    <workAmount>600</workAmount>
+    <workAmount>1400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -322,7 +322,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>18</count>
       </li>
       <li>
         <filter>
@@ -330,7 +330,7 @@
             <li>Cloth</li>
           </thingDefs>
         </filter>
-        <count>3</count>
+        <count>6</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -340,9 +340,9 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_410Bore_Beanbag>200</Ammo_410Bore_Beanbag>
+      <Ammo_410Bore_Beanbag>500</Ammo_410Bore_Beanbag>
     </products>
-    <workAmount>1100</workAmount>
+    <workAmount>2400</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -358,7 +358,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>6</count>
+        <count>16</count>
       </li>
       <li>
         <filter>
@@ -366,7 +366,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>4</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -376,9 +376,9 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_410Bore_ElectroSlug>200</Ammo_410Bore_ElectroSlug>
+      <Ammo_410Bore_ElectroSlug>500</Ammo_410Bore_ElectroSlug>
     </products>
-    <workAmount>1800</workAmount>
+    <workAmount>4000</workAmount>
   </RecipeDef>
 
 </Defs>


### PR DESCRIPTION
## Additions

- Added the High Velocity .45 Colt ammoset to be used in rifles.
- Added .410 slug, beanbag and EMP shells in slow and normal variants.
- Made small adjustments to other shotgun shells and ammosets.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070
- .410 Slugs: https://www.opticsplanet.com/winchester-ammunition-410ga-3-1-4oz-supx-riflehp-slug-5-x413rs5.html

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
