### PR TITLE
20 gauge shells' sharp AP adjusted

### DIFF
--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -123,7 +123,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
 			<pelletCount>20</pelletCount>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.92</armorPenetrationBlunt>
 			<spreadMult>10.9</spreadMult>
 		</projectile>
@@ -139,7 +139,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>97</speed>
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.14</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- Decreased the sharp AP of the 20 gauge buck and slug shells after updating the gel test source. the No. 4 pellets we use can effectively penetrate a maximum of 8 inches of gel.

## References

- https://www.youtube.com/watch?v=8GqZaVQW7O4 
- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
