### PR TITLE
Mini-shotgun rechambered

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -44,28 +44,27 @@
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
     <defName>Gun_MiniShotgun</defName>
     <statBases>
-      <RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.4</RangedWeapon_Cooldown>
       <SightsEfficiency>1</SightsEfficiency>
       <ShotSpread>0.15</ShotSpread>
       <SwayFactor>0.53</SwayFactor>
       <Bulk>6.00</Bulk>
     </statBases>
     <Properties>
-      <recoilAmount>2.80</recoilAmount>
+      <recoilAmount>2.42</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
-      <defaultProjectile>Bullet_20Gauge_Buck</defaultProjectile>
+      <defaultProjectile>Bullet_410Bore_Buck</defaultProjectile>
       <warmupTime>0.8</warmupTime>
       <range>14</range>
-      <burstShotCount>1</burstShotCount>
       <soundCast>Shot_Shotgun_NoRack</soundCast>
-      <soundCastTail>GunTail_Heavy</soundCastTail>
+      <soundCastTail>GunTail_Nedium</soundCastTail>
       <muzzleFlashScale>6</muzzleFlashScale>
     </Properties>
     <AmmoUser>
-      <magazineSize>8</magazineSize>
+      <magazineSize>10</magazineSize>
       <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_20Gauge</ammoSet>
+      <ammoSet>AmmoSet_410Bore</ammoSet>
     </AmmoUser>
     <FireModes>
       <aiAimMode>Snapshot</aiAimMode>
@@ -94,7 +93,6 @@
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
       <warmupTime>1.3</warmupTime>
       <range>35</range>
-      <burstShotCount>1</burstShotCount>
       <soundCast>Shot_Slugthrower</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
@@ -131,7 +129,6 @@
       <defaultProjectile>Bullet_5x16mmCharged</defaultProjectile>
       <warmupTime>1.1</warmupTime>   <!-- Intentionally increased from 0.8 due to balance reasons-->
       <range>15</range>
-      <burstShotCount>1</burstShotCount>
       <soundCast>Shot_Spiner</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
## Changes

- Rechambered the Militor mini-shotgun in .410.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- For a mini-shotgun, 20 gauge is too big and deals too much raw damage (100) in buckshot form which can lead to the mech being very strong when they are unlocked and very punishing when hostile. .410 shells with the new shell types added in #2265 offers enough strength.

## Alternatives

- Leave the shotgun chambered in 20 gauge.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
