### PR TITLE
biocode sidearms.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -62,7 +62,7 @@ namespace CombatExtended
             allShieldPairs = ThingStuffPair.AllWith(td => td.thingClass == typeof(Apparel_Shield));
         }
 
-        public void GenerateLoadoutFor(Pawn pawn)
+        public void GenerateLoadoutFor(Pawn pawn, float biocodeWeaponChance)
         {
             if (!pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation)
                     || (pawn.WorkTagIsDisabled(WorkTags.Violent))
@@ -81,7 +81,7 @@ namespace CombatExtended
             // Generate forced sidearm
             if (forcedSidearm != null)
             {
-                TryGenerateWeaponWithAmmoFor(pawn, inventory, forcedSidearm);
+                TryGenerateWeaponWithAmmoFor(pawn, inventory, forcedSidearm, biocodeWeaponChance);
             }
 
             // Generate primary ammo
@@ -107,7 +107,7 @@ namespace CombatExtended
             {
                 foreach (SidearmOption current in sidearms)
                 {
-                    TryGenerateWeaponWithAmmoFor(pawn, inventory, current);
+                    TryGenerateWeaponWithAmmoFor(pawn, inventory, current, biocodeWeaponChance);
                 }
             }
         }
@@ -153,7 +153,7 @@ namespace CombatExtended
             weapon.UpdateConfiguration();
         }
 
-        private void TryGenerateWeaponWithAmmoFor(Pawn pawn, CompInventory inventory, SidearmOption option)
+        private void TryGenerateWeaponWithAmmoFor(Pawn pawn, CompInventory inventory, SidearmOption option, float biocodeChance)
         {
             if (option.weaponTags.NullOrEmpty() || !Rand.Chance(option.generateChance))
             {
@@ -188,6 +188,10 @@ namespace CombatExtended
             {
                 // Create the actual weapon and put it into inventory
                 ThingWithComps thingWithComps = (ThingWithComps)ThingMaker.MakeThing(thingStuffPair.thing, thingStuffPair.stuff);
+                if (Rand.Value < biocodeChance)
+                {
+                    thingWithComps.TryGetComp<CompBiocodable>()?.CodeFor(pawn);
+                }
                 LoadWeaponWithRandAmmo(thingWithComps); //Custom
                 int count; //Custom
                 if (inventory.CanFitInInventory(thingWithComps, out count)) //Custom

--- a/Source/CombatExtended/Harmony/Harmony_PawnInventoryGenerator.cs
+++ b/Source/CombatExtended/Harmony/Harmony_PawnInventoryGenerator.cs
@@ -17,7 +17,8 @@ namespace CombatExtended.HarmonyCE
             var loadoutProps = p.kindDef.GetModExtension<LoadoutPropertiesExtension>();
             if (loadoutProps != null)
             {
-                loadoutProps.GenerateLoadoutFor(p);
+                float biocodeChance = (request.BiocodeWeaponChance > 0f) ? request.BiocodeWeaponChance : p.kindDef.biocodeWeaponChance;  //pass biocode weapon chance to generate loadout
+                loadoutProps.GenerateLoadoutFor(p, biocodeChance);
             }
         }
     }


### PR DESCRIPTION
## Changes

- Sidearms will now follow base game rules for biocoding.  Note: knives do not appear to be biocodable.

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #2269


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (5 minutes, spawned multiple raids)
