### PR TITLE
Buff .22LR's sharp armor penetration and other adjustments

### DIFF
--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -99,7 +99,7 @@
 		<label>.22 LR bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.22 LR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>4</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.22 LR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>1</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -99,7 +99,7 @@
 		<label>.25 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>.25 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>3</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,7 +119,7 @@
 		<label>.25 ACP bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -97,7 +97,7 @@
 		<label>.32 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.980</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -107,7 +107,7 @@
 		<label>.32 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.980</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38ACP.xml
+++ b/Defs/Ammo/Pistols/38ACP.xml
@@ -98,7 +98,7 @@
 		<label>.38 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>8.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -108,7 +108,7 @@
 		<label>.38 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>8.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/58x21mmDAP92.xml
+++ b/Defs/Ammo/Pistols/58x21mmDAP92.xml
@@ -99,7 +99,7 @@
 		<label>5.8mm DAP92 bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.86</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>5.8mm DAP92 bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>16.86</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -119,7 +119,7 @@
 		<label>7.63mm Mauser bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -99,7 +99,7 @@
 		<label>7.65x20mm Longue bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.880</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -109,7 +109,7 @@
 		<label>7.65x20mm Longue bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>5</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.880</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Changes

- The nerf in #1937 was not really necessary after some comparisons.
- Adjusted other pistol cartridges' sharp AP values due to them being inconsistent after comparing some blunt AP values with other similar cartridges.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- Does the cartridge deserve that much sharp AP? probably not but it's year 5500 baby and we have the American-180!

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
