### PR TITLE
Make apparel worn bulk affected by item quality

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Light.xml
@@ -70,7 +70,7 @@
       <warmupTime>0.8</warmupTime>
       <range>14</range>
       <soundCast>Shot_Shotgun_NoRack</soundCast>
-      <soundCastTail>GunTail_Nedium</soundCastTail>
+      <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>6</muzzleFlashScale>
     </Properties>
     <AmmoUser>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -20,10 +20,10 @@
         <factorAwful>1.25</factorAwful>
         <factorPoor>1.1</factorPoor>
         <factorNormal>1</factorNormal>
-        <factorGood>1</factorGood>
-        <factorExcellent>0.95</factorExcellent>
-        <factorMasterwork>0.90</factorMasterwork>
-        <factorLegendary>0.80</factorLegendary>
+        <factorGood>0.95</factorGood>
+        <factorExcellent>0.90</factorExcellent>
+        <factorMasterwork>0.85</factorMasterwork>
+        <factorLegendary>0.75</factorLegendary>
       </li>
     </parts>
   </StatDef>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -16,6 +16,15 @@
         <stuffPowerStat>WornBulk</stuffPowerStat>
         <multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
       </li>
+      <li Class="StatPart_Quality">
+        <factorAwful>1.25</factorAwful>
+        <factorPoor>1.1</factorPoor>
+        <factorNormal>1</factorNormal>
+        <factorGood>1</factorGood>
+        <factorExcellent>0.95</factorExcellent>
+        <factorMasterwork>0.90</factorMasterwork>
+        <factorLegendary>0.80</factorLegendary>
+      </li>
     </parts>
   </StatDef>
 
@@ -43,6 +52,5 @@
     <toStringStyle>PercentZero</toStringStyle>
     <showIfUndefined>false</showIfUndefined>
   </StatDef>  
-
 
 </Defs>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -18,7 +18,7 @@
       </li>
       <li Class="StatPart_Quality">
         <factorAwful>1.2</factorAwful>
-        <factorPoor>1.1</factorPoor>
+        <factorPoor>1.05</factorPoor>
         <factorNormal>1</factorNormal>
         <factorGood>1.0</factorGood>
         <factorExcellent>0.95</factorExcellent>

--- a/Defs/Stats/Stats_Apparel.xml
+++ b/Defs/Stats/Stats_Apparel.xml
@@ -17,13 +17,13 @@
         <multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
       </li>
       <li Class="StatPart_Quality">
-        <factorAwful>1.25</factorAwful>
+        <factorAwful>1.2</factorAwful>
         <factorPoor>1.1</factorPoor>
         <factorNormal>1</factorNormal>
-        <factorGood>0.95</factorGood>
-        <factorExcellent>0.90</factorExcellent>
-        <factorMasterwork>0.85</factorMasterwork>
-        <factorLegendary>0.75</factorLegendary>
+        <factorGood>1.0</factorGood>
+        <factorExcellent>0.95</factorExcellent>
+        <factorMasterwork>0.9</factorMasterwork>
+        <factorLegendary>0.8</factorLegendary>
       </li>
     </parts>
   </StatDef>


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- To simulate higher quality items having a better fit or joints to be less bulky in general.

## Alternatives

- Let pawns suffer and suffocate in their bulky apparel.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
