### PR TITLE
Remove the simplified ammo system

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -52,9 +52,6 @@
   <CE_Settings_GenericAmmo>Use generic ammo system</CE_Settings_GenericAmmo>
   <CE_Settings_GenericAmmo_Desc>Instead of using full caliber system use several generic calibers, while retaining ammo types and ammo system. (requires game reload)</CE_Settings_GenericAmmo_Desc>
 
-  <CE_Settings_EnableSimplifiedAmmo_Title>Use simplified ammo types system</CE_Settings_EnableSimplifiedAmmo_Title>
-  <CE_Settings_EnableSimplifiedAmmo_Desc>Reduces the number of ammo variants available.\nRemoves hollow point, sabot (bullets only), beanbag, slug, and armor piercing variants.\n\nWARNING: Changing this setting on an existing colony may cause bugs and instability, do so at your own risk. (requires game reload)</CE_Settings_EnableSimplifiedAmmo_Desc>
-
   <CE_Settings_RightClickAmmoSelect_Title>Right-click ammo selection</CE_Settings_RightClickAmmoSelect_Title>
   <CE_Settings_RightClickAmmoSelect_Desc>Right-clicking the reload button brings up the ammo selection menu.</CE_Settings_RightClickAmmoSelect_Desc>
 

--- a/Languages/Russian/Keyed/ModMenu.xml
+++ b/Languages/Russian/Keyed/ModMenu.xml
@@ -31,9 +31,6 @@
   <CE_Settings_EnableAmmoSystem_Title>Включить систему боеприпасов</CE_Settings_EnableAmmoSystem_Title>
   <CE_Settings_EnableAmmoSystem_Desc>Оружие требует перезарядки боеприпасов и может использовать различные специализированные типы боеприпасов.\n\nВНИМАНИЕ: Изменение этой настройки в существующей колонии может вызвать ошибки и нестабильность, использовать это на свой страх и риск.</CE_Settings_EnableAmmoSystem_Desc>
 
-  <CE_Settings_EnableSimplifiedAmmo_Title>Упрощённая аммуниция</CE_Settings_EnableSimplifiedAmmo_Title>
-  <CE_Settings_EnableSimplifiedAmmo_Desc>Сокращает число различных типов боеприпасов.\nУбирает экспансивные, подкалиберные (только для пуль), пули Бинбэг, болванки и бронебойные боеприпасы.\n\nВНИМАНИЕ: Изменение этой настройки в существующей колонии может вызвать ошибки и нестабильность, использовать это на свой страх и риск.</CE_Settings_EnableSimplifiedAmmo_Desc>
-
   <CE_Settings_RightClickAmmoSelect_Title>Щелкните правой кнопкой мыши для выбора патронов</CE_Settings_RightClickAmmoSelect_Title>
   <CE_Settings_RightClickAmmoSelect_Desc>Щелчок правой кнопкой мыши по кнопке перезарядки вызывает меню выбора боеприпасов.</CE_Settings_RightClickAmmoSelect_Desc>
 

--- a/Languages/Spanish/Keyed/ModMenu.xml
+++ b/Languages/Spanish/Keyed/ModMenu.xml
@@ -28,9 +28,6 @@
   <CE_Settings_EnableAmmoSystem_Title>Habilitar sistema de municiones</CE_Settings_EnableAmmoSystem_Title>
   <CE_Settings_EnableAmmoSystem_Desc>Las armas requieren munición para recargar y pueden usar varios tipos de munición especializadas.\n\nADVERTENCIA: Cambiar esta configuración en una colonia existente puede causar errores e inestabilidad, hacerlo bajo su propio riesgo.</CE_Settings_EnableAmmoSystem_Desc>
 
-  <CE_Settings_EnableSimplifiedAmmo_Title>Munición simplificada</CE_Settings_EnableSimplifiedAmmo_Title>
-  <CE_Settings_EnableSimplifiedAmmo_Desc>Reduce la cantidad de variantes de munición disponibles.\nElimina las variantes de punta hueca, sabot (solo balas), beanbag, slug y perforadoras de armadura.\n\nADVERTENCIA: Cambiar esta configuración en una colonia existente puede causar errores e inestabilidad, hágalo en su propio riesgo.</CE_Settings_EnableSimplifiedAmmo_Desc>
-
   <CE_Settings_RightClickAmmoSelect_Title>Selección de munición con el botón derecho</CE_Settings_RightClickAmmoSelect_Title>
   <CE_Settings_RightClickAmmoSelect_Desc>Haciendo clic con el botón derecho en el botón de recarga se abre el menú de selección de munición.</CE_Settings_RightClickAmmoSelect_Desc>
 

--- a/Languages/SpanishLatin/Keyed/ModMenu.xml
+++ b/Languages/SpanishLatin/Keyed/ModMenu.xml
@@ -28,9 +28,6 @@
   <CE_Settings_EnableAmmoSystem_Title>Habilitar sistema de municiones</CE_Settings_EnableAmmoSystem_Title>
   <CE_Settings_EnableAmmoSystem_Desc>Las armas requieren munición para recargar y pueden usar varios tipos de munición especializadas.\n\nADVERTENCIA: Cambiar esta configuración en una colonia existente puede causar errores e inestabilidad, hacerlo bajo su propio riesgo.</CE_Settings_EnableAmmoSystem_Desc>
 
-  <CE_Settings_EnableSimplifiedAmmo_Title>Munición simplificada</CE_Settings_EnableSimplifiedAmmo_Title>
-  <CE_Settings_EnableSimplifiedAmmo_Desc>Reduce la cantidad de variantes de munición disponibles.\nElimina las variantes de punta hueca, sabot (solo balas), beanbag, slug y perforadoras de armadura.\n\nADVERTENCIA: Cambiar esta configuración en una colonia existente puede causar errores e inestabilidad, hágalo en su propio riesgo.</CE_Settings_EnableSimplifiedAmmo_Desc>
-
   <CE_Settings_RightClickAmmoSelect_Title>Selección de munición con el botón derecho</CE_Settings_RightClickAmmoSelect_Title>
   <CE_Settings_RightClickAmmoSelect_Desc>Haciendo clic con el botón derecho en el botón de recarga se abre el menú de selección de munición.</CE_Settings_RightClickAmmoSelect_Desc>
 

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -21,21 +21,10 @@ namespace CombatExtended
      */
     internal static class AmmoInjector
     {
-        public static readonly FieldInfo _allRecipesCached = typeof(ThingDef).GetField("allRecipesCached", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public const string destroyWithAmmoDisabledTag = "CE_AmmoInjector";               // The trade tag which automatically deleted this ammo with the ammo system disabled
         private const string enableTradeTag = "CE_AutoEnableTrade";             // The trade tag which designates ammo defs for being automatically switched to Tradeability.Stockable
         private const string enableCraftingTag = "CE_AutoEnableCrafting";        // The trade tag which designates ammo defs for having their crafting recipes automatically added to the crafting table
-        // these ammo classes are disabled when simplified ammo is turned on
-        private static HashSet<string> complexAmmoClasses = new HashSet<string>(new string[]
-        {
-            // pistol + rifle + high caliber
-            "ArmorPiercing", "HollowPoint", "Sabot", "IncendiaryAP", "ExplosiveAP",
-            // shotguns
-            "Beanbag", "Slug",
-            // advanced
-            "ChargedAP"
-        });
 
         /*
         private static ThingDef ammoCraftingStationInt;                         // The crafting station to which ammo will be automatically added
@@ -66,7 +55,6 @@ namespace CombatExtended
         public static bool InjectAmmos()
         {
             bool enabled = Controller.settings.EnableAmmoSystem;
-            bool simplifiedAmmo = Controller.settings.EnableSimplifiedAmmo;
 
             // Initialize list of all weapons
             CE_Utility.allWeaponDefs.Clear();
@@ -124,11 +112,6 @@ namespace CombatExtended
 
                 // mortar ammo will always be enabled, even if the ammo system is turned off
                 bool ammoEnabled = enabled || ammoDef.isMortarAmmo;
-                if (simplifiedAmmo && complexAmmoClasses.Contains(ammoDef.ammoClass.defName))
-                {
-                    ammoEnabled = false;
-                }
-
 
                 if (ammoDef.tradeTags != null)
                 {

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -66,7 +66,6 @@ namespace CombatExtended
         private bool showCaliberOnGuns = true;
         private bool reuseNeolithicProjectiles = true;
         private bool realisticCookOff = true;
-        private bool enableSimplifiedAmmo = false;
 
         public bool EnableAmmoSystem => enableAmmoSystem;
         public bool RightClickAmmoSelect => rightClickAmmoSelect;
@@ -75,7 +74,6 @@ namespace CombatExtended
         public bool ShowCaliberOnGuns => showCaliberOnGuns;
         public bool ReuseNeolithicProjectiles => reuseNeolithicProjectiles;
         public bool RealisticCookOff => realisticCookOff;
-        public bool EnableSimplifiedAmmo => enableSimplifiedAmmo;
 
         // Debug settings - make sure all of these default to false for the release build
         private bool debuggingMode = false;
@@ -181,7 +179,6 @@ namespace CombatExtended
             Scribe_Values.Look(ref showCaliberOnGuns, "showCaliberOnGuns", true);
             Scribe_Values.Look(ref reuseNeolithicProjectiles, "reuseNeolithicProjectiles", true);
             Scribe_Values.Look(ref realisticCookOff, "realisticCookOff", true);
-            Scribe_Values.Look(ref enableSimplifiedAmmo, "enableSimplifiedAmmo", false);
             Scribe_Values.Look(ref genericammo, "genericAmmo", false);
 
             Scribe_Values.Look(ref ShowTutorialPopup, "ShowTutorialPopup", true);
@@ -273,7 +270,6 @@ namespace CombatExtended
                 list.CheckboxLabeled("CE_Settings_ShowCaliberOnGuns_Title".Translate(), ref showCaliberOnGuns, "CE_Settings_ShowCaliberOnGuns_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_ReuseNeolithicProjectiles_Title".Translate(), ref reuseNeolithicProjectiles, "CE_Settings_ReuseNeolithicProjectiles_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_RealisticCookOff_Title".Translate(), ref realisticCookOff, "CE_Settings_RealisticCookOff_Desc".Translate());
-                list.CheckboxLabeled("CE_Settings_EnableSimplifiedAmmo_Title".Translate(), ref enableSimplifiedAmmo, "CE_Settings_EnableSimplifiedAmmo_Desc".Translate());
                 list.CheckboxLabeled("CE_Settings_GenericAmmo".Translate(), ref genericammo, "CE_Settings_GenericAmmo_Desc".Translate()); ;
             }
             else
@@ -285,7 +281,6 @@ namespace CombatExtended
                 list.Label("CE_Settings_ShowCaliberOnGuns_Title".Translate());
                 list.Label("CE_Settings_ReuseNeolithicProjectiles_Title".Translate());
                 list.Label("CE_Settings_RealisticCookOff_Title".Translate());
-                list.Label("CE_Settings_EnableSimplifiedAmmo_Title".Translate());
 
                 GUI.contentColor = Color.white;
             }


### PR DESCRIPTION


## Changes

Remove the simplified ammo toggle.


## Reasoning

Simplified ammo is a common trap for people that want to avoid micromanaging many ammo types but end up finding themselves defenseless against threats that could be easily dealt with using advanced ammo types. The generic ammo system is a superior alternative for reducing the number of ammo types to manage, so there's no need for the simplified ammo toggle to exist now.



## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony - loaded up an existing colony with CE.
