### PR TITLE
JI AMR nerf

### DIFF
--- a/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Weapons_JI_CE.xml
@@ -229,9 +229,9 @@
 						<WorkToMake>50500</WorkToMake>
 						<SightsEfficiency>1.6</SightsEfficiency>
 						<ShotSpread>0.01</ShotSpread>
-						<SwayFactor>2.17</SwayFactor>
-						<Bulk>21</Bulk>
-						<Mass>10.51</Mass>
+						<SwayFactor>3.43</SwayFactor>
+						<Bulk>25</Bulk>
+						<Mass>15.50</Mass>
 						<RangedWeapon_Cooldown>2.45</RangedWeapon_Cooldown>
 					</statBases>				
 				</value>
@@ -241,13 +241,13 @@
 				<value>
 					<verbs>
 					<li Class="CombatExtended.VerbPropertiesCE">					
-						<recoilAmount>3.025</recoilAmount>
+						<recoilAmount>12.77</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_JI_AMR</defaultProjectile>
-						<warmupTime>3.025</warmupTime>
-						<ammoConsumedPerShotCount>20</ammoConsumedPerShotCount>
-						<range>70</range>
+						<warmupTime>3.525</warmupTime>
+						<ammoConsumedPerShotCount>30</ammoConsumedPerShotCount>
+						<range>58</range>
 						<soundCast>RS_ShotJI</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>15</muzzleFlashScale>
@@ -260,7 +260,7 @@
 				<value>
 					<comps>
 						<li Class="CombatExtended.CompProperties_AmmoUser">				
-							<magazineSize>80</magazineSize>
+							<magazineSize>90</magazineSize>
 							<reloadTime>6</reloadTime>
 							<ammoSet>AmmoSet_JI_AMR</ammoSet>
 						</li>


### PR DESCRIPTION


## Changes

Increased weight, increased bulk, sway increased to match, and now calculated from loaded weight, not empty weight. Reduced range to closer to other AMRs, increased warmup time as well as made recoil match characteristics now that it actually matters. Increased consumption per shot to 30, increased mag size so to 90, but it should have less firing cycles per magazine, mostly now each shot is 50% more expensive, which should add up a lot given that JI ammo isn't exactly cheap.

## Reasoning

AMR works a bit too effectively against boss mechs, since it's initial role was to slap around centipedes with 2-3 shots fairly reliably, boss mechs which aren't exactly any more durable than centipedes unfortunately also get slapped around and the pretty hefty cost per shot wasn't enough of a penalty to use the weapon.

Given the desire to keep it still fufilling this role, but not make it so optimal at it, the range has been reduced below actual sniper range now so while it can still reach just past the turrets on the boss mechs, it needs to actually be set up to fire before they get in range if they're on approach.

Overall inventory and maintaince costs (i.e. ammo, now consumes 50% more muntion load per shot with no actual stronger projectile) have been increased to make it less ideal as a anti-PA weapon, as well as corresponding increase to sway reflecting increased mass/bulk.

## Alternatives

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
