### PR TITLE
Tweak recipe base for generic GL ammo.

### DIFF
--- a/Defs/Ammo/GENERIC/LauncherGrenade.xml
+++ b/Defs/Ammo/GENERIC/LauncherGrenade.xml
@@ -124,7 +124,7 @@
 
   <!-- ==================== Recipes ========================== -->
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_LauncherGrenade_HE</defName>
     <label>make launcher HE grenades x100</label>
     <description>Craft 100 launcher HE grenades.</description>
@@ -169,7 +169,7 @@
   </RecipeDef>
 
   
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_LauncherGrenade_HEDP</defName>
     <label>make launcher HEDP grenades x100</label>
     <description>Craft 100 launcher HEDP grenades.</description>
@@ -213,7 +213,7 @@
     <workAmount>9000</workAmount>
   </RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_LauncherGrenade_EMP</defName>
     <label>make launcher EMP grenades x100</label>
     <description>Craft 100 launcher EMP grenades.</description>
@@ -252,7 +252,7 @@
     <workAmount>11000</workAmount>
   </RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_LauncherGrenade_Smoke</defName>
     <label>make launcher smoke grenades x100</label>
     <description>Craft 100 launcher smoke grenades.</description>


### PR DESCRIPTION

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Changed recipe base for generic grenade launcher ammo to match non-generic recipes. They were missing the `CE_Launchers` research prerequisite this way.

## References

Links to the associated issues or other related pull requests, e.g.
- see [40x53mm grenade recipes](https://github.com/CombatExtended-Continued/CombatExtended/blob/Development/Defs/Ammo/Grenade/40x53mmGrenade.xml#L221) and [LauncherAmmoRecipeBase def](https://github.com/CombatExtended-Continued/CombatExtended/blob/d46278b7de49e31050d48085b342b3ceb3b5be4e/Defs/Ammo/AmmoBases.xml#L124) as reference.


## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
