### PR TITLE
Add Medium Fragments and various ammo sharp AP tweaks

### DIFF
--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -57,7 +57,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>75</armorPenetrationSharp>
+			<armorPenetrationSharp>55</armorPenetrationSharp>
 			<armorPenetrationBlunt>252.720</armorPenetrationBlunt>
 			<speed>360</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -131,7 +131,7 @@
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>13.5</armorPenetrationSharp>
+      <armorPenetrationSharp>14</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -141,7 +141,7 @@
     <label>12.7x108mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>27</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -151,7 +151,7 @@
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>27</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -167,7 +167,7 @@
     <label>12.7x108mm bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>13.5</armorPenetrationSharp>
+      <armorPenetrationSharp>14</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -184,7 +184,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>234</speed>
 	    <damageAmountBase>21</damageAmountBase>
-	    <armorPenetrationSharp>47</armorPenetrationSharp>
+	    <armorPenetrationSharp>49</armorPenetrationSharp>
 	    <armorPenetrationBlunt>377.82</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -131,7 +131,7 @@
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>13.5</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -141,7 +141,7 @@
     <label>12.7x108mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>27</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -151,7 +151,7 @@
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>30</armorPenetrationSharp>
+      <armorPenetrationSharp>27</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -167,7 +167,7 @@
     <label>12.7x108mm bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>15</armorPenetrationSharp>
+      <armorPenetrationSharp>13.5</armorPenetrationSharp>
       <armorPenetrationBlunt>357.22</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -184,7 +184,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	    <speed>234</speed>
 	    <damageAmountBase>21</damageAmountBase>
-	    <armorPenetrationSharp>52.5</armorPenetrationSharp>
+	    <armorPenetrationSharp>47</armorPenetrationSharp>
 	    <armorPenetrationBlunt>377.82</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -130,7 +130,7 @@
 		<label>13.2mm TuF bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>40</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -140,7 +140,7 @@
 		<label>13.2mm TuF bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>28</armorPenetrationSharp>
+			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -150,7 +150,7 @@
 		<label>13.2x92mmSR TuF bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>28</armorPenetrationSharp>
+			<armorPenetrationSharp>26</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -166,7 +166,7 @@
 		<label>13.2x92mmSR TuF bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>40</damageAmountBase>
-			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -183,7 +183,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>236</speed>
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>49</armorPenetrationSharp>
+			<armorPenetrationSharp>45.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>406.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -116,7 +116,7 @@
 		<label>20x102mm NATO bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationSharp>30</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -126,7 +126,7 @@
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationSharp>30</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>20x102mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>56</armorPenetrationSharp>
+			<armorPenetrationSharp>53</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -116,7 +116,7 @@
 		<label>20x102mm NATO bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>30</armorPenetrationSharp>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -126,7 +126,7 @@
 		<label>20x102mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>44</damageAmountBase>
-			<armorPenetrationSharp>30</armorPenetrationSharp>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>20x102mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>70</damageAmountBase>
-			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
 			<armorPenetrationBlunt>1029.080</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>20x102mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>37</damageAmountBase>
-			<armorPenetrationSharp>53</armorPenetrationSharp>
+			<armorPenetrationSharp>56</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
 			<speed>309</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -157,10 +157,10 @@
 		<defName>Bullet_40x311mmR_Sabot</defName>
 		<label>40x311mmR bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>85</damageAmountBase>
+			<damageAmountBase>89</damageAmountBase>
 			<armorPenetrationSharp>175</armorPenetrationSharp>
-			<armorPenetrationBlunt>7264.6</armorPenetrationBlunt>
-			<speed>238</speed>
+			<armorPenetrationBlunt>8339.46</armorPenetrationBlunt>
+			<speed>255</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -131,7 +131,7 @@
     <label>.50 BMG bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>15.5</armorPenetrationSharp>
+      <armorPenetrationSharp>14</armorPenetrationSharp>
       <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -141,7 +141,7 @@
     <label>.50 BMG bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>31</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -151,7 +151,7 @@
     <label>.50 BMG bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
-      <armorPenetrationSharp>31</armorPenetrationSharp>
+      <armorPenetrationSharp>28</armorPenetrationSharp>
       <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -167,7 +167,7 @@
     <label>.50 BMG bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>42</damageAmountBase>
-      <armorPenetrationSharp>15.5</armorPenetrationSharp>
+      <armorPenetrationSharp>14</armorPenetrationSharp>
       <armorPenetrationBlunt>360.34</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -183,7 +183,7 @@
     <label>.50 BMG bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>21</damageAmountBase>	
-      <armorPenetrationSharp>54</armorPenetrationSharp>
+      <armorPenetrationSharp>49</armorPenetrationSharp>
       <armorPenetrationBlunt>388.88</armorPenetrationBlunt>
       <speed>244</speed>
     </projectile>

--- a/Defs/Ammo/Projectiles_Fragments.xml
+++ b/Defs/Ammo/Projectiles_Fragments.xml
@@ -17,6 +17,23 @@
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
+
+	<ThingDef ParentName="BaseFragment">
+		<defName>Fragment_Medium</defName>
+		<label>medium fragments</label>
+		<graphicData>
+			<texPath>Things/Projectile/Fragments/Fragment_Medium</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Fragment</damageDef>
+			<damageAmountBase>14</damageAmountBase>
+			<speed>50</speed>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>30.4</armorPenetrationBlunt>
+			<gravityFactor>5</gravityFactor>
+		</projectile>
+	</ThingDef>
 	
 	<ThingDef ParentName="BaseFragment">  <!-- Flies from around 4 to 35 cells away from the explosion if the angle range is unchanged. -->
 		<defName>Fragment_Small</defName>
@@ -27,10 +44,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Fragment</damageDef>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<speed>40</speed>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>6.48</armorPenetrationBlunt>
+			<armorPenetrationBlunt>6.4</armorPenetrationBlunt>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -146,7 +146,7 @@
 		<label>12.7mm bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -156,7 +156,7 @@
 		<label>12.7mm bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -166,7 +166,7 @@
 		<label>12.7mm bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -182,7 +182,7 @@
 				  <amount>8</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -198,7 +198,7 @@
 				  <amount>13</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -208,7 +208,7 @@
 		<label>12.7mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>17.5</armorPenetrationSharp>
+			<armorPenetrationSharp>24.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>65.84</armorPenetrationBlunt>
 			<speed>89</speed>			
 		</projectile>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -146,7 +146,7 @@
 		<label>12.7mm bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -156,7 +156,7 @@
 		<label>12.7mm bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -166,7 +166,7 @@
 		<label>12.7mm bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>3.75</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -182,7 +182,7 @@
 				  <amount>8</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -198,7 +198,7 @@
 				  <amount>13</amount>
 				</li>
 			</secondaryDamage>
-			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -208,7 +208,7 @@
 		<label>12.7mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
-			<armorPenetrationSharp>26.25</armorPenetrationSharp>
+			<armorPenetrationSharp>17.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>65.84</armorPenetrationBlunt>
 			<speed>89</speed>			
 		</projectile>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -146,7 +146,7 @@
 		<label>.44-40 Winchester bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -157,7 +157,7 @@
 		<label>.44-40 Winchester bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -167,7 +167,7 @@
 		<label>.44-40 Winchester bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -177,7 +177,7 @@
 		<label>.44-40 Winchester bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>9</damageAmountBase>
-		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationSharp>8</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -193,7 +193,7 @@
 		<label>.44-40 Winchester bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
-		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationSharp>4</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -209,7 +209,7 @@
 		<label>.44-40 Winchester bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>7</damageAmountBase>
-		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
 		  <armorPenetrationBlunt>23.94</armorPenetrationBlunt>
 		  <speed>114</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -146,7 +146,7 @@
 		<label>.44-40 Winchester bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -157,7 +157,7 @@
 		<label>.44-40 Winchester bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -167,7 +167,7 @@
 		<label>.44-40 Winchester bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -177,7 +177,7 @@
 		<label>.44-40 Winchester bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>9</damageAmountBase>
-		  <armorPenetrationSharp>8</armorPenetrationSharp>
+		  <armorPenetrationSharp>10</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -193,7 +193,7 @@
 		<label>.44-40 Winchester bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
-		  <armorPenetrationSharp>4</armorPenetrationSharp>
+		  <armorPenetrationSharp>5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -209,7 +209,7 @@
 		<label>.44-40 Winchester bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>7</damageAmountBase>
-		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>23.94</armorPenetrationBlunt>
 		  <speed>114</speed>
 		</projectile>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -19,9 +19,23 @@
 			<Ammo_545x39mmSoviet_HP>Bullet_545x39mmSoviet_HP</Ammo_545x39mmSoviet_HP>
 			<Ammo_545x39mmSoviet_Incendiary>Bullet_545x39mmSoviet_Incendiary</Ammo_545x39mmSoviet_Incendiary>
 			<Ammo_545x39mmSoviet_HE>Bullet_545x39mmSoviet_HE</Ammo_545x39mmSoviet_HE>
-			<Ammo_545x39mmSoviet_Sabot>Bullet_545x39mmSoviet_Sabot</Ammo_545x39mmSoviet_Sabot>				
+			<Ammo_545x39mmSoviet_Sabot>Bullet_545x39mmSoviet_Sabot</Ammo_545x39mmSoviet_Sabot>
 		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>	
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_545x39mmSoviet_SB</defName>
+		<label>5.45x39mm Soviet</label>
+		<ammoTypes>
+			<Ammo_545x39mmSoviet_FMJ>Bullet_545x39mmSoviet_FMJ_SB</Ammo_545x39mmSoviet_FMJ>
+			<Ammo_545x39mmSoviet_AP>Bullet_545x39mmSoviet_AP_SB</Ammo_545x39mmSoviet_AP>
+			<Ammo_545x39mmSoviet_HP>Bullet_545x39mmSoviet_HP_SB</Ammo_545x39mmSoviet_HP>
+			<Ammo_545x39mmSoviet_Incendiary>Bullet_545x39mmSoviet_Incendiary_SB</Ammo_545x39mmSoviet_Incendiary>
+			<Ammo_545x39mmSoviet_HE>Bullet_545x39mmSoviet_HE_SB</Ammo_545x39mmSoviet_HE>
+			<Ammo_545x39mmSoviet_Sabot>Bullet_545x39mmSoviet_Sabot_SB</Ammo_545x39mmSoviet_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
@@ -145,7 +159,7 @@
 		<label>5.45mm Soviet bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>5.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>28.04</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +169,7 @@
 		<label>5.45mm Soviet bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>11</armorPenetrationSharp>
 			<armorPenetrationBlunt>28.04</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +189,7 @@
 		<label>5.45mm Soviet bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>8</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>11</armorPenetrationSharp>
 		  <armorPenetrationBlunt>28.04</armorPenetrationBlunt>
 		  <secondaryDamage>
 			<li>
@@ -191,7 +205,7 @@
 		<label>5.45mm Soviet bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>28.04</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,9 +221,89 @@
 		<label>5.45mm Soviet bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>7</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.6</armorPenetrationBlunt>
 		  <speed>264</speed>
+		</projectile>
+	  </ThingDef>
+
+	<!-- Short barrel -->	
+
+	<ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_FMJ_SB</defName>
+		<label>5.45mm Soviet bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
+			<speed>147</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_AP_SB</defName>
+		<label>5.45mm Soviet bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
+			<speed>147</speed>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_HP_SB</defName>
+		<label>5.45mm Soviet bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
+			<speed>147</speed>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_Incendiary_SB</defName>
+		<label>5.45mm Soviet bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>7</damageAmountBase>
+		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationBlunt>19.56</armorPenetrationBlunt>
+		  <secondaryDamage>
+			<li>
+			  <def>Flame_Secondary</def>
+			  <amount>4</amount>
+			</li>
+		  </secondaryDamage>
+		  <speed>147</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_HE_SB</defName>
+		<label>5.45mm Soviet bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>19.56</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>7</amount>
+				</li>
+		  </secondaryDamage>
+		  <speed>147</speed>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base545x39mmSovietBullet">
+		<defName>Bullet_545x39mmSoviet_Sabot_SB</defName>
+		<label>5.45mm Soviet bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>6</damageAmountBase>
+		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>25.5</armorPenetrationBlunt>
+		  <speed>221</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -19,9 +19,9 @@
 			<Ammo_556x45mmNATO_HP>Bullet_556x45mmNATO_HP</Ammo_556x45mmNATO_HP>
 			<Ammo_556x45mmNATO_Incendiary>Bullet_556x45mmNATO_Incendiary</Ammo_556x45mmNATO_Incendiary>
 			<Ammo_556x45mmNATO_HE>Bullet_556x45mmNATO_HE</Ammo_556x45mmNATO_HE>
-			<Ammo_556x45mmNATO_Sabot>Bullet_556x45mmNATO_Sabot</Ammo_556x45mmNATO_Sabot>				
+			<Ammo_556x45mmNATO_Sabot>Bullet_556x45mmNATO_Sabot</Ammo_556x45mmNATO_Sabot>
 		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>		
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>
@@ -33,9 +33,9 @@
 			<Ammo_556x45mmNATO_HP>Bullet_556x45mmNATO_HP_SB</Ammo_556x45mmNATO_HP>
 			<Ammo_556x45mmNATO_Incendiary>Bullet_556x45mmNATO_Incendiary_SB</Ammo_556x45mmNATO_Incendiary>
 			<Ammo_556x45mmNATO_HE>Bullet_556x45mmNATO_HE_SB</Ammo_556x45mmNATO_HE>
-			<Ammo_556x45mmNATO_Sabot>Bullet_556x45mmNATO_Sabot_SB</Ammo_556x45mmNATO_Sabot>				
+			<Ammo_556x45mmNATO_Sabot>Bullet_556x45mmNATO_Sabot_SB</Ammo_556x45mmNATO_Sabot>
 		</ammoTypes>
-		<similarTo>AmmoSet_RifleIntermediate</similarTo>		
+		<similarTo>AmmoSet_RifleIntermediate</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -2,7 +2,7 @@
 <Defs>
 
 	<ThingCategoryDef>
-		<defName>Ammo65x48mmBlackout</defName>
+		<defName>Ammo65x48mmCreedmoor</defName>
 		<label>6.5mm Creedmoor</label>
 		<parent>AmmoRifles</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
@@ -11,22 +11,22 @@
 	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_65x48mmBlackout</defName>
+		<defName>AmmoSet_65x48mmCreedmoor</defName>
 		<label>6.5mm Creedmoor</label>
 		<ammoTypes>
-			<Ammo_65x48mmBlackout_FMJ>Bullet_65x48mmBlackout_FMJ</Ammo_65x48mmBlackout_FMJ>
-			<Ammo_65x48mmBlackout_AP>Bullet_65x48mmBlackout_AP</Ammo_65x48mmBlackout_AP>
-			<Ammo_65x48mmBlackout_HP>Bullet_65x48mmBlackout_HP</Ammo_65x48mmBlackout_HP>
-			<Ammo_65x48mmBlackout_Incendiary>Bullet_65x48mmBlackout_Incendiary</Ammo_65x48mmBlackout_Incendiary>
-			<Ammo_65x48mmBlackout_HE>Bullet_65x48mmBlackout_HE</Ammo_65x48mmBlackout_HE>
-			<Ammo_65x48mmBlackout_Sabot>Bullet_65x48mmBlackout_Sabot</Ammo_65x48mmBlackout_Sabot>			
+			<Ammo_65x48mmCreedmoor_FMJ>Bullet_65x48mmCreedmoor_FMJ</Ammo_65x48mmCreedmoor_FMJ>
+			<Ammo_65x48mmCreedmoor_AP>Bullet_65x48mmCreedmoor_AP</Ammo_65x48mmCreedmoor_AP>
+			<Ammo_65x48mmCreedmoor_HP>Bullet_65x48mmCreedmoor_HP</Ammo_65x48mmCreedmoor_HP>
+			<Ammo_65x48mmCreedmoor_Incendiary>Bullet_65x48mmCreedmoor_Incendiary</Ammo_65x48mmCreedmoor_Incendiary>
+			<Ammo_65x48mmCreedmoor_HE>Bullet_65x48mmCreedmoor_HE</Ammo_65x48mmCreedmoor_HE>
+			<Ammo_65x48mmCreedmoor_Sabot>Bullet_65x48mmCreedmoor_Sabot</Ammo_65x48mmCreedmoor_Sabot>			
 		</ammoTypes>
 		<similarTo>AmmoSet_Rifle</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="65x48mmBlackoutBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="65x48mmCreedmoorBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>An intermediate centerfire rifle cartridge desinged for long range shooting.</description>
 		<statBases>
 			<Mass>0.023</Mass>
@@ -37,12 +37,12 @@
 			<li>CE_AutoEnableCrafting</li>
 		</tradeTags>
 		<thingCategories>
-			<li>Ammo65x48mmBlackout</li>
+			<li>Ammo65x48mmCreedmoor</li>
 		</thingCategories>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_FMJ</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_FMJ</defName>
 		<label>6.5mm Creedmoor cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/FMJ</texPath>
@@ -52,11 +52,11 @@
 			<MarketValue>0.1</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_FMJ</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_FMJ</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_AP</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_AP</defName>
 		<label>6.5mm Creedmoor cartridge (AP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/AP</texPath>
@@ -66,11 +66,11 @@
 			<MarketValue>0.1</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_AP</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_AP</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_HP</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_HP</defName>
 		<label>6.5mm Creedmoor cartridge (HP)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HP</texPath>
@@ -80,11 +80,11 @@
 			<MarketValue>0.1</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_HP</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_HP</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_Incendiary</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_Incendiary</defName>
 		<label>6.5mm Creedmoor cartridge (AP-I)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
@@ -94,11 +94,11 @@
 			<MarketValue>0.14</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_Incendiary</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_Incendiary</cookOffProjectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_HE</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_HE</defName>
 		<label>6.5mm Creedmoor cartridge (AP-HE)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/HE</texPath>
@@ -108,11 +108,11 @@
 			<MarketValue>0.2</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_HE</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_HE</cookOffProjectile>
 	</ThingDef>
 	
-	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmBlackoutBase">
-		<defName>Ammo_65x48mmBlackout_Sabot</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="65x48mmCreedmoorBase">
+		<defName>Ammo_65x48mmCreedmoor_Sabot</defName>
 		<label>6.5mm Creedmoor cartridge (Sabot)</label>
 		<graphicData>
 			<texPath>Things/Ammo/Rifle/Sabot</texPath>
@@ -123,12 +123,12 @@
 			<Mass>0.019</Mass>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
-		<cookOffProjectile>Bullet_65x48mmBlackout_Sabot</cookOffProjectile>
+		<cookOffProjectile>Bullet_65x48mmCreedmoor_Sabot</cookOffProjectile>
 	</ThingDef>
   
 	<!-- ================== Projectiles ================== -->
 
-	<ThingDef Name="Base65x48mmBlackoutBullet" ParentName="BaseBullet" Abstract="true">
+	<ThingDef Name="Base65x48mmCreedmoorBullet" ParentName="BaseBullet" Abstract="true">
 		<graphicData>
 			<texPath>Things/Projectile/Bullet_Small</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -140,42 +140,42 @@
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_FMJ</defName>
+	<ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_FMJ</defName>
 		<label>6.5mm Creedmoor bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_AP</defName>
+	<ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_AP</defName>
 		<label>6.5mm Creedmoor bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_HP</defName>
+	<ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_HP</defName>
 		<label>6.5mm Creedmoor bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	  <ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_Incendiary</defName>
+	  <ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_Incendiary</defName>
 		<label>6.5mm Creedmoor bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>12</damageAmountBase>
-		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationSharp>13</armorPenetrationSharp>
 		  <armorPenetrationBlunt>67.34</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -186,12 +186,12 @@
 		</projectile>
 	  </ThingDef>
 	  
-	  <ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_HE</defName>
+	  <ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_HE</defName>
 		<label>6.5mm Creedmoor bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
-		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationSharp>6.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>67.34</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -202,12 +202,12 @@
 		</projectile>
 	  </ThingDef>
 
-	  <ThingDef ParentName="Base65x48mmBlackoutBullet">
-		<defName>Bullet_65x48mmBlackout_Sabot</defName>
+	  <ThingDef ParentName="Base65x48mmCreedmoorBullet">
+		<defName>Bullet_65x48mmCreedmoor_Sabot</defName>
 		<label>6.5mm Creedmoor bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>10</damageAmountBase>
-		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationSharp>23</armorPenetrationSharp>
 		  <armorPenetrationBlunt>87.28</armorPenetrationBlunt>
 		  <speed>203</speed>
 		</projectile>
@@ -216,7 +216,7 @@
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_65x48mmBlackout_FMJ</defName>
+		<defName>MakeAmmo_65x48mmCreedmoor_FMJ</defName>
 		<label>make 6.5mm Creedmoor (FMJ) cartridge x500</label>
 		<description>Craft 500 6.5mm Creedmoor (FMJ) cartridges.</description>
 		<jobString>Making 6.5mm Creedmoor (FMJ) cartridges.</jobString>
@@ -236,13 +236,13 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_65x48mmBlackout_FMJ>500</Ammo_65x48mmBlackout_FMJ>
+			<Ammo_65x48mmCreedmoor_FMJ>500</Ammo_65x48mmCreedmoor_FMJ>
 		</products>
 		<workAmount>2400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_65x48mmBlackout_AP</defName>
+		<defName>MakeAmmo_65x48mmCreedmoor_AP</defName>
 		<label>make 6.5mm Creedmoor (AP) cartridge x500</label>
 		<description>Craft 500 6.5mm Creedmoor (AP) cartridges.</description>
 		<jobString>Making 6.5mm Creedmoor (AP) cartridges.</jobString>
@@ -262,13 +262,13 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_65x48mmBlackout_AP>500</Ammo_65x48mmBlackout_AP>
+			<Ammo_65x48mmCreedmoor_AP>500</Ammo_65x48mmCreedmoor_AP>
 		</products>
 		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
-		<defName>MakeAmmo_65x48mmBlackout_HP</defName>
+		<defName>MakeAmmo_65x48mmCreedmoor_HP</defName>
 		<label>make 6.5mm Creedmoor (HP) cartridge x500</label>
 		<description>Craft 500 6.5mm Creedmoor (HP) cartridges.</description>
 		<jobString>Making 6.5mm Creedmoor (HP) cartridges.</jobString>
@@ -288,13 +288,13 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_65x48mmBlackout_HP>500</Ammo_65x48mmBlackout_HP>
+			<Ammo_65x48mmCreedmoor_HP>500</Ammo_65x48mmCreedmoor_HP>
 		</products>
 		<workAmount>2400</workAmount>
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_65x48mmBlackout_Incendiary</defName>
+    <defName>MakeAmmo_65x48mmCreedmoor_Incendiary</defName>
     <label>make 6.5mm Creedmoor (AP-I) cartridge x500</label>
     <description>Craft 500 6.5mm Creedmoor (AP-I) cartridges.</description>
     <jobString>Making 6.5mm Creedmoor (AP-I) cartridges.</jobString>
@@ -323,13 +323,13 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_65x48mmBlackout_Incendiary>500</Ammo_65x48mmBlackout_Incendiary>
+      <Ammo_65x48mmCreedmoor_Incendiary>500</Ammo_65x48mmCreedmoor_Incendiary>
     </products>
     <workAmount>3600</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_65x48mmBlackout_HE</defName>
+    <defName>MakeAmmo_65x48mmCreedmoor_HE</defName>
     <label>make 6.5mm Creedmoor (AP-HE) cartridge x500</label>
     <description>Craft 500 6.5mm Creedmoor (AP-HE) cartridges.</description>
     <jobString>Making 6.5mm Creedmoor (AP-HE) cartridges.</jobString>
@@ -358,13 +358,13 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_65x48mmBlackout_HE>500</Ammo_65x48mmBlackout_HE>
+      <Ammo_65x48mmCreedmoor_HE>500</Ammo_65x48mmCreedmoor_HE>
     </products>
     <workAmount>4400</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_65x48mmBlackout_Sabot</defName>
+    <defName>MakeAmmo_65x48mmCreedmoor_Sabot</defName>
     <label>make 6.5mm Creedmoor (Sabot) cartridge x500</label>
     <description>Craft 500 6.5mm Creedmoor (Sabot) cartridges.</description>
     <jobString>Making 6.5mm Creedmoor (Sabot) cartridges.</jobString>
@@ -402,7 +402,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Ammo_65x48mmBlackout_Sabot>500</Ammo_65x48mmBlackout_Sabot>
+      <Ammo_65x48mmCreedmoor_Sabot>500</Ammo_65x48mmCreedmoor_Sabot>
     </products>
     <workAmount>3200</workAmount>
   </RecipeDef>

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -145,7 +145,7 @@
 		<label>8mmR Lebel bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>8mmR Lebel bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>8mmR Lebel bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -191,7 +191,7 @@
 		<label>8mmR Lebel bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
-		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>8mmR Lebel bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>11</damageAmountBase>
-		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>87.52</armorPenetrationBlunt>
 		  <speed>219</speed>
 		</projectile>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -124,7 +124,7 @@
 			<damageAmountBase>5</damageAmountBase>
 			<pelletCount>20</pelletCount>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>1.92</armorPenetrationBlunt>
+			<armorPenetrationBlunt>2.1</armorPenetrationBlunt>
 			<spreadMult>10.9</spreadMult>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
## Additions

- Added the medium fragment projectiles.
- Added the slow ammoset for 5.45x39mm.

## Changes

- Tweaked some ammo sharp AP values based on some comparisons and usage of gray matter. Since the joke went over people's heads I'll explain: 6.5 Creedmoor has the same ballistic behavior, if not better, as 7.62 nato. 8x50mmB is similar to other pre-ww1 era cartridges hence the buff and 12.7x55mm is tweaked to be accurate to the source claiming its armor penetration capabilities which is the same as 7.62 nato (Level III armor).
- Fixed the typo in 6.5 Creedmoor's projectile defNames.
- No.3 pellets used for 20 gauge buckshot shells weight 1.57 grams which was incorrectly set in the projectile sheet.
- Fixed the 8mm railgun ammo that had incorrectly high sharp AP relative to 6mm which is a rifle railgun ammo, contrary to 8mm being pistol ammo.
- Reverted .50 BMG and 12.7x108mm's sharp AP values to their original and less overtuned values. Did the same sanity check for 13.2x92mm's sharp AP values as it has less muzzle energy as the previous two.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

The source for the 5.45x39mm ammo, GOST 5 is NIJ III for reference.
https://atekdefense.reamaze.com/kb/armor-standards/gost-armor-standard-russia

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
