### PR TITLE
Fix bursts continuing to fire in random directions with null target.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -966,11 +966,16 @@ namespace CombatExtended
                 projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
                 if (firingWithoutTarget)
                 {
+                    //cease fire if targeting mode is not suppressive and target is null
+                    if (CompFireModes != null && (CompFireModes?.CurrentAimMode == AimMode.AimedShot || CompFireModes?.CurrentAimMode == AimMode.Snapshot))
+                    {
+                        return false;
+                    }
+                    //TODO: Make suppressive fire continue firing in the proper direction instead of randomly drifting where ever recoil+sway takes it.
                     shotAngle = lastShotAngle;
                     shotRotation = lastShotRotation;
                     GetSwayVec(ref shotRotation, ref shotAngle);
                     GetRecoilVec(ref shotRotation, ref shotAngle);
-
                 }
                 this.lastShotAngle = shotAngle;
                 this.lastShotRotation = shotRotation;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -947,6 +947,15 @@ namespace CombatExtended
                 aperatureSize = 0.03f;
             }
 
+            if (firingWithoutTarget)
+            {
+                currentTarget = new LocalTargetInfo(lastTargetPos);
+                if (!currentTarget.IsValid)
+                {
+                    return false;
+                }
+            }
+
             ShiftVecReport report = ShiftVecReportFor(currentTarget);
             bool pelletMechanicsOnly = false;
             for (int i = 0; i < projectilePropsCE.pelletCount; i++)
@@ -971,7 +980,7 @@ namespace CombatExtended
                     {
                         return false;
                     }
-                    //TODO: Make suppressive fire continue firing in the proper direction instead of randomly drifting where ever recoil+sway takes it.
+                    
                     shotAngle = lastShotAngle;
                     shotRotation = lastShotRotation;
                     GetSwayVec(ref shotRotation, ref shotAngle);

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -980,7 +980,7 @@ namespace CombatExtended
                     {
                         return false;
                     }
-                    
+
                     shotAngle = lastShotAngle;
                     shotRotation = lastShotRotation;
                     GetSwayVec(ref shotRotation, ref shotAngle);


### PR DESCRIPTION
## Changes

- Fix aimed and snap shots continuing their burst after target is killed/downed or otherwise invalid.
- suppressive fire mode will continue firing at the target's last position, instead of wildly firing wherever recoil takes them.

## Reasoning

-long bursts from weapons like a minigun turret (300 round burst) would continue firing wildly in whatever direction recoil and sway takes them when the target is killed or downed and retargeting fails.  This generally results in the recoil carrying the shooting vector upwards and into a vertical loop.  If the burst is long enough, this can result in a turret's aim rotating through 270 degrees and shooting down at itself.

## Alternatives

-have all shot modes continue firing in the same direction that the target was until the burst ends normally
-have all shot modes end when the target is null.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (1hr)
