### PR TITLE
Add mini cannon ball ammoset

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
 	<ThingCategoryDef>
@@ -26,7 +26,6 @@
 		<defName>AmmoSet_CannonBall_Mortar</defName>
 		<label>Cannon Ball</label>
 		<ammoTypes>
-			<Ammo_CannonBall_Round>Bullet_CannonBall_Round_Mortar</Ammo_CannonBall_Round>
 			<Ammo_CannonBall_Bursting>Bullet_CannonBall_Bursting_Mortar</Ammo_CannonBall_Bursting>
 			<Ammo_CannonBall_Incendiary>Bullet_CannonBall_Incendiary_Mortar</Ammo_CannonBall_Incendiary>									
 		</ammoTypes>
@@ -58,7 +57,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="CannonBallBase">
 		<defName>Ammo_CannonBall_Round</defName>
 		<label>round shot</label>
-		<description>A solid ball of metal, capable of delivering significant damage on a direct hit.</description>
+		<description>A solid ball of metal fired, capable of delivering significant damage on a direct hit.</description>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -78,7 +77,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>57.78</MarketValue>
+			<MarketValue>47.45</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>
@@ -93,7 +92,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>41.72</MarketValue>
+			<MarketValue>39.18</MarketValue>
 		</statBases>
 		<ammoClass>FireShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Incendiary</cookOffProjectile>
@@ -108,8 +107,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>26.18</MarketValue>
-			<Mass>6.53</Mass>
+			<MarketValue>5.56</MarketValue>
 		</statBases>
 		<ammoClass>Grapeshot</ammoClass>
 	</ThingDef>
@@ -214,31 +212,12 @@
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<soundAmbient>MortarRound_Ambient</soundAmbient>
 			<flyOverhead>true</flyOverhead>
-			<dropsCasings>true</dropsCasings>
-			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
- 			<casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+			<dropsCasings>false</dropsCasings>
 			<gravityFactor>5</gravityFactor>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseCannonBall">
-		<defName>Bullet_CannonBall_Round_Mortar</defName>
-		<label>round shot</label>
-		<graphicData>
-			<texPath>Things/Projectile/Bullet_Big</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>293</damageAmountBase>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
-			<armorPenetrationBlunt>11491</armorPenetrationBlunt>
-			<suppressionFactor>1.0</suppressionFactor>
-			<dangerFactor>1.0</dangerFactor>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="BaseCannonBall">
+	<ThingDef ParentName="BaseCannonBall_Mortar">
 		<defName>Bullet_CannonBall_Bursting_Mortar</defName>
 		<label>bursting shell</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
@@ -265,7 +244,7 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef ParentName="BaseCannonBall">
+	<ThingDef ParentName="BaseCannonBall_Mortar">
 		<defName>Bullet_CannonBall_Incendiary_Mortar</defName>
 		<label>flaming shell</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
@@ -279,7 +258,6 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<explosionRadius>1.5</explosionRadius>
-			<flyOverhead>true</flyOverhead>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -58,7 +58,7 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="CannonBallBase">
 		<defName>Ammo_CannonBall_Round</defName>
 		<label>round shot</label>
-		<description>A solid ball of metal fired, capable of delivering significant damage on a direct hit.</description>
+		<description>A solid ball of metal, capable of delivering significant damage on a direct hit.</description>
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -78,7 +78,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>47.45</MarketValue>
+			<MarketValue>57.78</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>
@@ -93,7 +93,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>39.18</MarketValue>
+			<MarketValue>41.72</MarketValue>
 		</statBases>
 		<ammoClass>FireShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Incendiary</cookOffProjectile>
@@ -108,7 +108,8 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>5.56</MarketValue>
+			<MarketValue>26.18</MarketValue>
+			<Mass>6.53</Mass>
 		</statBases>
 		<ammoClass>Grapeshot</ammoClass>
 	</ThingDef>

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>MiniCannonBall</defName>
+		<label>Mini Cannon Ball</label>
+		<parent>AmmoShells</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberCannon</iconPath>
+	</ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_MiniCannonBall</defName>
+		<label>Mini Cannon Ball</label>
+		<ammoTypes>
+			<Ammo_MiniCannonBall_Round>Bullet_MiniCannonBall_Round</Ammo_MiniCannonBall_Round>
+			<Ammo_MiniCannonBall_Grape>Bullet_MiniCannonBall_Grape</Ammo_MiniCannonBall_Grape>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="MiniCannonBallBase" ParentName="HeavyAmmoBase" Abstract="True">
+		<thingCategories>
+			<li>MiniCannonBall</li>
+		</thingCategories>
+		<stackLimit>500</stackLimit>
+		<graphicData>
+		<drawSize>1.0</drawSize>
+		</graphicData>  		
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_FueledSmithy</li>
+			<li>CE_AutoEnableCrafting_ElectricSmithy</li>
+		</tradeTags>
+		<statBases>
+			<MaxHitPoints>200</MaxHitPoints>
+			<Mass>0.27</Mass>
+			<Bulk>0.38</Bulk>
+		</statBases>
+		<techLevel>Medieval</techLevel>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MiniCannonBallBase">
+		<defName>Ammo_MiniCannonBall_Round</defName>
+		<label>mini round shot</label>
+		<description>A solid ball of metal, capable of delivering significant damage on a direct hit.</description>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Round</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.12</MarketValue>
+		</statBases>
+		<ammoClass>CannonBall</ammoClass>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="MiniCannonBallBase">
+		<defName>Ammo_MiniCannonBall_Grape</defName>
+		<label>mini grape shot shell</label>
+		<description>A canister of numerous metal balls, fired in a wide spread to deal horrific damage against enemy infantry.</description>
+		<graphicData>
+			<texPath>Things/Ammo/Cannon/BlackPowder/Cannon_Grape</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.12</MarketValue>
+		</statBases>
+		<ammoClass>Grapeshot</ammoClass>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="BaseMiniCannonBall" ParentName="BaseExplosiveBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>1.5,1.5</drawSize>
+		</graphicData>	
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>60</speed>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+			<flyOverhead>false</flyOverhead>
+			<dropsCasings>false</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="BaseMiniCannonBall">
+		<defName>Bullet_MiniCannonBall_Round</defName>
+		<label>mini round shot</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>50</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>207</armorPenetrationBlunt>
+			<suppressionFactor>1.0</suppressionFactor>
+			<dangerFactor>1.0</dangerFactor>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base12GaugeChargedBullet"> 
+		<defName>Bullet_MiniCannonBall_Grape</defName>
+		<label>mini grape shot</label>
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>1,1</drawSize>
+		</graphicData>			
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>20.7</armorPenetrationBlunt>
+			<pelletCount>10</pelletCount>
+			<spreadMult>17.8</spreadMult>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_MiniCannonBall_Round</defName>
+		<label>make mini round shot cannon balls x50</label>
+		<description>Craft 50 mini round shot cannon balls.</description>
+		<jobString>Making mini round shot cannon balls.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
+		<workAmount>2800</workAmount>
+		<ingredients>
+		<li>
+			<filter>
+				<thingDefs>
+					<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>28</count>
+		</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MiniCannonBall_Round>5</Ammo_MiniCannonBall_Round>
+		</products>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_MiniCannonBall_Grape</defName>
+		<label>Make mini grape shot cannon shells x5</label>
+		<description>Craft 50 mini grape shot cannon shells.</description>
+		<jobString>Making mini grape shot cannon shells.</jobString>
+		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
+		<workAmount>2800</workAmount>
+		<ingredients>
+		<li>
+			<filter>
+				<thingDefs>
+					<li>Steel</li>
+				</thingDefs>
+			</filter>
+			<count>28</count>
+		</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_MiniCannonBall_Grape>5</Ammo_MiniCannonBall_Grape>
+		</products>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -141,7 +141,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MiniCannonBall_Round>5</Ammo_MiniCannonBall_Round>
+			<Ammo_MiniCannonBall_Round>50</Ammo_MiniCannonBall_Round>
 		</products>
 	</RecipeDef>
 
@@ -168,7 +168,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_MiniCannonBall_Grape>5</Ammo_MiniCannonBall_Grape>
+			<Ammo_MiniCannonBall_Grape>50</Ammo_MiniCannonBall_Grape>
 		</products>
 	</RecipeDef>
 

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -108,7 +108,7 @@
 			<drawSize>1,1</drawSize>
 		</graphicData>			
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>23</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>20.7</armorPenetrationBlunt>
 			<pelletCount>10</pelletCount>


### PR DESCRIPTION
## Additions

- What it says on the tin, to be used for Organ Guns instead of musket balls.

## Changes

- Fixed some values in the cannon ball ammo file.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
