### PR TITLE
Add minimum ammo count spawn tag

### DIFF
--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -103,6 +103,7 @@
           <li>OutlanderShield</li>
         </shieldTags>
         <shieldChance>0.8</shieldChance>
+        <minAmmoCount>20</minAmmoCount>
         <sidearms>
           <li>
             <generateChance>0.5</generateChance>

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -14,6 +14,7 @@ namespace CombatExtended
 
         public FloatRange primaryMagazineCount = FloatRange.Zero;
         public AttachmentOption primaryAttachments;
+        public int minAmmoCount = 10;
 
         public FloatRange shieldMoney = FloatRange.Zero;
         public List<string> shieldTags;
@@ -244,12 +245,19 @@ namespace CombatExtended
             }
             ThingDef thingToAdd;
             int unitCount = 1;  // How many ammo things to add per ammoCount
+            int minAmmoSpawned = minAmmoCount; //how many ammo things should the pawn have no matter the magsize
             var compAmmo = gun.TryGetComp<CompAmmoUser>();
             if (compAmmo == null || !compAmmo.UseAmmo)
             {
                 if (gun.TryGetComp<CompEquippable>().PrimaryVerb.verbProps.verbClass == typeof(Verb_ShootCEOneUse))
                 {
                     thingToAdd = gun.def;   // For one-time use weapons such as grenades, add duplicates instead of ammo
+                    if (minAmmoSpawned == 10)
+                    {
+                        //don't spawn 10 (the default value) of single-use weapons,
+                        //unless the xml patcher explicitly set a different value
+                        minAmmoSpawned = 1;
+                    }
                 }
                 else
                 {
@@ -273,7 +281,8 @@ namespace CombatExtended
             }
 
             var ammoThing = thingToAdd.MadeFromStuff ? ThingMaker.MakeThing(thingToAdd, gun.Stuff) : ThingMaker.MakeThing(thingToAdd);
-            ammoThing.stackCount = ammoCount * unitCount;
+            //check if total ammo required to load all magazines is less than minimum amount for pawnkind
+            ammoThing.stackCount = Math.Max(ammoCount * unitCount, minAmmoSpawned);
             int maxCount;
             if (inventory.CanFitInInventory(ammoThing, out maxCount))
             {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a `minAmmoCount` tag that defines how much ammo should the pawn at least spawn with. Can be set per pawnkinddef in loadout generation xml. Gives 10 bullets by default, unless it's a single-use weapon.

## Reasoning

Why did you choose to implement things this way, e.g.
- Pawnkinds like `Pirate Gunner` often might spawn with a musket or double-barrel shotgun, while having only 3-4 mags of ammo set. This makes them spawn with very few bullets. Pirate gunner xml commit is an example of a use case.
- Grenades, disposable launchers, etc should not be affected by this, so minAmmoCount is 1 for them, unless pawnkind's minAmmoCount is set otherwise. 
- If minAmmoCount is higher than pawn's bulk limit, it gets reduced to fit inventory like before.
- Unfortunately, I haven't found another way to check whether the tag is set manually in xml or uses the default value, so number "10" can't be used to force minimum single-use weapon count.

## Alternatives

Describe alternative implementations you have considered, e.g.
- Set the minimum ammo count per weapondef, instead of per pawnkinddef. Would require more manual work.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
