### PR TITLE
Fix #2069

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_CompAbilityEffect_LaunchProjectile.cs
+++ b/Source/CombatExtended/Harmony/Harmony_CompAbilityEffect_LaunchProjectile.cs
@@ -28,13 +28,14 @@ namespace CombatExtended.HarmonyCE
                     var sourceLoc = new Vector2();
                     sourceLoc.Set(u.x, u.z);
                     var targetLocation = new Vector2();
-                    targetLocation.Set(target.Pawn.TrueCenter().x, target.Pawn.TrueCenter().z);
+                    targetLocation.Set(target.Thing.TrueCenter().x, target.Thing.TrueCenter().z);
 
                     var w = (targetLocation - sourceLoc);
                     float shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x)) % 360;
 
-                    var angle = ProjectileCE.GetShotAngle(projectileDef.projectile.speed, (target.Cell - pawn.Position).LengthHorizontal, 0, false, ppce.Gravity);
-                    CE_Utility.LaunchProjectileCE(projectileDef, sourceLoc, target, pawn, angle, shotRotation, 1, 80);
+                    var targetVert = new CollisionVertical(target.Thing);
+                    var angle = ProjectileCE.GetShotAngle(ppce.speed, (target.Cell - pawn.Position).LengthHorizontal, targetVert.HeightRange.Average - 1, ppce.flyOverhead, ppce.Gravity);
+                    CE_Utility.LaunchProjectileCE(projectileDef, sourceLoc, target, pawn, angle, shotRotation, 1, ppce.speed);
                     return false;
                 }
             }


### PR DESCRIPTION
## Changes
1. Our patch to `CompAbilityEffect_LaunchProjectile` to use CE's system now uses the target as a `Thing` and not a `Pawn`;
2. Made the projectiles launched by `CompAbilityEffect_LaunchProjectile` use the projectile's speed, `flyOverhead` flag, difference in height between shot height and target height.

## Reasoning
1. Targeting walls would call `TrueCenter()` with null, throwing a null reference exception;
2. Unhardcode some values and fix overshooting.

## Testing
- [x] Compiles without warnings;
- [x] Game runs without errors;
- [x] Playtested a colony.
