### PR TITLE
Fix the melee shield issues in ATR's patch

### DIFF
--- a/Patches/Android Tiers Reforged/Bodies/Bodies_Android.xml
+++ b/Patches/Android Tiers Reforged/Bodies/Bodies_Android.xml
@@ -10,6 +10,34 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ATR_AndroidBody"]/corePart/parts/li[customLabel="left shoulder"]/groups</xpath>
+					<value>
+						<li>LeftShoulder</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ATR_AndroidBody"]/corePart/parts/li[customLabel="right shoulder"]/groups</xpath>
+					<value>
+						<li>RightShoulder</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ATR_AndroidBody"]/corePart/parts/li[def="ATR_MechanicalShoulder"]/parts/li[customLabel="left arm"]/groups</xpath>
+					<value>
+						<li>LeftArm</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="ATR_AndroidBody"]/corePart/parts/li[def="ATR_MechanicalShoulder"]/parts/li[customLabel="right arm"]/groups</xpath>
+					<value>
+						<li>RightArm</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BodyDef[defName="ATR_AndroidBody"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>


### PR DESCRIPTION
## Changes

- Completed the bodypart patches for the androids in ATR that was causing them to be able to "wear" multiple melee shields.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (no more infinite equipped melee shields)
