### PR TITLE
Settings menu housekeeping

### DIFF
--- a/Languages/English/Keyed/ModMenu.xml
+++ b/Languages/English/Keyed/ModMenu.xml
@@ -33,7 +33,7 @@
   <CE_Settings_MergeExplosions_Desc>Nearby explosions are merged into eachother, significantly improving performance during a massive explosives cook-off. Strongly recommended to leave on.</CE_Settings_MergeExplosions_Desc>
 
   <CE_Settings_TurretsBreakShields_Title>Disable shield belts while manning turrets</CE_Settings_TurretsBreakShields_Title>
-  <CE_Settings_TurretsBreakShields_Desc> When enabled, shield belts will deactivate while colonists are manning turrets. If disabled, shield belts will instead remain active, offering additional protection.</CE_Settings_TurretsBreakShields_Desc>
+  <CE_Settings_TurretsBreakShields_Desc>When enabled, shield belts will deactivate while colonists are manning turrets. If disabled, shield belts will instead remain active, offering additional protection.</CE_Settings_TurretsBreakShields_Desc>
 
   <CE_Settings_ShowBackpacks_Title>Show backpacks</CE_Settings_ShowBackpacks_Title>
   <CE_Settings_ShowBackpacks_Desc>Enables / Disables the rendering of backpacks (all pawns)</CE_Settings_ShowBackpacks_Desc>

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -253,7 +253,7 @@ namespace CombatExtended
             list.CheckboxLabeled("Enable race autopatcher", ref enableRaceAutopatcher, "This will enable the race autopatcher.");
             list.CheckboxLabeled("Enable weapon autopatcher", ref enableWeaponAutopatcher, "This will enable the weapon autopatcher.");
             list.CheckboxLabeled("Enable weapon toughness autopatcher", ref enableWeaponToughnessAutopatcher, "This will enable the weapon toughness autopatcher.");
-            list.CheckboxLabeled("Enable pawn kind autopatcher", ref enablePawnKindAutopatcher, "This will enable the pawn kind autopatcher.");
+            list.CheckboxLabeled("Enable PawnKind autopatcher", ref enablePawnKindAutopatcher, "This will enable the PawnKind autopatcher.");
 
             // Do ammo settings
             list.NewColumn();


### PR DESCRIPTION
## Changes

- Some minor housekeeping in the settings menu. Removed a redundant space and fixed how "PawnKind" should be written.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
