### PR TITLE
Fix gas mask extension patch op

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -109,10 +109,9 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
+	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]</xpath>
 		<value>
-			<modExtensions>
 				<li Class="CombatExtended.ApparelHediffExtension">
 					<hediff>WearingGasMask</hediff>
 				</li>
@@ -120,7 +119,6 @@
 					<HideHair>false</HideHair>
 					<HideBeard>true</HideBeard>
 				</li>
-			</modExtensions>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Changes

- Replaced the Add patch op with an Extension specific one to avoid future patch conflicts

## Reasoning

- If another mod adds an extension to the mask, our current patch would create a duplicate node.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
