### PR TITLE
Armor scaling sanity rebalance

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -39,7 +39,6 @@
 		<li>SteveZero.FullArmorHandsFeet</li>
 		<li>Dingo.GrenadeFixRearmed</li>
 		<li>automatic.gunplay</li>
-		<li>roolo.runandgun</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>

--- a/About/About.xml
+++ b/About/About.xml
@@ -39,6 +39,7 @@
 		<li>SteveZero.FullArmorHandsFeet</li>
 		<li>Dingo.GrenadeFixRearmed</li>
 		<li>automatic.gunplay</li>
+		<li>roolo.runandgun</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>

--- a/Defs/Stats/Stats_Weapons_Melee.xml
+++ b/Defs/Stats/Stats_Weapons_Melee.xml
@@ -72,7 +72,7 @@
     <showIfUndefined>true</showIfUndefined>
     <parts>
       <li Class="StatPart_Quality">
-        <factorAwful>0.75</factorAwful>
+        <factorAwful>0.65</factorAwful>
         <factorPoor>0.85</factorPoor>
         <factorNormal>1</factorNormal>
         <factorGood>1.1</factorGood>

--- a/Defs/Stats/Stats_Weapons_Melee.xml
+++ b/Defs/Stats/Stats_Weapons_Melee.xml
@@ -76,8 +76,8 @@
         <factorPoor>0.85</factorPoor>
         <factorNormal>1</factorNormal>
         <factorGood>1.1</factorGood>
-        <factorExcellent>1.3</factorExcellent>
-        <factorMasterwork>1.4</factorMasterwork>
+        <factorExcellent>1.2</factorExcellent>
+        <factorMasterwork>1.35</factorMasterwork>
         <factorLegendary>1.5</factorLegendary>
       </li>
       <li Class="StatPart_Health">

--- a/Defs/Stats/Stats_Weapons_Melee.xml
+++ b/Defs/Stats/Stats_Weapons_Melee.xml
@@ -72,7 +72,7 @@
     <showIfUndefined>true</showIfUndefined>
     <parts>
       <li Class="StatPart_Quality">
-        <factorAwful>0.5</factorAwful>
+        <factorAwful>0.75</factorAwful>
         <factorPoor>0.85</factorPoor>
         <factorNormal>1</factorNormal>
         <factorGood>1.1</factorGood>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -46,19 +46,19 @@
 		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
 		<value>
 			<li Class="CombatExtended.StatPart_QualityConditional">
-			  <factorAwful>0.75</factorAwful>
-			  <factorPoor>0.9</factorPoor>
+			  <factorAwful>0.6</factorAwful>
+			  <factorPoor>0.8</factorPoor>
 			  <factorNormal>1</factorNormal>
-			  <factorGood>1.1</factorGood>
-			  <factorExcellent>1.2</factorExcellent>
-			  <factorMasterwork>1.35</factorMasterwork>
-			  <factorLegendary>1.5</factorLegendary>
+			  <factorGood>1.15</factorGood>
+			  <factorExcellent>1.3</factorExcellent>
+			  <factorMasterwork>1.45</factorMasterwork>
+			  <factorLegendary>1.7</factorLegendary>
 			</li>
 			<li Class="StatPart_Health">
 			  <curve>
 			    <points>
-			      <li>(0.0, 0.25)</li>
-			      <li>(0.5, 0.75)</li>
+			      <li>(0.0, 0.0)</li>
+			      <li>(0.5, 0.5)</li>
 			      <li>(0.8, 1.0)</li>
 			    </points>
 			  </curve>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -46,19 +46,19 @@
 		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
 		<value>
 			<li Class="CombatExtended.StatPart_QualityConditional">
-			  <factorAwful>0.5</factorAwful>
-			  <factorPoor>0.75</factorPoor>
+			  <factorAwful>0.75</factorAwful>
+			  <factorPoor>0.9</factorPoor>
 			  <factorNormal>1</factorNormal>
-			  <factorGood>1.15</factorGood>
-			  <factorExcellent>1.3</factorExcellent>
-			  <factorMasterwork>1.5</factorMasterwork>
-			  <factorLegendary>1.75</factorLegendary>
+			  <factorGood>1.1</factorGood>
+			  <factorExcellent>1.2</factorExcellent>
+			  <factorMasterwork>1.35</factorMasterwork>
+			  <factorLegendary>1.5</factorLegendary>
 			</li>
 			<li Class="StatPart_Health">
 			  <curve>
 			    <points>
-			      <li>(0.0, 0.0)</li>
-			      <li>(0.5, 0.5)</li>
+			      <li>(0.0, 0.25)</li>
+			      <li>(0.5, 0.75)</li>
 			      <li>(0.8, 1.0)</li>
 			    </points>
 			  </curve>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -51,8 +51,8 @@
 			  <factorNormal>1</factorNormal>
 			  <factorGood>1.15</factorGood>
 			  <factorExcellent>1.3</factorExcellent>
-			  <factorMasterwork>1.45</factorMasterwork>
-			  <factorLegendary>1.7</factorLegendary>
+			  <factorMasterwork>1.5</factorMasterwork>
+			  <factorLegendary>1.75</factorLegendary>
 			</li>
 			<li Class="StatPart_Health">
 			  <curve>


### PR DESCRIPTION
R&G breaks bipods and some other things and just generally doesn't work and isnt maintained, pls get rid of it already!

Changed armor scaling to values proposed by Sam here https://discord.com/channels/278818534069501953/356498503847116801/1064071382952067092
The scale of armor value change is very annoying at lower values making preindustrial armors hard to relative-balance against eachother. These values are bit higher than I had in mind but still much better than before.
