### PR TITLE
Fix the Heavy Auto-Turret's tech level

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -166,7 +166,6 @@
       <AimingAccuracy>0.5</AimingAccuracy>
       <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
     </statBases>
-    <techLevel>Spacer</techLevel>
     <description>Plated automatic turret equiped with a high caliber machine gun. Very resistant to damage.</description>
     <costList>
       <Steel>275</Steel>
@@ -216,7 +215,6 @@
       <AimingAccuracy>0.5</AimingAccuracy>
       <ShootingAccuracyTurret>0.75</ShootingAccuracyTurret>
     </statBases>
-    <techLevel>Industrial</techLevel>
     <description>Automatic turret equiped with a full powered cartridge machine gun. Fairly resistant to damage.</description>
     <costList>
       <Steel>150</Steel>


### PR DESCRIPTION
## Changes

- Removed the tech level node override of the medium and heavy auto-turret as the heavy one should be industrial and the medium is already inheriting the tech level from the parent def.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
