### PR TITLE
Add 30x165mm ammo.

### DIFF
--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -116,7 +116,7 @@
     <label>25x137mm NATO bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>62</damageAmountBase>
-      <armorPenetrationSharp>57</armorPenetrationSharp>
+      <armorPenetrationSharp>56</armorPenetrationSharp>
       <armorPenetrationBlunt>2238.500</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
 		<label>25x137mm NATO bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>62</damageAmountBase>
-			<armorPenetrationSharp>57</armorPenetrationSharp>
+			<armorPenetrationSharp>56</armorPenetrationSharp>
 			<armorPenetrationBlunt>2238.500</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>25x137mm NATO bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>98</damageAmountBase>
-			<armorPenetrationSharp>29</armorPenetrationSharp>
+			<armorPenetrationSharp>28</armorPenetrationSharp>
 			<armorPenetrationBlunt>2238.500</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>25x137mm NATO bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>52</damageAmountBase>
-			<armorPenetrationSharp>100</armorPenetrationSharp>
+			<armorPenetrationSharp>98</armorPenetrationSharp>
 			<armorPenetrationBlunt>2870.88</armorPenetrationBlunt>
 			<speed>330</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -116,7 +116,7 @@
     <label>30x165mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>74</damageAmountBase>
-      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationSharp>57</armorPenetrationSharp>
       <armorPenetrationBlunt>3159</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
 		<label>30x165mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>74</damageAmountBase>
-			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationSharp>57</armorPenetrationSharp>
 			<armorPenetrationBlunt>3159</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -142,7 +142,7 @@
 		<label>30x165mm bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>118</damageAmountBase>
-			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationSharp>28.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>3159</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
@@ -158,7 +158,7 @@
 		<label>30x165mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>63</damageAmountBase>
-			<armorPenetrationSharp>123</armorPenetrationSharp>
+			<armorPenetrationSharp>100</armorPenetrationSharp>
 			<armorPenetrationBlunt>4051.42</armorPenetrationBlunt>
 			<speed>270</speed>
 		</projectile>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -116,8 +116,8 @@
     <label>30x165mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>74</damageAmountBase>
-      <armorPenetrationSharp>70</armorPenetrationSharp>
-      <armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+      <armorPenetrationSharp>40</armorPenetrationSharp>
+      <armorPenetrationBlunt>3159</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -125,13 +125,13 @@
 		<defName>Bullet_30x165mm_Incendiary</defName>
 		<label>30x165mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>80</damageAmountBase>
-			<armorPenetrationSharp>70</armorPenetrationSharp>
-			<armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+			<damageAmountBase>74</damageAmountBase>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
+			<armorPenetrationBlunt>3159</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>50</amount>
+					<amount>46</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -141,13 +141,13 @@
 		<defName>Bullet_30x165mm_HE</defName>
 		<label>30x165mm bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>127</damageAmountBase>
-			<armorPenetrationSharp>35</armorPenetrationSharp>
-			<armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+			<damageAmountBase>118</damageAmountBase>
+			<armorPenetrationSharp>20</armorPenetrationSharp>
+			<armorPenetrationBlunt>3159</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>76</amount>
+					<amount>71</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -157,10 +157,10 @@
 		<defName>Bullet_30x165mm_Sabot</defName>
 		<label>30x165mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>58</damageAmountBase>
+			<damageAmountBase>63</damageAmountBase>
 			<armorPenetrationSharp>123</armorPenetrationSharp>
-			<armorPenetrationBlunt>4936.96</armorPenetrationBlunt>
-			<speed>306</speed>
+			<armorPenetrationBlunt>4051.42</armorPenetrationBlunt>
+			<speed>270</speed>
 		</projectile>
 	</ThingDef>
 
@@ -168,8 +168,8 @@
 
     <RecipeDef ParentName="AmmoRecipeBase">
       <defName>MakeAmmo_30x165mm_AP</defName>
-      <label>make 30x165mm (AP) cartridge x200</label>
-      <description>Craft 200 30x165mm (AP) cartridges.</description>
+      <label>make 30x165mm (AP) cartridge x100</label>
+      <description>Craft 100 30x165mm (AP) cartridges.</description>
       <jobString>Making 30x165mm (AP) cartridges.</jobString>
       <ingredients>
         <li>
@@ -187,16 +187,16 @@
         </thingDefs>
       </fixedIngredientFilter>
       <products>
-        <Ammo_30x165mm_AP>200</Ammo_30x165mm_AP>
+        <Ammo_30x165mm_AP>100</Ammo_30x165mm_AP>
       </products>
       <workAmount>20160</workAmount>
     </RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x165mm_Incendiary</defName>
-		<label>make 30x165mm (AP-I) cartridge x200</label>
-		<description>Craft 200 .30x165mm (AP-I) cartridges.</description>
-		<jobString>Making .30x165mm (AP-I) cartridges.</jobString>
+		<label>make 30x165mm (AP-I) cartridge x100</label>
+		<description>Craft 100 30x165mm (AP-I) cartridges.</description>
+		<jobString>Making 30x165mm (AP-I) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -212,7 +212,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>19</count>
+				<count>20</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -222,16 +222,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_30x165mm_Incendiary>200</Ammo_30x165mm_Incendiary>
+			<Ammo_30x165mm_Incendiary>100</Ammo_30x165mm_Incendiary>
 		</products>
-		<workAmount>24400</workAmount>
+		<workAmount>29760</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x165mm_HE</defName>
-		<label>make 30x165mm (AP-HE) cartridge x200</label>
-		<description>Craft 200 .30x165mm (AP-HE) cartridges.</description>
-		<jobString>Making .30x165mm (AP-HE) cartridges.</jobString>
+		<label>make 30x165mm (AP-HE) cartridge x100</label>
+		<description>Craft 100 30x165mm (AP-HE) cartridges.</description>
+		<jobString>Making 30x165mm (AP-HE) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -247,7 +247,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>35</count>
+				<count>37</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -257,16 +257,16 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_30x165mm_HE>200</Ammo_30x165mm_HE>
+			<Ammo_30x165mm_HE>100</Ammo_30x165mm_HE>
 		</products>
-		<workAmount>30800</workAmount>
+		<workAmount>37920</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
 		<defName>MakeAmmo_30x165mm_Sabot</defName>
-		<label>make 30x165mm (Sabot) cartridge x200</label>
-		<description>Craft 200 .30x165mm (Sabot) cartridges.</description>
-		<jobString>Making .30x165mm (Sabot) cartridges.</jobString>
+		<label>make 30x165mm (Sabot) cartridge x100</label>
+		<description>Craft 100 30x165mm (Sabot) cartridges.</description>
+		<jobString>Making 30x165mm (Sabot) cartridges.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -274,7 +274,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>94</count>
+				<count>90</count>
 			</li>
 			<li>
 				<filter>
@@ -282,7 +282,7 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>22</count>
+				<count>23</count>
 			</li>
 			<li>
 				<filter>
@@ -290,7 +290,7 @@
 						<li>Chemfuel</li>
 					</thingDefs>
 				</filter>
-				<count>22</count>
+				<count>23</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -301,9 +301,9 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_30x165mm_Sabot>200</Ammo_30x165mm_Sabot>
+			<Ammo_30x165mm_Sabot>100</Ammo_30x165mm_Sabot>
 		</products>
-		<workAmount>22600</workAmount>
+		<workAmount>22800</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -27,8 +27,8 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x165mmBase" ParentName="MediumAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons.</description>
 		<statBases>
-			<Mass>0.837</Mass>
-			<Bulk>1.22</Bulk>
+			<Mass>0.832</Mass>
+			<Bulk>0.69</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -37,7 +37,7 @@
 		<thingCategories>
 			<li>Ammo30x165mm</li>
 		</thingCategories>
-		<stackLimit>150</stackLimit>
+		<stackLimit>500</stackLimit>
 	</ThingDef>
 
     <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.54</MarketValue>
+			<MarketValue>4.64</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_30x165mm_Incendiary</cookOffProjectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>6.95</MarketValue>
+			<MarketValue>7.21</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_30x165mm_HE</cookOffProjectile>
@@ -90,7 +90,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<Mass>0.678</Mass>
+			<Mass>0.665</Mass>
 			<MarketValue>3.81</MarketValue>
 		</statBases>
 		<ammoClass>Sabot</ammoClass>
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>204</speed>
+			<speed>180</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -115,7 +115,7 @@
     <defName>Bullet_30x165mm_AP</defName>
     <label>30x165mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>80</damageAmountBase>
+      <damageAmountBase>74</damageAmountBase>
       <armorPenetrationSharp>70</armorPenetrationSharp>
       <armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
     </projectile>

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo30x165mm</defName>
+		<label>30x165mm</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_30x165mm</defName>
+		<label>30x165mm</label>
+		<ammoTypes>
+		    <Ammo_30x165mm_AP>Bullet_30x165mm_AP</Ammo_30x165mm_AP>
+			<Ammo_30x165mm_Incendiary>Bullet_30x165mm_Incendiary</Ammo_30x165mm_Incendiary>
+			<Ammo_30x165mm_HE>Bullet_30x165mm_HE</Ammo_30x165mm_HE>
+			<Ammo_30x165mm_Sabot>Bullet_30x165mm_Sabot</Ammo_30x165mm_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo30x165mmBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.837</Mass>
+			<Bulk>1.22</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo30x165mm</li>
+		</thingCategories>
+		<stackLimit>150</stackLimit>
+	</ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
+      <defName>Ammo_30x165mm_AP</defName>
+      <label>30x165mm cartridge (AP)</label>
+      <graphicData>
+        <texPath>Things/Ammo/HighCaliber/AP</texPath>
+        <graphicClass>Graphic_StackCount</graphicClass>
+      </graphicData>
+      <statBases>
+        <MarketValue>3.36</MarketValue>
+      </statBases>
+      <ammoClass>ArmorPiercing</ammoClass>
+      <cookOffProjectile>Bullet_30x165mm_AP</cookOffProjectile>
+    </ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
+		<defName>Ammo_30x165mm_Incendiary</defName>
+		<label>30x165mm cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>4.54</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_30x165mm_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
+		<defName>Ammo_30x165mm_HE</defName>
+		<label>30x165mm cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>6.95</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_30x165mm_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo30x165mmBase">
+		<defName>Ammo_30x165mm_Sabot</defName>
+		<label>30x165mm cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.678</Mass>
+			<MarketValue>3.81</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_30x165mm_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base30x165mmBullet" ParentName="BaseBullet" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>204</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+  <ThingDef ParentName="Base30x165mmBullet">
+    <defName>Bullet_30x165mm_AP</defName>
+    <label>30x165mm bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>80</damageAmountBase>
+      <armorPenetrationSharp>70</armorPenetrationSharp>
+      <armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+	<ThingDef ParentName="Base30x165mmBullet">
+		<defName>Bullet_30x165mm_Incendiary</defName>
+		<label>30x165mm bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>80</damageAmountBase>
+			<armorPenetrationSharp>70</armorPenetrationSharp>
+			<armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>50</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x165mmBullet">
+		<defName>Bullet_30x165mm_HE</defName>
+		<label>30x165mm bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>127</damageAmountBase>
+			<armorPenetrationSharp>35</armorPenetrationSharp>
+			<armorPenetrationBlunt>3849.480</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>76</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base30x165mmBullet">
+		<defName>Bullet_30x165mm_Sabot</defName>
+		<label>30x165mm bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>58</damageAmountBase>
+			<armorPenetrationSharp>123</armorPenetrationSharp>
+			<armorPenetrationBlunt>4936.96</armorPenetrationBlunt>
+			<speed>306</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+    <RecipeDef ParentName="AmmoRecipeBase">
+      <defName>MakeAmmo_30x165mm_AP</defName>
+      <label>make 30x165mm (AP) cartridge x200</label>
+      <description>Craft 200 30x165mm (AP) cartridges.</description>
+      <jobString>Making 30x165mm (AP) cartridges.</jobString>
+      <ingredients>
+        <li>
+          <filter>
+            <thingDefs>
+              <li>Steel</li>
+            </thingDefs>
+          </filter>
+          <count>168</count>
+        </li>
+      </ingredients>
+      <fixedIngredientFilter>
+        <thingDefs>
+          <li>Steel</li>
+        </thingDefs>
+      </fixedIngredientFilter>
+      <products>
+        <Ammo_30x165mm_AP>200</Ammo_30x165mm_AP>
+      </products>
+      <workAmount>20160</workAmount>
+    </RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x165mm_Incendiary</defName>
+		<label>make 30x165mm (AP-I) cartridge x200</label>
+		<description>Craft 200 .30x165mm (AP-I) cartridges.</description>
+		<jobString>Making .30x165mm (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>168</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x165mm_Incendiary>200</Ammo_30x165mm_Incendiary>
+		</products>
+		<workAmount>24400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x165mm_HE</defName>
+		<label>make 30x165mm (AP-HE) cartridge x200</label>
+		<description>Craft 200 .30x165mm (AP-HE) cartridges.</description>
+		<jobString>Making .30x165mm (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>168</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>35</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x165mm_HE>200</Ammo_30x165mm_HE>
+		</products>
+		<workAmount>30800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_30x165mm_Sabot</defName>
+		<label>make 30x165mm (Sabot) cartridge x200</label>
+		<description>Craft 200 .30x165mm (Sabot) cartridges.</description>
+		<jobString>Making .30x165mm (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>94</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_30x165mm_Sabot>200</Ammo_30x165mm_Sabot>
+		</products>
+		<workAmount>22600</workAmount>
+	</RecipeDef>
+
+</Defs>


### PR DESCRIPTION
## Additions
- Adds 30x165mm ammo, widely used by Soviet and Soviet-derived autocannons.

https://docs.google.com/spreadsheets/d/1zH9dSvBVxwzF9GDx1234Bxz35Cy7OZQu30SGi7MfblY/edit?usp=sharing

## Changes
- Very slightly reduce the 25x137mm NATO ammo AP. New AP values based on a better source than we were previously using for AP numbers. Notes and values on the official sheet updated accordingly.

## References
Closes #2289

## Reasoning
After reviewing some AP data from several sources (linked below), I went ahead and gave the 30x165mm the same Sharp AP as the 30x173mm NATO. The two rounds are fairly comparable (x165 is a bit heavier, x173mm is a bit faster), and while the types of x165 rounds I could find RHA values for don't fall cleanly into our ammo categories, their AP values are in the neighborhood and are decent guidelines.

E.g:
Tungsten-core AP is listed as 45mm RHA @ 100m.
Armor-Piercing Tracer (unclear if it has a penetrator core) is listed as 22mm RHA @ 500m.

If we cared to, we might be able to spend another couple of hours researching and comparing the ammo types to arrive at a more "accurate" AP value, but I strongly suspect it wouldn't be a difference of more than 3 - 4mm either way on the Armor Piercing rounds.

Sources:
https://thesovietarmourblog.blogspot.com/p/30x165mm-cartridges.html
http://www.armaco.bg/en/product/medium-caliber-ammunitions-c35/30x165mm-round-with-ap-t-projectile-p178#product

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
