### PR TITLE
Update the Kenshi Armory & Anty the War Ant mod.

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -73,6 +73,7 @@
 		<li>VanillaExpanded.VTEXE.SOS2</li>
 		<li>sarg.alphaanimals</li>
 		<li>sarg.magicalmenagerie</li>
-    <li>ObsidiaExpansion.Xenos.Mothoids</li>
+    	<li>ObsidiaExpansion.Xenos.Mothoids</li>
+		<li>Roo.AntyRaceMod</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/Anty the war Ant/Ammo/Ammo_Anty.xml
+++ b/Patches/Anty the war Ant/Ammo/Ammo_Anty.xml
@@ -179,7 +179,7 @@
 						<defName>Ammo_CrossbowBolt_AntyAcid</defName>
 						<label>crossbow bolt (Acid)</label>
 						<graphicData>
-						  <texPath>Things/Ammo/Neolithic/Bolt/Steel</texPath>
+						  <texPath>Things/Ammo/Medieval/Bolt/Steel</texPath>
 						  <graphicClass>Graphic_StackCount</graphicClass>
 						</graphicData>
 						<statBases>

--- a/Patches/Anty the war Ant/PawnKindDefs/Anty_PawnKind.xml
+++ b/Patches/Anty the war Ant/PawnKindDefs/Anty_PawnKind.xml
@@ -97,7 +97,7 @@
 			</li>
 			
 			<!--Backpack-->
-			
+		
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/PawnKindDef[
 				defName="Anty_Commander" or
@@ -134,19 +134,19 @@
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_Backpack"]/apparel/tags</xpath>
+				<xpath>Defs/ThingDef[defName="CE_Apparel_Backpack"]/apparel/tags</xpath>
 				<value>
 					<li>AntyALL</li>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_TribalBackpack"]/apparel/tags</xpath>
+				<xpath>Defs/ThingDef[defName="CE_Apparel_TribalBackpack"]/apparel/tags</xpath>
 				<value>
 					<li>AntyME</li>
 				</value>
 			</li>
-			
+		
 		</operations>
 		</match>	
 	  </li>

--- a/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
+++ b/Patches/Anty the war Ant/ThingDefs_Misc/Anty_Apparel.xml
@@ -21,6 +21,7 @@
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
+					<WornBulk>0</WornBulk>
 				</value>
 			</li>
 			
@@ -570,7 +571,21 @@
 					<CarryBulk>5</CarryBulk>
 				</value>
 			</li>
-			
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+					defName="AT_Apparel_CombatSmoke" or
+					defName="AT_Apparel_pheromone_TP" or
+					defName="AT_Apparel_chunk" or
+					defName="AT_Apparel_barricade" or
+					defName="AT_Apparel_bunker"
+				]/statBases</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
 		</operations>
 		</match>	
 	  </li>

--- a/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
+++ b/Patches/Black Widows/ThingDefs_Weapons/Patch_Weapons.xml
@@ -49,7 +49,7 @@
 					<defName>Ammo_BlackWidowArrow_Steel</defName>
 					<label>black widow arrow (steel)</label>
 					<graphicData>
-					  <texPath>Things/Ammo/Neolithic/Bolt/Steel</texPath>
+					  <texPath>Things/Ammo/Medieval/Bolt/Steel</texPath>
 					  <graphicClass>Graphic_StackCount</graphicClass>
 					</graphicData>
 					<statBases>

--- a/Patches/Kenshi Armory/KenshiArmory_Apparel.xml
+++ b/Patches/Kenshi Armory/KenshiArmory_Apparel.xml
@@ -4,6 +4,7 @@
   <Operation Class="PatchOperationFindMod">
     <mods>
       <li>Kenshi Armory</li>
+      <li>Kenshi Armory (1.4)</li>	  
     </mods>
     <match Class="PatchOperationSequence">
       <operations>

--- a/Patches/Kenshi Armory/KenshiArmory_Armour.xml
+++ b/Patches/Kenshi Armory/KenshiArmory_Armour.xml
@@ -91,7 +91,65 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_HeavyHolyChestPlate"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Holy Full Helmet -->
 
 		<li Class="PatchOperationAdd">
@@ -125,7 +183,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_HeavyPaladinsHelm"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Samurai Plate -->
 
 		<li Class="PatchOperationAdd">
@@ -158,7 +238,65 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_SamuraiPlateArmor"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Samurai Helmet -->
 
 		<li Class="PatchOperationAdd">
@@ -192,7 +330,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_SamuraiHelmet"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Mercenary Plate -->
 
 		<li Class="PatchOperationAdd">
@@ -225,7 +385,53 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_UnstrainedMercenaryPlate"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Tin Can -->
 
 		<li Class="PatchOperationAdd">
@@ -257,6 +463,28 @@
 					<AimingAccuracy>-0.4</AimingAccuracy>
 					<MeleeHitChance>-2</MeleeHitChance>
 				</equippedStatOffsets>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_SamuraiHelmet"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 			</value>
 		</li>
 
@@ -365,7 +593,65 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_PaladinsHeavyPlate"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Holy Full Helmet -->
 
 		<li Class="PatchOperationAdd">
@@ -406,7 +692,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_PaladinsHeavyHelm"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Samurai Plate -->
 
 		<li Class="PatchOperationAdd">
@@ -444,6 +752,64 @@
 				<equippedStatOffsets>
 					<MeleeDodgeChance>-0.08</MeleeDodgeChance>
 				</equippedStatOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_EmpireSamuraiPlateArmor"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 			</value>
 		</li>
 		
@@ -487,7 +853,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_EmpireSamuraiHelmet"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Crab Plate -->
 
 		<li Class="PatchOperationAdd">
@@ -527,7 +915,65 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_CrabArmor"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Crab Helmet -->
 
 		<li Class="PatchOperationAdd">
@@ -568,7 +1014,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_CrabRaiderHelmet"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Mercenary Plate -->
 
 		<li Class="PatchOperationAdd">
@@ -606,6 +1074,52 @@
 				<equippedStatOffsets>
 					<MeleeDodgeChance>-0.02</MeleeDodgeChance>
 				</equippedStatOffsets>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_GuildMercenaryPlate"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 			</value>
 		</li>
 		
@@ -649,7 +1163,29 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_TinCan"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Hack Stopper Jacket -->
 
 		<li Class="PatchOperationAdd">
@@ -689,7 +1225,53 @@
 				</equippedStatOffsets>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_HackStopperJacket"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Hand</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+			</value>
+		</li>
+
 		<!-- Hack Stopper Helmet -->
 
 		<li Class="PatchOperationAdd">
@@ -718,6 +1300,28 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_HackStopperHat"]/statBases/Mass</xpath>
 			<value>
 				<Mass>1</Mass>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Kenshi_HackStopperHat"]</xpath>
+			<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
 			</value>
 		</li>
 

--- a/Patches/Kenshi Armory/KenshiArmory_Armour.xml
+++ b/Patches/Kenshi Armory/KenshiArmory_Armour.xml
@@ -4,6 +4,7 @@
   <Operation Class="PatchOperationFindMod">
     <mods>
       <li>Kenshi Armory</li>
+      <li>Kenshi Armory (1.4)</li>	  	  
     </mods>
     <match Class="PatchOperationSequence">
       <operations>

--- a/Patches/Kenshi Armory/KenshiArmory_Weapons.xml
+++ b/Patches/Kenshi Armory/KenshiArmory_Weapons.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
     <mods>
         <li>Kenshi Armory</li>
+      <li>Kenshi Armory (1.4)</li>	  		
     </mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
## Changes
**Kenshi Armory:**
- Added the name of the 1.4 temporary update to the FindMod.
- Implemented partial armor in line with the plate helmet and plate armor.

**Anty the War Ant:**
- Made the mod load before CE; if loaded after, it overwrites the scenario ammo patches.
- Fixed a patch that was using the old defNames for the CE apparel.
- Fixed a couple of outdated texture paths for crossbow bolts.

## References
Closes #2127 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
