### PR TITLE
Fix RM2's weapon drawSizes

### DIFF
--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_PlasmaWeaponry.xml
@@ -78,6 +78,16 @@
                </value>
             </li>
 
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="RM_MeleeWeapon_GravitonMace"]</xpath>
+				<value>
+				  <li Class="CombatExtended.GunDrawExtension">
+					<DrawSize>1.5,1.5</DrawSize>
+					<DrawOffset>0.0,0.0</DrawOffset>
+				  </li>
+				</value>
+			</li>
+
             <!-- ======== Royalty Add-On ======= -->
             <li Class="PatchOperationFindMod">
                <mods>
@@ -402,6 +412,16 @@
                   </value>
                </match>
             </li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="RM_Gun_PlasmaHellgator"]</xpath>
+				<value>
+				  <li Class="CombatExtended.GunDrawExtension">
+					<DrawSize>2.0,2.0</DrawSize>
+					<DrawOffset>0.0,0.0</DrawOffset>
+				  </li>
+				</value>
+			</li>
 
             <!-- === Immolator Grenade === -->
             <li Class="CombatExtended.PatchOperationMakeGunCECompatible">


### PR DESCRIPTION
## Changes

- Two weapons from the mod had a drawSize node that made them bigger which does not work in CE, added a patch to fix their size via CE's own mod extension.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
