### PR TITLE
[MultiplayerCompat] Fix ITab_Inventory syncing 

### DIFF
--- a/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
+++ b/Source/MultiplayerCompat/MultiplayerCompat/MultiplayerCompat.cs
@@ -199,5 +199,11 @@ namespace CombatExtended.Compatibility.MultiplayerAPI
                 loadoutSlot = LoadoutManager.Loadouts[loadoutIndex].Slots[sync.Read<int>()];
             }
         }
+
+        // Don't sync anything, we just want a blank instance for method calling purposes
+        // We only care about shouldConstruct being true
+        [SyncWorker(shouldConstruct = true)]
+        private static void SyncITab_Inventory(SyncWorker sync, ref ITab_Inventory inventory)
+        { }
     }
 }


### PR DESCRIPTION
## Changes

- Fix ITab_Inventory syncing, recovered SyncWorker for ITab_Inventory.

## Reasoning

- Fire a gun caused Desync in Multiplayer
- Try any command in pawn's equipment(drop, drop and haul, consume thing) produce Exception cuz no SyncWorker for ITab_Inventory.

## Alternatives

N/A

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (3days)
