### PR TITLE
Generic Ammosets housekeeping

### DIFF
--- a/Defs/Ammo/GENERIC/AntiMateriel.xml
+++ b/Defs/Ammo/GENERIC/AntiMateriel.xml
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-<!--really just relabeled .338 Lapua Magnum-->
+	<!-- Relabeled .50 BMG -->
 
 	<ThingCategoryDef>
 		<defName>AmmoAntiMateriel</defName>
@@ -10,96 +10,108 @@
 		<iconPath>UI/Icons/ThingCategories/AmmoHighCaliber</iconPath>
 	</ThingCategoryDef>
 
-  <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_AntiMateriel</defName>
-    <label>anti-materiel</label>
-    <ammoTypes>
-      <Ammo_AntiMateriel_FMJ>Bullet_50BMG_FMJ</Ammo_AntiMateriel_FMJ>
-      <Ammo_AntiMateriel_Incendiary>Bullet_50BMG_Incendiary</Ammo_AntiMateriel_Incendiary>
-      <Ammo_AntiMateriel_HE>Bullet_50BMG_HE</Ammo_AntiMateriel_HE>
-      <Ammo_AntiMateriel_Sabot>Bullet_50BMG_Sabot</Ammo_AntiMateriel_Sabot>	  
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_AntiMateriel</defName>
+		<label>anti-materiel</label>
+		<ammoTypes>
+			<Ammo_AntiMateriel_FMJ>Bullet_50BMG_FMJ</Ammo_AntiMateriel_FMJ>
+			<Ammo_AntiMateriel_AP>Bullet_50BMG_AP</Ammo_AntiMateriel_AP>
+			<Ammo_AntiMateriel_Incendiary>Bullet_50BMG_Incendiary</Ammo_AntiMateriel_Incendiary>
+			<Ammo_AntiMateriel_HE>Bullet_50BMG_HE</Ammo_AntiMateriel_HE>
+			<Ammo_AntiMateriel_Sabot>Bullet_50BMG_Sabot</Ammo_AntiMateriel_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
-  
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAntiMaterielBase" ParentName="MediumAmmoBase" Abstract="True">
-        <description>Large caliber bullet used by heavy machine guns and anti-materiel rifles.</description>
+		<description>Large caliber bullet used by heavy machine guns and anti-materiel rifles.</description>
 		<statBases>
-            <Mass>0.140</Mass>
-            <Bulk>0.20</Bulk>
-            <MarketValue>0.60</MarketValue>      
-        </statBases>
-        <tradeTags>
-            <li>CE_AutoEnableTrade</li>
-            <li>CE_AutoEnableCrafting</li>
-        </tradeTags>
+			<Mass>0.118</Mass>
+			<Bulk>0.14</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
 		<thingCategories>
 			<li>AmmoAntiMateriel</li>
 		</thingCategories>
-        <stackLimit>2000</stackLimit>
+		<stackLimit>5000</stackLimit>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">		
-        <defName>Ammo_AntiMateriel_FMJ</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
+		<defName>Ammo_AntiMateriel_FMJ</defName>
 		<label>anti-materiel cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/FMJ</texPath>
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.60</MarketValue>
+			<MarketValue>0.5</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_50BMG_FMJ</cookOffProjectile>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
-        <defName>Ammo_AntiMateriel_Incendiary</defName>
-        <label>anti-materiel cartridge (AP-I)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.74</MarketValue>
-        </statBases>
-        <ammoClass>IncendiaryAP</ammoClass>
-        <cookOffProjectile>Bullet_50BMG_Incendiary</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
+		<defName>Ammo_AntiMateriel_AP</defName>
+		<label>anti-materiel cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.5</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_50BMG_AP</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
-        <defName>Ammo_AntiMateriel_HE</defName>
-        <label>anti-materiel cartridge (HE)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>1.25</MarketValue>
-        </statBases>
-        <ammoClass>ExplosiveAP</ammoClass>
-        <cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>
-    </ThingDef>
-    
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
-        <defName>Ammo_AntiMateriel_Sabot</defName>
-        <label>anti-materiel cartridge (Sabot)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.68</MarketValue>
-        <Mass>0.120</Mass>
-        </statBases>
-        <ammoClass>Sabot</ammoClass>
-        <cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
+		<defName>Ammo_AntiMateriel_Incendiary</defName>
+		<label>anti-materiel cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.66</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_50BMG_Incendiary</cookOffProjectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
+		<defName>Ammo_AntiMateriel_HE</defName>
+		<label>anti-materiel cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.02</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_50BMG_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAntiMaterielBase">
+		<defName>Ammo_AntiMateriel_Sabot</defName>
+		<label>anti-materiel cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.57</MarketValue>
+			<Mass>0.099</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
+	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 
@@ -115,7 +127,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>60</count>
+				<count>50</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -126,122 +138,147 @@
 		<products>
 			<Ammo_AntiMateriel_FMJ>200</Ammo_AntiMateriel_FMJ>
 		</products>
+		<workAmount>5000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_AntiMateriel_AP</defName>
+		<label>make anti-materiel (AP) cartridge x200</label>
+		<description>Craft 200 anti-materiel (AP) cartridges.</description>
+		<jobString>Making anti-materiel (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_AntiMateriel_AP>200</Ammo_AntiMateriel_AP>
+		</products>
 		<workAmount>6000</workAmount>
 	</RecipeDef>
 
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_AntiMateriel_Incendiary</defName>
+		<label>make anti-materiel (AP-I) cartridge x200</label>
+		<description>Craft 200 anti-materiel (AP-I) cartridges.</description>
+		<jobString>Making anti-materiel (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_AntiMateriel_Incendiary>200</Ammo_AntiMateriel_Incendiary>
+		</products>
+		<workAmount>7000</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_AntiMateriel_Incendiary</defName>
-    <label>make anti-materiel (AP-I) cartridge x200</label>
-    <description>Craft 200 anti-materiel (AP-I) cartridges.</description>
-    <jobString>Making anti-materiel (AP-I) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>58</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>5</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_AntiMateriel_Incendiary>200</Ammo_AntiMateriel_Incendiary>
-    </products>
-    <workAmount>7800</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_AntiMateriel_HE</defName>
-    <label>make anti-materiel (HE) cartridge x200</label>
-    <description>Craft 200 anti-materiel (HE) cartridges.</description>
-    <jobString>Making anti-materiel (HE) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>60</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>12</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_AntiMateriel_HE>200</Ammo_AntiMateriel_HE>
-    </products>
-    <workAmount>3600</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_AntiMateriel_Sabot</defName>
-    <label>make anti-materiel (Sabot) cartridge x200</label>
-    <description>Craft 200 anti-materiel (Sabot) cartridges.</description>
-    <jobString>Making anti-materiel (Sabot) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>45</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Uranium</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Chemfuel</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>		  
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Uranium</li>
-        <li>Chemfuel</li>		
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_AntiMateriel_Sabot>200</Ammo_AntiMateriel_Sabot>
-    </products>
-    <workAmount>2400</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_AntiMateriel_HE</defName>
+		<label>make anti-materiel (HE) cartridge x200</label>
+		<description>Craft 200 anti-materiel (HE) cartridges.</description>
+		<jobString>Making anti-materiel (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_AntiMateriel_HE>200</Ammo_AntiMateriel_HE>
+		</products>
+		<workAmount>9000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_AntiMateriel_Sabot</defName>
+		<label>make anti-materiel (Sabot) cartridge x200</label>
+		<description>Craft 200 anti-materiel (Sabot) cartridges.</description>
+		<jobString>Making anti-materiel (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>30</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_AntiMateriel_Sabot>200</Ammo_AntiMateriel_Sabot>
+		</products>
+		<workAmount>6600</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/Autocannon.xml
+++ b/Defs/Ammo/GENERIC/Autocannon.xml
@@ -1,245 +1,243 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <!--Actually just 20x110 Hispano-->
+	<!-- Relabeled 20x102mm NATO -->
 
-    <ThingCategoryDef>
-      <defName>AmmoAutocannon</defName>
-      <label>autocannon shell</label>
-      <parent>AmmoHighCaliber</parent>
-      <iconPath>UI/Icons/ThingCategories/AmmoHighCaliber</iconPath>
-    </ThingCategoryDef>
-  
-  <!-- ==================== AmmoSet ========================== -->
+	<ThingCategoryDef>
+		<defName>AmmoAutocannon</defName>
+		<label>autocannon shell</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/AmmoHighCaliber</iconPath>
+	</ThingCategoryDef>
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_Autocannon</defName>
-    <label>autocannon shell</label>
-    <ammoTypes>
-      <Ammo_Autocannon_AP>Bullet_20x110mmHispano_AP</Ammo_Autocannon_AP>
-      <Ammo_Autocannon_Incendiary>Bullet_20x110mmHispano_Incendiary</Ammo_Autocannon_Incendiary>
-      <Ammo_Autocannon_HE>Bullet_20x110mmHispano_HE</Ammo_Autocannon_HE>
-	    <Ammo_Autocannon_Sabot>Bullet_20x110mmHispano_Sabot</Ammo_Autocannon_Sabot>	        
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
-  
-  <!-- ==================== Ammo ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAutocannonShellBase" ParentName="MediumAmmoBase" Abstract="True">
-    <description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
-    <statBases>
-    <Mass>0.257</Mass>
-    <Bulk>0.27</Bulk>
-    </statBases>
-    <tradeTags>
-      <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
-    </tradeTags>
-    <thingCategories>
-      <li>AmmoAutocannon</li>
-    </thingCategories>
-    <stackLimit>2000</stackLimit>
-  </ThingDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Autocannon</defName>
+		<label>autocannon shell</label>
+		<ammoTypes>
+			<Ammo_Autocannon_AP>Bullet_20x102mmNATO_AP</Ammo_Autocannon_AP>
+			<Ammo_Autocannon_Incendiary>Bullet_20x102mmNATO_Incendiary</Ammo_Autocannon_Incendiary>
+			<Ammo_Autocannon_HE>Bullet_20x102mmNATO_HE</Ammo_Autocannon_HE>
+			<Ammo_Autocannon_Sabot>Bullet_20x102mmNATO_Sabot</Ammo_Autocannon_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
-    <defName>Ammo_Autocannon_AP</defName>
-    <label>autocannon shell (AP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>1.04</MarketValue>
-    </statBases>
-    <ammoClass>ArmorPiercing</ammoClass>
-    <cookOffProjectile>Bullet_20x110mmHispano_AP</cookOffProjectile>
-  </ThingDef>
+	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
-    <defName>Ammo_Autocannon_Incendiary</defName>
-    <label>autocannon shell (AP-I)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>1.45</MarketValue>
-    </statBases>
-    <ammoClass>IncendiaryAP</ammoClass>
-    <cookOffProjectile>Bullet_20x110mmHispano_Incendiary</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoAutocannonShellBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons and a handful of anti-tank rifles.</description>
+		<statBases>
+			<Mass>0.254</Mass>
+			<Bulk>0.34</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoAutocannon</li>
+		</thingCategories>
+		<stackLimit>1000</stackLimit>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
-    <defName>Ammo_Autocannon_HE</defName>
-    <label>autocannon shell (HE)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>2.22</MarketValue>
-    </statBases>
-    <ammoClass>ExplosiveAP</ammoClass>
-    <cookOffProjectile>Bullet_20x110mmHispano_HE</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
+		<defName>Ammo_Autocannon_AP</defName>
+		<label>autocannon shell (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.04</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_20x102mmNATO_AP</cookOffProjectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
+		<defName>Ammo_Autocannon_Incendiary</defName>
+		<label>autocannon shell (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.35</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_20x102mmNATO_Incendiary</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
-    <defName>Ammo_Autocannon_Sabot</defName>
-    <label>autocannon shell (Sabot)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>1.16</MarketValue>
-	    <Mass>0.205</Mass>
-    </statBases>
-    <ammoClass>Sabot</ammoClass>
-    <cookOffProjectile>Bullet_20x110mmHispano_Sabot</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
+		<defName>Ammo_Autocannon_HE</defName>
+		<label>autocannon shell (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.02</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_20x102mmNATO_HE</cookOffProjectile>
+	</ThingDef>
 
-  <!-- ==================== Recipes ========================== -->
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoAutocannonShellBase">
+		<defName>Ammo_Autocannon_Sabot</defName>
+		<label>autocannon shell (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.213</Mass>
+			<MarketValue>1.17</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_20x102mmNATO_Sabot</cookOffProjectile>
+	</ThingDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_Autocannon_AP</defName>
-    <label>make autocannon shell (AP) x200</label>
-    <description>Craft 200 autocannon shell (AP).</description>
-    <jobString>Making autocannon shell (AP).</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>194</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Autocannon_AP>200</Ammo_Autocannon_AP>
-    </products>
-    <workAmount>10400</workAmount>
-  </RecipeDef>
+	<!-- ==================== Recipes ========================== -->
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Autocannon_Incendiary</defName>
-    <label>make autocannon shell (AP-I) x200</label>
-    <description>Craft 200 autocannon shell (AP-I).</description>
-    <jobString>Making autocannon shell (AP-I).</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>104</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>13</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Autocannon_Incendiary>200</Ammo_Autocannon_Incendiary>
-    </products>
-    <workAmount>15600</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_Autocannon_AP</defName>
+		<label>make autocannon shell (AP) x200</label>
+		<description>Craft 200 autocannon shell (AP).</description>
+		<jobString>Making autocannon shell (AP).</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Autocannon_AP>200</Ammo_Autocannon_AP>
+		</products>
+		<workAmount>12480</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Autocannon_HE</defName>
-    <label>make autocannon shell (HE) x200</label>
-    <description>Craft 200 autocannon shell (HE).</description>
-    <jobString>Making autocannon shell (HE).</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>104</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>23</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Autocannon_HE>200</Ammo_Autocannon_HE>
-    </products>
-    <workAmount>19600</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Autocannon_Incendiary</defName>
+		<label>make autocannon shell (AP-I) x200</label>
+		<description>Craft 200 autocannon shell (AP-I).</description>
+		<jobString>Making autocannon shell (AP-I).</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Autocannon_Incendiary>200</Ammo_Autocannon_Incendiary>
+		</products>
+		<workAmount>14400</workAmount>
+	</RecipeDef>
 
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Autocannon_HE</defName>
+		<label>make autocannon shell (HE) x200</label>
+		<description>Craft 200 autocannon shell (HE).</description>
+		<jobString>Making autocannon shell (HE).</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Autocannon_HE>200</Ammo_Autocannon_HE>
+		</products>
+		<workAmount>18000</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Autocannon_Sabot</defName>
-    <label>make autocannon shell (Sabot) x200</label>
-    <description>Craft 200 autocannon shell (Sabot).</description>
-    <jobString>Making autocannon shell (Sabot).</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>54</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Uranium</li>
-          </thingDefs>
-        </filter>
-        <count>14</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Chemfuel</li>
-          </thingDefs>
-        </filter>
-        <count>14</count>
-      </li>	  
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-		    <li>Chemfuel</li>	  
-        <li>Steel</li>
-		    <li>Uranium</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Autocannon_Sabot>200</Ammo_Autocannon_Sabot>
-    </products>
-    <workAmount>13800</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Autocannon_Sabot</defName>
+		<label>make autocannon shell (Sabot) x200</label>
+		<description>Craft 200 autocannon shell (Sabot).</description>
+		<jobString>Making autocannon shell (Sabot).</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>64</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Chemfuel</li>
+				<li>Steel</li>
+				<li>Uranium</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Autocannon_Sabot>200</Ammo_Autocannon_Sabot>
+		</products>
+		<workAmount>13600</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/LauncherGrenade.xml
+++ b/Defs/Ammo/GENERIC/LauncherGrenade.xml
@@ -1,299 +1,275 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <ThingCategoryDef>
-    <defName>AmmoLauncherGrenade</defName>
-    <label>launcher Grenade</label>
-    <parent>AmmoGrenades</parent>
-    <iconPath>UI/Icons/ThingCategories/CaliberGrenade</iconPath>
-  </ThingCategoryDef>
+	<!-- Relabeled 40x46mm grenades -->
 
+	<ThingCategoryDef>
+		<defName>AmmoLauncherGrenade</defName>
+		<label>launcher Grenade</label>
+		<parent>AmmoGrenades</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberGrenade</iconPath>
+	</ThingCategoryDef>
 
 	<!-- ==================== AmmoSet ========================== -->
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_LauncherGrenade</defName>
-    <label>launcher grenade</label>
-    <ammoTypes>
-      <Ammo_LauncherGrenade_HE>Bullet_40x53mmGrenade_HE</Ammo_LauncherGrenade_HE>
-      <Ammo_LauncherGrenade_HEDP>Bullet_40x53mmGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
-      <Ammo_LauncherGrenade_EMP>Bullet_40x53mmGrenade_EMP</Ammo_LauncherGrenade_EMP>
-      <Ammo_LauncherGrenade_Smoke>Bullet_40x53mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>	        
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_LauncherGrenade</defName>
+		<label>launcher grenade</label>
+		<ammoTypes>
+			<Ammo_LauncherGrenade_HE>Bullet_40x46mmGrenade_HE</Ammo_LauncherGrenade_HE>
+			<Ammo_LauncherGrenade_HEDP>Bullet_40x46mmGrenade_HEDP</Ammo_LauncherGrenade_HEDP>
+			<Ammo_LauncherGrenade_EMP>Bullet_40x46mmGrenade_EMP</Ammo_LauncherGrenade_EMP>
+			<Ammo_LauncherGrenade_Smoke>Bullet_40x46mmGrenade_Smoke</Ammo_LauncherGrenade_Smoke>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
-  
-  <!-- ==================== Ammo ========================== -->
+	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoLauncherGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
-    <description>Low velocity grenade fired from various grenade launchers</description>
-    <statBases>
-      <Mass>0.26</Mass>
-      <Bulk>0.40</Bulk>
-    </statBases>
-    <tradeTags>
-      <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting_TableMachining</li>
-    </tradeTags>
-    <thingCategories>
-      <li>AmmoLauncherGrenade</li>
-    </thingCategories>
-    <stackLimit>500</stackLimit>
-    <cookOffFlashScale>100</cookOffFlashScale>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoLauncherGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Low velocity grenade fired from various grenade launchers</description>
+		<statBases>
+			<Mass>0.239</Mass>
+			<Bulk>0.40</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting_TableMachining</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoLauncherGrenade</li>
+		</thingCategories>
+		<stackLimit>500</stackLimit>
+		<cookOffFlashScale>100</cookOffFlashScale>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
-    <defName>Ammo_LauncherGrenade_HE</defName>
-    <label>launcher grenade (HE)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/HE</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>2.5</MarketValue>
-    </statBases>
-    <ammoClass>GrenadeHE</ammoClass>
-	<detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
+		<defName>Ammo_LauncherGrenade_HE</defName>
+		<label>launcher grenade (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.37</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHE</ammoClass>
+		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
-    <defName>Ammo_LauncherGrenade_HEDP</defName>
-    <label>launcher grenade (HEDP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/DP</texPath>
-      <graphicClass>Graphic_StackCount</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>3</MarketValue>
-    </statBases>
-    <ammoClass>GrenadeHEDP</ammoClass>
-	<detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
+		<defName>Ammo_LauncherGrenade_HEDP</defName>
+		<label>launcher grenade (HEDP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/DP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.68</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeHEDP</ammoClass>
+		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
-    <defName>Ammo_LauncherGrenade_EMP</defName>
-    <label>launcher grenade (EMP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/EMP</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>4.5</MarketValue>
-    </statBases>
-    <ammoClass>GrenadeEMP</ammoClass>
-    <comps>
-	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>5</damageAmountBase>
-		<explosiveDamageType>Bomb</explosiveDamageType>
-		<explosiveRadius>0.75</explosiveRadius>
-	  </li>
-	  <li Class="CombatExtended.CompProperties_Fragments">
-		<fragments>
-			<Fragment_Large>1</Fragment_Large>
-        </fragments>
-      </li>
-    </comps>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
+		<defName>Ammo_LauncherGrenade_EMP</defName>
+		<label>launcher grenade (EMP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/EMP</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>4.25</MarketValue>
+		</statBases>
+		<ammoClass>GrenadeEMP</ammoClass>
+		<detonateProjectile>Bullet_40x46mmGrenade_EMP</detonateProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
-    <defName>Ammo_LauncherGrenade_Smoke</defName>
-    <label>launcher grenade (Smoke)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/SMK</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>2</MarketValue>
-    </statBases>
-    <ammoClass>Smoke</ammoClass>
-    <generateAllowChance>0</generateAllowChance>
-    <comps>
-	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>5</damageAmountBase>
-		<explosiveDamageType>Bomb</explosiveDamageType>
-		<explosiveRadius>0.75</explosiveRadius>
-	  </li>
-	  <li Class="CombatExtended.CompProperties_Fragments">
-		<fragments>
-			<Fragment_Large>1</Fragment_Large>
-        </fragments>
-      </li>
-    </comps>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoLauncherGrenadeBase">
+		<defName>Ammo_LauncherGrenade_Smoke</defName>
+		<label>launcher grenade (Smoke)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/GrenadeLauncher/SMK</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.84</MarketValue>
+		</statBases>
+		<ammoClass>Smoke</ammoClass>
+		<generateAllowChance>0</generateAllowChance>
+		<detonateProjectile>Bullet_40x46mmGrenade_Smoke</detonateProjectile>
+	</ThingDef>
 
+	<!-- ==================== Recipes ========================== -->
 
-  <!-- ==================== Recipes ========================== -->
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_LauncherGrenade_HE</defName>
+		<label>make launcher HE grenades x100</label>
+		<description>Craft 100 launcher HE grenades.</description>
+		<jobString>Making launcher HE grenades.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>7</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_HE>100</Ammo_LauncherGrenade_HE>
+		</products>
+		<workAmount>9000</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_LauncherGrenade_HE</defName>
-    <label>make launcher HE grenades x100</label>
-    <description>Craft 100 launcher HE grenades.</description>
-    <jobString>Making launcher HE grenades.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>58</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>7</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_LauncherGrenade_HE>100</Ammo_LauncherGrenade_HE>
-    </products>
-    <workAmount>9000</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_LauncherGrenade_HEDP</defName>
+		<label>make launcher HEDP grenades x100</label>
+		<description>Craft 100 launcher HEDP grenades.</description>
+		<jobString>Making launcher HEDP grenades.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_HEDP>100</Ammo_LauncherGrenade_HEDP>
+		</products>
+		<workAmount>10200</workAmount>
+	</RecipeDef>
 
-  
-  <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_LauncherGrenade_HEDP</defName>
-    <label>make launcher HEDP grenades x100</label>
-    <description>Craft 100 launcher HEDP grenades.</description>
-    <jobString>Making launcher HEDP grenades.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>58</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>11</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_LauncherGrenade_HEDP>100</Ammo_LauncherGrenade_HEDP>
-    </products>
-    <workAmount>9000</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_LauncherGrenade_EMP</defName>
+		<label>make launcher EMP grenades x100</label>
+		<description>Craft 100 launcher EMP grenades.</description>
+		<jobString>Making launcher EMP grenades.</jobString>
+		<researchPrerequisites>
+			<li>MicroelectronicsBasics</li>
+			<li>CE_Launchers</li>
+		</researchPrerequisites>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_EMP>100</Ammo_LauncherGrenade_EMP>
+		</products>
+		<workAmount>11000</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_LauncherGrenade_EMP</defName>
-    <label>make launcher EMP grenades x100</label>
-    <description>Craft 100 launcher EMP grenades.</description>
-    <jobString>Making launcher EMP grenades.</jobString>
-    <researchPrerequisites>
-      <li>MicroelectronicsBasics</li>
-      <li>CE_Launchers</li>
-    </researchPrerequisites>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>58</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>10</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_LauncherGrenade_EMP>100</Ammo_LauncherGrenade_EMP>
-    </products>
-    <workAmount>11000</workAmount>
-  </RecipeDef>
-
-  <RecipeDef ParentName="LauncherAmmoRecipeBase">
-    <defName>MakeAmmo_LauncherGrenade_Smoke</defName>
-    <label>make launcher smoke grenades x100</label>
-    <description>Craft 100 launcher smoke grenades.</description>
-    <jobString>Making launcher smoke grenades.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>58</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>3</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>      
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-        <li>ComponentIndustrial</li>        
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_LauncherGrenade_Smoke>100</Ammo_LauncherGrenade_Smoke>
-    </products>
-    <workAmount>7400</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="LauncherAmmoRecipeBase">
+		<defName>MakeAmmo_LauncherGrenade_Smoke</defName>
+		<label>make launcher smoke grenades x100</label>
+		<description>Craft 100 launcher smoke grenades.</description>
+		<jobString>Making launcher smoke grenades.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>50</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_LauncherGrenade_Smoke>100</Ammo_LauncherGrenade_Smoke>
+		</products>
+		<workAmount>7400</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/Pistol.xml
+++ b/Defs/Ammo/GENERIC/Pistol.xml
@@ -1,5 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
+
+	<!-- Relabeled .45 ACP -->
 
 	<ThingCategoryDef>
 		<defName>AmmoPistol</defName>
@@ -14,19 +16,19 @@
 		<defName>AmmoSet_Pistol</defName>
 		<label>pistol</label>
 		<ammoTypes>
-			<Ammo_Pistol_FMJ>Bullet_9x19mmPara_FMJ</Ammo_Pistol_FMJ>
-			<Ammo_Pistol_AP>Bullet_9x19mmPara_AP</Ammo_Pistol_AP>
-			<Ammo_Pistol_HP>Bullet_9x19mmPara_HP</Ammo_Pistol_HP>
+			<Ammo_Pistol_FMJ>Bullet_45ACP_FMJ</Ammo_Pistol_FMJ>
+			<Ammo_Pistol_AP>Bullet_45ACP_AP</Ammo_Pistol_AP>
+			<Ammo_Pistol_HP>Bullet_45ACP_HP</Ammo_Pistol_HP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
-	
-    <!-- ==================== Ammo ========================== -->
+
+	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoPistolBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Common pistol cartridge used by a variety of handguns and SMGs.</description>
 		<statBases>
-			<Mass>0.012</Mass>
-			<Bulk>0.01</Bulk>
+			<Mass>0.02</Mass>
+			<Bulk>0.02</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -45,10 +47,10 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.06</MarketValue>
+			<MarketValue>0.09</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
-		<cookOffProjectile>Bullet_9x19mmPara_FMJ</cookOffProjectile>
+		<cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoPistolBase">
@@ -59,10 +61,10 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.06</MarketValue>
+			<MarketValue>0.09</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<cookOffProjectile>Bullet_9x19mmPara_AP</cookOffProjectile>
+		<cookOffProjectile>Bullet_45ACP_AP</cookOffProjectile>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoPistolBase">
@@ -73,13 +75,12 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.06</MarketValue>
+			<MarketValue>0.09</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
-		<cookOffProjectile>Bullet_9x19mmPara_HP</cookOffProjectile>
+		<cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
 	</ThingDef>
 
-    
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -94,7 +95,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>22</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -105,7 +106,7 @@
 		<products>
 			<Ammo_Pistol_FMJ>500</Ammo_Pistol_FMJ>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>2200</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -120,7 +121,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>22</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -131,7 +132,7 @@
 		<products>
 			<Ammo_Pistol_AP>500</Ammo_Pistol_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>2640</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -146,7 +147,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>22</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -157,7 +158,7 @@
 		<products>
 			<Ammo_Pistol_HP>500</Ammo_Pistol_HP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>2200</workAmount>
 	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/PistolMagnum.xml
+++ b/Defs/Ammo/GENERIC/PistolMagnum.xml
@@ -1,5 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
+
+	<!-- Relabeled .44 Magnum -->
 
 	<ThingCategoryDef>
 		<defName>AmmoPistolMagnum</defName>
@@ -7,7 +9,6 @@
 		<parent>AmmoPistols</parent>
 		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
 	</ThingCategoryDef>
-
 
 	<!-- ==================== AmmoSet ========================== -->
 
@@ -20,7 +21,6 @@
 			<Ammo_PistolMagnum_HP>Bullet_44Magnum_HP</Ammo_PistolMagnum_HP>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
-
 
 	<!-- ==================== Ammo ========================== -->
 
@@ -133,7 +133,7 @@
 		<products>
 			<Ammo_PistolMagnum_AP>500</Ammo_PistolMagnum_AP>
 		</products>
-		<workAmount>2400</workAmount>
+		<workAmount>2880</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/GENERIC/Rifle.xml
+++ b/Defs/Ammo/GENERIC/Rifle.xml
@@ -1,5 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
+
+	<!-- Relabeled 7.62x51mm NATO -->
 
 	<ThingCategoryDef>
 		<defName>AmmoRifle</defName>
@@ -8,8 +10,7 @@
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
 	</ThingCategoryDef>
 
-  
-  <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
 	<CombatExtended.AmmoSetDef>
 		<defName>AmmoSet_Rifle</defName>
@@ -18,13 +19,11 @@
 			<Ammo_Rifle_FMJ>Bullet_762x51mmNATO_FMJ</Ammo_Rifle_FMJ>
 			<Ammo_Rifle_AP>Bullet_762x51mmNATO_AP</Ammo_Rifle_AP>
 			<Ammo_Rifle_HP>Bullet_762x51mmNATO_HP</Ammo_Rifle_HP>
-		    <Ammo_Rifle_Incendiary>Bullet_762x51mmNATO_Incendiary</Ammo_Rifle_Incendiary>
+			<Ammo_Rifle_Incendiary>Bullet_762x51mmNATO_Incendiary</Ammo_Rifle_Incendiary>
 			<Ammo_Rifle_HE>Bullet_762x51mmNATO_HE</Ammo_Rifle_HE>
-			<Ammo_Rifle_Sabot>Bullet_762x51mmNATO_Sabot</Ammo_Rifle_Sabot>				
+			<Ammo_Rifle_Sabot>Bullet_762x51mmNATO_Sabot</Ammo_Rifle_Sabot>
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
-
-
 
 	<!-- ==================== Ammo ========================== -->
 
@@ -51,7 +50,7 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.12</MarketValue>
+			<MarketValue>0.11</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_762x51mmNATO_FMJ</cookOffProjectile>
@@ -65,7 +64,7 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.12</MarketValue>
+			<MarketValue>0.11</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_762x51mmNATO_AP</cookOffProjectile>
@@ -79,55 +78,55 @@
 			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.12</MarketValue>
+			<MarketValue>0.11</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
 		<cookOffProjectile>Bullet_762x51mmNATO_HP</cookOffProjectile>
 	</ThingDef>
-        
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
-        <defName>Ammo_Rifle_Incendiary</defName>
-        <label>rifle cartridge (AP-I)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.16</MarketValue>
-        </statBases>
-        <ammoClass>IncendiaryAP</ammoClass>
-        <cookOffProjectile>Bullet_762x51mmNATO_Incendiary</cookOffProjectile>
-    </ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
-        <defName>Ammo_Rifle_HE</defName>
-        <label>rifle cartridge (HE)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.21</MarketValue>
-        </statBases>
-        <ammoClass>ExplosiveAP</ammoClass>
-        <cookOffProjectile>Bullet_762x51mmNATO_HE</cookOffProjectile>
-    </ThingDef>
-    
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
-        <defName>Ammo_Rifle_Sabot</defName>
-        <label>rifle cartridge (Sabot)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.12</MarketValue>
-        <Mass>0.02</Mass>
-        </statBases>
-        <ammoClass>Sabot</ammoClass>
-        <cookOffProjectile>Bullet_762x51mmNATO_Sabot</cookOffProjectile>
-    </ThingDef>
-    
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
+		<defName>Ammo_Rifle_Incendiary</defName>
+		<label>rifle cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_762x51mmNATO_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
+		<defName>Ammo_Rifle_HE</defName>
+		<label>rifle cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.21</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_762x51mmNATO_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleBase">
+		<defName>Ammo_Rifle_Sabot</defName>
+		<label>rifle cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.12</MarketValue>
+			<Mass>0.02</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_762x51mmNATO_Sabot</cookOffProjectile>
+	</ThingDef>
+
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -153,7 +152,7 @@
 		<products>
 			<Ammo_Rifle_FMJ>500</Ammo_Rifle_FMJ>
 		</products>
-	<workAmount>2600</workAmount>		
+		<workAmount>2600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -179,7 +178,7 @@
 		<products>
 			<Ammo_Rifle_AP>500</Ammo_Rifle_AP>
 		</products>
-	<workAmount>2600</workAmount>		
+		<workAmount>3120</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -205,121 +204,121 @@
 		<products>
 			<Ammo_Rifle_HP>500</Ammo_Rifle_HP>
 		</products>
-	<workAmount>2600</workAmount>		
+		<workAmount>2600</workAmount>
 	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Rifle_Incendiary</defName>
-    <label>make rifle (AP-I) cartridge x500</label>
-    <description>Craft 500 rifle (AP-I) cartridges.</description>
-    <jobString>Making rifle (AP-I) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>26</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Rifle_Incendiary>500</Ammo_Rifle_Incendiary>
-    </products>
-    <workAmount>3800</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Rifle_HE</defName>
-    <label>make rifle (HE) cartridge x500</label>
-    <description>Craft 500 rifle (HE) cartridges.</description>
-    <jobString>Making rifle (HE) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>26</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>6</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Rifle_HE>500</Ammo_Rifle_HE>
-    </products>
-    <workAmount>4600</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_Rifle_Sabot</defName>
-    <label>make rifle (Sabot) cartridge x500</label>
-    <description>Craft 500 rifle (Sabot) cartridges.</description>
-    <jobString>Making rifle (Sabot) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>18</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Uranium</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Chemfuel</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>		  
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Uranium</li>
-        <li>Chemfuel</li>		
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Rifle_Sabot>500</Ammo_Rifle_Sabot>
-    </products>
-    <workAmount>3400</workAmount>
-  </RecipeDef>
-  
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Rifle_Incendiary</defName>
+		<label>make rifle (AP-I) cartridge x500</label>
+		<description>Craft 500 rifle (AP-I) cartridges.</description>
+		<jobString>Making rifle (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Rifle_Incendiary>500</Ammo_Rifle_Incendiary>
+		</products>
+		<workAmount>3800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Rifle_HE</defName>
+		<label>make rifle (HE) cartridge x500</label>
+		<description>Craft 500 rifle (HE) cartridges.</description>
+		<jobString>Making rifle (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Rifle_HE>500</Ammo_Rifle_HE>
+		</products>
+		<workAmount>4600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_Rifle_Sabot</defName>
+		<label>make rifle (Sabot) cartridge x500</label>
+		<description>Craft 500 rifle (Sabot) cartridges.</description>
+		<jobString>Making rifle (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>3</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Rifle_Sabot>500</Ammo_Rifle_Sabot>
+		</products>
+		<workAmount>3400</workAmount>
+	</RecipeDef>
+
 </Defs>

--- a/Defs/Ammo/GENERIC/RifleIntermediate.xml
+++ b/Defs/Ammo/GENERIC/RifleIntermediate.xml
@@ -1,5 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
+
+	<!-- Relabeled 5.56x45mm NATO -->
 
 	<ThingCategoryDef>
 		<defName>AmmoRifleIntermediate</defName>
@@ -8,30 +10,29 @@
 		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
 	</ThingCategoryDef>
 
+	<!-- ==================== AmmoSet ========================== -->
 
-  	<!-- ==================== AmmoSet ========================== -->
-
-    <CombatExtended.AmmoSetDef>
-      <defName>AmmoSet_RifleIntermediate</defName>
-      <label>intermediate rifle</label>
-      <ammoTypes>
-        <Ammo_RifleIntermediate_FMJ>Bullet_545x39mmSoviet_FMJ</Ammo_RifleIntermediate_FMJ>
-        <Ammo_RifleIntermediate_AP>Bullet_545x39mmSoviet_AP</Ammo_RifleIntermediate_AP>
-        <Ammo_RifleIntermediate_HP>Bullet_545x39mmSoviet_HP</Ammo_RifleIntermediate_HP>
-        <Ammo_RifleIntermediate_Incendiary>Bullet_545x39mmSoviet_Incendiary</Ammo_RifleIntermediate_Incendiary>
-        <Ammo_RifleIntermediate_HE>Bullet_545x39mmSoviet_HE</Ammo_RifleIntermediate_HE>
-        <Ammo_RifleIntermediate_Sabot>Bullet_545x39mmSoviet_Sabot</Ammo_RifleIntermediate_Sabot>				
-      </ammoTypes>
-    </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_RifleIntermediate</defName>
+		<label>intermediate rifle</label>
+		<ammoTypes>
+			<Ammo_RifleIntermediate_FMJ>Bullet_556x45mmNATO_FMJ</Ammo_RifleIntermediate_FMJ>
+			<Ammo_RifleIntermediate_AP>Bullet_556x45mmNATO_AP</Ammo_RifleIntermediate_AP>
+			<Ammo_RifleIntermediate_HP>Bullet_556x45mmNATO_HP</Ammo_RifleIntermediate_HP>
+			<Ammo_RifleIntermediate_Incendiary>Bullet_556x45mmNATO_Incendiary</Ammo_RifleIntermediate_Incendiary>
+			<Ammo_RifleIntermediate_HE>Bullet_556x45mmNATO_HE</Ammo_RifleIntermediate_HE>
+			<Ammo_RifleIntermediate_Sabot>Bullet_556x45mmNATO_Sabot</Ammo_RifleIntermediate_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleIntermediateBase" ParentName="SmallAmmoBase" Abstract="True">
-        <description>Intermediate power rifle ammunition, used mainly by assault rifles.</description>
+		<description>Intermediate power rifle ammunition, used mainly by assault rifles.</description>
 		<statBases>
-			<Mass>0.012</Mass>
+			<Mass>0.013</Mass>
 			<Bulk>0.02</Bulk>
-			<MarketValue>0.06</MarketValue>   
+			<MarketValue>0.06</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -42,8 +43,8 @@
 		</thingCategories>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">		
-        <defName>Ammo_RifleIntermediate_FMJ</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
+		<defName>Ammo_RifleIntermediate_FMJ</defName>
 		<label>intermediate rifle cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/STACK_RANGED/Rifle/FMJ</texPath>
@@ -84,49 +85,48 @@
 		<cookOffProjectile>Bullet_556x45mmNATO_HP</cookOffProjectile>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
-        <defName>Ammo_RifleIntermediate_Incendiary</defName>
-        <label>intermediate rifle cartridge (AP-I)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.08</MarketValue>
-        </statBases>
-        <ammoClass>IncendiaryAP</ammoClass>
-        <cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
+		<defName>Ammo_RifleIntermediate_Incendiary</defName>
+		<label>intermediate rifle cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/Incendiary</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.14</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
-        <defName>Ammo_RifleIntermediate_HE</defName>
-        <label>intermediate rifle cartridge (HE)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.14</MarketValue>
-        </statBases>
-        <ammoClass>ExplosiveAP</ammoClass>
-        <cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>
-    </ThingDef>
-    
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
-        <defName>Ammo_RifleIntermediate_Sabot</defName>
-        <label>intermediate rifle cartridge (Sabot)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.08</MarketValue>
-        <Mass>0.011</Mass>
-        </statBases>
-        <ammoClass>Sabot</ammoClass>
-        <cookOffProjectile>Bullet_556x45mmNATO_Sabot</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
+		<defName>Ammo_RifleIntermediate_HE</defName>
+		<label>intermediate rifle cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.07</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleIntermediateBase">
+		<defName>Ammo_RifleIntermediate_Sabot</defName>
+		<label>intermediate rifle cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Rifle/Sabot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.07</MarketValue>
+			<Mass>0.011</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_556x45mmNATO_Sabot</cookOffProjectile>
+	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 
@@ -179,7 +179,7 @@
 		<products>
 			<Ammo_RifleIntermediate_AP>500</Ammo_RifleIntermediate_AP>
 		</products>
-		<workAmount>1400</workAmount>
+		<workAmount>1680</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -208,118 +208,118 @@
 		<workAmount>1400</workAmount>
 	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleIntermediate_Incendiary</defName>
-    <label>make intermediate rifle (AP-I) cartridge x500</label>
-    <description>Craft 500 intermediate rifle (AP-I) cartridges.</description>
-    <jobString>Making intermediate rifle (AP-I) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>14</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleIntermediate_Incendiary>500</Ammo_RifleIntermediate_Incendiary>
-    </products>
-    <workAmount>2200</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleIntermediate_HE</defName>
-    <label>make intermediate rifle (HE) cartridge x500</label>
-    <description>Craft 500 intermediate rifle (HE) cartridges.</description>
-    <jobString>Making intermediate rifle (HE) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>14</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleIntermediate_HE>500</Ammo_RifleIntermediate_HE>
-    </products>
-    <workAmount>3000</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleIntermediate_Sabot</defName>
-    <label>make intermediate rifle (Sabot) cartridge x500</label>
-    <description>Craft 500 intermediate rifle (Sabot) cartridges.</description>
-    <jobString>Making intermediate rifle (Sabot) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>8</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Uranium</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Chemfuel</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>		  
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Uranium</li>
-        <li>Chemfuel</li>		
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleIntermediate_Sabot>500</Ammo_RifleIntermediate_Sabot>
-    </products>
-    <workAmount>2000</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleIntermediate_Incendiary</defName>
+		<label>make intermediate rifle (AP-I) cartridge x500</label>
+		<description>Craft 500 intermediate rifle (AP-I) cartridges.</description>
+		<jobString>Making intermediate rifle (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleIntermediate_Incendiary>500</Ammo_RifleIntermediate_Incendiary>
+		</products>
+		<workAmount>2200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleIntermediate_HE</defName>
+		<label>make intermediate rifle (HE) cartridge x500</label>
+		<description>Craft 500 intermediate rifle (HE) cartridges.</description>
+		<jobString>Making intermediate rifle (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleIntermediate_HE>500</Ammo_RifleIntermediate_HE>
+		</products>
+		<workAmount>3000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleIntermediate_Sabot</defName>
+		<label>make intermediate rifle (Sabot) cartridge x500</label>
+		<description>Craft 500 intermediate rifle (Sabot) cartridges.</description>
+		<jobString>Making intermediate rifle (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleIntermediate_Sabot>500</Ammo_RifleIntermediate_Sabot>
+		</products>
+		<workAmount>2000</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/RifleMagnum.xml
+++ b/Defs/Ammo/GENERIC/RifleMagnum.xml
@@ -66,7 +66,7 @@
 		<statBases>
 			<MarketValue>0.2</MarketValue>
 		</statBases>
-		<ammoClass>FullMetalJacket</ammoClass>
+		<ammoClass>ArmorPiercing</ammoClass>
 		<cookOffProjectile>Bullet_338Lapua_AP</cookOffProjectile>
 	</ThingDef>
 

--- a/Defs/Ammo/GENERIC/RifleMagnum.xml
+++ b/Defs/Ammo/GENERIC/RifleMagnum.xml
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-<!--really just relabeled .338 Lapua Magnum-->
+	<!-- Relabeled .338 Lapua Magnum -->
 
 	<ThingCategoryDef>
 		<defName>AmmoRifleMagnum</defName>
@@ -10,29 +10,28 @@
 		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
 	</ThingCategoryDef>
 
-  <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_RifleMagnum</defName>
-    <label>magnum rifle</label>
-    <ammoTypes>
-      <Ammo_RifleMagnum_FMJ>Bullet_338Lapua_FMJ</Ammo_RifleMagnum_FMJ>
-      <Ammo_RifleMagnum_Incendiary>Bullet_338Lapua_Incendiary</Ammo_RifleMagnum_Incendiary>
-	    <Ammo_RifleMagnum_HE>Bullet_338Lapua_HE</Ammo_RifleMagnum_HE>
-	    <Ammo_RifleMagnum_Sabot>Bullet_338Lapua_Sabot</Ammo_RifleMagnum_Sabot>
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
-
-
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_RifleMagnum</defName>
+		<label>magnum rifle</label>
+		<ammoTypes>
+			<Ammo_RifleMagnum_FMJ>Bullet_338Lapua_FMJ</Ammo_RifleMagnum_FMJ>
+			<Ammo_RifleMagnum_AP>Bullet_338Lapua_AP</Ammo_RifleMagnum_AP>
+			<Ammo_RifleMagnum_Incendiary>Bullet_338Lapua_Incendiary</Ammo_RifleMagnum_Incendiary>
+			<Ammo_RifleMagnum_HE>Bullet_338Lapua_HE</Ammo_RifleMagnum_HE>
+			<Ammo_RifleMagnum_Sabot>Bullet_338Lapua_Sabot</Ammo_RifleMagnum_Sabot>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoRifleMagnumBase" ParentName="AmmoBase" Abstract="True">
-        <description>High power rifle ammunition, used mainly by long range sniper rifles.</description>
+		<description>High power rifle ammunition, used mainly by long range sniper rifles.</description>
 		<statBases>
-			<Mass>0.05</Mass>
+			<Mass>0.043</Mass>
 			<Bulk>0.05</Bulk>
-			<MarketValue>0.06</MarketValue>   
+			<MarketValue>0.06</MarketValue>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>
@@ -41,11 +40,10 @@
 		<thingCategories>
 			<li>AmmoRifleMagnum</li>
 		</thingCategories>
-        <stackLimit>2000</stackLimit>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">		
-        <defName>Ammo_RifleMagnum_FMJ</defName>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
+		<defName>Ammo_RifleMagnum_FMJ</defName>
 		<label>magnum rifle cartridge (FMJ)</label>
 		<graphicData>
 			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/FMJ</texPath>
@@ -58,49 +56,62 @@
 		<cookOffProjectile>Bullet_338Lapua_FMJ</cookOffProjectile>
 	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
-        <defName>Ammo_RifleMagnum_Incendiary</defName>
-        <label>magnum rifle cartridge (AP-I)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.27</MarketValue>
-        </statBases>
-        <ammoClass>IncendiaryAP</ammoClass>
-        <cookOffProjectile>Bullet_338Lapua_Incendiary</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
+		<defName>Ammo_RifleMagnum_AP</defName>
+		<label>magnum rifle cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/AP</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.2</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_338Lapua_AP</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
-        <defName>Ammo_RifleMagnum_HE</defName>
-        <label>magnum rifle cartridge (HE)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.41</MarketValue>
-        </statBases>
-        <ammoClass>ExplosiveAP</ammoClass>
-        <cookOffProjectile>Bullet_338Lapua_HE</cookOffProjectile>
-    </ThingDef>
-    
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
-        <defName>Ammo_RifleMagnum_Sabot</defName>
-        <label>magnum rifle cartridge (Sabot)</label>
-        <graphicData>
-        <texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
-        <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-        </graphicData>
-        <statBases>
-        <MarketValue>0.21</MarketValue>
-        <Mass>0.04</Mass>
-        </statBases>
-        <ammoClass>Sabot</ammoClass>
-        <cookOffProjectile>Bullet_338Lapua_Sabot</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
+		<defName>Ammo_RifleMagnum_Incendiary</defName>
+		<label>magnum rifle cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Incendiary</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.27</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_338Lapua_Incendiary</cookOffProjectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
+		<defName>Ammo_RifleMagnum_HE</defName>
+		<label>magnum rifle cartridge (HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/HE</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.41</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_338Lapua_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoRifleMagnumBase">
+		<defName>Ammo_RifleMagnum_Sabot</defName>
+		<label>magnum rifle cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/HighCaliber/Sabot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.21</MarketValue>
+			<Mass>0.037</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_338Lapua_Sabot</cookOffProjectile>
+	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 
@@ -130,119 +141,144 @@
 		<workAmount>2000</workAmount>
 	</RecipeDef>
 
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_RifleMagnum_AP</defName>
+		<label>make magnum rifle (AP) cartridge x200</label>
+		<description>Craft 200 magnum rifle (AP) cartridges.</description>
+		<jobString>Making magnum rifle (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleMagnum_AP>200</Ammo_RifleMagnum_AP>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleMagnum_Incendiary</defName>
-    <label>make magnum rifle (AP-I) cartridge x200</label>
-    <description>Craft 200 magnum rifle (AP-I) cartridges.</description>
-    <jobString>Making magnum rifle (AP-I) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>20</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Prometheum</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Prometheum</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleMagnum_Incendiary>200</Ammo_RifleMagnum_Incendiary>
-    </products>
-    <workAmount>2800</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleMagnum_HE</defName>
-    <label>make magnum rifle (HE) cartridge x200</label>
-    <description>Craft 200 magnum rifle (HE) cartridges.</description>
-    <jobString>Making magnum rifle (HE) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>20</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>FSX</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>FSX</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleMagnum_HE>200</Ammo_RifleMagnum_HE>
-    </products>
-    <workAmount>3600</workAmount>
-  </RecipeDef>
-  
-  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-    <defName>MakeAmmo_RifleMagnum_Sabot</defName>
-    <label>make magnum rifle (Sabot) cartridge x200</label>
-    <description>Craft 200 magnum rifle (Sabot) cartridges.</description>
-    <jobString>Making magnum rifle (Sabot) cartridges.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>12</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Uranium</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Chemfuel</li>
-          </thingDefs>
-        </filter>
-        <count>2</count>
-      </li>		  
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Uranium</li>
-        <li>Chemfuel</li>		
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_RifleMagnum_Sabot>200</Ammo_RifleMagnum_Sabot>
-    </products>
-    <workAmount>2400</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleMagnum_Incendiary</defName>
+		<label>make magnum rifle (AP-I) cartridge x200</label>
+		<description>Craft 200 magnum rifle (AP-I) cartridges.</description>
+		<jobString>Making magnum rifle (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleMagnum_Incendiary>200</Ammo_RifleMagnum_Incendiary>
+		</products>
+		<workAmount>2800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleMagnum_HE</defName>
+		<label>make magnum rifle (HE) cartridge x200</label>
+		<description>Craft 200 magnum rifle (HE) cartridges.</description>
+		<jobString>Making magnum rifle (HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleMagnum_HE>200</Ammo_RifleMagnum_HE>
+		</products>
+		<workAmount>3600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_RifleMagnum_Sabot</defName>
+		<label>make magnum rifle (Sabot) cartridge x200</label>
+		<description>Craft 200 magnum rifle (Sabot) cartridges.</description>
+		<jobString>Making magnum rifle (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_RifleMagnum_Sabot>200</Ammo_RifleMagnum_Sabot>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/GENERIC/ShotgunShell.xml
+++ b/Defs/Ammo/GENERIC/ShotgunShell.xml
@@ -1,230 +1,228 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <ThingCategoryDef>
-    <defName>AmmoShotgun</defName>
-    <label>shotgun ammo</label>
-    <parent>AmmoShotguns</parent>
-    <iconPath>UI/Icons/ThingCategories/CaliberShotgun</iconPath>
-  </ThingCategoryDef>
+	<!-- Relabeled 12 gauge shells -->
 
+	<ThingCategoryDef>
+		<defName>AmmoShotgun</defName>
+		<label>shotgun ammo</label>
+		<parent>AmmoShotguns</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberShotgun</iconPath>
+	</ThingCategoryDef>
 
-  <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-  <CombatExtended.AmmoSetDef>
-    <defName>AmmoSet_Shotgun</defName>
-    <label>shotgun shell</label>
-    <ammoTypes>
-      <Ammo_Shotgun_Buck>Bullet_12Gauge_Buck</Ammo_Shotgun_Buck>
-      <Ammo_Shotgun_Slug>Bullet_12Gauge_Slug</Ammo_Shotgun_Slug>
-      <Ammo_Shotgun_Beanbag>Bullet_12Gauge_Beanbag</Ammo_Shotgun_Beanbag>
-      <Ammo_Shotgun_ElectroSlug>Bullet_12Gauge_ElectroSlug</Ammo_Shotgun_ElectroSlug>
-    </ammoTypes>
-  </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_Shotgun</defName>
+		<label>shotgun shell</label>
+		<ammoTypes>
+			<Ammo_Shotgun_Buck>Bullet_12Gauge_Buck</Ammo_Shotgun_Buck>
+			<Ammo_Shotgun_Slug>Bullet_12Gauge_Slug</Ammo_Shotgun_Slug>
+			<Ammo_Shotgun_Beanbag>Bullet_12Gauge_Beanbag</Ammo_Shotgun_Beanbag>
+			<Ammo_Shotgun_ElectroSlug>Bullet_12Gauge_ElectroSlug</Ammo_Shotgun_ElectroSlug>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
 
-  
-  <!-- ==================== Ammo ========================== -->
+	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoShotgunBase" ParentName="AmmoBase" Abstract="True">
-    <description>Extremely common shotgun caliber used in almost every application, from hunting and riot control to military firearms.</description>
-    <statBases>
-      <Mass>0.023</Mass>
-      <Bulk>0.06</Bulk>
-    </statBases>
-    <tradeTags>
-      <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
-    </tradeTags>
-    <thingCategories>
-      <li>AmmoShotgun</li>
-    </thingCategories>
-    <stackLimit>2000</stackLimit>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="AmmoShotgunBase" ParentName="AmmoBase" Abstract="True">
+		<description>Extremely common shotgun caliber used in almost every application, from hunting and riot control to military firearms.</description>
+		<statBases>
+			<Mass>0.051</Mass>
+			<Bulk>0.06</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>AmmoShotgun</li>
+		</thingCategories>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
-    <defName>Ammo_Shotgun_Buck</defName>
-    <label>shotgun shell (Buck)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/Shotgun/Shot</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <MarketValue>0.1</MarketValue>
-    </statBases>
-    <ammoClass>BuckShot</ammoClass>
-    <cookOffProjectile>Bullet_12Gauge_Buck</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
+		<defName>Ammo_Shotgun_Buck</defName>
+		<label>shotgun shell (Buck)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Shot</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.22</MarketValue>
+		</statBases>
+		<ammoClass>BuckShot</ammoClass>
+		<cookOffProjectile>Bullet_12Gauge_Buck</cookOffProjectile>
+	</ThingDef>
 
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
+		<defName>Ammo_Shotgun_Slug</defName>
+		<label>shotgun shell (Slug)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Slug</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.048</Mass>
+			<MarketValue>0.2</MarketValue>
+		</statBases>
+		<ammoClass>Slug</ammoClass>
+		<cookOffProjectile>Bullet_12Gauge_Slug</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
-    <defName>Ammo_Shotgun_Slug</defName>
-    <label>shotgun shell (Slug)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/Shotgun/Slug</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <Mass>0.048</Mass>
-      <MarketValue>0.2</MarketValue>
-    </statBases>
-    <ammoClass>Slug</ammoClass>
-    <cookOffProjectile>Bullet_12Gauge_Slug</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
+		<defName>Ammo_Shotgun_Beanbag</defName>
+		<label>shotgun shell (Bean)</label>
+		<generateAllowChance>0</generateAllowChance>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Shotgun/Beanbag</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.059</Mass>
+			<MarketValue>0.32</MarketValue>
+		</statBases>
+		<ammoClass>Beanbag</ammoClass>
+		<cookOffProjectile>Bullet_12Gauge_Beanbag</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
-    <defName>Ammo_Shotgun_Beanbag</defName>
-    <label>shotgun shell (Bean)</label>
-    <generateAllowChance>0</generateAllowChance>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/Shotgun/Beanbag</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <Mass>0.059</Mass>
-      <MarketValue>0.32</MarketValue>
-    </statBases>
-    <ammoClass>Beanbag</ammoClass>
-    <cookOffProjectile>Bullet_12Gauge_Beanbag</cookOffProjectile>
-  </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
+		<defName>Ammo_Shotgun_ElectroSlug</defName>
+		<label>shotgun shell (EMP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/STACK_RANGED/Shotgun/EMP</texPath>
+			<graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.054</Mass>
+			<MarketValue>0.87</MarketValue>
+		</statBases>
+		<ammoClass>ElectroSlug</ammoClass>
+		<cookOffProjectile>Bullet_12Gauge_ElectroSlug</cookOffProjectile>
+	</ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoShotgunBase">
-    <defName>Ammo_Shotgun_ElectroSlug</defName>
-    <label>shotgun shell (EMP)</label>
-    <graphicData>
-      <texPath>Things/Ammo/STACK_RANGED/Shotgun/EMP</texPath>
-      <graphicClass>CombatExtended.Graphic_StackCountRanged</graphicClass>
-    </graphicData>
-    <statBases>
-      <Mass>0.054</Mass>
-      <MarketValue>0.87</MarketValue>
-    </statBases>
-    <ammoClass>ElectroSlug</ammoClass>
-    <cookOffProjectile>Bullet_12Gauge_ElectroSlug</cookOffProjectile>
-  </ThingDef>
+	<!-- ==================== Recipes ========================== -->
 
-  <!-- ==================== Recipes ========================== -->
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_Shotgun_Buck</defName>
+		<label>make shotgun (Buck) shell x200</label>
+		<description>Craft 200 shotgun (Buck) shells.</description>
+		<jobString>Making shotgun (Buck) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Shotgun_Buck>200</Ammo_Shotgun_Buck>
+		</products>
+		<workAmount>2200</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_Shotgun_Buck</defName>
-    <label>make shotgun (Buck) shell x200</label>
-    <description>Craft 200 shotgun (Buck) shells.</description>
-    <jobString>Making shotgun (Buck) shells.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>10</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Shotgun_Buck>200</Ammo_Shotgun_Buck>
-    </products>
-    <workAmount>1000</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_Shotgun_Slug</defName>
+		<label>make shotgun (Slug) shell x200</label>
+		<description>Craft 200 shotgun (Slug) shells.</description>
+		<jobString>Making shotgun (Slug) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Shotgun_Slug>200</Ammo_Shotgun_Slug>
+		</products>
+		<workAmount>2000</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_Shotgun_Slug</defName>
-    <label>make shotgun (Slug) shell x200</label>
-    <description>Craft 200 shotgun (Slug) shells.</description>
-    <jobString>Making shotgun (Slug) shells.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>20</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Shotgun_Slug>200</Ammo_Shotgun_Slug>
-    </products>
-    <workAmount>2000</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_Shotgun_Beanbag</defName>
+		<label>make shotgun (Beanbag) shell x200</label>
+		<description>Craft 200 shotgun (Beanbag) shells.</description>
+		<jobString>Making shotgun (Beanbag) shells.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Cloth</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Cloth</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Shotgun_Beanbag>200</Ammo_Shotgun_Beanbag>
+		</products>
+		<workAmount>3400</workAmount>
+	</RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_Shotgun_Beanbag</defName>
-    <label>make shotgun (Beanbag) shell x200</label>
-    <description>Craft 200 shotgun (Beanbag) shells.</description>
-    <jobString>Making shotgun (Beanbag) shells.</jobString>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>24</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Cloth</li>
-          </thingDefs>
-        </filter>
-        <count>10</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>Cloth</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Shotgun_Beanbag>200</Ammo_Shotgun_Beanbag>
-    </products>
-    <workAmount>3400</workAmount>
-  </RecipeDef>
-
-  <RecipeDef ParentName="AmmoRecipeBase">
-    <defName>MakeAmmo_Shotgun_ElectroSlug</defName>
-    <label>make shotgun (EMP) shell x200</label>
-    <description>Craft 200 shotgun (EMP) shells.</description>
-    <jobString>Making shotgun (EMP) shells.</jobString>
-    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Steel</li>
-          </thingDefs>
-        </filter>
-        <count>22</count>
-      </li>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>ComponentIndustrial</li>
-          </thingDefs>
-        </filter>
-        <count>4</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Steel</li>
-        <li>ComponentIndustrial</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Ammo_Shotgun_ElectroSlug>200</Ammo_Shotgun_ElectroSlug>
-    </products>
-    <workAmount>4600</workAmount>
-  </RecipeDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_Shotgun_ElectroSlug</defName>
+		<label>make shotgun (EMP) shell x200</label>
+		<description>Craft 200 shotgun (EMP) shells.</description>
+		<jobString>Making shotgun (EMP) shells.</jobString>
+		<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>ComponentIndustrial</li>
+					</thingDefs>
+				</filter>
+				<count>4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>ComponentIndustrial</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_Shotgun_ElectroSlug>200</Ammo_Shotgun_ElectroSlug>
+		</products>
+		<workAmount>4600</workAmount>
+	</RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -91,7 +91,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.09</MarketValue>
+			<MarketValue>0.06</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_HP</cookOffProjectile>
@@ -105,7 +105,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.14</MarketValue>
+			<MarketValue>0.09</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_Incendiary</cookOffProjectile>
@@ -119,7 +119,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.07</MarketValue>
+			<MarketValue>0.14</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_556x45mmNATO_HE</cookOffProjectile>


### PR DESCRIPTION
## Changes

- Added the missing AP ammo type to anti-materiel and magnum rifle generic ammosets.
- Tweaked all the ammosets to be based on the most commonly used ammo types in the game in each category for ease of tracking.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
