### PR TITLE
Tweaks the Scorcher and Inquisitor mechs' loadout and bulk cap

### DIFF
--- a/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
+++ b/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Medium.xml
@@ -41,6 +41,18 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Mech_Scorcher"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>4</min>
+					<max>5</max>
+				</primaryMagazineCount>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/PawnKindDef[defName="Mech_Apocriton"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
@@ -118,6 +130,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Mech_Scorcher"]/statBases</xpath>
 		<value>
+			<CarryBulk>30</CarryBulk>
 			<MeleeDodgeChance>0.13</MeleeDodgeChance>
 			<MeleeCritChance>0.12</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/PawnKindDefs/Pawnkinds_Mech.xml
@@ -65,8 +65,8 @@
 			<value>
 			  <li Class="CombatExtended.LoadoutPropertiesExtension">
 				<primaryMagazineCount>
-				  <min>1</min>
-				  <max>2</max>
+				  <min>2</min>
+				  <max>3</max>
 				</primaryMagazineCount>
 			  </li>
 			</value>


### PR DESCRIPTION
## Changes

- Increased the bulk capacity of the Scorcher mech from 20 to 30 and gave it a proper loadout.
- Increased the loadout range of the Inquisitor mech from 1~2 to 2~3.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
