### PR TITLE
Patch Thog's Armor

### DIFF
--- a/Patches/Thog's Armor/Armor_Thogs.xml
+++ b/Patches/Thog's Armor/Armor_Thogs.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Thog's Armor</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ===== Flak & Simple Armor ===== -->
+			
+			<!-- === Flak Shoulderpads === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_FlakShoulderpads"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_FlakShoulderpads"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>4.8</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_FlakShoulderpads"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>7.2</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_FlakShoulderpads"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Simple Chestplate === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_SimpleChestplate"]/statBases</xpath>
+				<value>
+					<Bulk>20</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimpleChestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.85</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimpleChestplate"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimpleChestplate"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Simple Pauldrons === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_SimplePauldrons"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimplePauldrons"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimplePauldrons"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Simple Chausses === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="Apparel_SimpleChausses"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_SimpleChausses"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="Apparel_SimpleChausses"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- ===== Visors ===== -->
+
+			<!-- === Wooden Visor === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenVisor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<Bulk>1</Bulk>				
+				</value>
+			</li>
+
+			<!-- === Simple Visor === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_SimpleVisor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					<Bulk>1</Bulk>
+					<WornBulk>0.75</WornBulk>								
+				</value>
+			</li>
+
+			<!-- === Flak Visor === -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_FlakVisor"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>1</Bulk>
+					<WornBulk>0.75</WornBulk>								
+				</value>
+			</li>
+
+			<!-- === Ablative Visor === -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_AblativeVisor"]/statBases</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>								
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_AblativeVisor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>6</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_AblativeVisor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>8</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- ===== Wooden Armor ===== -->
+
+			<!-- === Wooden Chestplate === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_WoodenChestplate"]/statBases</xpath>
+				<value>
+					<Bulk>20</Bulk>
+					<WornBulk>5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenChestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenChestplate"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenChestplate"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Wooden Arm Guards === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_WoodenArmGuards"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenArmGuards"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>4.5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenArmGuards"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Wooden Chausses === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_WoodenChausses"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>2</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenChausses"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_WoodenChausses"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Thog's Armor/Armor_ThogsChild.xml
+++ b/Patches/Thog's Armor/Armor_ThogsChild.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>	
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Thog's Armor</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- === Child Flak Helmet === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_FlakHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>0.75</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_FlakHelmet"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>5</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_FlakHelmet"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- === Child Squire Helmet === -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_SquireHelmet"]/statBases</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>0.75</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_SquireHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.65</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_SquireHelmet"]</xpath>
+				<value>
+					<li Class="CombatExtended.PartialArmorExt">
+						<stats>
+							<li>
+							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+							<parts>
+								<li>Eye</li>
+							</parts>
+							</li>
+							<li>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+							<parts>
+								<li>Eye</li>
+							</parts>
+							</li>
+							<li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+							</li>
+							<li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+							</li>
+						</stats>
+					</li>
+				</value>
+			</li>
+
+			<!-- === Child Wooden Chestplate === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_WoodenChestplate"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>3.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_WoodenChestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>3.75</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_WoodenChestplate"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_WoodenChestplate"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Child Wooden Arm Guards === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_WoodenArmGuards"]/statBases</xpath>
+				<value>
+					<Bulk>2.5</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_WoodenArmGuards"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2.7</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_WoodenArmGuards"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Child Simple Chestplate === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_SimpleChestplate"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<WornBulk>3.5</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_SimpleChestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.20</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_SimpleChestplate"]</xpath>
+				<value>
+				<li Class="CombatExtended.PartialArmorExt">
+					<stats>
+						<li>
+							<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+							<parts>
+								<li>Neck</li>
+							</parts>
+						</li>
+					</stats>
+				</li>
+				</value>
+			</li>
+
+			<!-- === Child Plate Gorget === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_Neckguard"]/statBases</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>0.75</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_Neckguard"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_Neckguard"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+			<!-- === Child Flak Shoulderpads === -->
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_FlakShoulderpads"]/statBases</xpath>
+				<value>
+					<Bulk>2.5</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_FlakShoulderpads"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>2.9</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="ThogsArmor_Kid_FlakShoulderpads"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>4.6</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="ThogsArmor_Kid_FlakShoulderpads"]/equippedStatOffsets/MoveSpeed</xpath>
+			</li>
+
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -417,6 +417,7 @@ T-45b Power Armor	|
 The GiantRace	|
 The Joris Experience	|
 The Tuffalo |
+Thog's Armor    |
 Thog's Guns - More Brukka Pack  |
 Toolmetrics Redux (Continued)   |
 TouhouStyle	|


### PR DESCRIPTION
## Additions
Patch Thog's Armor.
  - Armor patched in line with existing flak and plate armor.
  - Child armor generally has around 50 - 75% bulk/wornbulk and roughly 60% protection of the adult version.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
