### PR TITLE
Assorted fixes

### DIFF
--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -109,6 +109,7 @@
       <soundExplode>CE_FlamethrowerExplosion</soundExplode>
       <explosionRadius>1.0</explosionRadius>
       <ai_IsIncendiary>true</ai_IsIncendiary>
+      <screenShakeFactor>0</screenShakeFactor>
     </projectile>
   </ThingDef>
 
@@ -124,6 +125,7 @@
       <soundExplode>CE_FlamethrowerExplosion</soundExplode>
       <explosionRadius>1.2</explosionRadius>
       <ai_IsIncendiary>true</ai_IsIncendiary>
+      <screenShakeFactor>0</screenShakeFactor>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -161,7 +161,7 @@
     <label>20x42mm bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>20</damageAmountBase>
-      <armorPenetrationSharp>16</armorPenetrationSharp>
+      <armorPenetrationSharp>12</armorPenetrationSharp>
       <armorPenetrationBlunt>105.72</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -171,7 +171,7 @@
     <label>20x42mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>20</damageAmountBase>
-      <armorPenetrationSharp>16</armorPenetrationSharp>
+      <armorPenetrationSharp>12</armorPenetrationSharp>
       <armorPenetrationBlunt>105.72</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -187,7 +187,7 @@
     <label>20x42mm bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>32</damageAmountBase>
-      <armorPenetrationSharp>8.0</armorPenetrationSharp>
+      <armorPenetrationSharp>6</armorPenetrationSharp>
       <armorPenetrationBlunt>105.72</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -211,7 +211,7 @@
 		<comps>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-			  <Fragment_Small>11</Fragment_Small>
+			  <Fragment_Small>12</Fragment_Small>
 			</fragments>
 		  </li>
 		</comps>
@@ -266,7 +266,7 @@
     <products>
       <Ammo_20x42mm_AP>100</Ammo_20x42mm_AP>
     </products>
-    <workAmount>4080</workAmount>
+    <workAmount>4896</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -381,6 +381,7 @@
     </costList>
     <costListForDifficulty>
       <difficultyVar>classicMortars</difficultyVar>
+      <invert>true</invert>
       <costList>
         <ComponentIndustrial>5</ComponentIndustrial>
         <ReinforcedBarrel>1</ReinforcedBarrel>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Addon Weapons/VFEIMeleeSpacer.xml
@@ -12,6 +12,17 @@
       <match Class="PatchOperationSequence">
         <operations>
 
+		<!-- Weapon Draw Size -->	
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]</xpath>
+			<value>
+			  <li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1.7,1.7</DrawSize>
+				<DrawOffset>0.0,0.0</DrawOffset>
+			  </li>
+			</value>
+		</li>
+
 		<!-- === Plasma Sword === -->
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_PlasmaSword"]/statBases</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
@@ -8,6 +8,17 @@
 		<match Class="PatchOperationSequence">
 			<operations>			
 
+			<!-- Melee Weapon Draw Size -->	
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_CombatKnife" or defName="VFEP_WarcasketMeleeWeapon_Broadsword" or defName="VFEP_WarcasketMeleeWeapon_GravityHammer"]</xpath>
+				<value>
+				  <li Class="CombatExtended.GunDrawExtension">
+					<DrawSize>1.7,1.7</DrawSize>
+					<DrawOffset>0.0,0.0</DrawOffset>
+				  </li>
+				</value>
+			</li>
+
 			<!-- Warcasket Combat Knife -->	
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="VFEP_WarcasketMeleeWeapon_CombatKnife"]/tools</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -8,6 +8,17 @@
     <match Class="PatchOperationSequence">
       <operations>
 
+		<!-- Ranged Weapon Draw Size -->	
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[@Name="VFEP_BaseWarcasketGun"]</xpath>
+			<value>
+			  <li Class="CombatExtended.GunDrawExtension">
+				<DrawSize>1.7,1.7</DrawSize>
+				<DrawOffset>0.0,0.0</DrawOffset>
+			  </li>
+			</value>
+		</li>
+
         <!-- === Remove the added weapon tag from the Charge Lance === -->
         <li Class="PatchOperationRemove">
           <xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"VFEP_Captain")]</xpath>


### PR DESCRIPTION
## Changes

- Fixed warcasket weaponry's draw size being borked in CE and requiring a mod extension being patched in.
- Added a screen shake node set to 0 for flamethrower projectiles.
- Updated the 20x42mm ammoset based on a new reference mentioning that the SAPHEI cartridge can go through 6mm of steel, also tweaked some incorrect values.
- Fixed the flak cannon's classic mortar set up, it was missing a single necessary node.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
