### PR TITLE
Royal Warcaskets patch

### DIFF
--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -387,6 +387,7 @@ Rimworld-Style Pilas and Bows Strapped with Grenades and Shells Extended    |
 Rimworld of Magic |
 Risk of Rain: UES Contact Light Armory (Continued) |
 Rockmen race    |
+Royal Warcaskets   |
 Saclean Race    |
 Save Our Ship 2	|
 SCP |


### PR DESCRIPTION
## Additions

Simple compatibility patch for Royal Warcaskets mod

## Changes

- Armor values are identical to patched values for corresponding non-prestige warcaskets
- Steel, component, and gold costs were doubled to fit better with corresponding patched VFEP warcasket costs. Plasteel costs were not touched

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
