### PR TITLE
Update Paniel Patch

### DIFF
--- a/Patches/Paniel the Automata/HediffDef/Hediff.xml
+++ b/Patches/Paniel the Automata/HediffDef/Hediff.xml
@@ -61,17 +61,6 @@
 					  <AimingAccuracy>-0.6</AimingAccuracy>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/HediffDef[
-					defName="PN_CQC" or
-					defName="PN_CQCOverload"
-					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
-					<value>
-					  <ShootingAccuracyPawn>-0.8</ShootingAccuracyPawn>
-					  <AimingAccuracy>-0.4</AimingAccuracy>
-					</value>
-				</li>
 			</operations>
 			</match>
 		</li>

--- a/Patches/Paniel the Automata/PawnKindDefs/Paniel_PawnKind.xml
+++ b/Patches/Paniel the Automata/PawnKindDefs/Paniel_PawnKind.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Paniel the Automata</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+			<!--Ammo-->
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="PN_GrenadePBase"]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>10</min>
+						<max>20</max>
+					</primaryMagazineCount>
+					<forcedSidearm>
+					  <sidearmMoney>
+						<min>50</min>
+						<max>500</max>
+					  </sidearmMoney>
+					  <weaponTags>
+						<li>CE_Sidearm</li>
+					  </weaponTags>
+					  <magazineCount>
+						<min>1</min>
+						<max>2</max>
+					  </magazineCount>
+					</forcedSidearm>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[
+				defName="PN_Mid_RangeUnit" or 
+				defName="PN_EliteRangeUnit"
+				]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>8</min>
+						<max>10</max>
+					</primaryMagazineCount>
+					</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="PN_EliteCannonUnit"]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>15</min>
+						<max>20</max>
+					</primaryMagazineCount>
+					<forcedSidearm>
+					  <sidearmMoney>
+						<min>500</min>
+						<max>1200</max>
+					  </sidearmMoney>
+					  <weaponTags>
+						<li>PN_Revolver</li>
+					  </weaponTags>
+					  <magazineCount>
+						<min>2</min>
+						<max>3</max>
+					  </magazineCount>
+					</forcedSidearm>
+					</li>
+				</value>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -148,7 +148,7 @@
 			<value>
 				<Mass>12</Mass>
 				<Bulk>28</Bulk>
-				<WornBulk>18</WornBulk>
+				<WornBulk>16</WornBulk>
 			</value>
 		</li>
 		


### PR DESCRIPTION
## Additions

Added loadout extension to the low ammo count pawns.

## Changes

Removed patch targeting a no longer present stat in the hediff.
Slightly reduced worn bulk on security uniform to more reliably allow sufficent ammo.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
