### PR TITLE
Misc. Compatibility Patch Fixes

### DIFF
--- a/Patches/Paniel the Automata/HediffDef/Hediff.xml
+++ b/Patches/Paniel the Automata/HediffDef/Hediff.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 	<Operation Class="PatchOperationFindMod">
-		<mods><li>Paniel the Automata</li></mods>
+		<mods>
+			<li>Paniel the Automata</li>
+		</mods>
 		<match Class="PatchOperationSequence">
 		<operations>
-		
+
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/HediffDef[
 			defName="PN_RapidFireModuleHediff"
@@ -24,13 +26,16 @@
 			  <AimingAccuracy>-0.2</AimingAccuracy>
 			</value>
 		</li>
-		
+
 		<!-- ==========  Abilities  =========== -->
-		
-		<li Class="PatchOperationConditional">
-			<xpath>/Defs/HediffDef[defName="PN_OfficerCommand"]</xpath>
+
+		<li Class="PatchOperationFindMod">
+			<mods>
+				<li>Ideology</li>
+			</mods>
 			<match Class="PatchOperationSequence">
 			<operations>
+
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/HediffDef[
 					defName="PN_OfficerCommand" or
@@ -41,7 +46,7 @@
 					  <AimingAccuracy>0.2</AimingAccuracy>
 					</value>
 				</li>
-				
+			
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/HediffDef[
 					defName="PN_RapidFire"
@@ -51,7 +56,7 @@
 					  <AimingAccuracy>-0.4</AimingAccuracy>
 					</value>
 				</li>
-				
+			
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/HediffDef[
 					defName="PN_RapidFireOverload"
@@ -61,24 +66,11 @@
 					  <AimingAccuracy>-0.6</AimingAccuracy>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/HediffDef[
-					defName="PN_CQC" or
-					defName="PN_CQCOverload"
-					]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
-					<value>
-					  <ShootingAccuracyPawn>-0.8</ShootingAccuracyPawn>
-					  <AimingAccuracy>-0.4</AimingAccuracy>
-					</value>
-				</li>
+
 			</operations>
 			</match>
 		</li>
-		
 
-		
-		
 		</operations>
 		</match>
 	</Operation>

--- a/Patches/Paniel the Automata/PawnKindsDef_Paniel/PawnKinds_Misc.xml
+++ b/Patches/Paniel the Automata/PawnKindsDef_Paniel/PawnKinds_Misc.xml
@@ -10,11 +10,11 @@
 
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[
-					defName="PN_AssociateH" or
-          defName="PN_AssociateP_EngineerA" or
-          defName="PN_AssociateP_EngineerB" or
-          defName="PN_AssociateP_DomesticA" or
-          defName="PN_AssociateP_DomesticB"
+				defName="PN_AssociateH" or
+				defName="PN_AssociateP_EngineerA" or
+				defName="PN_AssociateP_EngineerB" or
+				defName="PN_AssociateP_DomesticA" or
+				defName="PN_AssociateP_DomesticB"
 					]</xpath>
 				<value>	
 				<li Class="CombatExtended.LoadoutPropertiesExtension">	
@@ -28,11 +28,11 @@
 
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[
-					defName="PN_ManagerH" or
-          defName="PN_ManageUnit_Enginer" or
-          defName="PN_ManageUnit_Domestic" or
-          defName="PN_Director" or
-          @Name="PN_NPCBasePawnKind"
+				defName="PN_ManagerH" or
+				defName="PN_ManageUnit_Enginer" or
+				defName="PN_ManageUnit_Domestic" or
+				defName="PN_Director" or
+				@Name="PN_NPCBasePawnKind"
 					]</xpath>
 				<value>	
 				<li Class="CombatExtended.LoadoutPropertiesExtension">	
@@ -45,10 +45,60 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[@Name="PN_GrenadePBase"]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>10</min>
+						<max>20</max>
+					</primaryMagazineCount>
+					<forcedSidearm>
+					  <sidearmMoney>
+						<min>50</min>
+						<max>500</max>
+					  </sidearmMoney>
+					  <weaponTags>
+						<li>CE_Sidearm</li>
+					  </weaponTags>
+					  <magazineCount>
+						<min>1</min>
+						<max>2</max>
+					  </magazineCount>
+					</forcedSidearm>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/PawnKindDef[defName="PN_EliteCannonUnit"]</xpath>
+				<value>
+					<li Inherit="False" Class="CombatExtended.LoadoutPropertiesExtension">
+					<primaryMagazineCount>
+						<min>15</min>
+						<max>20</max>
+					</primaryMagazineCount>
+					<forcedSidearm>
+					  <sidearmMoney>
+						<min>500</min>
+						<max>1200</max>
+					  </sidearmMoney>
+					  <weaponTags>
+						<li>PN_Revolver</li>
+					  </weaponTags>
+					  <magazineCount>
+						<min>2</min>
+						<max>3</max>
+					  </magazineCount>
+					</forcedSidearm>
+					</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[
-					defName="PN_SecurityGuardH" or
-          defName="PN_SecurityUnit" or
-          @Name="PN_MidUnitBase"
+				defName="PN_SecurityGuardH" or
+				defName="PN_SecurityUnit" or
+				@Name="PN_MidUnitBase"
 					]</xpath>
 				<value>	
 				<li Class="CombatExtended.LoadoutPropertiesExtension">	

--- a/Patches/Paniel the Automata/PawnKindsDef_Paniel/PawnKinds_Misc.xml
+++ b/Patches/Paniel the Automata/PawnKindsDef_Paniel/PawnKinds_Misc.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Paniel the Automata</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/PawnKindDef[
+					defName="PN_AssociateH" or
+          defName="PN_AssociateP_EngineerA" or
+          defName="PN_AssociateP_EngineerB" or
+          defName="PN_AssociateP_DomesticA" or
+          defName="PN_AssociateP_DomesticB"
+					]</xpath>
+				<value>	
+				<li Class="CombatExtended.LoadoutPropertiesExtension">	
+					<primaryMagazineCount>
+						<min>2</min>
+						<max>3</max>
+					</primaryMagazineCount>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/PawnKindDef[
+					defName="PN_ManagerH" or
+          defName="PN_ManageUnit_Enginer" or
+          defName="PN_ManageUnit_Domestic" or
+          defName="PN_Director" or
+          @Name="PN_NPCBasePawnKind"
+					]</xpath>
+				<value>	
+				<li Class="CombatExtended.LoadoutPropertiesExtension">	
+					<primaryMagazineCount>
+						<min>3</min>
+						<max>5</max>
+					</primaryMagazineCount>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/PawnKindDef[
+					defName="PN_SecurityGuardH" or
+          defName="PN_SecurityUnit" or
+          @Name="PN_MidUnitBase"
+					]</xpath>
+				<value>	
+				<li Class="CombatExtended.LoadoutPropertiesExtension">	
+					<primaryMagazineCount>
+						<min>4</min>
+						<max>6</max>
+					</primaryMagazineCount>
+				</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/PawnKindDef[@Name="PN_EliteUnitBase"]</xpath>
+				<value>	
+				<li Class="CombatExtended.LoadoutPropertiesExtension">	
+					<primaryMagazineCount>
+						<min>4</min>
+						<max>6</max>
+					</primaryMagazineCount>
+				</li>
+				</value>
+			</li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>    

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -167,7 +167,7 @@
 			<value>
 				<Mass>12</Mass>
 				<Bulk>28</Bulk>
-				<WornBulk>18</WornBulk>
+				<WornBulk>16</WornBulk>
 			</value>
 		</li>
 		

--- a/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Misc/Paniel_Apparel.xml
@@ -6,18 +6,36 @@
 		
 	<match Class="PatchOperationSequence">
 	<operations>
-	
+
+		<!-- ==========  Module  =========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[@Name="PN_ApparelModuleBase"]/statBases</xpath>
+			<value>
+				<Bulk>1</Bulk>
+				<WornBulk>0</WornBulk>
+			</value>
+		</li>
+
 		<!--========= Stuffable =========-->
 		
 		<!--Fabric-->
 		
 		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="PN_ApparelBasic" or defName="PN_ApparelBasicHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<xpath>Defs/ThingDef[defName="PN_ApparelBasic"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				<WornBulk>1</WornBulk>
 			</value>
 		</li>
-		
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="PN_ApparelBasicHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+			<value>
+				<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+				<WornBulk>0</WornBulk>
+			</value>
+		</li>
+
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/ThingDef[defName="PN_ApparelCape"]/statBases</xpath>
 			<value>
@@ -53,6 +71,7 @@
 			]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
 				<StuffEffectMultiplierArmor>5.5</StuffEffectMultiplierArmor>
+				<WornBulk>1</WornBulk>
 			</value>
 		</li>
 		

--- a/Patches/Paniel the Automata/ThingDefs_Races/AlienRace_Paniel.xml
+++ b/Patches/Paniel the Automata/ThingDefs_Races/AlienRace_Paniel.xml
@@ -1,64 +1,64 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
   <Operation Class="PatchOperationFindMod">
-		
-	<mods><li>Paniel the Automata</li></mods>
-		
+	<mods>
+		<li>Paniel the Automata</li>
+	</mods>
 	<match Class="PatchOperationSequence">
 	<operations>
-		
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/comps</xpath>
-			<value>
-				<li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/comps</xpath>
+		<value>
+			<li>
 				<compClass>CombatExtended.CompPawnGizmo</compClass>
-				</li>
-				<li Class="CombatExtended.CompProperties_Suppressable" />
-			</value>
-		</li>
-		
-		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]</xpath>
-			<value>
-				<li Class="CombatExtended.RacePropertiesExtensionCE">
-					<bodyShape>Humanoid</bodyShape>
-				</li>
-			</value>
-		</li>
-		
-		<li Class="PatchOperationAdd">
-		 <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/statBases</xpath>
-			<value>
+			</li>
+			<li Class="CombatExtended.CompProperties_Suppressable" />
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAddModExtension">
+		<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Humanoid</bodyShape>
+			</li>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/statBases</xpath>
+		<value>
 			<MeleeCritChance>1</MeleeCritChance>
 			<MeleeParryChance>1</MeleeParryChance>
 			<Suppressability>0.5</Suppressability>
 			<SmokeSensitivity>0</SmokeSensitivity>
-			</value>
-		</li>
-		
-		<li Class="PatchOperationReplace">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/tools</xpath> 
-			<value>
-				<tools>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationReplace">
+		<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/tools</xpath> 
+		<value>
+			<tools>
 			<li Class="CombatExtended.ToolCE">
-			<label>left fist</label>
-			<capacities>
-				<li>Blunt</li>
-			</capacities>
-			<power>1</power>
-			<cooldownTime>1.26</cooldownTime>
-			<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-			<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
+				<label>left fist</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>1</power>
+				<cooldownTime>1.26</cooldownTime>
+				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
-			<label>right fist</label>
-			<capacities>
-				<li>Blunt</li>
-			</capacities>
-			<power>1</power>
-			<cooldownTime>1.26</cooldownTime>
-			<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-			<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
+				<label>right fist</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>1</power>
+				<cooldownTime>1.26</cooldownTime>
+				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+				<armorPenetrationBlunt>0.125</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
@@ -71,23 +71,22 @@
 				<chanceFactor>0.2</chanceFactor>
 				<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
 			</li>
-		</tools>
+			</tools>
+		</value>
+	</li>
+	
+	<li Class="PatchOperationAdd">
+		<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
+			<value>
+			<li>CE_Apparel_TacVest</li>
+			<li>CE_Apparel_Backpack</li>
+			<li>CE_Apparel_TribalBackpack</li>
+			<li>CE_Apparel_BallisticShield</li>
+			<li>CE_Apparel_MeleeShield</li>
+			<li>CE_Apparel_GasMask</li>
+			<li>CE_Apparel_ImprovGasMask</li>
 			</value>
-		</li>
-		
-		<li Class="PatchOperationAdd">
-			<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Paniel_Race"]/alienRace/raceRestriction/whiteApparelList</xpath>
-			  <value>
-				<li>CE_Apparel_TacVest</li>
-				<li>CE_Apparel_Backpack</li>
-				<li>CE_Apparel_TribalBackpack</li>
-				<li>CE_Apparel_BallisticShield</li>
-				<li>CE_Apparel_MeleeShield</li>
-				<li>CE_Apparel_GasMask</li>
-				<li>CE_Apparel_ImprovGasMask</li>
-			  </value>
-		</li>
-		
+	</li>
 		
 	</operations>
 	</match>	

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -407,11 +407,10 @@
 
 			<!-- ========== Unity Guard Armor =========== -->
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
 				<value>
 					<Bulk>15</Bulk>
 					<WornBulk>5</WornBulk>
-					<Mass>11</Mass>
 				</value>
 			</li>
 

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -8,6 +8,43 @@
 		<match Class="PatchOperationSequence">
 		<operations>
 
+			<!-- ==========  Patched Shirt =========== -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_PatchedShirt"]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>0</WornBulk>					
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Apparel_PatchedShirt"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.03</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="Apparel_PatchedShirt"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.024</ArmorRating_Blunt>
+				</value>			
+			</li>
+
+			<!-- ==========  Hoods =========== -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[
+				defName="Apparel_HuskerHood" or
+				defName="Apparel_SkulkerHood" or
+				defName="Apparel_ThumperHood" or
+				defName="Apparel_FeralHood"
+				]/statBases</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>0</WornBulk>					
+				</value>
+			</li>
+
 			<!-- ==========  Grinder Helmet =========== -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_GrinderHelmet"]/statBases</xpath>
@@ -15,13 +52,15 @@
 					<Bulk>4</Bulk>
 					<WornBulk>2</WornBulk>					
 				</value>
-			</li>			
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_GrinderHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_GrinderHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
@@ -33,7 +72,7 @@
 				<xpath>Defs/ThingDef[defName="Apparel_GrinderHelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-0.3</SmokeSensitivity>
-			</value>
+				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
@@ -51,13 +90,15 @@
 					<Bulk>3.5</Bulk>
 					<WornBulk>1.8</WornBulk>					
 				</value>
-			</li>			
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases</xpath>
 				<value>
@@ -79,7 +120,7 @@
 				<xpath>Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
-			</value>
+				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
@@ -98,13 +139,15 @@
 					<WornBulk>1.5</WornBulk>	
 					<NightVisionEfficiency_Apparel>0.25</NightVisionEfficiency_Apparel> 
 				</value>
-			</li>			
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>28</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
@@ -129,13 +172,15 @@
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/costList/Plasteel</xpath>
 				<value>
 					<Plasteel>36</Plasteel>
 					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
-			</li>		
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/apparel/layers</xpath>
 				<value>
@@ -153,18 +198,21 @@
 					<WornBulk>5</WornBulk>					
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ScrapArmor"]/statBases/Mass</xpath>
 				<value>
 					<Mass>13</Mass>		
 				</value>
-			</li>			
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScrapArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScrapArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
@@ -215,18 +263,21 @@
 					<WornBulk>8</WornBulk>					
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralMail"]/statBases/Mass</xpath>
 				<value>
 					<Mass>15</Mass>						
 				</value>
-			</li>			
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralMail"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralMail"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
@@ -331,12 +382,14 @@
 					<WornBulk>25</WornBulk>					
 				</value>
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/Mass</xpath>
 				<value>
 					<Mass>75</Mass>		
 				</value>
-			</li>					
+			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/equippedStatOffsets</xpath>
 				<value>
@@ -345,31 +398,36 @@
 					<ToxicEnvironmentResistance>0.45</ToxicEnvironmentResistance>
 			</value>
 		    </li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Plasteel</xpath>
 				<value>
 					<Plasteel>83</Plasteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
-			</li>		
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Steel</xpath>
 				<value>
 					<Steel>204</Steel>
 				</value>
-			</li>	
+			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>			
 			</li>
+
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
+
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/apparel/bodyPartGroups</xpath>
 				<value>

--- a/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
@@ -52,7 +52,7 @@
 
 		<!-- ========== Shoulders ========== -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Sentinel"]/statBases</xpath>
 			<value>
 				<Bulk>15</Bulk>
 				<WornBulk>5</WornBulk>
@@ -60,14 +60,14 @@
 		</li>
 			
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>21.83</ArmorRating_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Sentinel"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>54.575</ArmorRating_Blunt>
 			</value>
@@ -150,7 +150,7 @@
 
 		<!-- ========== Shoulders ========== -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_GuardianX"]/statBases</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_GuardianX"]/statBases</xpath>
 			<value>
 				<Bulk>15</Bulk>
 				<WornBulk>5</WornBulk>
@@ -158,14 +158,14 @@
 		</li>
 			
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_GuardianX"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_GuardianX"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>28</ArmorRating_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_GuardianX"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_GuardianX"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>112</ArmorRating_Blunt>
 			</value>
@@ -250,7 +250,7 @@
 
 		<!-- ========== Shoulders ========== -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Tyrant"]/statBases</xpath>
 			<value>
 				<Bulk>15</Bulk>
 				<WornBulk>5</WornBulk>
@@ -258,28 +258,28 @@
 		</li>
 			
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>20</ArmorRating_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Tyrant"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>48</ArmorRating_Blunt>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoDef</xpath>
 			<value>
 				<ammoDef>Ammo_40x53mmGrenade_Smoke</ammoDef>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/VFEPirates.WarcasketDef[defName="VFEP_WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Tyrant"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountPerCharge</xpath>
 			<value>
 				<ammoCountPerCharge>1</ammoCountPerCharge>
 			</value>

--- a/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
+++ b/Patches/WarCasket Expanded/Apparel_Warcaskets.xml
@@ -327,6 +327,103 @@
 				<ArmorRating_Blunt>50</ArmorRating_Blunt>
 			</value>
 		</li>
+
+	<!-- Centurion Warcasket -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Centurion"]/statBases</xpath>
+			<value>
+				<Bulk>230</Bulk>
+				<WornBulk>25</WornBulk>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Centurion"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Centurion"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>112</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="Warcasket_Centurion"]/equippedStatOffsets</xpath>
+			<value>
+				<CarryWeight>225</CarryWeight>
+				<CarryBulk>175</CarryBulk>
+				<Suppressability>-100</Suppressability>
+			</value>
+		</li>
+
+		<!-- ========== Shoulders ========== -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Centurion"]/statBases</xpath>
+			<value>
+				<Bulk>15</Bulk>
+				<WornBulk>5</WornBulk>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Centurion"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>28</ArmorRating_Sharp>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketShoulders_Centurion"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>112</ArmorRating_Blunt>
+			</value>
+		</li>
+
+		<!-- === Helmet === -->
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/statBases</xpath>
+			<value>
+				<Bulk>12.5</Bulk>
+				<WornBulk>6.25</WornBulk>
+				<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+			</value>
+		</li>
+
+		<li Class="PatchOperationConditional">
+			<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/apparel/immuneToToxGasExposure</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/apparel</xpath>
+				<value>
+					<immuneToToxGasExposure>true</immuneToToxGasExposure>
+				</value>
+			</nomatch>
+		</li>
+
+		<li Class="PatchOperationAdd">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/equippedStatOffsets</xpath>
+			<value>
+				<SmokeSensitivity>-1</SmokeSensitivity>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/statBases/ArmorRating_Sharp</xpath>
+			<value>
+				<ArmorRating_Sharp>30</ArmorRating_Sharp>
+			</value>
+		</li>
+			
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/VFEPirates.WarcasketDef[defName="WarcasketHelmet_Centurion"]/statBases/ArmorRating_Blunt</xpath>
+			<value>
+				<ArmorRating_Blunt>120</ArmorRating_Blunt>
+			</value>
+		</li>
+
 		</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes
**Paniel Race:**
- Patch the pawnkinds to give them ammo.
- Fix the Hediff patch, restructure to work better.
- Add some bulk/wornbulk as needed to avoid the autopatcher firing.
  
**Rimsenal:**
- Tweak some Federation and Feral apparel to avoid the apparel autopatcher.

**Warcaskets Expanded:**
- Patch the Centurion warcasket.
- Fix patches with the corrected defNames.
## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
