### PR TITLE
Reduce plate armor's worn bulk value

### DIFF
--- a/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
+++ b/Patches/Animal Armor - Vanilla/ThingDefs_Apparel.xml
@@ -76,7 +76,7 @@
           <xpath>/Defs/ThingDef[defName="Apparel_AnimalPlateArmor"]/statBases</xpath>
           <value>
             <Bulk>35</Bulk>
-            <WornBulk>10</WornBulk>
+            <WornBulk>7</WornBulk>
           </value>
         </li>
 

--- a/Patches/Animal Equipment/CE_patch_Apparel_Plate.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Plate.xml
@@ -22,7 +22,7 @@
 					<xpath>/Defs/ThingDef[@Name="AnimalPlateArmorBase"]/statBases</xpath>
 					<value>
 						<Bulk>35</Bulk>
-						<WornBulk>10</WornBulk>
+						<WornBulk>7</WornBulk>
 					</value>
 				</li>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -119,7 +119,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_PlateArmor"]/statBases</xpath>
 		<value>
 			<Bulk>100</Bulk>
-			<WornBulk>15</WornBulk>
+			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
 

--- a/Patches/Darkest Rim Core/Apparel_DarkestCE.xml
+++ b/Patches/Darkest Rim Core/Apparel_DarkestCE.xml
@@ -132,7 +132,7 @@
         <value>
           <ArmorRating_Blunt>4</ArmorRating_Blunt>
           <Bulk>100</Bulk>
-          <WornBulk>12</WornBulk>
+          <WornBulk>8</WornBulk>
         </value>
       </li>
 

--- a/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
+++ b/Patches/Epona Race/ThingDefs_Misc/Epona_Apparel.xml
@@ -143,7 +143,7 @@
 				<value>
 					<StuffEffectMultiplierArmor>2.7</StuffEffectMultiplierArmor>
 					<Bulk>100</Bulk>
-					<WornBulk>8</WornBulk>
+					<WornBulk>6</WornBulk>
 				</value>
 			</li>
 			

--- a/Patches/Kenshi Armory/KenshiArmory_Armour.xml
+++ b/Patches/Kenshi Armory/KenshiArmory_Armour.xml
@@ -65,7 +65,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_HeavyHolyChestPlate"]/statBases</xpath>
 			<value>
 				<Bulk>115</Bulk>
-				<WornBulk>18</WornBulk>
+				<WornBulk>12</WornBulk>
 			</value>
 		</li>
 
@@ -212,7 +212,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_SamuraiPlateArmor"]/statBases</xpath>
 			<value>
 				<Bulk>95</Bulk>
-				<WornBulk>12</WornBulk>
+				<WornBulk>8</WornBulk>
 			</value>
 		</li>
 
@@ -359,7 +359,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_UnstrainedMercenaryPlate"]/statBases</xpath>
 			<value>
 				<Bulk>85</Bulk>
-				<WornBulk>8</WornBulk>
+				<WornBulk>6</WornBulk>
 			</value>
 		</li>
 
@@ -560,7 +560,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_PaladinsHeavyPlate"]/statBases</xpath>
 			<value>
 				<Bulk>115</Bulk>
-				<WornBulk>18</WornBulk>
+				<WornBulk>12</WornBulk>
 			</value>
 		</li>
 
@@ -721,7 +721,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_EmpireSamuraiPlateArmor"]/statBases</xpath>
 			<value>
 				<Bulk>95</Bulk>
-				<WornBulk>12</WornBulk>
+				<WornBulk>8</WornBulk>
 			</value>
 		</li>
 
@@ -882,7 +882,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_CrabArmor"]/statBases</xpath>
 			<value>
 				<Bulk>115</Bulk>
-				<WornBulk>22</WornBulk>
+				<WornBulk>15</WornBulk>
 			</value>
 		</li>
 
@@ -1043,7 +1043,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_GuildMercenaryPlate"]/statBases</xpath>
 			<value>
 				<Bulk>85</Bulk>
-				<WornBulk>8</WornBulk>
+				<WornBulk>6</WornBulk>
 			</value>
 		</li>
 
@@ -1192,7 +1192,7 @@
 			<xpath>Defs/ThingDef[defName = "Kenshi_HackStopperJacket"]/statBases</xpath>
 			<value>
 				<Bulk>95</Bulk>
-				<WornBulk>12</WornBulk>
+				<WornBulk>8</WornBulk>
 			</value>
 		</li>
 

--- a/Patches/Medieval Overhaul/MO_Apparel_Armor.xml
+++ b/Patches/Medieval Overhaul/MO_Apparel_Armor.xml
@@ -202,7 +202,7 @@
                <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlate" or defName="DankPyon_Apparel_FullPlateGilded" or defName="DankPyon_Apparel_AdornedHeavyPlate"]/statBases</xpath>
                <value>
                   <Bulk>100</Bulk>
-                  <WornBulk>15</WornBulk>
+                  <WornBulk>10</WornBulk>
                </value>
             </li>
 
@@ -290,7 +290,7 @@
                <xpath>Defs/ThingDef[defName="DankPyon_Apparel_FullPlateNamed"]/statBases</xpath>
                <value>
                   <Bulk>100</Bulk>
-                  <WornBulk>15</WornBulk>
+                  <WornBulk>10</WornBulk>
                </value>
             </li>
 

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -325,7 +325,7 @@
 				<xpath>Defs/ThingDef[defName="RK_Plate"]/statBases</xpath>
 				<value>
 					<Bulk>80</Bulk>
-					<WornBulk>12</WornBulk>					
+					<WornBulk>8</WornBulk>					
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/O21 Dragons Not Included/Apparel_Dragon.xml
+++ b/Patches/O21 Dragons Not Included/Apparel_Dragon.xml
@@ -53,7 +53,7 @@
 				<value>
 					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					<Bulk>90</Bulk>
-					<WornBulk>13</WornBulk>
+					<WornBulk>9</WornBulk>
 				</value>
 			</li>
 

--- a/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Armor.xml
+++ b/Patches/RimFantasy - House Doyle/Patch_RFDoyle_Armor.xml
@@ -45,7 +45,7 @@
                <xpath>Defs/ThingDef[defName="RF_Apparel_HeraldicGildedFullPlate_Doyle"]/statBases</xpath>
                <value>
                   <Bulk>100</Bulk>
-                  <WornBulk>15</WornBulk>
+                  <WornBulk>10</WornBulk>
                </value>
             </li>
 

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
@@ -93,7 +93,7 @@
 					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>52.5</Bulk>
-						<WornBulk>8</WornBulk>
+						<WornBulk>6</WornBulk>
 						<Mass>8</Mass>
 					</value>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
@@ -121,7 +121,7 @@
 					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/statBases</xpath>
 					<value>
 						<Bulk>100</Bulk>
-						<WornBulk>18</WornBulk>
+						<WornBulk>12</WornBulk>
 					</value>
 				</li>
 

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
@@ -69,7 +69,7 @@
                <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]/statBases</xpath>
                <value>
                   <Bulk>100</Bulk>
-                  <WornBulk>15</WornBulk>
+                  <WornBulk>10</WornBulk>
                </value>
             </li>
 


### PR DESCRIPTION
## Changes

- What it says on the tin, reduce the base game's plate armor and modded plate armors' worn bulk values by 2/3, resulting in the base game plate armor having 10 worn bulk instead of 15.

## Reasoning

- After the discussion among the team, the decision was to reduce it from 15 to 10 as it was too high and a arbitrary value.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
