### PR TITLE
Shotgun shell fixes and tweaks

### DIFF
--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -62,8 +62,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.76</MarketValue>
-      <Mass>0.183</Mass>
+      <MarketValue>0.36</MarketValue>
+      <Mass>0.086</Mass>
     </statBases>
     <ammoClass>Slug</ammoClass>
     <cookOffProjectile>Bullet_23x75mmR_Slug</cookOffProjectile>
@@ -78,8 +78,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.02</MarketValue>
-      <Mass>0.0191</Mass>
+      <MarketValue>0.62</MarketValue>
+      <Mass>0.112</Mass>
     </statBases>
     <ammoClass>Beanbag</ammoClass>
     <cookOffProjectile>Bullet_23x75mmR_Beanbag</cookOffProjectile>
@@ -93,8 +93,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.186</Mass>
-      <MarketValue>3.03</MarketValue>
+      <Mass>0.101</Mass>
+      <MarketValue>2.7</MarketValue>
     </statBases>
     <ammoClass>ElectroSlug</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -109,8 +109,8 @@
 			<speed>78</speed>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
-      <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
-    </projectile>
+			<casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
+		</projectile>
 	</ThingDef>
 	
 	<ThingDef ParentName="Base23x75mmRBullet">
@@ -137,10 +137,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>114</speed>
-			<damageAmountBase>57</damageAmountBase>
-			<armorPenetrationSharp>9</armorPenetrationSharp>
-			<armorPenetrationBlunt>526.34</armorPenetrationBlunt>
+			<speed>100</speed>
+			<damageAmountBase>38</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>162.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -154,8 +154,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>18</speed>
 			<damageDef>Beanbag</damageDef>
-			<damageAmountBase>16</damageAmountBase>
-			<armorPenetrationBlunt>13.78</armorPenetrationBlunt>
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationBlunt>7.38</armorPenetrationBlunt>
 			<spreadMult>2</spreadMult>
 		</projectile>
 	</ThingDef>
@@ -217,7 +217,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>76</count>
+        <count>36</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -228,7 +228,7 @@
     <products>
       <Ammo_23x75mmR_Slug>200</Ammo_23x75mmR_Slug>
     </products>
-    <workAmount>7600</workAmount>
+    <workAmount>3600</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -243,7 +243,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>78</count>
+        <count>38</count>
       </li>
       <li>
         <filter>
@@ -251,7 +251,7 @@
             <li>Cloth</li>
           </thingDefs>
         </filter>
-        <count>31</count>
+        <count>15</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -263,7 +263,7 @@
     <products>
       <Ammo_23x75mmR_Beanbag>200</Ammo_23x75mmR_Beanbag>
     </products>
-    <workAmount>10900</workAmount>
+    <workAmount>5300</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -279,7 +279,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>76</count>
+        <count>36</count>
       </li>
       <li>
         <filter>
@@ -299,7 +299,7 @@
     <products>
       <Ammo_23x75mmR_ElectroSlug>200</Ammo_23x75mmR_ElectroSlug>
     </products>
-    <workAmount>16000</workAmount>
+    <workAmount>12000</workAmount>
   </RecipeDef>
 	
 </Defs>

--- a/Patches/Android Tiers Reforged/Ammo/RotaryShrapnelcannonShell.xml
+++ b/Patches/Android Tiers Reforged/Ammo/RotaryShrapnelcannonShell.xml
@@ -13,6 +13,13 @@
 					<xpath>Defs</xpath>
 					<value>
 
+						<ThingCategoryDef>
+							<defName>AmmoRotaryShrapnelcannonShell</defName>
+							<label>Rotary Shrapnelcannon shell</label>
+							<parent>AmmoShotguns</parent>
+							<iconPath>UI/Icons/ThingCategories/CaliberShotgun</iconPath>
+						</ThingCategoryDef>
+
 						<!-- ==================== AmmoSet ========================== -->
 
 						<CombatExtended.AmmoSetDef>
@@ -21,11 +28,12 @@
 							<ammoTypes>
 								<Ammo_RotaryShrapnelcannonShell>Bullet_RotaryShrapnelcannonShell</Ammo_RotaryShrapnelcannonShell>
 							</ammoTypes>
+							<similarTo>AmmoSet_Shotgun</similarTo>
 						</CombatExtended.AmmoSetDef>
 
 						<!-- ==================== Ammo ========================== -->
 
-						<ThingDef Class="CombatExtended.AmmoDef" Name="MastiffShotgunShellBase" ParentName="HeavyAmmoBase" Abstract="True">
+						<ThingDef Class="CombatExtended.AmmoDef" Name="RotaryShrapnelcannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 							<description>Very large caliber buckshot shell designed specifically for the mech-operated Rotary Shrapnelcannon.</description>
 							<statBases>
 								<Mass>1.072</Mass>
@@ -36,12 +44,12 @@
 								<li>CE_AutoEnableCrafting_TableMachining</li>
 							</tradeTags>
 							<thingCategories>
-								<li>AmmoAdvanced</li>
+								<li>AmmoRotaryShrapnelcannonShell</li>
 							</thingCategories>
 							<stackLimit>25</stackLimit>
 						</ThingDef>
 
-						<ThingDef Class="CombatExtended.AmmoDef" ParentName="MastiffShotgunShellBase">
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="RotaryShrapnelcannonShellBase">
 							<defName>Ammo_RotaryShrapnelcannonShell</defName>
 							<label>Shrapnelcannon shell (Buck)</label>
 							<graphicData>

--- a/Patches/Vanilla Factions Expanded - Pirates/Ammo/SlughthrowerShell.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Ammo/SlughthrowerShell.xml
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Pirates</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs</xpath>
+					<value>
+
+						<ThingCategoryDef>
+							<defName>AmmoSlugthrowerShell</defName>
+							<label>Slugthrower shell</label>
+							<parent>AmmoShotguns</parent>
+							<iconPath>UI/Icons/ThingCategories/CaliberShotgun</iconPath>
+						</ThingCategoryDef>
+
+						<!-- ==================== AmmoSet ========================== -->
+
+						<CombatExtended.AmmoSetDef>
+							<defName>AmmoSet_SlugthrowerShell</defName>
+							<label>Slugthrower shell</label>
+							<ammoTypes>
+								<Ammo_Slugthrower_Buck>Bullet_Slugthrower_Buck</Ammo_Slugthrower_Buck>
+								<Ammo_Slugthrower_Slug>Bullet_Slugthrower_Slug</Ammo_Slugthrower_Slug>
+								<Ammo_Slugthrower_Beanbag>Bullet_Slugthrower_Beanbag</Ammo_Slugthrower_Beanbag>
+								<Ammo_Slugthrower_ElectroSlug>Bullet_Slugthrower_ElectroSlug</Ammo_Slugthrower_ElectroSlug>
+							</ammoTypes>
+							<similarTo>AmmoSet_Shotgun</similarTo>
+						</CombatExtended.AmmoSetDef>
+
+						<!-- ==================== Ammo ========================== -->
+
+						<ThingDef Class="CombatExtended.AmmoDef" Name="SlugthrowerShellBase" ParentName="AmmoBase" Abstract="True">
+							<description>Large 40mm shotgun shells designed to be fired by the warcasket slugthrower shotgun.</description>
+							<statBases>
+								<Mass>0.17</Mass>
+								<Bulk>0.38</Bulk>
+							</statBases>
+							<tradeTags>
+								<li>CE_AutoEnableTrade</li>
+								<li>CE_AutoEnableCrafting</li>
+							</tradeTags>
+							<thingCategories>
+								<li>AmmoSlugthrowerShell</li>
+							</thingCategories>
+							<stackLimit>500</stackLimit>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="SlugthrowerShellBase">
+							<defName>Ammo_Slugthrower_Buck</defName>
+							<label>Slugthrower shell (Buck)</label>
+							<graphicData>
+								<texPath>Things/Ammo/Shotgun/Shot</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>0.64</MarketValue>
+							</statBases>
+							<ammoClass>BuckShot</ammoClass>
+							<cookOffProjectile>Bullet_Slugthrower_Buck</cookOffProjectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="SlugthrowerShellBase">
+							<defName>Ammo_Slugthrower_Slug</defName>
+							<label>Slugthrower shell (Slug)</label>
+							<graphicData>
+								<texPath>Things/Ammo/Shotgun/Slug</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>0.6</MarketValue>
+								<Mass>0.16</Mass>
+							</statBases>
+							<ammoClass>Slug</ammoClass>
+							<cookOffProjectile>Bullet_Slugthrower_Slug</cookOffProjectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="SlugthrowerShellBase">
+							<defName>Ammo_Slugthrower_Beanbag</defName>
+							<label>Slugthrower shell (Bean)</label>
+							<generateAllowChance>0</generateAllowChance>
+							<graphicData>
+								<texPath>Things/Ammo/Shotgun/Beanbag</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<MarketValue>1.05</MarketValue>
+								<Mass>0.205</Mass>
+							</statBases>
+							<ammoClass>Beanbag</ammoClass>
+							<cookOffProjectile>Bullet_Slugthrower_Beanbag</cookOffProjectile>
+						</ThingDef>
+
+						<ThingDef Class="CombatExtended.AmmoDef" ParentName="SlugthrowerShellBase">
+							<defName>Ammo_Slugthrower_ElectroSlug</defName>
+							<label>Slugthrower shell (EMP)</label>
+							<graphicData>
+								<texPath>Things/Ammo/Shotgun/EMP</texPath>
+								<graphicClass>Graphic_StackCount</graphicClass>
+							</graphicData>
+							<statBases>
+								<Mass>0.186</Mass>
+								<MarketValue>4.62</MarketValue>
+							</statBases>
+							<ammoClass>ElectroSlug</ammoClass>
+							<generateAllowChance>0.5</generateAllowChance>
+							<cookOffProjectile>Bullet_Slugthrower_ElectroSlug</cookOffProjectile>
+						</ThingDef>
+
+						<!-- ================== Projectiles ================== -->
+
+						<ThingDef Name="BaseSlugthrowerBullet" ParentName="BaseBullet" Abstract="true">
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>Bullet</damageDef>
+								<speed>100</speed>
+								<dropsCasings>true</dropsCasings>
+								<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
+								<casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseSlugthrowerBullet">
+							<defName>Bullet_Slugthrower_Buck</defName>
+							<label>buckshot pellet</label>
+							<graphicData>
+								<texPath>Things/Projectile/Shotgun_Pellet</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageAmountBase>27</damageAmountBase>
+								<pelletCount>4</pelletCount>
+								<armorPenetrationSharp>6</armorPenetrationSharp>
+								<armorPenetrationBlunt>75</armorPenetrationBlunt>
+								<spreadMult>7.9</spreadMult>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseSlugthrowerBullet">
+							<defName>Bullet_Slugthrower_Slug</defName>
+							<label>shotgun slug</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>153</speed>
+								<damageAmountBase>74</damageAmountBase>
+								<armorPenetrationSharp>10</armorPenetrationSharp>
+								<armorPenetrationBlunt>638.7</armorPenetrationBlunt>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseSlugthrowerBullet">
+							<defName>Bullet_Slugthrower_Beanbag</defName>
+							<label>beanbag</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<speed>18</speed>
+								<damageDef>Beanbag</damageDef>
+								<damageAmountBase>19</damageAmountBase>
+								<armorPenetrationBlunt>12.56</armorPenetrationBlunt>
+								<spreadMult>2</spreadMult>
+							</projectile>
+						</ThingDef>
+
+						<ThingDef ParentName="BaseSlugthrowerBullet">
+							<defName>Bullet_Slugthrower_ElectroSlug</defName>
+							<label>EMP slug</label>
+							<graphicData>
+								<texPath>Things/Projectile/Bullet_big</texPath>
+								<graphicClass>Graphic_Single</graphicClass>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>EMP</damageDef>
+								<damageAmountBase>40</damageAmountBase>
+								<armorPenetrationSharp>0</armorPenetrationSharp>
+								<armorPenetrationBlunt>0</armorPenetrationBlunt>
+								<empShieldBreakChance>0.75</empShieldBreakChance>
+								<speed>46</speed>
+							</projectile>
+						</ThingDef>
+
+						<!-- ==================== Recipes ========================== -->
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_Slugthrower_Buck</defName>
+							<label>make Slugthrower (Buck) shell x100</label>
+							<description>Craft 100 Slugthrower (Buck) shells.</description>
+							<jobString>Making Slugthrower (Buck) shells.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>34</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_Slugthrower_Buck>100</Ammo_Slugthrower_Buck>
+							</products>
+							<workAmount>3400</workAmount>
+						</RecipeDef>
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_Slugthrower_Slug</defName>
+							<label>make Slugthrower (Slug) shell x100</label>
+							<description>Craft 100 Slugthrower (Slug) shells.</description>
+							<jobString>Making Slugthrower (Slug) shells.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>32</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_Slugthrower_Slug>100</Ammo_Slugthrower_Slug>
+							</products>
+							<workAmount>3200</workAmount>
+						</RecipeDef>
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_Slugthrower_Beanbag</defName>
+							<label>make Slugthrower (Beanbag) shell x100</label>
+							<description>Craft 100 Slugthrower (Beanbag) shells.</description>
+							<jobString>Making Slugthrower (Beanbag) shells.</jobString>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>42</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Cloth</li>
+										</thingDefs>
+									</filter>
+									<count>17</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+									<li>Cloth</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_Slugthrower_Beanbag>100</Ammo_Slugthrower_Beanbag>
+							</products>
+							<workAmount>5900</workAmount>
+						</RecipeDef>
+
+						<RecipeDef ParentName="AmmoRecipeBase">
+							<defName>MakeAmmo_Slugthrower_ElectroSlug</defName>
+							<label>make Slugthrower (EMP) shell x100</label>
+							<description>Craft 100 Slugthrower (EMP) shells.</description>
+							<jobString>Making Slugthrower (EMP) shells.</jobString>
+							<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+							<ingredients>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>Steel</li>
+										</thingDefs>
+									</filter>
+									<count>38</count>
+								</li>
+								<li>
+									<filter>
+										<thingDefs>
+											<li>ComponentIndustrial</li>
+										</thingDefs>
+									</filter>
+									<count>12</count>
+								</li>
+							</ingredients>
+							<fixedIngredientFilter>
+								<thingDefs>
+									<li>Steel</li>
+									<li>ComponentIndustrial</li>
+								</thingDefs>
+							</fixedIngredientFilter>
+							<products>
+								<Ammo_Slugthrower_ElectroSlug>100</Ammo_Slugthrower_ElectroSlug>
+							</products>
+							<workAmount>11000</workAmount>
+						</RecipeDef>
+
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -180,7 +180,7 @@
           <Properties>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
-            <defaultProjectile>Bullet_23x75mmR_Buck</defaultProjectile>
+            <defaultProjectile>Bullet_Slugthrower_Buck</defaultProjectile>
             <warmupTime>0.6</warmupTime>
             <range>28</range>
             <soundCast>VFEP_Shot_Slugthrower</soundCast>
@@ -191,7 +191,7 @@
             <magazineSize>8</magazineSize>
             <reloadOneAtATime>true</reloadOneAtATime>
             <reloadTime>0.85</reloadTime>
-            <ammoSet>AmmoSet_23x75mmR</ammoSet>
+            <ammoSet>AmmoSet_SlugthrowerShell</ammoSet>
           </AmmoUser>
           <FireModes />
         </li>


### PR DESCRIPTION
## Changes

- Tweaked the 23x75mm shotgun shells based on an actual real world replica of the shell. The slug shell is faster than what's stated in the video because the shell used there is underloaded. The previous existing slug, beanbag and EMP shells were very absurd to begin with, absurd as in firing something 3 times the mass of a .50 BMG bullet at half the speed from a shotgun resulting in almost double the blunt AP...
- Tweaked and fixed some stuff for the ATR's shrapnel cannon shotgun shells.
- Added special shotgun shells for the warcasket slugthrower based on the item description stating the shotgun firing x4 12ga slugs.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070
- https://www.youtube.com/watch?v=en_55fzWeVo
![image](https://user-images.githubusercontent.com/56392968/218334240-dfb16256-11d0-4dc9-be31-848d921b2aee.png)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (working as intended)
