### PR TITLE
Fix the Flesh Fly's texture/hitbox issue

### DIFF
--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Failures.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Failures.xml
@@ -12,7 +12,7 @@
         <!-- ========= Fleshling ============ -->
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_Fleshling"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Fleshling"]</xpath>
 			<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
@@ -21,7 +21,7 @@
 		</li>
 					
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Fleshling"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Fleshling"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.05</MeleeDodgeChance>
 				<MeleeCritChance>0.23</MeleeCritChance>
@@ -29,7 +29,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Fleshling"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Fleshling"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -49,7 +49,7 @@
         <!-- ========= Aberrant Fleshbeast ============ -->
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_AberrantFleshbeast"]</xpath>
 			<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>QuadrupedLow</bodyShape>
@@ -58,7 +58,7 @@
 		</li>
 					
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_AberrantFleshbeast"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.10</MeleeCritChance>
@@ -66,7 +66,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_AberrantFleshbeast"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_AberrantFleshbeast"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -86,7 +86,7 @@
         <!-- ========= Flesh Monstrosity ============ -->
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_FleshMonstrosity"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshMonstrosity"]</xpath>
 			<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
@@ -95,7 +95,7 @@
 		</li>
 					
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_FleshMonstrosity"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshMonstrosity"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.23</MeleeCritChance>
@@ -103,7 +103,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_FleshMonstrosity"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshMonstrosity"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -123,7 +123,7 @@
         <!-- ========= Flesh Growth ============ -->
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_FleshGrowth"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshGrowth"]</xpath>
 			<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Birdlike</bodyShape>
@@ -132,7 +132,7 @@
 		</li>
 					
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_FleshGrowth"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshGrowth"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.01</MeleeCritChance>
@@ -140,7 +140,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_FleshGrowth"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshGrowth"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -160,7 +160,7 @@
         <!-- ========= Fleshflies ============ -->
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_FleshFlies"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshFlies"]</xpath>
 			<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Vehicle</bodyShape> <!-- Not so much a 'body' as a swarm. -->
@@ -169,11 +169,11 @@
 		</li>
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="GR_FleshFlies"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshFlies"]/statBases/ArmorRating_Blunt</xpath>
 		</li>
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="GR_FleshFlies"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshFlies"]/statBases/ArmorRating_Sharp</xpath>
 		</li>
 
 		<!-- 
@@ -206,7 +206,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_FleshFlies"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshFlies"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.80</MeleeDodgeChance>
 				<MeleeCritChance>0.00</MeleeCritChance>
@@ -214,7 +214,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_FleshFlies"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FleshFlies"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -232,9 +232,16 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/PawnKindDef[defName="GR_FleshFlies"]/lifeStages/li/bodyGraphicData/texPath</xpath>
+			<xpath>Defs/PawnKindDef[defName="GR_FleshFlies"]/lifeStages/li/bodyGraphicData/texPath</xpath>
 			<value>
 				<texPath>Things/Pawn/Animal/Failures/Fleshflies/FleshfliesA</texPath>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/PawnKindDef[defName="GR_FleshFlies"]/lifeStages/li/bodyGraphicData/drawSize</xpath>
+			<value>
+				<drawSize>2.0</drawSize>
 			</value>
 		</li>
 

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Failures.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Failures.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
+
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Vanilla Genetics Expanded</li>
@@ -230,7 +231,15 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationReplace">
+			<xpath>/Defs/PawnKindDef[defName="GR_FleshFlies"]/lifeStages/li/bodyGraphicData/texPath</xpath>
+			<value>
+				<texPath>Things/Pawn/Animal/Failures/Fleshflies/FleshfliesA</texPath>
+			</value>
+		</li>
+
 		</operations>
 		</match>
 	</Operation>
+
 </Patch>


### PR DESCRIPTION
## Changes

- What it says on the tin, the error caused by the transparent texture is fixed by changing the texture directory of the pawn to the actual one that has stuff in it in the mod itself. Also made the drawSize smaller as it was too big in-game at x3.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Working as intended)
