### PR TITLE
Update several mod patches

### DIFF
--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackHive_Psycasts.xml
@@ -14,7 +14,7 @@
 					<operations>
 
 						<li Class="PatchOperationAddModExtension">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]</xpath>
 							<value>
 								<li Class="CombatExtended.RacePropertiesExtensionCE">
 									<bodyShape>QuadrupedLow</bodyShape>
@@ -23,35 +23,35 @@
 						</li>
 							
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/PawnKindDef[defName="AA_BlackScarab_Temporary"]/combatPower</xpath>
+							<xpath>Defs/PawnKindDef[defName="AA_BlackScarab_Temporary"]/combatPower</xpath>
 							<value>
 								<combatPower>60</combatPower>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Blunt</xpath>
 							<value>
 								<ArmorRating_Blunt>2.55</ArmorRating_Blunt>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/ArmorRating_Sharp</xpath>
 							<value>
 								<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/MoveSpeed</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases/MoveSpeed</xpath>
 							<value>
 								<MoveSpeed>4.9</MoveSpeed>
 							</value>
 						</li>
 
 						<li Class="PatchOperationAdd">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/statBases</xpath>
 							<value>
 								<MeleeDodgeChance>0.15</MeleeDodgeChance>
 								<MeleeCritChance>0.01</MeleeCritChance>
@@ -60,7 +60,7 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/tools</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackScarab_Temporary"]/tools</xpath>
 							<value>
 								<tools>
 									<li Class="CombatExtended.ToolCE">
@@ -91,7 +91,7 @@
 						</li>
 
 						<li Class="PatchOperationAddModExtension">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]</xpath>
 							<value>
 								<li Class="CombatExtended.RacePropertiesExtensionCE">
 									<bodyShape>QuadrupedLow</bodyShape>
@@ -100,28 +100,28 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Blunt</xpath>
 							<value>
 								<ArmorRating_Blunt>6</ArmorRating_Blunt>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/ArmorRating_Sharp</xpath>
 							<value>
 								<ArmorRating_Sharp>3</ArmorRating_Sharp>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/MoveSpeed</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases/MoveSpeed</xpath>
 							<value>
 								<MoveSpeed>4.7</MoveSpeed>
 							</value>
 						</li>
 
 						<li Class="PatchOperationAdd">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/statBases</xpath>
 							<value>
 								<AimingAccuracy>0.75</AimingAccuracy>
 								<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
@@ -133,21 +133,21 @@
 						</li>
 							
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/PawnKindDef[defName="AA_BlackSpelopede_Temporary"]/combatPower</xpath>
+							<xpath>Defs/PawnKindDef[defName="AA_BlackSpelopede_Temporary"]/combatPower</xpath>
 							<value>
 								<combatPower>100</combatPower>
 							</value>
 						</li>
 							
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/race/baseHealthScale</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/race/baseHealthScale</xpath>
 							<value>
 								<baseHealthScale>1.4</baseHealthScale>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/tools</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/tools</xpath>
 							<value>
 								<tools>
 									<li Class="CombatExtended.ToolCE">
@@ -189,7 +189,7 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/verbs</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpelopede_Temporary"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -211,7 +211,7 @@
 						</li>
 
 						<li Class="PatchOperationAddModExtension">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]</xpath>
 							<value>
 								<li Class="CombatExtended.RacePropertiesExtensionCE">
 									<bodyShape>Quadruped</bodyShape>
@@ -220,35 +220,35 @@
 						</li>
 							
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/race/baseHealthScale</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/race/baseHealthScale</xpath>
 							<value>
 								<baseHealthScale>2.1</baseHealthScale>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Blunt</xpath>
 							<value>
 								<ArmorRating_Blunt>12</ArmorRating_Blunt>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/ArmorRating_Sharp</xpath>
 							<value>
 								<ArmorRating_Sharp>5</ArmorRating_Sharp>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/MoveSpeed</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases/MoveSpeed</xpath>
 							<value>
 								<MoveSpeed>4.6</MoveSpeed>
 							</value>
 						</li>
 
 						<li Class="PatchOperationAdd">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/statBases</xpath>
 							<value>
 								<AimingAccuracy>0.65</AimingAccuracy>
 								<ShootingAccuracyPawn>0.65</ShootingAccuracyPawn>
@@ -260,14 +260,14 @@
 						</li>
 							
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/PawnKindDef[defName="AA_BlackSpider_Temporary"]/combatPower</xpath>
+							<xpath>Defs/PawnKindDef[defName="AA_BlackSpider_Temporary"]/combatPower</xpath>
 							<value>
 								<combatPower>200</combatPower>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/tools</xpath>
+							<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/tools</xpath>
 							<value>
 								<tools>
 									<li Class="CombatExtended.ToolCE">
@@ -309,7 +309,7 @@
 						</li>
 
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="AA_BlackSpider_Temporary"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -331,7 +331,7 @@
 					</li>
 
 						<li Class="PatchOperationAddModExtension">
-							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]</xpath>
+							<xpath>Defs/ThingDef[defName="AA_MammothWorm_Temporary"]</xpath>
 							<value>
 								<li Class="CombatExtended.RacePropertiesExtensionCE">
 									<bodyShape>Quadruped</bodyShape>
@@ -340,28 +340,28 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/PawnKindDef[defName="AA_MammothWorm_Temporary"]/combatPower</xpath>
+							<xpath>Defs/PawnKindDef[defName="AA_MammothWorm_Temporary"]/combatPower</xpath>
 							<value>
 								<combatPower>250</combatPower>
 							</value>
 						</li>
 						
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Blunt</xpath>
+							<xpath>Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Blunt</xpath>
 							<value>
 								<ArmorRating_Blunt>24</ArmorRating_Blunt>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Sharp</xpath>
+							<xpath>Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/ArmorRating_Sharp</xpath>
 							<value>
 								<ArmorRating_Sharp>10</ArmorRating_Sharp>
 							</value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/MoveSpeed</xpath>
+							<xpath>Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/statBases/MoveSpeed</xpath>
 							<value>
 								<MoveSpeed>2.7</MoveSpeed>
 								<MeleeDodgeChance>0.08</MeleeDodgeChance>
@@ -371,7 +371,7 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/tools</xpath>
+							<xpath>Defs/ThingDef[defName="AA_MammothWorm_Temporary"]/tools</xpath>
 							<value>
 								<tools>
 									<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackLarva.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackLarva.xml
@@ -14,7 +14,7 @@
 					<operations>
 
 						<li Class="PatchOperationAdd">
-						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/statBases</xpath>
+						  <xpath>Defs/ThingDef[defName="AA_BlackLarvae"]/statBases</xpath>
 						  <value>
 							<MeleeDodgeChance>0.06</MeleeDodgeChance>
 							<MeleeCritChance>0.02</MeleeCritChance>
@@ -23,14 +23,14 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/race/baseHealthScale</xpath>
+						  <xpath>Defs/ThingDef[defName="AA_BlackLarvae"]/race/baseHealthScale</xpath>
 						  <value>
 							<baseHealthScale>0.2</baseHealthScale>
 						  </value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-						  <xpath>/Defs/ThingDef[defName="AA_BlackLarvae"]/tools</xpath>
+						  <xpath>Defs/ThingDef[defName="AA_BlackLarvae"]/tools</xpath>
 						  <value>
 							<tools>
 							  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_BlackQueen.xml
@@ -14,7 +14,7 @@
 					<operations>
 
 						<li Class="PatchOperationAdd">
-						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases</xpath>
+						  <xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases</xpath>
 						  <value>
 							<MeleeDodgeChance>0.03</MeleeDodgeChance>
 							<MeleeCritChance>0.30</MeleeCritChance>
@@ -23,21 +23,21 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Blunt</xpath>
+						  <xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Blunt</xpath>
 						  <value>
 							<ArmorRating_Blunt>30</ArmorRating_Blunt>
 						  </value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Sharp</xpath>
+						  <xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/statBases/ArmorRating_Sharp</xpath>
 						  <value>
 							<ArmorRating_Sharp>12</ArmorRating_Sharp>
 						  </value>
 						</li>
 
 						<li Class="PatchOperationReplace">
-						  <xpath>/Defs/ThingDef[defName="AAVPE_BlackQueen"]/tools</xpath>
+						  <xpath>Defs/ThingDef[defName="AAVPE_BlackQueen"]/tools</xpath>
 						  <value>
 							<tools>
 							  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_OcularOriginator.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_OcularOriginator.xml
@@ -14,7 +14,7 @@
 					<operations>
 
 						<li Class="PatchOperationAddModExtension">
-							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]</xpath>
+							<xpath>Defs/ThingDef[defName="AA_OcularOriginator"]</xpath>
 							<value>
 								<li Class="CombatExtended.RacePropertiesExtensionCE">
 									<bodyShape>Birdlike</bodyShape>
@@ -23,7 +23,7 @@
 						</li>
 
 						<li Class="PatchOperationAdd">
-							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]/statBases</xpath>
+							<xpath>Defs/ThingDef[defName="AA_OcularOriginator"]/statBases</xpath>
 							<value>
 								<MeleeDodgeChance>0.3</MeleeDodgeChance>
 								<MeleeCritChance>0.04</MeleeCritChance>
@@ -32,7 +32,7 @@
 						</li>
 
 						<li Class="PatchOperationReplace">
-							<xpath>/Defs/ThingDef[defName="AA_OcularOriginator"]/tools</xpath>
+							<xpath>Defs/ThingDef[defName="AA_OcularOriginator"]/tools</xpath>
 							<value>
 								<tools>
 									<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_Summoned_Eyeling.xml
+++ b/Patches/Alpha Animals/AA_VPE/ThingDefs_Races/Races_Summoned_Eyeling.xml
@@ -17,7 +17,7 @@
 						<operations>
 
 							<li Class="PatchOperationAddModExtension">
-								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]</xpath>
+								<xpath>Defs/ThingDef[defName="AA_Summoned_Eyeling"]</xpath>
 								<value>
 									<li Class="CombatExtended.RacePropertiesExtensionCE">
 										<bodyShape>Quadruped</bodyShape>
@@ -26,7 +26,7 @@
 							</li>
 
 							<li Class="PatchOperationAdd">
-								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]/statBases</xpath>
+								<xpath>Defs/ThingDef[defName="AA_Summoned_Eyeling"]/statBases</xpath>
 								<value>
 									<MeleeDodgeChance>0.1</MeleeDodgeChance>
 									<MeleeCritChance>0.1</MeleeCritChance>
@@ -35,7 +35,7 @@
 							</li>
 
 							<li Class="PatchOperationReplace">
-								<xpath>/Defs/ThingDef[defName="AA_Summoned_Eyeling"]/tools</xpath>
+								<xpath>Defs/ThingDef[defName="AA_Summoned_Eyeling"]/tools</xpath>
 								<value>
 									<tools>
 										<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/DamageDef/AlphaAnimals_CE_Patch_DamageDef.xml
+++ b/Patches/Alpha Animals/DamageDef/AlphaAnimals_CE_Patch_DamageDef.xml
@@ -11,21 +11,21 @@
 					<!-- Changing the workerClass -->
 				
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[workerClass="DamageWorker_Stab"]/workerClass</xpath>
+					<xpath>Defs/DamageDef[workerClass="DamageWorker_Stab"]/workerClass</xpath>
 						<value>
 							<workerClass>DamageWorker_AddInjury</workerClass>
 						</value>
 					</li>
 					
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[workerClass="DamageWorker_Blunt"]/workerClass</xpath>
+					<xpath>Defs/DamageDef[workerClass="DamageWorker_Blunt"]/workerClass</xpath>
 						<value>
 							<workerClass>CombatExtended.DamageWorker_BluntCE</workerClass>
 						</value>
 					</li>
 
 					<li Class="PatchOperationAddModExtension">
-						<xpath>/Defs/DamageDef[defName="AA_AcidSpit" or defName="AA_SecondaryAcidBurn" or defName="AA_PermanentBurn"]</xpath>
+						<xpath>Defs/DamageDef[defName="AA_AcidSpit" or defName="AA_SecondaryAcidBurn" or defName="AA_PermanentBurn"]</xpath>
 						<value>
 							<li Class="CombatExtended.DamageDefExtensionCE">
 								<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>
@@ -37,7 +37,7 @@
 					<!-- Buffing some Hediffs -->
 					
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="AA_ToxicSting" or
+					<xpath>Defs/DamageDef[defName="AA_ToxicSting" or
 					defName="AA_InfectedClaws" or
 					defName="AA_ToxicBite" or
 					defName="AA_ToxicBolt"]/additionalHediffs/li[hediff="AA_ToxicBuildup"]/severityPerDamageDealt</xpath>
@@ -47,28 +47,28 @@
 					</li>
 					
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="AA_VeryToxicSting"]/additionalHediffs/li[hediff="AA_ToxicBuildup"]/severityPerDamageDealt</xpath>
+					<xpath>Defs/DamageDef[defName="AA_VeryToxicSting"]/additionalHediffs/li[hediff="AA_ToxicBuildup"]/severityPerDamageDealt</xpath>
 						<value>
 							<severityPerDamageDealt>0.03</severityPerDamageDealt>
 						</value>
 					</li>
 					
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="AA_ParalysingBite"]/additionalHediffs/li[hediff="AA_Paralysis"]/severityPerDamageDealt</xpath>
+					<xpath>Defs/DamageDef[defName="AA_ParalysingBite"]/additionalHediffs/li[hediff="AA_Paralysis"]/severityPerDamageDealt</xpath>
 						<value>
 							<severityPerDamageDealt>0.02</severityPerDamageDealt>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="AA_Electric"]/additionalHediffs/li[hediff="AA_Electric"]/severityPerDamageDealt</xpath>
+					<xpath>Defs/DamageDef[defName="AA_Electric"]/additionalHediffs/li[hediff="AA_Electric"]/severityPerDamageDealt</xpath>
 						<value>
 							<severityPerDamageDealt>0.025</severityPerDamageDealt>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="AA_SwarmlingClaws"]/additionalHediffs/li[hediff="AA_SwarmlingImplantation"]/severityPerDamageDealt</xpath>
+					<xpath>Defs/DamageDef[defName="AA_SwarmlingClaws"]/additionalHediffs/li[hediff="AA_SwarmlingImplantation"]/severityPerDamageDealt</xpath>
 						<value>
 							<severityPerDamageDealt>0.0003</severityPerDamageDealt>
 						</value>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AA_Resource_CEStuff.xml
@@ -8,14 +8,14 @@
 		<operations>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="AA_MeatMealBase"]/statBases</xpath>
+			<xpath>Defs/ThingDef[@Name="AA_MeatMealBase"]/statBases</xpath>
 			<value>
 				<Bulk>1</Bulk>
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="AA_CactipineQuill"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="AA_CactipineQuill"]/statBases</xpath>
 			<value>
 				<Bulk>0.1</Bulk>
 			</value>
@@ -23,7 +23,7 @@
 
 		<!-- ======== Red Wood ======== -->
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GU_RedWood"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -39,9 +39,9 @@
 		</li>
 
 				<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
 					<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
 						<value>
 							<equippedStatOffsets>
 								<MeleeCritChance>0.2</MeleeCritChance>
@@ -51,7 +51,7 @@
 						</value>
 					</nomatch>
 					<match Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]/equippedStatOffsets</xpath>
 						<value>
 							<equippedStatOffsets>
 								<MeleeCritChance>0.2</MeleeCritChance>
@@ -64,9 +64,9 @@
 
 
 				<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases/Bulk</xpath>
 					<nomatch Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 						<value>
 							<statBases>
 								<Bulk>0.07</Bulk>
@@ -85,7 +85,7 @@
 						</value>
 					</nomatch>
 					<match Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]/statBases</xpath>
 						<value>
 							<statBases>
 								<Bulk>0.07</Bulk>
@@ -106,16 +106,16 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors/Mass</xpath>
 					<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/statFactors</xpath>
 						<value>
 							<Mass>0.3</Mass>
 							<MeleePenetrationFactor>0.3</MeleePenetrationFactor>
 						</value>
 					</nomatch>
 					<match Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]/stuffProps/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]/stuffProps/Mass</xpath>
 						<value>
 							<Mass>0.3</Mass>
 						</value>
@@ -123,7 +123,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="GU_RedWood"]</xpath>
+					<xpath>Defs/ThingDef[defName="GU_RedWood"]</xpath>
 					<value>
 						<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
 							<toughnessMultiplier>5</toughnessMultiplier>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Gas.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Gas.xml
@@ -11,7 +11,7 @@
 			<!-- Adding CE's gas attributes to certain creatures, except OcularGas since it has a particular AA effect -->
 			
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_RedGas" or
+					<xpath>Defs/ThingDef[defName="AA_RedGas" or
 					defName="AA_SandPuff" or
 					defName="AA_Filth_Slime" or
 					defName="AA_Filth_RedSlime" or

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -9,7 +9,7 @@
 				<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
 
 				<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="AA_FrostWeb" or 
 				defName="AA_FireWeb" or 
 				defName="AA_AcidicWeb" or 
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="AA_AcidicWeb" or
 				defName="AA_Bullet_Barb" or
 				defName="AA_Bullet_VenomBarb" or
@@ -43,7 +43,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="AA_Bullet_Rock" or
 				defName="AA_ToxicInk" or
 				defName="AA_IncendiaryMote" or
@@ -56,7 +56,7 @@
 
 				<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
 				<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="AA_Barbslinger" or
 				defName="AA_Blizzarisk" or
 				defName="AA_BlizzariskClutchMother" or
@@ -91,7 +91,7 @@
 
 				<!-- Different accuracy for spammy stuff -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Needlepost" or defName="AA_Needleroll"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Needlepost" or defName="AA_Needleroll"]/statBases</xpath>
 					<value>
 						<AimingAccuracy>0.3</AimingAccuracy>
 					</value>
@@ -99,7 +99,7 @@
 
 				<!-- Different accuracy for Gallatross since his Projectile isn't directly under his control (it's just a random boulder he picks off the ground with his psionic abilities) -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Gallatross"]/statBases</xpath>
 					<value>
 						<AimingAccuracy>0.6</AimingAccuracy>
 					</value>
@@ -107,7 +107,7 @@
 
 				<!-- Dunelisk web, does burn damage but does not set the target on fire -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs</xpath>
+					<xpath>Defs</xpath>
 					<value>
 						<ThingDef ParentName="BaseBullet">
 							<defName>AA_BurnWeb</defName>
@@ -157,7 +157,7 @@
 
 				<!-- =============== Now defining Projectiles in CE Procedure ============= -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Bullet_Barb"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bullet_Barb"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -171,7 +171,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_PoisonBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_PoisonBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -185,7 +185,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_RedPoisonBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_RedPoisonBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -199,7 +199,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Plasma"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Plasma"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -213,7 +213,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Quill"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Quill"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -227,7 +227,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Bullet_VenomBarb"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bullet_VenomBarb"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -241,7 +241,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Bullet_Rock"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bullet_Rock"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<explosionRadius>1.5</explosionRadius>
@@ -259,7 +259,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Bullet_Rock"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bullet_Rock"]</xpath>
 					<value>
 						<comps>
 							<li Class="CombatExtended.CompProperties_Fragments">
@@ -273,7 +273,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_FrostWeb"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FrostWeb"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -294,7 +294,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_FireWeb"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FireWeb"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -315,7 +315,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_AcidicWeb"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AcidicWeb"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -337,7 +337,7 @@
 
 				<!-- ======== Note: AA_ExplodingWeb wasn't used in any Race, so it wasn't included. If it gets added, just add a secondaryDamage to the corresponding projectile, with the Bomb damageDef ======== -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Web"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Web"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -350,7 +350,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_IncendiaryMote"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_IncendiaryMote"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>20</speed>
@@ -368,7 +368,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ToxicInk"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ToxicInk"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>25</speed>
@@ -389,7 +389,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_FireSpit"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FireSpit"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -402,7 +402,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_AcidBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AcidBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -415,7 +415,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DarkBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DarkBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -427,7 +427,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ElectricBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ElectricBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -439,7 +439,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_WindBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -452,7 +452,7 @@
 
 				<!-- Windbolt uses an unsupported graphics class. -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_WindBolt"]/graphicData</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBolt"]/graphicData</xpath>
 					<value>
 						<graphicData>
 							<texPath>Things/Pawn/Animal/AA_ArcticLion/AA_ArcticLion_Invisible</texPath>
@@ -462,7 +462,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_FrostBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FrostBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<explosionDelay>1</explosionDelay>
@@ -481,7 +481,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs</xpath>
+					<xpath>Defs</xpath>
 					<value>
 						<ThingDef ParentName="BaseBullet">
 							<defName>AA_FlameBreathAnimated_CE</defName>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Resources_Leathers.xml
@@ -9,21 +9,21 @@
 
 				<!-- Remove GallatrossHorn as a weapon -->
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="AA_GallatrossHorn"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/tools</xpath>
 				</li>
 				<li Class="PatchOperationAttributeSet">
-					<xpath>/Defs/ThingDef[defName="AA_GallatrossHorn"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]</xpath>
 					<attribute>ParentName</attribute>
 					<value>ResourceBase</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_GallatrossHorn"]/description</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/description</xpath>
 					<value>
 						<description>A single horn of the mighty Gallatross. Proof that you're a warrior worthy of the title of Aberration Killer. Traders and collectors might pay a high price for this.</description>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_GallatrossHorn"]/statBases/MarketValue</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GallatrossHorn"]/statBases/MarketValue</xpath>
 					<value>
 						<MarketValue>1800</MarketValue>
 					</value>
@@ -31,42 +31,42 @@
 
 				<!-- SkySteel -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases</xpath>
 					<value>
 						<Bulk>0.025</Bulk>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/statFactors</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/statFactors</xpath>
 					<value>
 						<Mass>0.9</Mass>
 						<MeleePenetrationFactor>1.10</MeleePenetrationFactor>
 					</value>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/statBases/SharpDamageMultiplier</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/SharpDamageMultiplier</xpath>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/categories</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/stuffProps/categories</xpath>
 					<value>
 						<li>Metallic_Weapon</li>
 						<li>Steeled</li>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>2.0</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="AA_SkySteel"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
 						<StuffPower_Armor_Heat>-0.05</StuffPower_Armor_Heat>
 					</value>
@@ -74,13 +74,13 @@
 
 				<!-- Nehemoth leather -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Leather_Behemoth"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Leather_Behemoth"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Leather_Behemoth"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Leather_Behemoth"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.3</StuffPower_Armor_Blunt>
 					</value>
@@ -88,19 +88,19 @@
 
 				<!--aerofleet stuff and plant leather -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Leather_Aerofleet" or defName="Leather_Cactus"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Leather_Aerofleet" or defName="Leather_Cactus"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Leather_Aerofleet"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Leather_Aerofleet"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.032</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Leather_Cactus"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Cactus"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.032</StuffPower_Armor_Blunt>
 					</value>
@@ -108,13 +108,13 @@
 
 				<!-- Lion Leather -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ArcticLion_Leather" or defName="AA_SandLion_Leather"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>
 					</value>
@@ -122,13 +122,13 @@
 
 				<!-- Night Leather -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_Night"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Night"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.08</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Leather_Night"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Night"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.064</StuffPower_Armor_Blunt>
 					</value>
@@ -136,37 +136,37 @@
 
 				<!-- Chitin stuff-->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_Chitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Chitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.21</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_BlackChitin"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.16</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Leather_Chitin"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Chitin"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.36</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_RaptorPlates" or defName="Leather_IronChitin"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 					</value>
@@ -174,13 +174,13 @@
 
 				<!-- Gallatross Leather-->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_Gallatross"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Gallatross"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Leather_Gallatross"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="Leather_Gallatross"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.125</StuffPower_Armor_Blunt>
 					</value>
@@ -188,37 +188,37 @@
 
 				<!--Chameleon Yak -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolDesert" or defName="AA_ChameleonYakWoolTemperate"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolDesert" or defName="AA_ChameleonYakWoolTemperate"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolDesert" or defName="AA_ChameleonYakWoolTemperate"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolDesert" or defName="AA_ChameleonYakWoolTemperate"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolJungle"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ChameleonYakWoolWinter"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 					</value>
@@ -226,19 +226,19 @@
 
 				<!-- CinderSilk -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CinderSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
 						<StuffPower_Armor_Heat>0.02</StuffPower_Armor_Heat>
 					</value>
@@ -263,19 +263,19 @@
 
 				<!-- MothSilk -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.32</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="AA_MothSilk"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
 						<StuffPower_Armor_Heat>0.015</StuffPower_Armor_Heat>
 					</value>
@@ -300,7 +300,7 @@
 
 				<!-- Wools -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_GreyCoatedMouflonWool" or defName="AA_GiantCrownedSilkieSilk"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GreyCoatedMouflonWool" or defName="AA_GiantCrownedSilkieSilk"]/statBases</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 						<StuffPower_Armor_Blunt>0.045</StuffPower_Armor_Blunt>
@@ -308,19 +308,19 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Sharp</xpath>
 					<value>
 						<StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Blunt</xpath>
 					<value>
 						<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="AA_NightWool"]/statBases/StuffPower_Armor_Heat</xpath>
 					<value>
 						<StuffPower_Armor_Heat>0.06</StuffPower_Armor_Heat>
 					</value>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
@@ -10,7 +10,7 @@
 
 				<!-- Syntax
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName=""]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName=""]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -25,7 +25,7 @@
 				<!-- Black Hive Insects -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -47,7 +47,7 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -71,7 +71,7 @@
 					<!-- Barbslinger -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Barbslinger"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -95,7 +95,7 @@
 				<!-- Animalisk -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Animalisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Animalisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -119,7 +119,7 @@
 					<!-- Blizzarisk and Blizzarisk mom -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -141,7 +141,7 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -163,7 +163,7 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -187,7 +187,7 @@
 					<!-- Dunealisk and Dunemom -->
 
 						<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Dunealisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -209,7 +209,7 @@
 					</li>
 
 						<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -233,7 +233,7 @@
 					<!-- Feralisk and Fera-san -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Feralisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Feralisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -255,7 +255,7 @@
 					</li>
 
 				<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -279,7 +279,7 @@
 					<!-- Gallatross -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Gallatross"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -303,7 +303,7 @@
 					<!-- Gallatross Mounribound-->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_GallatrossMoribund"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_GallatrossMoribund"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -327,7 +327,7 @@
 					<!-- Green Goo -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_GreenGoo"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_GreenGoo"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -351,7 +351,7 @@
 					<!-- Infected Aerofleet -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_InfectedAerofleet"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_InfectedAerofleet"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -375,7 +375,7 @@
 					<!-- Junglelisk -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Junglelisk"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -399,7 +399,7 @@
 					<!-- Mantrap -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Mantrap"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -423,7 +423,7 @@
 					<!-- NeedlePost -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Needlepost"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -447,7 +447,7 @@
 					<!-- Needleroll -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Needleroll"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -471,7 +471,7 @@
 					<!-- NightAve -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_NightAve"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_NightAve"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -495,7 +495,7 @@
 					<!-- Nightling -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Nightling"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Nightling"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -519,7 +519,7 @@
 					<!-- Glassy Cat -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_CrystallineCaracal"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_CrystallineCaracal"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -542,7 +542,7 @@
 					<!-- OcularJelly -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_OcularJelly"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_OcularJelly"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -566,7 +566,7 @@
 					<!-- RedGoo -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_RedGoo"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_RedGoo"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -590,7 +590,7 @@
 					<!-- Plasmorph -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Plasmorph"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -614,7 +614,7 @@
 					<!-- RedSpore -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_RedSpore"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_RedSpore"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -638,7 +638,7 @@
 					<!-- TetraSlug -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_TetraSlug"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_TetraSlug"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -662,7 +662,7 @@
 					<!-- Thermadon -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Thermadon"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -686,7 +686,7 @@
 					<!-- Dark Beast -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Darkbeast"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -709,7 +709,7 @@
 					<!-- Erin -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Erin"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Erin"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -732,7 +732,7 @@
 					<!-- Thunderbeast -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -754,7 +754,7 @@
 					<!-- Windbeast -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_WindBeast"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -776,7 +776,7 @@
 					<!-- FrostLynx -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_FrostLynx"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_FrostLynx"]/verbs</xpath>
 							<value>
 								<verbs>
 									<li Class="CombatExtended.VerbPropertiesCE">
@@ -798,7 +798,7 @@
 					<!-- Behemoth -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Behemoth"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Alpha Animals/ThingDefs_Misc/Ideological_stuff.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/Ideological_stuff.xml
@@ -15,7 +15,7 @@
 					<!-- eye -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -35,14 +35,14 @@
 					</li>
 
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/ThingDef[defName="AA_Dryad_Spitter"]/statBases</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Dryad_Spitter"]/statBases</xpath>
 						<value>
    							<AimingAccuracy>0.6</AimingAccuracy>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_Dryad_Spitter"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_Dryad_Spitter"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -65,7 +65,7 @@
 					<!-- Nightling -->
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_OcularNightling"]/verbs</xpath>
+						<xpath>Defs/ThingDef[defName="AA_OcularNightling"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aerofleet.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aerofleet.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Aerofleet"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Aerofleet"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Aerofleet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Aerofleet"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.36</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -34,7 +34,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Aerofleet"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Aerofleet"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -63,7 +63,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_ColossalAerofleet"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ColossalAerofleet"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -72,7 +72,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_ColossalAerofleet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ColossalAerofleet"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.16</MeleeDodgeChance>
 					<MeleeCritChance>0.05</MeleeCritChance>
@@ -88,7 +88,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ColossalAerofleet"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ColossalAerofleet"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripawn.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripawn.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripawn"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripawn"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripawn"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripawn"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripawn"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripawn"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripawn"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripawn"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.07</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripawn"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripawn"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripod.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Agaripod.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripod"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripod"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripod"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripod"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>50</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripod"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripod"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>25</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripod"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripod"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.06</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Agaripod"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Agaripod"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AmoebaHuge.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AmoebaHuge.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.3</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaHuge"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Amoebachungus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Amoebachungus.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.00</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaLarge"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Amoebasmol.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Amoebasmol.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.00</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AcanthamoebaGiganteaSmall"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AngelaMorthal.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AngelaMorthal.xml
@@ -11,7 +11,7 @@
 			<!-- Larval Atispec -->
 			
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMothLarva"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMothLarva"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -20,7 +20,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMothLarva"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMothLarva"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.00</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -29,7 +29,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMothLarva"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMothLarva"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -49,7 +49,7 @@
 				</li>
 				
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMoth"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMoth"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -58,7 +58,7 @@
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMoth"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMoth"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.3</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -69,7 +69,7 @@
 				<!-- Atispec -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_AngelMoth"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_AngelMoth"]/tools</xpath>
 					<value>
 						<tools>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animalisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Animalisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Animalisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Animalisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Animalisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Animalisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Animalisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Animalisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Animalisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.28</MeleeCritChance>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Animalisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Animalisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animus_Vox.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Animus_Vox.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_AnimusVox"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AnimusVox"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_AnimusVox"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AnimusVox"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.36</MeleeDodgeChance>
 					<MeleeCritChance>0.02</MeleeCritChance>
@@ -34,7 +34,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_AnimusVox"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AnimusVox"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Arctic_Lion.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_ArcticLion"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ArcticLion"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -26,7 +26,7 @@
 
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_ArcticLion"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ArcticLion"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.34</MeleeCritChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ArcticLion"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ArcticLion"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Atispec.xml
@@ -11,7 +11,7 @@
 			<!-- Larval Atispec -->
 			
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_LarvalAtispec"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_LarvalAtispec"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -20,7 +20,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_LarvalAtispec"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_LarvalAtispec"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.00</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -29,7 +29,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_LarvalAtispec"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_LarvalAtispec"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -48,7 +48,7 @@
 				</li>
 				
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -57,21 +57,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>9</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>3</ArmorRating_Sharp>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]/statBases/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]/statBases/MoveSpeed</xpath>
 					<value>
 						<MoveSpeed>5</MoveSpeed>
 						<MeleeDodgeChance>0.35</MeleeDodgeChance>
@@ -81,7 +81,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]/comps</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]/comps</xpath>
 					<value>
 						<li Class="AnimalBehaviours.CompProperties_InitialHediff">
 						<hediffname>AA_LowBleed</hediffname>
@@ -93,7 +93,7 @@
 				<!-- Atispec -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Atispec"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Atispec"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AuroraSylph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_AuroraSylph.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_AuroraSylph"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AuroraSylph"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_AuroraSylph"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AuroraSylph"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.33</MeleeDodgeChance>
 					<MeleeCritChance>0</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_AuroraSylph"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_AuroraSylph"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Barb_Slinger.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Barbslinger"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Barbslinger"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.4</MeleeCritChance>
@@ -27,21 +27,21 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Barbslinger"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Barbslinger"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Barbslinger"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Barbslinger"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bed_Bug.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BedBug"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BedBug"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.4</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BedBug"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BedBug"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -41,7 +41,7 @@
 			</li>
 								
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BedBug"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BedBug"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Behemoth.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Behemoth.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]/statBases</xpath>
 					<value>
 						<AimingAccuracy>1.0</AimingAccuracy>
 						<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
@@ -40,28 +40,28 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>21</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]/statBases/ArmorRating_Heat</xpath>
 					<value>
 						<ArmorRating_Heat>0.6</ArmorRating_Heat>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Behemoth"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Behemoth"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -9,14 +9,14 @@
 			<operations>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="BaseInsect2"]/statBases</xpath>
+				<xpath>Defs/ThingDef[@Name="BaseInsect2"]/statBases</xpath>
 				<value>
 					<NightVisionEfficiency>0.5</NightVisionEfficiency>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -25,35 +25,35 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="AA_BlackScarab"]/combatPower</xpath>
+				<xpath>Defs/PawnKindDef[defName="AA_BlackScarab"]/combatPower</xpath>
 				<value>
 					<combatPower>60</combatPower>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2.55</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>4.9</MoveSpeed>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -62,7 +62,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackScarab"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackScarab"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -93,7 +93,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -102,28 +102,28 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>4.7</MoveSpeed>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.75</AimingAccuracy>
 					<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
@@ -135,21 +135,21 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="AA_BlackSpelopede"]/combatPower</xpath>
+				<xpath>Defs/PawnKindDef[defName="AA_BlackSpelopede"]/combatPower</xpath>
 				<value>
 					<combatPower>100</combatPower>
 				</value>
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/race/baseHealthScale</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/race/baseHealthScale</xpath>
 				<value>
 					<baseHealthScale>1.4</baseHealthScale>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpelopede"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -191,7 +191,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -200,35 +200,35 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/race/baseHealthScale</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/race/baseHealthScale</xpath>
 				<value>
 					<baseHealthScale>2.1</baseHealthScale>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>4.6</MoveSpeed>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.65</AimingAccuracy>
 					<ShootingAccuracyPawn>0.65</ShootingAccuracyPawn>
@@ -240,14 +240,14 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="AA_BlackSpider"]/combatPower</xpath>
+				<xpath>Defs/PawnKindDef[defName="AA_BlackSpider"]/combatPower</xpath>
 				<value>
 					<combatPower>200</combatPower>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlackSpider"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Blizzarisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Blizzarisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Blizzarisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -100,7 +100,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -109,21 +109,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 
 	               <li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.11</MeleeDodgeChance>
 					<MeleeCritChance>0.5</MeleeCritChance>
@@ -132,7 +132,7 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BlizzariskClutchMother"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bloodshrimp.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BloodShrimp"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BloodShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BloodShrimp"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BloodShrimp"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BloodShrimp"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bobeene.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bobeene.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Bobeene"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bobeene"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Bobeene"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bobeene"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.24</MeleeCritChance>
@@ -28,7 +28,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Bobeene"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Bobeene"]/tools</xpath>
 					<value>
 						<tools>
 						  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Boulder_Mit.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BoulderMit"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BoulderMit"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BoulderMit"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BoulderMit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>30</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BoulderMit"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BoulderMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BoulderMit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BoulderMit"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.00</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BoulderMit"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BoulderMit"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -69,7 +69,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_SummitCrab"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SummitCrab"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -78,20 +78,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SummitCrab"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SummitCrab"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SummitCrab"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SummitCrab"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>40</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_SummitCrab"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SummitCrab"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.00</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -100,7 +100,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SummitCrab"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SummitCrab"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Bumbledrone.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Bumbledrone"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Bumbledrone"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Bumbledrone"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Bumbledrone"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.18</MeleeDodgeChance>
 					<MeleeCritChance>0.05</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Bumbledrone"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Bumbledrone"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -69,7 +69,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneHierophant"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneHierophant"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -78,7 +78,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneHierophant"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneHierophant"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.18</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -87,7 +87,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneHierophant"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneHierophant"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -129,7 +129,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneQueen"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneQueen"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -138,7 +138,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneQueen"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneQueen"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.11</MeleeDodgeChance>
 					<MeleeCritChance>0.17</MeleeCritChance>
@@ -147,7 +147,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_BumbledroneQueen"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_BumbledroneQueen"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cactipine.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cactipine.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Cactipine"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cactipine"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Cactipine"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cactipine"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.18</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Cactipine"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cactipine"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Chameleon Yak.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Chameleon Yak.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_ChameleonYak"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChameleonYak"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_ChameleonYak"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChameleonYak"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.35</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ChameleonYak"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChameleonYak"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ChemfuelMyrmidon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ChemfuelMyrmidon.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>0.24</MeleeCritChance>
@@ -50,7 +50,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ChemfuelMyrmidon"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Cinderlisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.20</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -50,7 +50,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Cinderlisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Cinderlisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrepuscularBeetle.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrepuscularBeetle"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrepuscularBeetle"]/statBases</xpath>
 				<value>
 					<NightVisionEfficiency>0.8</NightVisionEfficiency>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
@@ -42,7 +42,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrepuscularBeetle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrepuscularBeetle"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrescendoAnole.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrescendoAnole.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_CrescendoAnole"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrescendoAnole"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -15,7 +15,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_CrescendoAnole"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrescendoAnole"]/statBases</xpath>
 					<!-- Used CE's formula to calculate these values -->
 					<!-- (Note this is a lizard that grows strong when angered) -->
 					<value>
@@ -25,7 +25,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_CrescendoAnole"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrescendoAnole"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystalMit.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrystalMit"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrystalMit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrystalMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrystalMit"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.07</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_CrystalMit"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_CrystalMit"]/tools</xpath>
 				<value>
 					<tools>
 						      <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystallineCaracal.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_CrystallineCaracal.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_CrystallineCaracal"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrystallineCaracal"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,7 +16,7 @@
 				</li>
 				<!-- Used weight of a cougar to generate these -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_CrystallineCaracal"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrystallineCaracal"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.18</MeleeDodgeChance>
 						<MeleeCritChance>0.08</MeleeCritChance>
@@ -24,7 +24,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_CrystallineCaracal"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_CrystallineCaracal"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkBeast.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Darkbeast"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,21 +16,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Darkbeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Darkbeast"]/statBases</xpath>
 					<value>
 						<NightVisionEfficiency>0.8</NightVisionEfficiency>
 						<MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -40,7 +40,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Darkbeast"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Darkbeast"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkVandal.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DarkVandal.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_DarkVandal"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DarkVandal"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_DarkVandal"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DarkVandal"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.3</MeleeCritChance>
@@ -28,7 +28,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DarkVandal"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DarkVandal"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DecayDrake.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DecayDrake.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_DecayDrake"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DecayDrake"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_DecayDrake"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DecayDrake"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
@@ -28,7 +28,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DecayDrake"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DecayDrake"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Desert Aves.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Desert Aves.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_DesertAve"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DesertAve"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_DesertAve"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DesertAve"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.35</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DesertAve"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DesertAve"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Devil_Sheep.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Devil_Sheep.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_DevilSheep"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DevilSheep"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_DevilSheep"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DevilSheep"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.11</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DevilSheep"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DevilSheep"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Drainer.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Drainer.xml
@@ -11,7 +11,7 @@
 			<!-- Larval Drainer -->
 			
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_DrainerLarva"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DrainerLarva"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -20,7 +20,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_DrainerLarva"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DrainerLarva"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.00</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -29,7 +29,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DrainerLarva"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DrainerLarva"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -49,7 +49,7 @@
 				</li>
 				
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Drainer"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Drainer"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -58,7 +58,7 @@
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Drainer"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Drainer"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.3</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -69,7 +69,7 @@
 				<!-- Atispec -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Drainer"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Drainer"]/tools</xpath>
 					<value>
 						<tools>
 

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Dunealisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Dunealisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Dunealisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Dunealisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Dunealisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Dunealisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Dunealisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -99,7 +99,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -108,20 +108,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.18</MeleeDodgeChance>
 					<MeleeCritChance>0.5</MeleeCritChance>
@@ -130,7 +130,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DunealiskClutchMother"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DunealiskClutchMother"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskProwler.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_DuskProwler"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DuskProwler"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_DuskProwler"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DuskProwler"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.9</MeleeDodgeChance>
 						<MeleeCritChance>0.27</MeleeCritChance>
@@ -28,21 +28,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DuskProwler"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DuskProwler"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>1</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DuskProwler"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DuskProwler"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_DuskProwler"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_DuskProwler"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskRat.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_DuskRat.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_DuskRat"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DuskRat"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_DuskRat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DuskRat"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.52</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_DuskRat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_DuskRat"]/tools</xpath>
 				<value>
 					<tools>
 					  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EmpressButterfly.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EmpressButterfly.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>	
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterflyLarva"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterflyLarva"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -15,7 +15,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.00</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -23,7 +23,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterflyLarva"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -41,7 +41,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterfly"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Birdlike</bodyShape>
@@ -49,7 +49,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterfly"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.3</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -57,7 +57,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_EmpressButterfly"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_EmpressButterfly"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EngorgedTentacularAberration.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_EngorgedTentacularAberration.xml
@@ -13,7 +13,7 @@
 				<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>3.0</MoveSpeed>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -32,7 +32,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -63,7 +63,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="AA_EngorgedTentacularAberration"]/comps</xpath>
 				<value>
 					<li Class="AnimalBehaviours.CompProperties_InitialHediff">
 					<hediffname>AA_LowBleed</hediffname>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Erin.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Erin.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Erin"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Erin"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,7 +16,7 @@
 				</li>
 				<!-- Don't know about balancing -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Erin"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Erin"]/statBases</xpath>
 					<value>
 						<ArmorRating_Blunt>1</ArmorRating_Blunt>
 						<ArmorRating_Sharp>0.12</ArmorRating_Sharp>
@@ -26,7 +26,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Erin"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Erin"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Eyeling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Eyeling.xml
@@ -13,7 +13,7 @@
 				<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Eyeling"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Eyeling"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Eyeling"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Eyeling"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -31,7 +31,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Eyeling"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Eyeling"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Feralisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Feralisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Feralisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Feralisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Feralisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Feralisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Feralisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Feralisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Feralisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Feralisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Feralisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -99,7 +99,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -108,20 +108,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.11</MeleeDodgeChance>
 					<MeleeCritChance>0.5</MeleeCritChance>
@@ -130,7 +130,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FeraliskClutchMother"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FeraliskClutchMother"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Firewasp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Firewasp.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FireWasp"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FireWasp"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FireWasp"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FireWasp"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
 					<MeleeCritChance>0.05</MeleeCritChance>
@@ -36,7 +36,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FireWasp"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FireWasp"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FissionMouse.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FissionMouse.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouse"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouse"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouse"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouse"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.23</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouse"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouse"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -79,7 +79,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseSecond"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseSecond"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -88,7 +88,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseSecond"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseSecond"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.17</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -97,7 +97,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseSecond"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseSecond"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -149,7 +149,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseThird"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseThird"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -158,7 +158,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseThird"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseThird"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.05</MeleeCritChance>
@@ -167,7 +167,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FissionMouseThird"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FissionMouseThird"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FlamigoPheonix.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FlamigoPheonix.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FlamingoPhoenix"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FlamingoPhoenix"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FlamingoPhoenix"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FlamingoPhoenix"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.24</MeleeDodgeChance>
 					<MeleeCritChance>0.03</MeleeCritChance>
@@ -36,7 +36,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FlamingoPhoenix"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FlamingoPhoenix"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostLynx.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostLynx.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_FrostLynx"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FrostLynx"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,7 +16,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_FrostLynx"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FrostLynx"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.26</MeleeDodgeChance>
 						<MeleeCritChance>0.20</MeleeCritChance>
@@ -25,7 +25,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_FrostLynx"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_FrostLynx"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frost_Ave.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frost_Ave.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FrostAve"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostAve"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FrostAve"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostAve"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.32</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FrostAve"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostAve"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostboundBehemoth.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FrostboundBehemoth.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FrostboundBehemoth"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostboundBehemoth"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostboundBehemoth"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.22</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FrostboundBehemoth"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FrostboundBehemoth"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostling.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Frostling"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostling"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostling"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostling"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostling"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostling"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Frostling"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostling"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.3</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostling"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostling"]/tools</xpath>
 				<value>
 					<tools>
 						  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Frostmite.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostmite"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostmite"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostmite"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Frostmite"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Frostmite"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_FungalHusk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_FungalHusk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FungalHusk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Humanoid</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_FungalHusk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FungalHusk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.17</MeleeDodgeChance>
 					<MeleeCritChance>0.33</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_FungalHusk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_FungalHusk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gallatross.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gallatross"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gallatross"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>26</ArmorRating_Blunt>
 					<ArmorRating_Sharp>13</ArmorRating_Sharp>
@@ -29,7 +29,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gallatross"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -71,7 +71,7 @@
 			<!-- Add Low Bleed Hediff -->
 
 			<li Class="PatchOperationAdd"> 
-			<xpath>/Defs</xpath>
+			<xpath>Defs</xpath>
 				<value>
 					<HediffDef>
 						<defName>AA_LowBleed</defName>
@@ -92,9 +92,9 @@
 			<!-- Add Low Bleed Hediff -->
 
 			<li Class="PatchOperationConditional">
-			<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
+			<xpath>Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Gallatross"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Gallatross"]</xpath>
 					<value>
 						<comps />
 					</value>
@@ -102,7 +102,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
 				<value>
 					<li Class="AnimalBehaviours.CompProperties_InitialHediff">
 						<hediffname>AA_LowBleed</hediffname>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Genix.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Genix.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Genix"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Genix"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,7 +16,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Genix"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Genix"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.26</MeleeDodgeChance>
 						<MeleeCritChance>0.20</MeleeCritChance>
@@ -25,7 +25,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Genix"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Genix"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GiantCrownedSilkie.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GiantCrownedSilkie.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_GiantCrownedSilkie"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GiantCrownedSilkie"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GiantCrownedSilkie"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GiantCrownedSilkie"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>5</MoveSpeed>
 					<MeleeDodgeChance>0.17</MeleeDodgeChance>
@@ -28,7 +28,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GiantCrownedSilkie"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GiantCrownedSilkie"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gigantelope.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Gigantelope.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Gigantelope"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gigantelope"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Gigantelope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gigantelope"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.22</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Gigantelope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gigantelope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Great_Devourer.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreatDevourer"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreatDevourer"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreatDevourer"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.45</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GreatDevourer"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreatDevourer"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreenGoo.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreenGoo.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_GreenGoo"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreenGoo"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_GreenGoo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreenGoo"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.4</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GreenGoo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GreenGoo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreyCoatedMouflon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_GreyCoatedMouflon.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_GreyCoatedMouflon"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GreyCoatedMouflon"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -16,7 +16,7 @@
 				</li>
 				<!-- Don't know about balancing -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_GreyCoatedMouflon"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GreyCoatedMouflon"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.05</MeleeDodgeChance>
 						<MeleeCritChance>0.07</MeleeCritChance>
@@ -24,7 +24,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_GreyCoatedMouflon"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_GreyCoatedMouflon"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Groundrunner.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Groundrunner"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Groundrunner"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Groundrunner"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Groundrunner"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Groundrunner"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Groundrunner"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Groundrunner"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Groundrunner"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Helixien.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Helixien.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Helixien"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Helixien"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Serpentine</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Helixien"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Helixien"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.00</MeleeDodgeChance>
 					<MeleeCritChance>0.5</MeleeCritChance>
@@ -28,7 +28,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Helixien"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Helixien"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_InfectedAerofleet.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_InfectedAerofleet.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_InfectedAerofleet"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_InfectedAerofleet"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_InfectedAerofleet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_InfectedAerofleet"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_InfectedAerofleet"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_InfectedAerofleet"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ironhusk_Beetle.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_IronhuskBeetle"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_IronhuskBeetle"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_IronhuskBeetle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_IronhuskBeetle"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Junglelisk.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Junglelisk"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Junglelisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Junglelisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Junglelisk"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.2</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Junglelisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Junglelisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Lockjaw.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Lockjaw.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Lockjaw"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Lockjaw"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Lockjaw"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Lockjaw"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.65</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Lockjaw"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Lockjaw"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Luciferbug.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_LuciferBug"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_LuciferBug"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_LuciferBug"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_LuciferBug"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_LuciferBug"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mammoth_Worm.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MammothWorm"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,28 +18,28 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="AA_MammothWorm"]/combatPower</xpath>
+				<xpath>Defs/PawnKindDef[defName="AA_MammothWorm"]/combatPower</xpath>
 				<value>
 					<combatPower>250</combatPower>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>24</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MammothWorm"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MammothWorm"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>2.7</MoveSpeed>
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
@@ -49,7 +49,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MammothWorm"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MammothWorm"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mantrap.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mantrap"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mantrap"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mantrap"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.14</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Mantrap"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mantrap"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MatureFleshbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MatureFleshbeast.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MatureFleshbeast"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -19,11 +19,11 @@
 
 			<!-- Remove the 'Swallow Whole' attack, since it doesn't work in CE and insta-kills instead. -->
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MatureFleshbeast"]/thingClass</xpath>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MatureFleshbeast"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.23</MeleeCritChance>
@@ -31,7 +31,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MatureFleshbeast"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MatureFleshbeast"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Meadow_Ave.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Meadow_Ave.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_MeadowAve"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MeadowAve"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_MeadowAve"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MeadowAve"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.35</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MeadowAve"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MeadowAve"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MegaLouse.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,35 +18,35 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/PawnKindDef[defName="AA_MegaLouse"]/combatPower</xpath>
+				<xpath>Defs/PawnKindDef[defName="AA_MegaLouse"]/combatPower</xpath>
 				<value>
 					<combatPower>50</combatPower>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>3.8</MoveSpeed>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -55,7 +55,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MegaLouse"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MegaLouse"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Metallovore.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Metallovore.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Metallovore"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Metallovore"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Metallovore"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Metallovore"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.18</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Metallovore"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Metallovore"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mimes.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Mimes.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Mime"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mime"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Humanoid</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Mime"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mime"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Mime"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Mime"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MoribundGallatross.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_GallatrossMoribund"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GallatrossMoribund"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_GallatrossMoribund"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GallatrossMoribund"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>26</ArmorRating_Blunt>
 					<ArmorRating_Sharp>13</ArmorRating_Sharp>
@@ -29,7 +29,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_GallatrossMoribund"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_GallatrossMoribund"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -71,9 +71,9 @@
 			<!-- Add Low Bleed Hediff -->
 
 			<li Class="PatchOperationConditional">
-			<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
+			<xpath>Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Gallatross"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Gallatross"]</xpath>
 					<value>
 						<comps />
 					</value>
@@ -81,7 +81,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Gallatross"]/comps</xpath>
 				<value>
 					<li Class="AnimalBehaviours.CompProperties_InitialHediff">
 						<hediffname>AA_LowBleed</hediffname>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Murkling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Murkling.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Murkling"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Murkling"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Murkling"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Murkling"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.6</MeleeDodgeChance>
 						<MeleeCritChance>0.01</MeleeCritChance>
@@ -27,7 +27,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Murkling"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Murkling"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_MycoidColossus.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_MycoidColossus"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MycoidColossus"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_MycoidColossus"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MycoidColossus"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>0.14</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_MycoidColossus"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_MycoidColossus"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needlepost.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needlepost"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needlepost"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needlepost"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Needlepost"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needlepost"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Needleroll.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needleroll"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needleroll"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needleroll"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Needleroll"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Needleroll"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_NightMule.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_NightMule.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_NightMule"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightMule"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_NightMule"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightMule"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.04</MeleeDodgeChance>
 					<MeleeCritChance>0.2</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_NightMule"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightMule"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_NightRam.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_NightRam.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_NightRam"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightRam"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_NightRam"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightRam"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_NightRam"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightRam"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Night_Aves.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Night_Aves.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_NightAve"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightAve"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_NightAve"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightAve"]/statBases</xpath>
 				<value>
 					<NightVisionEfficiency>0.8</NightVisionEfficiency>
 					<MeleeDodgeChance>0.45</MeleeDodgeChance>
@@ -28,7 +28,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_NightAve"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_NightAve"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Nightling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Nightling.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Nightling"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Nightling"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Nightling"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Nightling"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>7.2</MoveSpeed>
 					<NightVisionEfficiency>0.8</NightVisionEfficiency>
@@ -29,7 +29,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Nightling"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Nightling"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularJelly.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularJelly.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_OcularJelly"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularJelly"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_OcularJelly"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularJelly"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_OcularJelly"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularJelly"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularNightling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_OcularNightling.xml
@@ -13,7 +13,7 @@
 				<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_OcularNightling"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularNightling"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_OcularNightling"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularNightling"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>6.8</MoveSpeed>
 					<NightVisionEfficiency>0.8</NightVisionEfficiency>
@@ -34,7 +34,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_OcularNightling"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_OcularNightling"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Overgrown_Colossus.xml
@@ -7,7 +7,7 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_OvergrownColossus" or
+					<xpath>Defs/ThingDef[defName="AA_OvergrownColossus" or
 						defName="AA_AnimaColossus"
 						]</xpath>
 					<value>
@@ -17,7 +17,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_OvergrownColossus" or
+					<xpath>Defs/ThingDef[defName="AA_OvergrownColossus" or
 						defName="AA_AnimaColossus"
 						]/statBases</xpath>
 					<value>
@@ -27,7 +27,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_OvergrownColossus" or
+					<xpath>Defs/ThingDef[defName="AA_OvergrownColossus" or
 						defName="AA_AnimaColossus"
 						]/tools</xpath>
 					<value>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Pebble_Mit.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PebbleMit"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>15</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PebbleMit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PebbleMit"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.05</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_PebbleMit"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PebbleMit"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_PedigreedRaptor.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_PedigreedRaptor.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_PedigreedRaptor"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PedigreedRaptor"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_PedigreedRaptor"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PedigreedRaptor"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.27</MeleeDodgeChance>
 					<MeleeCritChance>0.13</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_PedigreedRaptor"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PedigreedRaptor"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_PheonixOwlcat.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_PheonixOwlcat.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_PhoenixOwlcat"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PhoenixOwlcat"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_PhoenixOwlcat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PhoenixOwlcat"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.36</MeleeDodgeChance>
 					<MeleeCritChance>0.02</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_PhoenixOwlcat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_PhoenixOwlcat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Plasmorph.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Plasmorph"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Serpentine</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Plasmorph"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
@@ -42,7 +42,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Plasmorph"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>0.05</MeleeCritChance>
@@ -51,7 +51,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Plasmorph"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Plasmorph"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Radyak.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Radyak.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Radyak"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Radyak"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Radyak"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Radyak"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.04</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Radyak"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Radyak"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Raptor_Shrimp.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RaptorShrimp"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,14 +18,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RaptorShrimp"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
@@ -35,7 +35,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RaptorShrimp"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RaptorShrimp"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Ravager.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,28 +18,28 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>8</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]/race/baseHealthScale</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]/race/baseHealthScale</xpath>
 				<value>
 					<baseHealthScale>3.1</baseHealthScale>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>
 					<MeleeCritChance>0.36</MeleeCritChance>
@@ -48,7 +48,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Ravager"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Ravager"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Rayhound.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RayHound"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RayHound"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,21 +18,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RayHound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RayHound"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.33</MeleeDodgeChance>
 					<MeleeCritChance>0.18</MeleeCritChance>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RayHound"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RayHound"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Razorjack.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Razorjack.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Razorjack"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Razorjack"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Razorjack"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Razorjack"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.02</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Razorjack"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Razorjack"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RedGoo.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RedGoo.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RedGoo"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedGoo"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RedGoo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedGoo"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.06</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RedGoo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedGoo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RedSpore.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RedSpore.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RedSpore"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedSpore"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RedSpore"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedSpore"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
 					<MeleeCritChance>0.06</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RedSpore"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RedSpore"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RipperHound.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RipperHound"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RipperHound"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,21 +27,21 @@
 			</li>
 				
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RipperHound"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1.85</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RipperHound"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RipperHound"]/tools</xpath>
 				<value>
 					<tools>
 					  <li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_RoughPlatedMonitor.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoughPlatedMonitor"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Serpentine</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3.4</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1.6</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.24</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoughPlatedMonitor"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Royal_Aves.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Royal_Aves.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_RoyalAve"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoyalAve"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_RoyalAve"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoyalAve"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_RoyalAve"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_RoyalAve"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandLion.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_SandLion"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandLion"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_SandLion"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandLion"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.56</MeleeDodgeChance>
 					<MeleeCritChance>0.24</MeleeCritChance>
@@ -34,7 +34,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandLion"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandLion"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandProwler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SandProwler.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_SandProwler"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandProwler"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_SandProwler"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandProwler"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.66</MeleeDodgeChance>
 					<MeleeCritChance>0.27</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandProwler"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandProwler"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Sand_Squid.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandSquid"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Serpentine</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>18</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandSquid"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandSquid"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.08</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SandSquid"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SandSquid"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShadowCharger.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShadowCharger.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_ShadowCharger"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ShadowCharger"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_ShadowCharger"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ShadowCharger"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.4</MeleeCritChance>
@@ -28,7 +28,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_ShadowCharger"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_ShadowCharger"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShockGoat.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_ShockGoat.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_ShockGoat"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ShockGoat"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_ShockGoat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ShockGoat"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.07</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ShockGoat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ShockGoat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skiphound.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skiphound.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Skiphound"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skiphound"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Skiphound"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skiphound"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>0.18</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Skiphound"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skiphound"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Skyeel.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skyeel"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.8</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skyeel"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.3</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skyeel"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.4</MeleeDodgeChance>
 					<MeleeCritChance>0.03</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Skyeel"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Skyeel"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Slurrypede.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Slurrypede"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Slurrypede"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,20 +27,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Slurrypede"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>9</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Slurrypede"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Slurrypede"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SpinedGow.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_SpinedGow.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_SpinedGow"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SpinedGow"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_SpinedGow"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SpinedGow"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.04</MeleeDodgeChance>
 					<MeleeCritChance>0.32</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_SpinedGow"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_SpinedGow"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Swarmling.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Swarmling.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Swarmling"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Swarmling"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Swarmling"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Swarmling"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.33</MeleeDodgeChance>
 					<MeleeCritChance>0</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Swarmling"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Swarmling"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_TarGuzzler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_TarGuzzler.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_TarGuzzler"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TarGuzzler"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_TarGuzzler"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TarGuzzler"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
@@ -29,7 +29,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_TarGuzzler"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TarGuzzler"]/tools</xpath>
 				<value>
 					<tools>
 						

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_TeratogenicOriginator.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_TeratogenicOriginator.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_TeratogenicOriginator"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TeratogenicOriginator"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_TeratogenicOriginator"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TeratogenicOriginator"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_TeratogenicOriginator"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TeratogenicOriginator"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Terramorph.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Terramorph"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Terramorph"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>9</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Terramorph"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.02</MeleeDodgeChance>
 					<MeleeCritChance>0.27</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Terramorph"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Terramorph"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Tetra_Slug.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Tetra_Slug.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_TetraSlug"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TetraSlug"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Serpentine</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_TetraSlug"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TetraSlug"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.06</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_TetraSlug"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_TetraSlug"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thermadon.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]/statBases</xpath>
 				<value>
 					<NightVisionEfficiency>0.5</NightVisionEfficiency>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -41,7 +41,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/race/baseHealthScale</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]/race/baseHealthScale</xpath>
 				<value>
 					<baseHealthScale>2</baseHealthScale>
 				</value>
@@ -58,7 +58,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Thermadon"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Thermadon"]/tools</xpath>
 				<value>
 					<tools>
 					<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderbeast.xml
@@ -8,7 +8,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -17,14 +17,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>2.8</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 					</value>
@@ -32,7 +32,7 @@
 
 				<!-- Don't know about balancing -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.1</MeleeDodgeChance>
 						<MeleeCritChance>0.16</MeleeCritChance>
@@ -41,7 +41,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderbeast"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderbeast"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderox.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Thunderox.xml
@@ -10,7 +10,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderox"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderox"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderox"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderox"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.03</MeleeDodgeChance>
 						<MeleeCritChance>0.45</MeleeCritChance>
@@ -28,7 +28,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_Thunderox"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_Thunderox"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_UnblinkingEye.xml
@@ -13,7 +13,7 @@
 				<operations>
 
 					<li Class="PatchOperationAddModExtension">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]</xpath>
 						<value>
 							<li Class="CombatExtended.RacePropertiesExtensionCE">
 								<bodyShape>Birdlike</bodyShape>
@@ -22,7 +22,7 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/MoveSpeed</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/MoveSpeed</xpath>
 						<value>
 							<MoveSpeed>4</MoveSpeed>
 							<NightVisionEfficiency>0.8</NightVisionEfficiency>
@@ -34,20 +34,20 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Blunt</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Blunt</xpath>
 						<value>
 							<ArmorRating_Blunt>9.85</ArmorRating_Blunt>
 						</value>
 					</li>
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Sharp</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/statBases/ArmorRating_Sharp</xpath>
 						<value>
 							<ArmorRating_Sharp>4.25</ArmorRating_Sharp>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/tools</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/tools</xpath>
 						<value>
 							<tools>
 								<li Class="CombatExtended.ToolCE">
@@ -75,7 +75,7 @@
 					</li>
 
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/ThingDef[defName="AA_UnblinkingEye"]/comps</xpath>
+						<xpath>Defs/ThingDef[defName="AA_UnblinkingEye"]/comps</xpath>
 						<value>
 							<li Class="AnimalBehaviours.CompProperties_InitialHediff">
 							<hediffname>AA_LowBleed</hediffname>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_WaywardAssembler.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,20 +27,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>16</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>7</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/comps/li[@Class ="AnimalBehaviours.CompProperties_AnimalProduct"]/randomItems</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/comps/li[@Class ="AnimalBehaviours.CompProperties_AnimalProduct"]/randomItems</xpath>
 				<value>
 					<li>FSX</li>
 					<li>Prometheum</li>
@@ -48,7 +48,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_WaywardMobileAssembler"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpawn.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpawn.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpawn"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpawn"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpawn"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpawn"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>20</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpawn"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpawn"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpawn"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpawn"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.07</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpawn"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpawn"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Wildpod.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpod"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -18,20 +18,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpod"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>23</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpod"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.06</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
@@ -40,7 +40,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Wildpod"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Wildpod"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Windbeast.xml
@@ -8,7 +8,7 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBeast"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Quadruped</bodyShape>
@@ -17,21 +17,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>2.8</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBeast"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.65</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBeast"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.1</MeleeDodgeChance>
 						<MeleeCritChance>0.16</MeleeCritChance>
@@ -40,7 +40,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="AA_WindBeast"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="AA_WindBeast"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
+++ b/Patches/Alpha Animals/VFE_Mechs/VFESlurrymaster.xml
@@ -13,7 +13,7 @@
 					<operations>
 
 					<li Class="PatchOperationAddModExtension">
-						<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]</xpath>
+						<xpath>Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]</xpath>
 						<value>
 							<li Class="CombatExtended.RacePropertiesExtensionCE">
 								<bodyShape>QuadrupedLow</bodyShape>
@@ -22,7 +22,7 @@
 					</li>
 
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases</xpath>
+						<xpath>Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases</xpath>
 						<value>
 							<MeleeDodgeChance>0.17</MeleeDodgeChance>
 							<MeleeCritChance>0.1</MeleeCritChance>
@@ -31,20 +31,20 @@
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Blunt</xpath>
+						<xpath>Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Blunt</xpath>
 						<value>
 							<ArmorRating_Blunt>25</ArmorRating_Blunt>
 						</value>
 					</li>
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Sharp</xpath>
+						<xpath>Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/statBases/ArmorRating_Sharp</xpath>
 						<value>
 							<ArmorRating_Sharp>11</ArmorRating_Sharp>
 						</value>
 					</li>
 
 					<li Class="PatchOperationReplace">
-						<xpath>/Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/tools</xpath>
+						<xpath>Defs/ThingDef[defName="VFE_Mech_Slurrymaster"]/tools</xpath>
 						<value>
 							<tools>
 								<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Biomes/Items_Resource_Stuff.xml
+++ b/Patches/Alpha Biomes/Items_Resource_Stuff.xml
@@ -9,7 +9,7 @@
 
 		<!-- ======== Psychotropic Fungus ======== -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="AB_PsychotropicFungus"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="AB_PsychotropicFungus"]/statBases</xpath>
 			<value>
 				<Bulk>0.05</Bulk>
 			</value>
@@ -17,28 +17,28 @@
 
 		<!-- ======== Alcyonite Chunk ======== -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases</xpath>
 			<value>
 				<Bulk>0.03</Bulk>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Sharp</xpath>
 			<value>
 				<StuffPower_Armor_Sharp>1.1</StuffPower_Armor_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Blunt</xpath>
 			<value>
 				<StuffPower_Armor_Blunt>1.7</StuffPower_Armor_Blunt>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Heat</xpath>
+			<xpath>Defs/ThingDef[defName="AB_AlcyoniteChunk"]/statBases/StuffPower_Armor_Heat</xpath>
 			<value>
 				<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 			</value>
@@ -47,7 +47,7 @@
 		<!-- ======== Red, Crystal and Mushroom Wood ======== -->
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -63,7 +63,7 @@
 		</li>
 
 		<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
+			<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]</xpath>
 			<value>
 				<li Class="CombatExtended.StuffToughnessMultiplierExtensionCE">
 					<toughnessMultiplier>4</toughnessMultiplier>
@@ -79,7 +79,7 @@
 		<operations>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/equippedStatOffsets</xpath>
 				<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.2</MeleeCritChance>
@@ -90,7 +90,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<Bulk>0.07</Bulk>
 					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
@@ -99,14 +99,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
 				</value>
@@ -119,7 +119,7 @@
 		<operations>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<Bulk>0.07</Bulk>
 					<MeleeCounterParryBonus>1.33</MeleeCounterParryBonus>
@@ -128,14 +128,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.2</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>Defs/ThingDef[defName="GU_RedWood" or defName="AB_MushroomWoodLog" or defName="AB_CrystalWood"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0.025</StuffPower_Armor_Heat>
 				</value>

--- a/Patches/Alpha Mythology/AM_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Mythology/AM_CE_Patch_Projectiles.xml
@@ -8,7 +8,7 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="MM_Quill" or
 				defName="MM_Tremor" or
 				defName="MM_WispProjectile" or
@@ -21,7 +21,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Quill"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Quill"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -36,7 +36,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Tremor"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Tremor"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -49,7 +49,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_WispProjectile"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WispProjectile"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>
@@ -61,7 +61,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_AcidicBreath"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="MM_AcidicBreath"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>20</speed>
@@ -73,7 +73,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_RazorSharpFeathers"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="MM_RazorSharpFeathers"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<speed>24</speed>
@@ -88,7 +88,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs</xpath>
+					<xpath>Defs</xpath>
 					<value>
 						<ThingDef ParentName="BaseBullet">
 							<defName>MM_GazeAttack_CE</defName>
@@ -147,7 +147,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/DamageDef[defName="MM_PetrifyingGaze"]/additionalHediffs/li[hediff="MM_Petrification"]/severityPerDamageDealt</xpath>
+					<xpath>Defs/DamageDef[defName="MM_PetrifyingGaze"]/additionalHediffs/li[hediff="MM_Petrification"]/severityPerDamageDealt</xpath>
 					<value>
 						<severityPerDamageDealt>0.035</severityPerDamageDealt>
 					</value>

--- a/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
+++ b/Patches/Alpha Mythology/AM_CE_Patch_Races.xml
@@ -10,7 +10,7 @@
 				<!-- Shared bodyShape patches -->
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[
+					<xpath>Defs/ThingDef[
 					defName="MM_Ahuizotl" or 
 					defName="MM_Catoblepas" or 
 					defName="MM_Cerberus" or 
@@ -34,7 +34,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>QuadrupedLow</bodyShape>
@@ -43,7 +43,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="MM_Basilisk" or defName="MM_Tlilcoatl" or defName="MM_Salamander"]</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Basilisk" or defName="MM_Tlilcoatl" or defName="MM_Salamander"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Serpentine</bodyShape>
@@ -52,7 +52,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur" or defName="MM_Kappa"]</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WildMinotaur" or defName="MM_Kappa"]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
 							<bodyShape>Humanoid</bodyShape>
@@ -61,7 +61,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[
+					<xpath>Defs/ThingDef[
 					defName="MM_Phoenix" or 
 					defName="MM_Fenghuang" or 
 					defName="MM_Ieltxu" or 
@@ -78,7 +78,7 @@
 				<!-- ========== Ahuizotl ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Ahuizotl"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Ahuizotl"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.26</MeleeCritChance>
@@ -87,7 +87,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Ahuizotl"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Ahuizotl"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -175,7 +175,7 @@
 				<!-- ========== Basilisk ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.19</MeleeDodgeChance>
 						<MeleeCritChance>0.18</MeleeCritChance>
@@ -186,7 +186,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -225,7 +225,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Basilisk"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Basilisk"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -247,7 +247,7 @@
 				<!-- ========== Catoblepas ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Catoblepas"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.10</MeleeDodgeChance>
 						<MeleeCritChance>0.35</MeleeCritChance>
@@ -258,7 +258,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Catoblepas"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -313,7 +313,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Catoblepas"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Catoblepas"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -335,7 +335,7 @@
 				<!-- ========== Cerberus ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Cerberus"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Cerberus"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.28</MeleeCritChance>
@@ -344,7 +344,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Cerberus"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Cerberus"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -399,7 +399,7 @@
 				<!-- ========== Ceryneian Hind ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_CeryneianHind"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_CeryneianHind"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.14</MeleeDodgeChance>
 						<MeleeCritChance>0.27</MeleeCritChance>
@@ -408,7 +408,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_CeryneianHind"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_CeryneianHind"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -473,7 +473,7 @@
 				<!-- ========== Chimera ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Chimera"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.09</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
@@ -484,7 +484,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Chimera"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -581,7 +581,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Chimera"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Chimera"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -605,7 +605,7 @@
 				<!-- ========== Erymanthian Boar ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_ErymanthianBoar"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_ErymanthianBoar"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
@@ -614,7 +614,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_ErymanthianBoar"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_ErymanthianBoar"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -670,7 +670,7 @@
 				<!-- ========== Fenghuang ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Fenghuang"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Fenghuang"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.17</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
@@ -679,7 +679,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Fenghuang"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Fenghuang"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -739,7 +739,7 @@
 				<!-- ========== Griffin ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Griffin"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Griffin"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.17</MeleeDodgeChance>
 						<MeleeCritChance>0.17</MeleeCritChance>
@@ -748,7 +748,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Griffin"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Griffin"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -828,7 +828,7 @@
 				<!-- ========== Ieltxu ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.06</MeleeCritChance>
@@ -839,7 +839,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -897,7 +897,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Ieltxu"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Ieltxu"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -920,7 +920,7 @@
 				<!-- ========== Kappa ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Kappa"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Kappa"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
@@ -929,7 +929,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Kappa"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Kappa"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1001,7 +1001,7 @@
 				<!-- ========== Kitsune ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Kitsune"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Kitsune"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.07</MeleeCritChance>
@@ -1010,7 +1010,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Kitsune"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Kitsune"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1088,7 +1088,7 @@
 				<!-- ========== Lernaean Hydra ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.08</MeleeDodgeChance>
 						<MeleeCritChance>0.22</MeleeCritChance>
@@ -1099,7 +1099,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1136,7 +1136,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LernaeanHydra"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1161,7 +1161,7 @@
 				<!-- ========== Lesser Wyvern ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.25</MeleeDodgeChance>
 						<MeleeCritChance>0.33</MeleeCritChance>
@@ -1170,7 +1170,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1232,14 +1232,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>16</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="MM_LesserWyvern"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>7</ArmorRating_Sharp>
 					</value>
@@ -1249,7 +1249,7 @@
 				<!-- ========== Manticore ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Manticore"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.31</MeleeCritChance>
@@ -1260,7 +1260,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Manticore"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1355,7 +1355,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Manticore"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Manticore"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1380,7 +1380,7 @@
 				<!-- ========== Pegasus ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Pegasus"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Pegasus"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.48</MeleeCritChance>
@@ -1389,7 +1389,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Pegasus"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Pegasus"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1459,7 +1459,7 @@
 				<!-- ========== Phoenix ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.36</MeleeDodgeChance>
 						<MeleeCritChance>0.17</MeleeCritChance>
@@ -1468,7 +1468,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1526,14 +1526,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]/statBases/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Phoenix"]/statBases/MoveSpeed</xpath>
 					<value>
 						<MoveSpeed>4.7</MoveSpeed>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Phoenix"]</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Phoenix"]</xpath>
 					<value>
 						<butcherProducts>
 							<Prometheum>10</Prometheum>
@@ -1544,7 +1544,7 @@
 				<!-- ========== Qilin ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Qilin"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Qilin"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.13</MeleeDodgeChance>
 						<MeleeCritChance>0.23</MeleeCritChance>
@@ -1553,7 +1553,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Qilin"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Qilin"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1637,7 +1637,7 @@
 				<!-- ========== Salamander ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Salamander"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Salamander"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.29</MeleeCritChance>
@@ -1646,7 +1646,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Salamander"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Salamander"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1687,7 +1687,7 @@
 				<!-- ========== Stymphalian bird ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_StymphalianBird"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_StymphalianBird"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.32</MeleeDodgeChance>
 						<MeleeCritChance>0.20</MeleeCritChance>
@@ -1698,7 +1698,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_StymphalianBird"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_StymphalianBird"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1756,7 +1756,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_StymphalianBird"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_StymphalianBird"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1777,7 +1777,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_StymphalianBird"]/statBases/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="MM_StymphalianBird"]/statBases/MoveSpeed</xpath>
 					<value>
 						<MoveSpeed>4.5</MoveSpeed>
 					</value>
@@ -1786,7 +1786,7 @@
 				<!-- ========== Tlilcoatl ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.23</MeleeDodgeChance>
 						<MeleeCritChance>0.12</MeleeCritChance>
@@ -1797,7 +1797,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1824,7 +1824,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Tlilcoatl"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -1848,7 +1848,7 @@
 				<!-- ========== Unicorn ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Unicorn"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Unicorn"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.16</MeleeDodgeChance>
 						<MeleeCritChance>0.41</MeleeCritChance>
@@ -1857,7 +1857,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Unicorn"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Unicorn"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -1949,7 +1949,7 @@
 				<!-- ========== Wild Minotaur ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WildMinotaur"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.12</MeleeDodgeChance>
 						<MeleeCritChance>0.14</MeleeCritChance>
@@ -1960,7 +1960,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WildMinotaur"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -2037,7 +2037,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_WildMinotaur"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WildMinotaur"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -2060,7 +2060,7 @@
 				<!-- ========== Will-O'-Wisp ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.22</MeleeDodgeChance>
 						<MeleeCritChance>0.00</MeleeCritChance>
@@ -2071,7 +2071,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -2097,7 +2097,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_WillOWisp"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="MM_WillOWisp"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -2122,7 +2122,7 @@
 				<!-- ========== Xiezhi ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="MM_Xiezhi"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Xiezhi"]/statBases</xpath>
 					<value>
 						<MeleeDodgeChance>0.25</MeleeDodgeChance>
 						<MeleeCritChance>0.18</MeleeCritChance>
@@ -2131,7 +2131,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="MM_Xiezhi"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="MM_Xiezhi"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">

--- a/Patches/Alpha Mythology/AM_CE_Patch_Resources.xml
+++ b/Patches/Alpha Mythology/AM_CE_Patch_Resources.xml
@@ -10,7 +10,7 @@
 
                 <!-- ===== Light Magical Leather ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[defName="MM_LightMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
+                    <xpath>Defs/ThingDef[defName="MM_LightMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
                     <value>
                         <StuffPower_Armor_Sharp>0.45</StuffPower_Armor_Sharp>
                         <StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
@@ -19,14 +19,14 @@
 
                 <!-- ===== Heavy Magical Leather ===== -->
                 <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
+                    <xpath>Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Sharp</xpath>
                     <value>
                         <StuffPower_Armor_Sharp>0.65</StuffPower_Armor_Sharp>
                     </value>
                 </li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
+                    <xpath>Defs/ThingDef[defName="MM_HeavyMagicalLeather"]/statBases/StuffPower_Armor_Blunt</xpath>
                     <value>
                         <StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
                     </value>

--- a/Patches/Android Tiers Reforged/Hediffs/Hediffs_Android.xml
+++ b/Patches/Android Tiers Reforged/Hediffs/Hediffs_Android.xml
@@ -107,11 +107,11 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>drill</label>
 								<capacities>
-									<li>Stab</li>
+									<li>Scratch</li>
 								</capacities>
-								<power>10</power>
+								<power>8</power>
 								<cooldownTime>1.25</cooldownTime>
-								<armorPenetrationSharp>1</armorPenetrationSharp>
+								<armorPenetrationSharp>0.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>2</armorPenetrationBlunt>
 							</li>
 						</tools>
@@ -125,9 +125,9 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>scythe</label>
 								<capacities>
-									<li>Cut</li>
+									<li>Scratch</li>
 								</capacities>
-								<power>10</power>
+								<power>8</power>
 								<cooldownTime>1.25</cooldownTime>
 								<armorPenetrationSharp>0.5</armorPenetrationSharp>
 								<armorPenetrationBlunt>1</armorPenetrationBlunt>
@@ -163,7 +163,7 @@
 									<li>Blunt</li>
 								</capacities>
 								<power>7</power>
-								<cooldownTime>1.19</cooldownTime>
+								<cooldownTime>1.25</cooldownTime>
 								<armorPenetrationBlunt>2.25</armorPenetrationBlunt>
 							</li>
 						</tools>

--- a/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
@@ -226,7 +226,7 @@
 								<power>2</power>
 								<cooldownTime>1.67</cooldownTime>
 								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>0.405</armorPenetrationBlunt>
+								<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 							</li>
 							<li Class="CombatExtended.ToolCE">
 								<label>right fist</label>
@@ -236,7 +236,7 @@
 								<power>2</power>
 								<cooldownTime>1.67</cooldownTime>
 								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-								<armorPenetrationBlunt>0.405</armorPenetrationBlunt>
+								<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
 							</li>
 							<li Class="CombatExtended.ToolCE">
 								<label>head</label>
@@ -299,7 +299,7 @@
 									<li>Blunt</li>
 								</capacities>
 								<power>5</power>
-								<cooldownTime>1.67</cooldownTime>
+								<cooldownTime>1.45</cooldownTime>
 								<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 								<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
 							</li>
@@ -309,7 +309,7 @@
 									<li>Blunt</li>
 								</capacities>
 								<power>5</power>
-								<cooldownTime>1.67</cooldownTime>
+								<cooldownTime>1.45</cooldownTime>
 								<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 								<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
 							</li>

--- a/Patches/Android Tiers Reforged/ThingDef_Races/Races_Animals.xml
+++ b/Patches/Android Tiers Reforged/ThingDef_Races/Races_Animals.xml
@@ -345,9 +345,9 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="ATR_DroneWatchdog"]/statBases</xpath>
 					<value>
-						<MeleeDodgeChance>0.28</MeleeDodgeChance>
-						<MeleeCritChance>0.29</MeleeCritChance>
-						<MeleeParryChance>0.2</MeleeParryChance>
+						<MeleeDodgeChance>0.16</MeleeDodgeChance>
+						<MeleeCritChance>0.21</MeleeCritChance>
+						<MeleeParryChance>0.1</MeleeParryChance>
 						<SmokeSensitivity>0</SmokeSensitivity>
 						<CarryWeight>60</CarryWeight>
 						<CarryBulk>30</CarryBulk>
@@ -357,14 +357,14 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="ATR_DroneWatchdog"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
-						<ArmorRating_Sharp>5</ArmorRating_Sharp>
+						<ArmorRating_Sharp>4</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="ATR_DroneWatchdog"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
-						<ArmorRating_Blunt>10</ArmorRating_Blunt>
+						<ArmorRating_Blunt>6</ArmorRating_Blunt>
 					</value>
 				</li>
 
@@ -377,8 +377,8 @@
 								<capacities>
 									<li>Scratch</li>
 								</capacities>
-								<power>15</power>
-								<cooldownTime>1.22</cooldownTime>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
 								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 								<armorPenetrationSharp>1</armorPenetrationSharp>
 								<armorPenetrationBlunt>2.475</armorPenetrationBlunt>
@@ -388,8 +388,8 @@
 								<capacities>
 									<li>Scratch</li>
 								</capacities>
-								<power>15</power>
-								<cooldownTime>1.22</cooldownTime>
+								<power>12</power>
+								<cooldownTime>1.5</cooldownTime>
 								<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 								<armorPenetrationSharp>1</armorPenetrationSharp>
 								<armorPenetrationBlunt>2.475</armorPenetrationBlunt>
@@ -398,8 +398,8 @@
 								<capacities>
 									<li>Bite</li>
 								</capacities>
-								<power>27</power>
-								<cooldownTime>2.24</cooldownTime>
+								<power>18</power>
+								<cooldownTime>2.5</cooldownTime>
 								<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 								<armorPenetrationSharp>3</armorPenetrationSharp>
 								<armorPenetrationBlunt>12.8</armorPenetrationBlunt>
@@ -409,8 +409,8 @@
 								<capacities>
 									<li>Blunt</li>
 								</capacities>
-								<power>7</power>
-								<cooldownTime>2.24</cooldownTime>
+								<power>5</power>
+								<cooldownTime>2.5</cooldownTime>
 								<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 								<chanceFactor>0.2</chanceFactor>
 								<armorPenetrationBlunt>2.5</armorPenetrationBlunt>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Accessories.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Accessories.xml
@@ -10,7 +10,7 @@
 				<!-- Scarf -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalScarfBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalScarfBase"]/statBases</xpath>
 					<value>
 						<Bulk>1</Bulk>
 						<WornBulk>1</WornBulk>
@@ -18,11 +18,11 @@
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[@Name="AnimalScarfBase"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalScarfBase"]/statBases/ArmorRating_Sharp</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalScarfBase"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalScarfBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Clothing.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Clothing.xml
@@ -10,7 +10,7 @@
 				<!-- Clothes -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalClothesBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalClothesBase"]/statBases</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>2</WornBulk>
@@ -18,7 +18,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalClothesBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalClothesBase"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Flak.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Flak.xml
@@ -10,11 +10,11 @@
 				<!-- Flak Armor -->
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakArmorBase"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakArmorBase"]/equippedStatOffsets</xpath>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>3</WornBulk>
@@ -22,42 +22,42 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>12</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakArmorBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>18</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>100</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>150</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalFlakArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>110</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalFlakArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalFlakArmor"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>60</Steel>
@@ -67,7 +67,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalFlakArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalFlakArmor"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>75</Steel>
@@ -77,7 +77,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalFlakArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalFlakArmor"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>65</Steel>
@@ -89,7 +89,7 @@
 				<!-- Flak Helmet -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakHelmBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakHelmBase"]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>1</WornBulk>
@@ -97,7 +97,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakHelmBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakHelmBase"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<ArmorRating_Sharp>10</ArmorRating_Sharp>
 						<ArmorRating_Blunt>15</ArmorRating_Blunt>
@@ -105,15 +105,15 @@
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalAdvancedHelmet" or defName="Apparel_LargeAnimalAdvancedHelmet" or defName="Apparel_AnimalAdvancedHelmet"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalAdvancedHelmet" or defName="Apparel_LargeAnimalAdvancedHelmet" or defName="Apparel_AnimalAdvancedHelmet"]/costStuffCount</xpath>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[@Name="AnimalFlakHelmBase"]/stuffCategories</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalFlakHelmBase"]/stuffCategories</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalAdvancedHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalAdvancedHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>25</Steel>
@@ -123,7 +123,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalAdvancedHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalAdvancedHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>40</Steel>
@@ -133,7 +133,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalAdvancedHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalAdvancedHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Steel>30</Steel>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Plate.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Plate.xml
@@ -10,7 +10,7 @@
 				<!-- Plate Armor -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateArmorBase"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateArmorBase"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.1</MeleeDodgeChance>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateArmorBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateArmorBase"]/statBases</xpath>
 					<value>
 						<Bulk>35</Bulk>
 						<WornBulk>7</WornBulk>
@@ -27,7 +27,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateArmorBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateArmorBase"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
@@ -36,7 +36,7 @@
 				<!-- Plate Helmet -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateHelmBase"]</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateHelmBase"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeHitChance>-1.0</MeleeHitChance>
@@ -45,7 +45,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateHelmBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateHelmBase"]/statBases</xpath>
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>1</WornBulk>
@@ -53,7 +53,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalPlateHelmBase"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalPlateHelmBase"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Riding.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Riding.xml
@@ -10,7 +10,7 @@
 				 <!-- Riding Gear -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>25</CarryWeight>
@@ -20,7 +20,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]/statBases</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>2</WornBulk>
@@ -28,7 +28,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalReins" or defName="Apparel_bridle"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>6</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
+++ b/Patches/Animal Equipment/CE_patch_Apparel_Spacer.xml
@@ -10,7 +10,7 @@
 				<!-- Power Armor -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases</xpath>
 					<value>
 						<Bulk>50</Bulk>
 						<WornBulk>15</WornBulk>
@@ -18,21 +18,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>20</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>45</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerArmorBase"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<CarryWeight>60</CarryWeight>
 						<CarryBulk>10</CarryBulk>
@@ -41,35 +41,35 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>450</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>550</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalPowerArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>500</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmor"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmor"]/costList/Plasteel</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmor"]/costList/Plasteel</xpath>
 					<value>
 						<DevilstrandCloth>60</DevilstrandCloth>
 						<Plasteel>150</Plasteel>
@@ -77,7 +77,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalPowerArmor"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>40</DevilstrandCloth>
 					</value>
@@ -86,7 +86,7 @@
 				<!-- Power Helm -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -94,30 +94,30 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/Flammability</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/Flammability</xpath>
 					<value>
 						<Flammability>0</Flammability>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>16</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>36</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel/immuneToToxGasExposure</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel/immuneToToxGasExposure</xpath>
 					<nomatch Class="PatchOperationAdd">
-						<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel</xpath>
+						<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]/apparel</xpath>
 						<value>
 							<immuneToToxGasExposure>true</immuneToToxGasExposure>
 						</value>
@@ -125,7 +125,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="AnimalSpacerHelmBase"]</xpath>
+					<xpath>Defs/ThingDef[@Name="AnimalSpacerHelmBase"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<ToxicEnvironmentResistance>0.50</ToxicEnvironmentResistance>
@@ -135,28 +135,28 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>220</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>260</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_SmallAnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
 					<value>
 						<DevilstrandCloth>10</DevilstrandCloth>
 						<Plasteel>50</Plasteel>
@@ -164,14 +164,14 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmorHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_LargeAnimalPowerArmorHelmet"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
+					<xpath>Defs/ThingDef[defName="Apparel_AnimalPowerArmorHelmet"]/costList/Plasteel</xpath>
 					<value>
 						<DevilstrandCloth>15</DevilstrandCloth>
 						<Plasteel>60</Plasteel>

--- a/Patches/Dubs Rimatomics/Apparel_Atomic.xml
+++ b/Patches/Dubs Rimatomics/Apparel_Atomic.xml
@@ -10,7 +10,7 @@
 
 			<!-- === Radiation Suits === -->
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="RadSuitBodyBase" or defName = "Apparel_RadiationSuit"]/apparel/bodyPartGroups</xpath>
+				<xpath>Defs/ThingDef[@Name="RadSuitBodyBase" or defName = "Apparel_RadiationSuit"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase" or defName = "Apparel_RadiationSuit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[@Name="MopSuitBodyBase" or defName = "Apparel_RadiationSuit"]/statBases</xpath>
 				<value>
 					<Bulk>10</Bulk>
 					<WornBulk>4</WornBulk>
@@ -26,14 +26,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[@Name="MopSuitBodyBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
@@ -41,7 +41,7 @@
 
 			<!-- === Radiation Masks === -->
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="RadSuitMaskBase"]/equippedStatOffsets</xpath>
+				<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]/equippedStatOffsets</xpath>
 				<value>
 					<AimingAccuracy>-0.1</AimingAccuracy>
 					<SmokeSensitivity>-1</SmokeSensitivity>
@@ -66,7 +66,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[@Name="RadSuitMaskBase"]</xpath>
+				<xpath>Defs/ThingDef[@Name="RadSuitMaskBase"]</xpath>
 				<value>
 					<li Class="CombatExtended.ApparelHediffExtension">
 						<hediff>WearingGasMask</hediff>
@@ -75,7 +75,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 					<Bulk>4</Bulk>
@@ -84,14 +84,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_RadiationMask"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 					<Bulk>7</Bulk>
@@ -100,7 +100,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[@Name="MopSuitMaskBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>

--- a/Patches/RH2 Faction - Task Force 141/TaskForce141_Apparel.xml
+++ b/Patches/RH2 Faction - Task Force 141/TaskForce141_Apparel.xml
@@ -73,7 +73,7 @@
         <!--Eyepros-->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[
+            <xpath>Defs/ThingDef[
                 defName="RNApparel_EyePros_SIBallistic" or 
                 defName="RNApparel_EyePros_PILLAPantherX"]/apparel/layers</xpath>
             <value>
@@ -100,7 +100,7 @@
         <!--Armor-->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/Mass</xpath>
+            <xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/Mass</xpath>
             <value>
                 <Mass>9</Mass>
                 <Bulk>6</Bulk>
@@ -108,30 +108,30 @@
             </value>
         </li>
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/MaxHitPoints</xpath>
+            <xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/MaxHitPoints</xpath>
             <value>
                     <MaxHitPoints>75</MaxHitPoints>
             </value>
         </li>
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Sharp</xpath>
+            <xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Sharp</xpath>
             <value>
                 <ArmorRating_Sharp>14</ArmorRating_Sharp>
             </value>
         </li>
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Blunt</xpath>
+            <xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/statBases/ArmorRating_Blunt</xpath>
             <value>
                 <ArmorRating_Blunt>20</ArmorRating_Blunt>
             </value>
         </li>
         <li Class="PatchOperationRemove">
-            <xpath>/Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/equippedStatOffsets/MoveSpeed</xpath>
+            <xpath>Defs/ThingDef[defName="RNApparel_CryeCAGE_Tan"]/equippedStatOffsets/MoveSpeed</xpath>
         </li>
 
         <!--Helmets-->
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[ 
+            <xpath>Defs/ThingDef[ 
                 defName="RNApparel_MICH2000_141Rook" or 
                 defName="RNApparel_MICH2000_141Roach"]/stuffCategories</xpath>
             <value>
@@ -141,7 +141,7 @@
             </value>
         </li>
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[
+            <xpath>Defs/ThingDef[
                 defName="RNApparel_MICH2000_141Rook" or 
                 defName="RNApparel_MICH2000_141Roach"]/statBases</xpath>
             <value>
@@ -155,7 +155,7 @@
 
         <!--Webbing, packs-->
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/apparel/layers</xpath>
+            <xpath>Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/apparel/layers</xpath>
             <value>
                 <layers>
                     <li>Webbing</li>
@@ -164,7 +164,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/apparel/bodyPartGroups</xpath>
+            <xpath>Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/apparel/bodyPartGroups</xpath>
             <value>
                 <bodyPartGroups>
                     <li>Shoulders</li>
@@ -173,7 +173,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[
+            <xpath>Defs/ThingDef[
                 @Name = "RHApparel_141HarnessBase" or
                 defName="RNApparel_Backpack_CamelbakMULE" or
                 defName="RNApparel_Backpack_MaxpeditionFalconIII" or
@@ -187,7 +187,7 @@
         </li>
 
         <li Class="PatchOperationreplace">
-            <xpath>/Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/equippedStatOffsets
+            <xpath>Defs/ThingDef[@Name = "RHApparel_141HarnessBase"]/equippedStatOffsets
             </xpath>
             <value>
                 <equippedStatOffsets>
@@ -198,7 +198,7 @@
         </li>
 
         <li Class="PatchOperationreplace">
-            <xpath>/Defs/ThingDef[defName = "RNApparel_Backpack_MaxpeditionFalconIII"]/equippedStatOffsets
+            <xpath>Defs/ThingDef[defName = "RNApparel_Backpack_MaxpeditionFalconIII"]/equippedStatOffsets
             </xpath>
             <value>
                 <equippedStatOffsets>
@@ -207,7 +207,7 @@
             </value>
         </li>
         <li Class="PatchOperationreplace">
-            <xpath>/Defs/ThingDef[defName = "RNApparel_Backpack_CamelbakMULE"]/equippedStatOffsets
+            <xpath>Defs/ThingDef[defName = "RNApparel_Backpack_CamelbakMULE"]/equippedStatOffsets
             </xpath>
             <value>
                 <equippedStatOffsets>
@@ -216,7 +216,7 @@
             </value>
         </li>
         <li Class="PatchOperationreplace">
-            <xpath>/Defs/ThingDef[defName = "RNApparel_Backpack_MFH"]/equippedStatOffsets
+            <xpath>Defs/ThingDef[defName = "RNApparel_Backpack_MFH"]/equippedStatOffsets
             </xpath>
             <value>
                 <equippedStatOffsets>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Apparel.xml
@@ -9,14 +9,14 @@
         <!-- ========== In-built Shield Patch ========== -->
 
         <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldRechargeRate</xpath>
+        <xpath>Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldRechargeRate</xpath>
             <value>
                 <EnergyShieldRechargeRate>0.075</EnergyShieldRechargeRate>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldEnergyMax</xpath>
+            <xpath>Defs/ThingDef[@ParentName="RHApparel_Armor_VigilanteBase"]/statBases/EnergyShieldEnergyMax</xpath>
             <value>
                 <EnergyShieldEnergyMax>0.75</EnergyShieldEnergyMax>
             </value>
@@ -131,7 +131,7 @@
         <!-- ========== Ranger Helmet ========== -->
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Mass</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Mass</xpath>
             <value>
               <Mass>5.0</Mass><Bulk>4</Bulk>
               <WornBulk>1</WornBulk>
@@ -140,28 +140,28 @@
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Flammability</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/Flammability</xpath>
             <value>
               <Flammability>0</Flammability>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
             <value>
               <ArmorRating_Sharp>16</ArmorRating_Sharp>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
             <value>
               <ArmorRating_Blunt>36</ArmorRating_Blunt>
             </value>
         </li>
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]</xpath>
             <value>
             <equippedStatOffsets>
                 <AimingAccuracy>0.15</AimingAccuracy>
@@ -172,7 +172,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/costList/Plasteel</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/costList/Plasteel</xpath>
             <value>
                 <Plasteel>60</Plasteel>
                 <DevilstrandCloth>20</DevilstrandCloth>
@@ -180,7 +180,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/apparel/layers</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_ArmorHelmetPower_VigilanteBase"]/apparel/layers</xpath>
             <value>
                 <li>OnHead</li>
                 <li>StrappedHead</li>
@@ -224,7 +224,7 @@
         <!-- ========== Ranger armor ========== -->
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases</xpath>
             <value>
                 <Bulk>90</Bulk>
                 <WornBulk>13</WornBulk>
@@ -232,49 +232,49 @@
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Mass</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Mass</xpath>
             <value>
                 <Mass>40</Mass>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Flammability</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/Flammability</xpath>
             <value>
                 <Flammability>0</Flammability>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/MaxHitPoints</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/MaxHitPoints</xpath>
             <value>
                 <MaxHitPoints>450</MaxHitPoints>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Sharp</xpath>
             <value>
                 <ArmorRating_Sharp>19</ArmorRating_Sharp>
             </value>
         </li>
 
         <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/statBases/ArmorRating_Blunt</xpath>
             <value>
                 <ArmorRating_Blunt>42</ArmorRating_Blunt>
             </value>
         </li>
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/costList</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]/costList</xpath>
             <value>
                 <DevilstrandCloth>40</DevilstrandCloth>
             </value>
         </li>
 
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
+            <xpath>Defs/ThingDef[@Name="RHApparel_Armor_VigilanteBase"]</xpath>
             <value>
             <equippedStatOffsets>
                 <CarryWeight>70</CarryWeight>
@@ -347,14 +347,14 @@
 
         <!-- Poncho & Duster-->
            <li Class="PatchOperationReplace">
-                <xpath>/Defs/ThingDef[defName="RHApparel_Duster_Ranger" or defName="RHApparel_Poncho_Western"]/statBases/StuffEffectMultiplierArmor</xpath>
+                <xpath>Defs/ThingDef[defName="RHApparel_Duster_Ranger" or defName="RHApparel_Poncho_Western"]/statBases/StuffEffectMultiplierArmor</xpath>
                 <value>
                     <StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
                 </value>
             </li>
 
            <li Class="PatchOperationAdd">
-                <xpath>/Defs/ThingDef[defName="RHApparel_Duster_Ranger" or defName="RHApparel_Poncho_Western"]/statBases</xpath>
+                <xpath>Defs/ThingDef[defName="RHApparel_Duster_Ranger" or defName="RHApparel_Poncho_Western"]/statBases</xpath>
                 <value>
                     <Bulk>7.5</Bulk>
                     <WornBulk>2</WornBulk>
@@ -364,7 +364,7 @@
             <!--Packs-->
 
            <li Class="PatchOperationReplace">
-                <xpath>/Defs/ThingDef[
+                <xpath>Defs/ThingDef[
                     defName = "RHApparel_M56Webbing_Ranger" or
                     defName = "RHApparel_Bandolier_Ranger"
                     ]/apparel/layers</xpath>
@@ -376,7 +376,7 @@
             </li>
 
            <li Class="PatchOperationReplace">
-                <xpath>/Defs/ThingDef[
+                <xpath>Defs/ThingDef[
                     defName = "RHApparel_M56Webbing_Ranger" or
                     defName = "RHApparel_Bandolier_Ranger"
                     ]/apparel/bodyPartGroups</xpath>
@@ -388,7 +388,7 @@
             </li>
 
            <li Class="PatchOperationAdd">
-                <xpath>/Defs/ThingDef[
+                <xpath>Defs/ThingDef[
                     defName = "RHApparel_M56Webbing_Ranger" or
                     defName = "RHApparel_Bandolier_Ranger" or
                     defName = "RNApparel_Backpack_AUGURDaypack" or
@@ -402,7 +402,7 @@
             </li>
 
            <li Class="PatchOperationreplace">
-                <xpath>/Defs/ThingDef[defName = "RHApparel_M56Webbing_Ranger"]/equippedStatOffsets
+                <xpath>Defs/ThingDef[defName = "RHApparel_M56Webbing_Ranger"]/equippedStatOffsets
                 </xpath>
                 <value>
                     <equippedStatOffsets>
@@ -413,7 +413,7 @@
             </li>
 
            <li Class="PatchOperationreplace">
-                <xpath>/Defs/ThingDef[defName = "RHApparel_Bandolier_Ranger"]/equippedStatOffsets
+                <xpath>Defs/ThingDef[defName = "RHApparel_Bandolier_Ranger"]/equippedStatOffsets
                 </xpath>
                 <value>
                     <equippedStatOffsets>
@@ -424,7 +424,7 @@
             </li>
 
            <li Class="PatchOperationreplace">
-                <xpath>/Defs/ThingDef[defName = "RNApparel_Backpack_AUGURDaypack"]/equippedStatOffsets
+                <xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AUGURDaypack"]/equippedStatOffsets
                 </xpath>
                 <value>
                     <equippedStatOffsets>
@@ -433,7 +433,7 @@
                 </value>
             </li>
            <li Class="PatchOperationreplace">
-                <xpath>/Defs/ThingDef[defName = "RNApparel_Backpack_AUGURDaypack"]/statBases/Mass
+                <xpath>Defs/ThingDef[defName = "RNApparel_Backpack_AUGURDaypack"]/statBases/Mass
                 </xpath>
                 <value>
                     <Mass>1.2</Mass>
@@ -441,7 +441,7 @@
             </li>
 
            <li Class="PatchOperationreplace">
-                <xpath>/Defs/ThingDef[
+                <xpath>Defs/ThingDef[
                     defName = "RNApparel_Backpack_AUGURSling" or
                     defName = "RNApparel_Backpack_AUGURHaversack"]/equippedStatOffsets
                 </xpath>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Melee.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Melee.xml
@@ -10,7 +10,7 @@
 
         <!-- === Vintage KABAR_Knife === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/statBases</xpath>
           <value>
             <Bulk>1</Bulk>
             <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]</xpath>
+          <xpath>Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.05</MeleeCritChance>
@@ -29,7 +29,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/weaponTags</xpath>
           <value>
             <li>CE_Sidearm_Melee</li>
             <li>CE_OneHandedWeapon</li>
@@ -37,7 +37,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="RNMeleeWeapon_VintageKABAR_Knife"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Pawns.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Pawns.xml
@@ -8,7 +8,7 @@
 			<operations>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[@Name="RH2_Ranger_NonEliteTierBase"]</xpath>
+				<xpath>Defs/PawnKindDef[@Name="RH2_Ranger_NonEliteTierBase"]</xpath>
 				<value>	
 				<li Class="CombatExtended.LoadoutPropertiesExtension">	
 					<primaryMagazineCount>
@@ -20,7 +20,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/PawnKindDef[@Name="RH2_Rangers_EliteTierBase"]</xpath>
+				<xpath>Defs/PawnKindDef[@Name="RH2_Rangers_EliteTierBase"]</xpath>
 				<value>	
 				<li Class="CombatExtended.LoadoutPropertiesExtension">	
 					<primaryMagazineCount>

--- a/Patches/RH2 Faction - VOID/Items_Drugs/Alcohol_RedWine.xml
+++ b/Patches/RH2 Faction - VOID/Items_Drugs/Alcohol_RedWine.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="RH_RedWine"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="RH_RedWine"]/statBases</xpath>
 					<value>
 						<Bulk>1.5</Bulk>
 					</value>
@@ -62,9 +62,9 @@
 				</li>
 
 				<li Class="PatchOperationConditional">
-					<xpath>/Defs/ThingDef[defName="RH_RedWine"]/weaponTags</xpath>
+					<xpath>Defs/ThingDef[defName="RH_RedWine"]/weaponTags</xpath>
 					<nomatch Class="PatchOperationAdd">
-						<xpath>/Defs/ThingDef[defName="RH_RedWine"]</xpath>
+						<xpath>Defs/ThingDef[defName="RH_RedWine"]</xpath>
 						<value>
 							<weaponTags />
 						</value>

--- a/Patches/RH2 Faction - VOID/Monsters/Bodies.xml
+++ b/Patches/RH2 Faction - VOID/Monsters/Bodies.xml
@@ -9,70 +9,70 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
@@ -81,70 +81,70 @@
 				<!-- ========== Humanlike (ArmBlade) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_ArmBlade"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
@@ -153,70 +153,70 @@
 				<!-- ========== Humanlike (BlackLeaper) ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_BlackLeaper"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
@@ -225,70 +225,70 @@
 				<!-- ========== Giant Spider ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_GiantSpider"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
@@ -297,70 +297,70 @@
 				<!-- ========== Mother ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Mother"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
@@ -369,70 +369,70 @@
 				<!-- ========== Wraith ========== -->
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Neck"]/parts/li[def = "RH_N4Mutant_Head"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Shoulder"]/parts/li[def = "RH_N4Mutant_Arm"]/parts/li[def = "RH_N4Mutant_Hand"]/parts/li[def = "RH_N4Mutant_Finger"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="RH_N4Mutant_Wraith"]/corePart/parts/li[def = "RH_N4Mutant_Leg"]/parts/li[def = "RH_N4Mutant_Foot"]/parts/li[def = "RH_N4Mutant_Toe"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>

--- a/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Misc/Caves_Projectiles.xml
+++ b/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Misc/Caves_Projectiles.xml
@@ -9,7 +9,7 @@
 
 	<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
 	<li Class="PatchOperationReplace">
-	<xpath>/Defs/ThingDef[defName="VAECaves_RangedSilk"]/thingClass</xpath>
+	<xpath>Defs/ThingDef[defName="VAECaves_RangedSilk"]/thingClass</xpath>
 		<value>
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		</value>
@@ -17,14 +17,14 @@
 
 	<!-- ============== Adding 'Standard' AimingAccuracy node to creatures' that use ranged attack statBases. =============== -->
 	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.6</AimingAccuracy>
 		</value>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/verbs</xpath>
 		<value>
 			<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
@@ -53,7 +53,7 @@
 
 	<!-- =============== Now defining Projectiles in CE Procedure(Please do not remove sharp penetration value >:(   ) ============= -->
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VAECaves_RangedSilk"]/projectile</xpath>
+		<xpath>Defs/ThingDef[defName="VAECaves_RangedSilk"]/projectile</xpath>
 		<value>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<flyOverhead>false</flyOverhead>

--- a/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Races/Caves_Animals.xml
+++ b/Patches/Vanilla Animals Expanded - Caves/ThingDefs_Races/Caves_Animals.xml
@@ -11,7 +11,7 @@
 
     <!-- === Cave Bear === -->
 		<li Class="PatchOperationAddModExtension">
-		  <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]</xpath>
+		  <xpath>Defs/ThingDef[defName="VAECaves_CaveBear"]</xpath>
 			<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -29,21 +29,21 @@
 	</li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>1.65</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveBear"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveBear"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveBear"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -119,7 +119,7 @@
 
     <!-- === Cave Crawler === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveCrawler"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -128,21 +128,21 @@
     </li>
     
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>8</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
     
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveCrawler"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.03</MeleeDodgeChance>
         <MeleeCritChance>0.4</MeleeCritChance>
@@ -151,7 +151,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_CaveCrawler"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_CaveCrawler"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -199,7 +199,7 @@
 
     <!-- === Giant Spider Hatchling === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -208,21 +208,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>2</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>1</ArmorRating_Sharp>
       </value>
     </li>
     
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.2</MeleeDodgeChance>
         <MeleeCritChance>0.07</MeleeCritChance>
@@ -231,7 +231,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpiderHatchling"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -270,7 +270,7 @@
 
     <!-- === Giant Spider === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpider"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Quadruped</bodyShape>
@@ -279,21 +279,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>8</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
     
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpider"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.13</MeleeDodgeChance>
         <MeleeCritChance>0.15</MeleeCritChance>
@@ -302,7 +302,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_GiantSpider"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_GiantSpider"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -340,7 +340,7 @@
 
     <!-- === Ancient Giant Spider === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Quadruped</bodyShape>
@@ -349,21 +349,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>12</ArmorRating_Blunt>
       </value>
     </li>
     
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
     
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.1</MeleeDodgeChance>
         <MeleeCritChance>0.72</MeleeCritChance>
@@ -372,7 +372,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_AncientGiantSpider"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -428,7 +428,7 @@
 
     <!-- === Insectoid Hulk === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_InsectoidHulk"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -437,21 +437,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>14</ArmorRating_Blunt>
       </value>
     </li>
     
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/statBases</xpath>
       <value>
           <MeleeDodgeChance>0.25</MeleeDodgeChance>
           <MeleeCritChance>0.75</MeleeCritChance>
@@ -460,7 +460,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_InsectoidHulk"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -535,7 +535,7 @@
 
     <!-- === Cave Salamander === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_BlindSalamander"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_BlindSalamander"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -544,7 +544,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_BlindSalamander"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_BlindSalamander"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.1</MeleeDodgeChance>
         <MeleeCritChance>0.03</MeleeCritChance>
@@ -553,7 +553,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_BlindSalamander"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_BlindSalamander"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -607,7 +607,7 @@
 
     <!-- === Wyrm === -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_Wyrm"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Quadruped</bodyShape>
@@ -616,21 +616,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>16</ArmorRating_Blunt>
       </value>
     </li>
     
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>7</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_Wyrm"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0.4</MeleeDodgeChance>
         <MeleeCritChance>0.33</MeleeCritChance>
@@ -639,7 +639,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VAECaves_Wyrm"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VAECaves_Wyrm"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Animals Expanded - Endangered/Bodies/Patch_Bodies_Animals.xml
+++ b/Patches/Vanilla Animals Expanded - Endangered/Bodies/Patch_Bodies_Animals.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Animals Expanded — Royal Animals</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Great Ape -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="VAERoy_GreatApe"]//*[
+				def="Torso" or
+				def="Neck" or
+				def="Shoulder" or
+				def="Arm" or
+				def="Hand" or
+				def="Leg" or
+				def="Foot" or
+				def="Toe"
+				]</xpath>
+					<value>
+						<groups/>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BodyDef[defName="VAERoy_GreatApe"]//*[
+				def="Torso" or
+				def="Neck" or
+				def="Head" or
+				def="AnimalJaw" or
+				def="Shoulder" or
+				def="Arm" or
+				def="Hand" or
+				def="Finger" or				
+				def="Leg" or
+				def="Foot" or
+				def="Toe"				
+				]/groups</xpath>
+					<value>
+						<li>CoveredByNaturalArmor</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Animals Expanded - Endangered/ThingDefs_Races/Endangered_Animals.xml
+++ b/Patches/Vanilla Animals Expanded - Endangered/ThingDefs_Races/Endangered_Animals.xml
@@ -142,7 +142,7 @@
 		</li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Panda"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Panda"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -220,7 +220,7 @@
 
         <!-- === Quagga === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Quagga"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Quagga"]/statBases</xpath>
           <value>
             <MeleeDodgeChance>0.1</MeleeDodgeChance>
             <MeleeCritChance>0.14</MeleeCritChance>
@@ -229,7 +229,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Quagga"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Quagga"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -614,7 +614,7 @@
 
         <!-- === Pangolin === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Pangolin"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Pangolin"]/statBases</xpath>
           <value>
 			<MeleeDodgeChance>0.17</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
@@ -623,21 +623,21 @@
 		</li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Pangolin"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Pangolin"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>0.32</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Pangolin"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Pangolin"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>0.26</ArmorRating_Sharp>
           </value>
         </li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="AEXP_Pangolin"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="AEXP_Pangolin"]/tools</xpath>
 		<value>
 			<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Animals Expanded - Royal Animals/ThingDefs_Races/Royal_Animals.xml
+++ b/Patches/Vanilla Animals Expanded - Royal Animals/ThingDefs_Races/Royal_Animals.xml
@@ -56,20 +56,6 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_AngoraRabbit"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.15</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_AngoraRabbit"]/combatPower</xpath>
-			<value>
-				<combatPower>10</combatPower>
-			</value>
-		</li>
-
         <!-- === Crane === -->
 
 		<li Class="PatchOperationAddModExtension">
@@ -138,20 +124,6 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Crane"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>1.2</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Crane"]/combatPower</xpath>
-			<value>
-				<combatPower>30</combatPower>
-			</value>
-		</li>
-
         <!-- === Megachicken === -->
 
 		<li Class="PatchOperationAddModExtension">
@@ -209,20 +181,6 @@
 						<armorPenetrationBlunt>0.192</armorPenetrationBlunt>
 					</li>
 				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Megachicken"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.2</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Megachicken"]/combatPower</xpath>
-			<value>
-				<combatPower>8</combatPower>
 			</value>
 		</li>
 
@@ -294,20 +252,6 @@
 						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 					</li>
 				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Orangutan"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>1.5</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Orangutan"]/combatPower</xpath>
-			<value>
-				<combatPower>75</combatPower>
 			</value>
 		</li>
 
@@ -387,20 +331,6 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Peacock"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.6</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Peacock"]/combatPower</xpath>
-			<value>
-				<combatPower>22</combatPower>
-			</value>
-		</li>
-
         <!-- === Pheasant === -->
 
 		<li Class="PatchOperationAddModExtension">
@@ -461,20 +391,6 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Pheasant"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.2</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Pheasant"]/combatPower</xpath>
-			<value>
-				<combatPower>10</combatPower>
-			</value>
-		</li>
-
         <!-- === Quail === -->
 
 		<li Class="PatchOperationAddModExtension">
@@ -532,20 +448,6 @@
 						<armorPenetrationBlunt>0.192</armorPenetrationBlunt>
 					</li>
 				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Quail"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.2</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Quail"]/combatPower</xpath>
-			<value>
-				<combatPower>8</combatPower>
 			</value>
 		</li>
 
@@ -644,20 +546,6 @@
 			</value>
 		</li>
 
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_RoyalTiger"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>1.2</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_RoyalTiger"]/combatPower</xpath>
-			<value>
-				<combatPower>110</combatPower>
-			</value>
-		</li>
-
         <!-- === Swan === -->
 
 		<li Class="PatchOperationAddModExtension">
@@ -715,20 +603,6 @@
 						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
 					</li>
 				</tools>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/ThingDef[defName="VAERoy_Swan"]/race/baseHealthScale</xpath>
-			<value>
-				<baseHealthScale>0.65</baseHealthScale>
-			</value>
-		</li>
-
-		<li Class="PatchOperationReplace">
-			<xpath>Defs/PawnKindDef[defName="VAERoy_Swan"]/combatPower</xpath>
-			<value>
-				<combatPower>15</combatPower>
 			</value>
 		</li>
 

--- a/Patches/Vanilla Animals Expanded - Vehicles/Bodies/Bodies_Car.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/Bodies/Bodies_Car.xml
@@ -11,7 +11,7 @@
 					<operations>
 					<!--VAEAF Car-->
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart</xpath>
+						<xpath>Defs/BodyDef[defName="VAEAF_CarBody"]/corePart</xpath>
 						<value>
 							<groups>
 								<li>CoveredByNaturalArmor</li>
@@ -20,14 +20,14 @@
 					</li>
 					
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_FrontGrille"]/groups</xpath>
+						<xpath>Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_FrontGrille"]/groups</xpath>
 						<value>
 							<li>CoveredByNaturalArmor</li>
 						</value>
 					</li>
 					
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]</xpath>
+						<xpath>Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]</xpath>
 						<value>
 							<groups>
 								<li>CoveredByNaturalArmor</li>
@@ -36,7 +36,7 @@
 					</li>
 					
 					<li Class="PatchOperationAdd">
-						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]/parts/li[def="VAEAF_ChassisRear"]</xpath>
+						<xpath>Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]/parts/li[def="VAEAF_ChassisRear"]</xpath>
 						<value>
 							<groups>
 								<li>CoveredByNaturalArmor</li>

--- a/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
@@ -9,7 +9,7 @@
 			  <operations>
 			    <!--Bodytype-->
 				<li Class="PatchOperationAddModExtension">
-				  <xpath>/Defs/ThingDef[
+				  <xpath>Defs/ThingDef[
 				  defName="VAEAF_CarFamily" or
 				  defName="VAEAF_CarDelivery" or
 				  defName="VAEAF_CarVintage" or
@@ -28,7 +28,7 @@
 				<!--Family Car-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarFamily"]/statBases</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarFamily"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.10</MeleeDodgeChance>
 					<MeleeCritChance>0.20</MeleeCritChance>
@@ -40,7 +40,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarFamily"]/tools</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarFamily"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -60,7 +60,7 @@
 				<!--Delivery Truck-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarDelivery"]/statBases</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarDelivery"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.10</MeleeDodgeChance>
 					<MeleeCritChance>0.20</MeleeCritChance>
@@ -72,7 +72,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarDelivery"]/tools</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarDelivery"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -92,7 +92,7 @@
 				<!--Vintage Car-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarVintage"]/statBases</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarVintage"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
@@ -104,7 +104,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarVintage"]/tools</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarVintage"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -124,7 +124,7 @@
 				<!--Pickup Truck-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarPickup"]/statBases</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarPickup"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.20</MeleeCritChance>
@@ -136,7 +136,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarPickup"]/tools</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarPickup"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -156,7 +156,7 @@
 				<!--Pickup Truck-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarForklift"]/statBases</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarForklift"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.20</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
@@ -168,7 +168,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAF_CarForklift"]/tools</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAF_CarForklift"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -186,7 +186,7 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/ThingDef[defName="VAEAP_Leather_Car"]/statBases/StuffPower_Armor_Sharp</xpath>
+				  <xpath>Defs/ThingDef[defName="VAEAP_Leather_Car"]/statBases/StuffPower_Armor_Sharp</xpath>
 				  <value>
 				    <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
 				  </value>

--- a/Patches/Vanilla Animals Expanded/AridShrubland_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/AridShrubland_AddClass.xml
@@ -11,7 +11,7 @@
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_Coyote" or
               defName="AEXP_Hippopotamus" or
               defName="AEXP_Zebra" or
@@ -28,7 +28,7 @@
 
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Crocodile"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Crocodile"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -39,7 +39,7 @@
 
         <!-- === Birdlike === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Giraffe"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Giraffe"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/AridShrubland_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/AridShrubland_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Cheetah === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Cheetah"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Cheetah"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.46</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Cheetah"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Cheetah"]</xpath>
 
           <value>
             <tools>
@@ -81,7 +81,7 @@
 
         <!-- === Coyote === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Coyote"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Coyote"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.27</MeleeDodgeChance>
@@ -91,7 +91,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Coyote"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Coyote"]/tools</xpath>
 
           <value>
             <tools>
@@ -144,7 +144,7 @@
 
         <!-- === Crocodile === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Crocodile"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Crocodile"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -154,7 +154,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Crocodile"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Crocodile"]/tools</xpath>
 
           <value>
             <tools>
@@ -207,7 +207,7 @@
 
         <!-- === Giraffe === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Giraffe"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Giraffe"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -217,7 +217,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Giraffe"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Giraffe"]/tools</xpath>
 
           <value>
             <tools>
@@ -270,7 +270,7 @@
 
         <!-- === Hippo === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Hippopotamus"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Hippopotamus"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
@@ -280,7 +280,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Hippopotamus"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Hippopotamus"]/tools</xpath>
 
           <value>
             <tools>
@@ -333,7 +333,7 @@
 
         <!-- === Wildebeest === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Wildebeest"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Wildebeest"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.18</MeleeDodgeChance>
@@ -343,7 +343,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Wildebeest"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Wildebeest"]/tools</xpath>
 
           <value>
             <tools>
@@ -396,7 +396,7 @@
 
         <!-- === Zebra === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Zebra"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Zebra"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -406,7 +406,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Zebra"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Zebra"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/AridShrubland_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/AridShrubland_Resources.xml
@@ -10,11 +10,11 @@
       <operations>
         <!-- === Hippo Leather === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Hippopotamus"]/statBases/StuffPower_Armor_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Hippopotamus"]/statBases/StuffPower_Armor_Sharp</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Hippopotamus"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Hippopotamus"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.36</StuffPower_Armor_Sharp>
@@ -24,11 +24,11 @@
 
         <!-- === Wildebeest Leather === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Wildebeest"]/statBases/StuffPower_Armor_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Wildebeest"]/statBases/StuffPower_Armor_Sharp</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Wildebeest"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Wildebeest"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>

--- a/Patches/Vanilla Animals Expanded/Australia_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/Australia_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Kangaroo"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Kangaroo"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === QuadrupedLow === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat" or defName="AEXP_Koala" or defName="AEXP_Platypus"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat" or defName="AEXP_Koala" or defName="AEXP_Platypus"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/Australia_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Australia_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Boombat === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat"]/tradeTags</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat"]/tradeTags</xpath>
 
           <value>
             <li>CE_AnimalBoom</li>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.10</MeleeDodgeChance>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat"]/tools</xpath>
 
           <value>
             <tools>
@@ -81,9 +81,9 @@
         </li>
 
         <li Class="PatchOperationConditional">
-          <xpath>/Defs/ThingDef[defName = "AEXP_Boombat"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName = "AEXP_Boombat"]/comps</xpath>
           <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[defName = "AEXP_Boombat"]</xpath>
+            <xpath>Defs/ThingDef[defName = "AEXP_Boombat"]</xpath>
             <value>
               <comps />
             </value>
@@ -91,7 +91,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat"]/comps</xpath>
           <value>
             <li Class="CombatExtended.CompProperties_ShearableRenameable">
               <compClass>CombatExtended.CompShearableRenameable</compClass>
@@ -104,7 +104,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Boombat"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Boombat"]</xpath>
           <value>
             <butcherProducts>
               <FSX>2</FSX>
@@ -114,7 +114,7 @@
 
         <!-- === Kangaroo === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Kangaroo"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Kangaroo"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.27</MeleeDodgeChance>
@@ -124,7 +124,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Kangaroo"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Kangaroo"]/tools</xpath>
 
           <value>
             <tools>
@@ -178,7 +178,7 @@
 
         <!-- === Koala === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Koala"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Koala"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -188,7 +188,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Koala"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Koala"]/tools</xpath>
 
           <value>
             <tools>
@@ -242,7 +242,7 @@
 
         <!-- === Platypus === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Platypus"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Platypus"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.12</MeleeDodgeChance>
@@ -252,7 +252,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Platypus"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Platypus"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/Australia_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/Australia_Resources.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Platypus Leather === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Platypus"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Platypus"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Blunt>0.06</StuffPower_Armor_Blunt>

--- a/Patches/Vanilla Animals Expanded/BorealForest_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/BorealForest_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_ArcticCoyote" or defName="AEXP_BlackBear"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_ArcticCoyote" or defName="AEXP_BlackBear"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === Serpentine === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Otter"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Otter"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/BorealForest_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/BorealForest_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Artic Coyote === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_ArcticCoyote"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_ArcticCoyote"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.26</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_ArcticCoyote"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_ArcticCoyote"]/tools</xpath>
 
           <value>
             <tools>
@@ -73,7 +73,7 @@
 
         <!-- === Black Bear === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_BlackBear"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_BlackBear"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -83,7 +83,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_BlackBear"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_BlackBear"]</xpath>
 
           <value>
             <tools>
@@ -162,7 +162,7 @@
 
         <!-- === Otter === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Otter"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Otter"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.24</MeleeDodgeChance>
@@ -172,7 +172,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="AEXP_Otter"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Otter"]/tools</xpath>
 
         <value>
           <tools>

--- a/Patches/Vanilla Animals Expanded/CatsAndDogs_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/CatsAndDogs_AddClass.xml
@@ -11,7 +11,7 @@
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_Rottweiler" or
               defName="AEXP_GermanShepherd" or
               defName="AEXP_GreatDane" or

--- a/Patches/Vanilla Animals Expanded/CatsAndDogs_Cats.xml
+++ b/Patches/Vanilla Animals Expanded/CatsAndDogs_Cats.xml
@@ -31,26 +31,6 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            Defs/PawnKindDef[
-              defName="AEXP_CatAbyssinian" or
-              defName="AEXP_CatBengal" or
-              defName="AEXP_CatBritishShorthair" or
-              defName="AEXP_CatMaineCoon" or
-              defName="AEXP_CatMunchkin" or
-              defName="AEXP_CatNorwegianForest" or
-              defName="AEXP_CatPersian" or
-              defName="AEXP_CatSiamese" or
-              defName="AEXP_CatSomali" or
-              defName="AEXP_CatSphynx"]/combatPower
-          </xpath>
-
-          <value>
-            <combatPower>14</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>
             Defs/ThingDef[
               defName="AEXP_CatAbyssinian" or
               defName="AEXP_CatBengal" or

--- a/Patches/Vanilla Animals Expanded/CatsAndDogs_Cats.xml
+++ b/Patches/Vanilla Animals Expanded/CatsAndDogs_Cats.xml
@@ -10,7 +10,7 @@
       <operations>
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_CatAbyssinian" or
               defName="AEXP_CatBengal" or
               defName="AEXP_CatBritishShorthair" or
@@ -31,7 +31,7 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/PawnKindDef[
+            Defs/PawnKindDef[
               defName="AEXP_CatAbyssinian" or
               defName="AEXP_CatBengal" or
               defName="AEXP_CatBritishShorthair" or
@@ -51,7 +51,7 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_CatAbyssinian" or
               defName="AEXP_CatBengal" or
               defName="AEXP_CatBritishShorthair" or

--- a/Patches/Vanilla Animals Expanded/CatsAndDogs_Dogs.xml
+++ b/Patches/Vanilla Animals Expanded/CatsAndDogs_Dogs.xml
@@ -29,22 +29,6 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            Defs/PawnKindDef[
-              defName="AEXP_Beagle" or
-              defName="AEXP_Chihuahua" or
-              defName="AEXP_Corgi" or
-              defName="AEXP_FrenchBulldog" or
-              defName="AEXP_Pug" or
-              defName="AEXP_Shih-Tzu" or
-              defName="AEXP_WelshTerrier"]/combatPower
-          </xpath>
-
-          <value>
-            <combatPower>12</combatPower>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <xpath>
             Defs/ThingDef[ 
               defName="AEXP_Beagle" or
               defName="AEXP_Chihuahua" or
@@ -116,14 +100,6 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/combatPower</xpath>
-
-          <value>
-            <combatPower>50</combatPower>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
           <xpath>Defs/ThingDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/tools</xpath>
 
           <value>
@@ -183,22 +159,6 @@
             <MeleeDodgeChance>0.23</MeleeDodgeChance>
             <MeleeCritChance>0.05</MeleeCritChance>
             <MeleeParryChance>0.05</MeleeParryChance>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/race/baseBodySize</xpath>
-
-          <value>
-            <baseBodySize>0.65</baseBodySize>
-          </value>
-        </li>
-
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/PawnKindDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/combatPower</xpath>
-
-          <value>
-            <combatPower>60</combatPower>
           </value>
         </li>
 

--- a/Patches/Vanilla Animals Expanded/CatsAndDogs_Dogs.xml
+++ b/Patches/Vanilla Animals Expanded/CatsAndDogs_Dogs.xml
@@ -11,7 +11,7 @@
         <!-- === Small Dogs === -->
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_Beagle" or
               defName="AEXP_Chihuahua" or
               defName="AEXP_Corgi" or
@@ -29,7 +29,7 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/PawnKindDef[
+            Defs/PawnKindDef[
               defName="AEXP_Beagle" or
               defName="AEXP_Chihuahua" or
               defName="AEXP_Corgi" or
@@ -45,7 +45,7 @@
         </li>
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[ 
+            Defs/ThingDef[ 
               defName="AEXP_Beagle" or
               defName="AEXP_Chihuahua" or
               defName="AEXP_Corgi" or
@@ -106,7 +106,7 @@
 
         <!-- === Big Dogs (Labrador) === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.20</MeleeDodgeChance>
@@ -116,7 +116,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/combatPower</xpath>
+          <xpath>Defs/PawnKindDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/combatPower</xpath>
 
           <value>
             <combatPower>50</combatPower>
@@ -124,7 +124,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_GreatDane" or defName="AEXP_Poodle"]/tools</xpath>
 
           <value>
             <tools>
@@ -177,7 +177,7 @@
 
         <!-- === Rottweiler / German Shepherd (Husky) === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.23</MeleeDodgeChance>
@@ -187,7 +187,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/race/baseBodySize</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/race/baseBodySize</xpath>
 
           <value>
             <baseBodySize>0.65</baseBodySize>
@@ -195,7 +195,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/combatPower</xpath>
+          <xpath>Defs/PawnKindDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/combatPower</xpath>
 
           <value>
             <combatPower>60</combatPower>
@@ -203,7 +203,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rottweiler" or defName="AEXP_GermanShepherd"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/Desert_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/Desert_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Hyena" or defName="AEXP_Lion"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Hyena" or defName="AEXP_Lion"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_DesertTortoise" or defName="AEXP_GilaMonster"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_DesertTortoise" or defName="AEXP_GilaMonster"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/Desert_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Desert_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Desert Tortoise === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases</xpath>
           <value>
             <MeleeDodgeChance>0.02</MeleeDodgeChance>
             <MeleeCritChance>0.01</MeleeCritChance>
@@ -19,7 +19,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>10</ArmorRating_Blunt>
@@ -27,7 +27,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>1</ArmorRating_Sharp>
@@ -35,7 +35,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_DesertTortoise"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_DesertTortoise"]/tools</xpath>
 
           <value>
             <tools>
@@ -66,7 +66,7 @@
 
         <!-- === Gila Monster === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_GilaMonster"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_GilaMonster"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -76,7 +76,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_GilaMonster"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_GilaMonster"]/tools</xpath>
 
           <value>
             <tools>
@@ -126,7 +126,7 @@
 
         <!-- === Hyena === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Hyena"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Hyena"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.21</MeleeDodgeChance>
@@ -136,7 +136,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Hyena"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Hyena"]/tools</xpath>
 
           <value>
             <tools>
@@ -189,7 +189,7 @@
 
         <!-- === Lion === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Lion"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Lion"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.19</MeleeDodgeChance>
@@ -199,7 +199,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="AEXP_Lion"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Lion"]/tools</xpath>
 
         <value>
           <tools>

--- a/Patches/Vanilla Animals Expanded/Desert_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/Desert_Resources.xml
@@ -10,11 +10,11 @@
       <operations>
         <!-- === Lion Leather === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Lion"]/statBases/StuffPower_Armor_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Lion"]/statBases/StuffPower_Armor_Sharp</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Lion"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Lion"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.04</StuffPower_Armor_Sharp>

--- a/Patches/Vanilla Animals Expanded/ExtremeDesert_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/ExtremeDesert_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Camel"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Camel"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Megascorpion"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -32,7 +32,7 @@
 
         <!-- === Serpentine === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rattlesnake"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rattlesnake"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/ExtremeDesert_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Camel === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Camel"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Camel"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Camel"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Camel"]/tools</xpath>
 
           <value>
             <tools>
@@ -73,7 +73,7 @@
 
         <!-- === Megarscorpion === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Megascorpion"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.19</MeleeDodgeChance>
@@ -83,7 +83,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Megascorpion"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Megascorpion"]/tools</xpath>
 
           <value>
             <tools>
@@ -133,7 +133,7 @@
 
         <!-- === Rattlesnake === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rattlesnake"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rattlesnake"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.19</MeleeDodgeChance>
@@ -143,7 +143,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Rattlesnake"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Rattlesnake"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/IceSheet_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/IceSheet_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Seal" or defNAme="AEXP_Walrus"]
+          <xpath>Defs/ThingDef[defName="AEXP_Seal" or defNAme="AEXP_Walrus"]
           </xpath>
 
           <value>
@@ -22,7 +22,7 @@
 
         <!-- === Birdlike === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Penguin"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Penguin"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/IceSheet_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/IceSheet_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Penguin === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Penguin"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Penguin"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.25</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Penguin"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Penguin"]/tools</xpath>
 
           <value>
             <tools>
@@ -62,7 +62,7 @@
 
         <!-- === Seal === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Seal"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Seal"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.08</MeleeDodgeChance>
@@ -72,7 +72,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Seal"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Seal"]/tools</xpath>
 
           <value>
             <tools>
@@ -126,7 +126,7 @@
 
         <!-- === Walrus === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Walrus"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Walrus"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.06</MeleeDodgeChance>
@@ -136,7 +136,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Walrus"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Walrus"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/IceSheet_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/IceSheet_Resources.xml
@@ -22,11 +22,11 @@
 
         <!-- === Pinniped Leather === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Pinniped"]/statBases/StuffPower_Armor_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Pinniped"]/statBases/StuffPower_Armor_Sharp</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Pinniped"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Pinniped"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>

--- a/Patches/Vanilla Animals Expanded/TemperateForest_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/TemperateForest_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_RedPanda" or defName="AEXP_Hedgehog" or defName="AEXP_Badger" or defName="AEXP_Beaver"]
+          <xpath>Defs/ThingDef[defName="AEXP_RedPanda" or defName="AEXP_Hedgehog" or defName="AEXP_Badger" or defName="AEXP_Beaver"]
           </xpath>
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/TemperateForest_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/TemperateForest_Animals.xml
@@ -239,13 +239,6 @@
         </value>
       </li>
 
-      <li Class="PatchOperationReplace">
-        <xpath>Defs/PawnKindDef[defName="AEXP_WildGoose"]/combatPower</xpath>
-        <value>
-          <combatPower>12</combatPower>
-        </value>
-      </li>
-
       <!-- === Beaver === -->
       <li Class="PatchOperationAdd">
         <xpath>Defs/ThingDef[defName="AEXP_Beaver"]/statBases</xpath>
@@ -315,13 +308,6 @@
           <MeleeDodgeChance>0.19</MeleeDodgeChance>
           <MeleeCritChance>0.05</MeleeCritChance>
           <MeleeParryChance>0</MeleeParryChance>
-        </value>
-      </li>
-
-      <li Class="PatchOperationReplace">
-        <xpath>Defs/PawnKindDef[defName="AEXP_Hedgehog"]/combatPower</xpath>
-        <value>
-          <combatPower>5</combatPower>
         </value>
       </li>
 

--- a/Patches/Vanilla Animals Expanded/TemperateForest_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/TemperateForest_Animals.xml
@@ -248,7 +248,7 @@
 
       <!-- === Beaver === -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="AEXP_Beaver"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Beaver"]/statBases</xpath>
         <value>
           <MeleeDodgeChance>0.22</MeleeDodgeChance>
           <MeleeCritChance>0.05</MeleeCritChance>
@@ -257,7 +257,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="AEXP_Beaver"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Beaver"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -310,7 +310,7 @@
 
       <!-- === Hedgehog === -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="AEXP_Hedgehog"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Hedgehog"]/statBases</xpath>
         <value>
           <MeleeDodgeChance>0.19</MeleeDodgeChance>
           <MeleeCritChance>0.05</MeleeCritChance>
@@ -319,14 +319,14 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/PawnKindDef[defName="AEXP_Hedgehog"]/combatPower</xpath>
+        <xpath>Defs/PawnKindDef[defName="AEXP_Hedgehog"]/combatPower</xpath>
         <value>
           <combatPower>5</combatPower>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="AEXP_Hedgehog"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="AEXP_Hedgehog"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Animals Expanded/TropicalRainforest_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalRainforest_AddClass.xml
@@ -11,7 +11,7 @@
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName="AEXP_Gorilla" or
               defName="AEXP_Jaguar" or
               defName="AEXP_Tiger" or
@@ -27,7 +27,7 @@
 
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Lemur"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Lemur"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -38,7 +38,7 @@
 
         <!-- === Humanoid === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Mandrill"]
+          <xpath>Defs/ThingDef[defName="AEXP_Mandrill"]
           </xpath>
 
           <value>

--- a/Patches/Vanilla Animals Expanded/TropicalRainforest_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalRainforest_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Gorilla === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Gorilla"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Gorilla"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.2</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Gorilla"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Gorilla"]/tools</xpath>
 
           <value>
             <tools>
@@ -88,7 +88,7 @@
 
         <!-- === Jaguar === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Jaguar"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Jaguar"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.26</MeleeDodgeChance>
@@ -99,7 +99,7 @@
 
         <!-- === Lemur === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Lemur"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Lemur"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.1</MeleeDodgeChance>
@@ -109,7 +109,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Lemur"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Lemur"]/tools</xpath>
           <value>
             <tools>
 
@@ -162,7 +162,7 @@
 
         <!-- === Mandrill === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Mandrill"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Mandrill"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.15</MeleeDodgeChance>
@@ -172,7 +172,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Mandrill"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Mandrill"]/tools</xpath>
 
           <value>
             <tools>
@@ -225,7 +225,7 @@
 
         <!-- === Tapir === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Tapir"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Tapir"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.11</MeleeDodgeChance>
@@ -235,7 +235,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Tapir"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Tapir"]/tools</xpath>
 
           <value>
             <tools>
@@ -267,7 +267,7 @@
 
         <!-- === Tiger === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Tiger"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Tiger"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.27</MeleeDodgeChance>
@@ -277,7 +277,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Tiger"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Tiger"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/TropicalRainforest_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalRainforest_Resources.xml
@@ -11,13 +11,13 @@
         <!-- === Tiger Leather === -->
         <li Class="PatchOperationRemove">
           <xpath>
-            /Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases/StuffPower_Armor_Sharp |
-            /Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases/StuffPower_Armor_Blunt
+            Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases/StuffPower_Armor_Sharp |
+            Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases/StuffPower_Armor_Blunt
           </xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Leather_Tiger"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>

--- a/Patches/Vanilla Animals Expanded/TropicalSwamp_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalSwamp_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === QuadrupedLow === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Alligator"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Alligator"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === Serpentine === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Anaconda"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Anaconda"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -32,7 +32,7 @@
 
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_IndianElephant"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_IndianElephant"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/TropicalSwamp_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/TropicalSwamp_Animals.xml
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Alligator"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Alligator"]/tools</xpath>
 
           <value>
             <tools>
@@ -59,7 +59,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Anaconda"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Anaconda"]/tools</xpath>
 
           <value>
             <tools>
@@ -110,7 +110,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_IndianElephant"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_IndianElephant"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/Tundra_AddClass.xml
+++ b/Patches/Vanilla Animals Expanded/Tundra_AddClass.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Quadruped === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Muskox" or defName="AEXP_Moose" or defName="AEXP_MegaWolverine"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Muskox" or defName="AEXP_Moose" or defName="AEXP_MegaWolverine"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -21,7 +21,7 @@
 
         <!-- === Quadruped Low === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="AEXP_Porcupine"]</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Porcupine"]</xpath>
 
           <value>
             <li Class="CombatExtended.RacePropertiesExtensionCE">

--- a/Patches/Vanilla Animals Expanded/Tundra_Animals.xml
+++ b/Patches/Vanilla Animals Expanded/Tundra_Animals.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Mega Wolverine === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_MegaWolverine"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_MegaWolverine"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_MegaWolverine"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_MegaWolverine"]/tools</xpath>
 
           <value>
             <tools>
@@ -96,7 +96,7 @@
 
         <!-- === Moose === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Moose"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Moose"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
@@ -106,7 +106,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Moose"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Moose"]/tools</xpath>
 
           <value>
             <tools>
@@ -137,7 +137,7 @@
 
         <!-- === Musk Ox === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Muskox"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Muskox"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.17</MeleeDodgeChance>
@@ -147,7 +147,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Muskox"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Muskox"]/tools</xpath>
 
           <value>
             <tools>
@@ -177,7 +177,7 @@
 
         <!-- === Porcupine === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_Porcupine"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Porcupine"]/statBases</xpath>
 
           <value>
             <MeleeDodgeChance>0.01</MeleeDodgeChance>
@@ -187,7 +187,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="AEXP_Porcupine"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_Porcupine"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Animals Expanded/Tundra_Resources.xml
+++ b/Patches/Vanilla Animals Expanded/Tundra_Resources.xml
@@ -10,11 +10,11 @@
       <operations>
         <!-- === Musk Ox Wool === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="AEXP_MuskOxWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_MuskOxWool"]/statBases/StuffPower_Armor_Sharp</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="AEXP_MuskOxWool"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="AEXP_MuskOxWool"]/statBases</xpath>
 
           <value>
             <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>

--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -151,7 +151,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VAEA_Apparel_MiniTurretPack"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_MiniTurretPack"]/verbs</xpath>
 				<value>
 					<verbs>
 						<li Class="CombatExtended.VerbPropertiesCE">
@@ -177,7 +177,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VAEA_Apparel_MiniTurretPack"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_MiniTurretPack"]/comps</xpath>
 				<value>
 				<li Class="CompProperties_Reloadable">
 					<maxCharges>25</maxCharges>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Footwear.xml
@@ -10,7 +10,7 @@
 				
 				<!-- === Plate Boots === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>1.5</WornBulk>
@@ -19,21 +19,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/Mass</xpath>
 					<value>
 						<Mass>2.5</Mass>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/EquipDelay</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/statBases/EquipDelay</xpath>
 					<value>
 						<EquipDelay>3.5</EquipDelay>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<MeleeDodgeChance>-0.05</MeleeDodgeChance>
 						<MoveSpeed>-0.46</MoveSpeed> <!-- 10% of 4.6 -->
@@ -41,14 +41,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/description</xpath>
 					<value>
 						<description>A pair of plate boots which resemble sabatons. Because of the construction and weight of the boots, the wearer is somewhat slower and less nimble.</description>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_PlateBoots"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
@@ -56,7 +56,7 @@
 
 				<!-- === Marine Boots === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>6.75</Bulk>
 						<WornBulk>1.5</WornBulk>
@@ -65,48 +65,48 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/label</xpath>
 					<value>
 						<label>power armor boots</label>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>5</DevilstrandCloth>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Plasteel</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/costList/Plasteel</xpath>
 					<value>
 						<Plasteel>15</Plasteel>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>6</CarryWeight>
@@ -115,7 +115,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Footwear_MarineBoots"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Handwear.xml
@@ -10,7 +10,7 @@
 				
 				<!-- === Plate Gloves === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>1</WornBulk>
@@ -19,21 +19,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/Mass</xpath>
 					<value>
 						<Mass>1.5</Mass>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/EquipDelay</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/statBases/EquipDelay</xpath>
 					<value>
 						<EquipDelay>2</EquipDelay>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/equippedStatOffsets</xpath>
 					<value>
 						<MeleeHitChance>-0.05</MeleeHitChance>
 						<AimingAccuracy>-0.05</AimingAccuracy>
@@ -41,14 +41,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/description</xpath>
 					<value>
 						<description>A pair of plate gloves which resemble gauntlets. Because of the construction of the gloves and the thickness of the material, the wearer is somewhat less capable of manipulation work.</description>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_PlateGloves"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>
@@ -56,7 +56,7 @@
 
 				<!-- === Marine Gloves === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>2</WornBulk>
@@ -65,49 +65,49 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>240</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>18</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>40.5</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/label</xpath>
 					<value>
 						<label>power armor gloves</label>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>10</DevilstrandCloth>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/costList/Plasteel</xpath>
 					<value>
 						<Plasteel>10</Plasteel>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Handwear_MarineGloves"]/apparel/layers</xpath>
 					<value>
 						<li>Shell</li>
 					</value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Industrial.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Ghillie Suit === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/statBases</xpath>
 					<value>
 						<Bulk>31</Bulk>
 						<WornBulk>4.7</WornBulk>
@@ -18,7 +18,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_GhillieSuit"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<AimingAccuracy>0.05</AimingAccuracy>
 					</value>
@@ -26,7 +26,7 @@
 
 				<!-- === HAZMAT Suit === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases</xpath>
 					<value>
 						<Bulk>10</Bulk>
 						<WornBulk>4</WornBulk>
@@ -34,18 +34,18 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HAZMATSuit"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Medieval.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Gambeson === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases</xpath>
 					<value>
 						<Bulk>2.5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -20,21 +20,21 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>30</costStuffCount>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]</xpath>
 					<value>
 						<costList>
 							<Cloth>40</Cloth>
@@ -44,7 +44,7 @@
 
 				<!-- === Quilted Vest === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
 						<Bulk>1.5</Bulk>
 						<WornBulk>0.5</WornBulk>
@@ -52,35 +52,35 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
 						<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases</xpath>
 					<value>
 						<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
 					</value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/costStuffCount</xpath>
 					<value>
 						<costStuffCount>20</costStuffCount>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]</xpath>
 					<value>
 						<costList>
 							<Cloth>30</Cloth>
@@ -90,7 +90,7 @@
 
 				<!-- === Light Plate Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>52.5</Bulk>
 						<WornBulk>6</WornBulk>
@@ -99,21 +99,21 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
 					<value>
 						<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.08</MeleeDodgeChance>
@@ -122,7 +122,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_LightPlateArmor"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>
@@ -145,7 +145,7 @@
 
 				<!-- === Plate Shoulderpads === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>4.5</Bulk>
 						<WornBulk>1.5</WornBulk>
@@ -154,14 +154,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateShoulderpads"]/statBases/StuffEffectMultiplierInsulation_Cold</xpath>
 					<value>
 						<StuffEffectMultiplierInsulation_Cold>0</StuffEffectMultiplierInsulation_Cold>
 					</value>
@@ -169,7 +169,7 @@
 
 				<!-- === Chestplate === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>30</Bulk>
 						<WornBulk>4.5</WornBulk>
@@ -178,14 +178,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.045</MeleeDodgeChance>
@@ -194,7 +194,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chestplate"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chestplate"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>
@@ -217,7 +217,7 @@
 
 				<!-- === Chainmail === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases</xpath>
 					<value>
 						<Bulk>10</Bulk>
 						<WornBulk>5</WornBulk>
@@ -225,14 +225,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1.341</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_Chainmail"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeDodgeChance>-0.1</MeleeDodgeChance>
@@ -242,7 +242,7 @@
 
 				<!-- === Plate Helmet === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -251,14 +251,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>-0.1</AimingAccuracy>
@@ -268,7 +268,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/stuffCategories</xpath>
 					<value>
 						<stuffCategories>
 							<li>Steeled</li>
@@ -277,7 +277,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<bodyPartGroups>
 							<li>UpperHead</li>
@@ -288,7 +288,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_PlateHelmet"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Neolithic.xml
@@ -10,7 +10,7 @@
 				
 				<!-- === Wooden Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>5</WornBulk>
@@ -19,32 +19,32 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>0.9</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>75</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/statBases/ArmorRating_Heat</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_WoodenArmor"]/description</xpath>
 					<value>
 						<description>A vest with wooden logs and planks covering the front and back. No one should be using this in an actual firefight, but anything is better than nothing.</description>
 					</value>
@@ -52,7 +52,7 @@
 
 				<!-- === Stone War Mask === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>1.5</WornBulk>
@@ -61,18 +61,18 @@
 				</li>
 				
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/statBases/ArmorRating_Blunt</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<Suppressability>-0.1</Suppressability>
 						<AimingAccuracy>-0.2</AimingAccuracy>
@@ -81,7 +81,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_StoneWarMask"]/apparel/layers</xpath>
 					<value>
 						<li>OnHead</li>
 						<li>StrappedHead</li>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Armor_Spacer.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Trooper Helmet === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk> <!-- Changed bulk to 4 since advanced helmet is 4 bulk and recon power armor helmet is 4 bulk. -->
 						<WornBulk>0.5</WornBulk>
@@ -19,7 +19,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>0.5</WornBulk>
@@ -28,35 +28,35 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>10.5</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>20</ArmorRating_Blunt> <!-- Blunt armor is based off it being 9mm RHA worth of sharp armor. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/Flammability</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/Flammability</xpath>
 					<value>
 						<Flammability>0.25</Flammability>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>190</MaxHitPoints> <!-- Same health as recon power armor helmet. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/equippedStatOffsets/MentalBreakThreshold</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/equippedStatOffsets/MentalBreakThreshold</xpath>
 					<value>
 						<PsychicSensitivity>-0.1</PsychicSensitivity>
 						<AimingAccuracy>0.1</AimingAccuracy>
@@ -65,7 +65,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalTrooperHelmet"]/equippedStatOffsets/MentalBreakThreshold</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalTrooperHelmet"]/equippedStatOffsets/MentalBreakThreshold</xpath>
 					<value>
 						<AimingAccuracy>0.1</AimingAccuracy>
 						<ToxicEnvironmentResistance>0.10</ToxicEnvironmentResistance>
@@ -73,7 +73,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet" or defName="VAE_Headgear_RoyalTrooperHelmet"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>10</DevilstrandCloth>
 					</value>
@@ -81,7 +81,7 @@
 
 				<!-- It has no visor... -->
 				<!--<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_TrooperHelmet"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Eyes</li>
 					</value>
@@ -89,7 +89,7 @@
 
 				<!-- === Trooper Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>40</Bulk> <!-- It's supposed to be just small enough to be able to wear something on the shell layer, I think dropping it to this is good enough. -->
 						<WornBulk>6</WornBulk>
@@ -98,42 +98,42 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>14</ArmorRating_Sharp> <!-- Just a bit better than a plasteel armor vest, enough to deflect 7.62mm NATO and 7.62mmR. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>28</ArmorRating_Blunt> <!-- Blunt armor is based off it being 12mm RHA worth of sharp armor. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/Flammability</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/Flammability</xpath>
 					<value>
 						<Flammability>0.25</Flammability>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>400</MaxHitPoints> <!-- Same health as recon power armor. -->
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 					<value>
 						<MoveSpeed>0.50</MoveSpeed>
 					</value>
 				</li>
         
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/equippedStatOffsets/MentalBreakThreshold</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/equippedStatOffsets/MentalBreakThreshold</xpath>
 					<value>
 						<CarryWeight>25</CarryWeight>
 						<CarryBulk>7.5</CarryBulk>
@@ -143,21 +143,21 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Feet</li>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]/costList</xpath>
 					<value>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_TrooperArmor" or defName="VAE_Apparel_RoyalTrooperArmor"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>
@@ -204,7 +204,7 @@
 
 				<!-- === Siegebreaker Helmet === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>2</WornBulk>
@@ -213,7 +213,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases</xpath>
 					<value>
 						<Bulk>6</Bulk>
 						<WornBulk>2</WornBulk>
@@ -222,28 +222,28 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>20.4</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>50</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>260</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/Flammability</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/statBases/Flammability</xpath>
 					<value>
 						<Flammability>0</Flammability>
 					</value>
@@ -260,7 +260,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>0.15</AimingAccuracy>
@@ -282,7 +282,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>0.15</AimingAccuracy>
@@ -296,7 +296,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>40</Plasteel>
@@ -308,7 +308,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_RoyalSiegeHelmet"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>60</Plasteel>
@@ -321,7 +321,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet" or defName="VAE_Headgear_RoyalSiegeHelmet"]/apparel/layers</xpath>
 					<value>
 						<li>OnHead</li>
 						<li>StrappedHead</li>
@@ -330,7 +330,7 @@
 
 				<!-- === Siegebreaker Armor === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/Mass</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/Mass</xpath>
 					<value>
 						<Bulk>100</Bulk>
 						<WornBulk>20</WornBulk>
@@ -339,35 +339,35 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/ArmorRating_Sharp</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/ArmorRating_Sharp</xpath>
 					<value>
 						<ArmorRating_Sharp>26</ArmorRating_Sharp>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/ArmorRating_Blunt</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/ArmorRating_Blunt</xpath>
 					<value>
 						<ArmorRating_Blunt>60</ArmorRating_Blunt>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/MaxHitPoints</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/MaxHitPoints</xpath>
 					<value>
 						<MaxHitPoints>600</MaxHitPoints>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/Flammability</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/Flammability</xpath>
 					<value>
 						<Flammability>0</Flammability>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>100</CarryWeight>
@@ -379,7 +379,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<CarryWeight>100</CarryWeight>
@@ -393,7 +393,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>
@@ -401,7 +401,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>140</Plasteel>
@@ -414,7 +414,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/costList</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/costList</xpath>
 					<value>
 						<costList>
 							<Plasteel>180</Plasteel>
@@ -428,7 +428,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>		  				  
@@ -451,35 +451,35 @@
 
 				<!-- === Energy shields === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldRechargeRate</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldRechargeRate</xpath>
 					<value>
 						<EnergyShieldRechargeRate>0.03</EnergyShieldRechargeRate>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldEnergyMax</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/statBases/EnergyShieldEnergyMax</xpath>
 					<value>
 						<EnergyShieldEnergyMax>0.6</EnergyShieldEnergyMax>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
 					<value>
 						<EnergyShieldRechargeRate>0.15</EnergyShieldRechargeRate>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace" MayRequire="ludeon.rimworld.royalty">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldRechargeRate</xpath>
 					<value>
 						<EnergyShieldRechargeRate>0.3</EnergyShieldRechargeRate>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor" or defName="VAE_Apparel_RoyalSiegeArmor"]/comps/li[@Class="VFECore.CompProperties_ShieldBubble"]/EnergyShieldEnergyMax</xpath>
 					<value>
 						<EnergyShieldEnergyMax>150</EnergyShieldEnergyMax>
 					</value>

--- a/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/ThingDefs_Misc/Headgear_Industrial.xml
@@ -10,7 +10,7 @@
 				
 				<!-- === Balaclava === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<Bulk>0.5</Bulk>
 						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
@@ -18,7 +18,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
 					<value>
 						<layers>
 							<li>OnHead</li>
@@ -27,7 +27,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<bodyPartGroups>
 							<li>UpperHead</li>
@@ -38,7 +38,7 @@
 
 				<!-- === Ghillie Hood === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/statBases</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>0.5</WornBulk>
@@ -46,7 +46,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_GhillieHood"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<AimingAccuracy>0.1</AimingAccuracy>
 					</value>
@@ -54,7 +54,7 @@
 
 				<!-- === HAZMAT Mask === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 						<Bulk>6</Bulk>
@@ -63,14 +63,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/equippedStatOffsets/WorkSpeedGlobal</xpath>
 					<value>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
+					<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
 					<value>
 						<li>StrappedHead</li>
 					</value>

--- a/Patches/Vanilla Brewing Expanded/Alcohol.xml
+++ b/Patches/Vanilla Brewing Expanded/Alcohol.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Beverages === -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[@Name="VBE_DrugToolBase"]</xpath>
+					<xpath>Defs/ThingDef[@Name="VBE_DrugToolBase"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeCritChance>0.1</MeleeCritChance>
@@ -21,7 +21,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[@Name="VBE_DrugToolBase"]/tools</xpath>
+					<xpath>Defs/ThingDef[@Name="VBE_DrugToolBase"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -50,7 +50,7 @@
 
 				<!-- === Mixing === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/HediffDef[defName="VBE_WhiskeyAsIngredient"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
+					<xpath>Defs/HediffDef[defName="VBE_WhiskeyAsIngredient"]/stages/li[1]/statOffsets/ShootingAccuracyPawn</xpath>
 					<value>
 						<ShootingAccuracyPawn>3</ShootingAccuracyPawn>
 						<AimingAccuracy>1.5</AimingAccuracy>
@@ -58,14 +58,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/HediffDef[defName="VBE_VodkaAsIngredient"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
+					<xpath>Defs/HediffDef[defName="VBE_VodkaAsIngredient"]/stages/li[1]/statOffsets/MeleeDodgeChance</xpath>
 					<value>
 						<MeleeDodgeChance>2</MeleeDodgeChance>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/HediffDef[defName="VBE_ConsumedGoStock"]/stages/li[1]</xpath>
+					<xpath>Defs/HediffDef[defName="VBE_ConsumedGoStock"]/stages/li[1]</xpath>
 					<value>
 						<statOffsets>
 							<Suppressability>-0.10</Suppressability>
@@ -74,7 +74,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/HediffDef[defName="VBE_RBMeadAsIngredient"]/stages/li[1]/statOffsets</xpath>
+					<xpath>Defs/HediffDef[defName="VBE_RBMeadAsIngredient"]/stages/li[1]/statOffsets</xpath>
 					<value>
 						<SmokeSensitivity>-0.10</SmokeSensitivity>
 					</value>

--- a/Patches/Vanilla Brewing Expanded/ThingDefs_Items.xml
+++ b/Patches/Vanilla Brewing Expanded/ThingDefs_Items.xml
@@ -9,49 +9,49 @@
 			<operations>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_Cigarettes"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_Cigarettes"]/statBases</xpath>
 					<value>
 						<Bulk>0.01</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_Cigars"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_Cigars"]/statBases</xpath>
 					<value>
 						<Bulk>0.05</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_Tea"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_Tea"]/statBases</xpath>
 					<value>
 						<Bulk>0.20</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_Soda"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_Soda"]/statBases</xpath>
 					<value>
 						<Bulk>0.25</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_Juice"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_Juice"]/statBases</xpath>
 					<value>
 						<Bulk>1.75</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_EnergyDrink"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_EnergyDrink"]/statBases</xpath>
 					<value>
 						<Bulk>0.70</Bulk>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VBE_HotCoffee" or defName="VBE_IcedCoffee"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VBE_HotCoffee" or defName="VBE_IcedCoffee"]/statBases</xpath>
 					<value>
 						<Bulk>0.40</Bulk>
 					</value>

--- a/Patches/Vanilla Chemfuel Expanded/Items_Chemfuel.xml
+++ b/Patches/Vanilla Chemfuel Expanded/Items_Chemfuel.xml
@@ -11,7 +11,7 @@
       <!-- Give chemfuel-like product appropriate bulk. -->
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VCHE_Deepchem"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="VCHE_Deepchem"]/statBases</xpath>
         <value>
           <Bulk>0.05</Bulk>
         </value>

--- a/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/CustomGenDefs_Vaults.xml
@@ -48,84 +48,84 @@
       <!-- I'm not sure if this works, and it's probably very fragile. -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultAlpha"]/layouts/li[1]/li[66]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultAlpha"]/layouts/li[1]/li[66]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultBravo"]/layouts/li[1]/li[14]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultBravo"]/layouts/li[1]/li[14]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultCharlie"]/layouts/li[1]/li[10]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultDelta"]/layouts/li[1]/li[19]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultF"]/layouts/li[1]/li[35]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_AssaultRifle,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultG"]/layouts/li[1]/li[23]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Ammo_12Gauge_Buck,Gun_ChainShotgun,Ammo_12Gauge_Buck,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[31]</xpath>
         <value>
               <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x51mmNATO_Incendiary,Ammo_762x54mmR_HE,Ammo_762x54mmR_HE,Gun_LMG,Ammo_45ACP_AP,Gun_Minigun,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultH"]/layouts/li[1]/li[35]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,MealSurvivalPack,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,Ammo_762x51mmNATO_Incendiary,.,.,.,.,.,MealSurvivalPack,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Apparel_PowerArmor,Gun_Autopistol,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultI"]/layouts/li[1]/li[19]</xpath>
         <value>
               <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,Gun_ChargeRifle,Ammo_6x24mmCharged,Ammo_6x24mmCharged,Gun_HeavySMG,Ammo_45ACP_AP,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[35]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Gun_MachinePistol,Ammo_45ACP_AP,Apparel_PowerArmorHelmet,Ammo_45ACP_AP,Ammo_556x45mmNATO_Incendiary,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,Apparel_PowerArmor,Ammo_556x45mmNATO_Incendiary,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
+        <xpath>Defs/KCSG.StructureLayoutDef[defName="VFEA_SealedVaultJ"]/layouts/li[1]/li[36]</xpath>
         <value>
           <li>.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,Ammo_556x45mmNATO_Incendiary,Gun_MachinePistol,Ammo_45ACP_AP,Ammo_45ACP_AP,Ammo_762x54mmR_HE,Gun_LMG,Ammo_762x54mmR_HE,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.</li>
         </value>

--- a/Patches/Vanilla Factions Expanded - Ancients/Hediffs_Powers.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/Hediffs_Powers.xml
@@ -9,7 +9,7 @@
       <operations>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/HediffDef[defName="VFEA_PlasteelClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+        <xpath>Defs/HediffDef[defName="VFEA_PlasteelClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Ancients/Patch_Abilities.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/Patch_Abilities.xml
@@ -9,14 +9,14 @@
 
       <!-- Super Jump -->
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/VFECore.Abilities.AbilityDef[defName="VFEA_SuperJump"]/range</xpath>
+        <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VFEA_SuperJump"]/range</xpath>
         <value>
           <range>20</range>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/VFECore.Abilities.AbilityDef[defName="VFEA_SuperJump"]/description</xpath>
+        <xpath>Defs/VFECore.Abilities.AbilityDef[defName="VFEA_SuperJump"]/description</xpath>
         <value>
           <description>Jump over a medium distance (20 cells) within line of sight to close the distance to the enemy.</description>
         </value>
@@ -24,7 +24,7 @@
 
       <!-- Weapon Expert --> 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="WeaponExpert"]/statFactors</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="WeaponExpert"]/statFactors</xpath>
         <value>
           <ReloadSpeed>2</ReloadSpeed>
           <ShootingAccuracyPawn>2</ShootingAccuracyPawn>
@@ -33,14 +33,14 @@
 
       <!-- Marksmanship -->
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="Marksmanship"]/setStats/ShootingAccuracyPawn</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="Marksmanship"]/setStats/ShootingAccuracyPawn</xpath>
         <value>
           <ShootingAccuracyPawn>20</ShootingAccuracyPawn>  
         </value>
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="Marksmanship"]</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="Marksmanship"]</xpath>
         <value>
         <statFactors>
           <AimingAccuracy>5</AimingAccuracy> 
@@ -50,7 +50,7 @@
 
       <!-- Assassin -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="Assassin"]</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="Assassin"]</xpath>
         <value>
         <statOffsets>
           <MeleeCritChance>100</MeleeCritChance>
@@ -60,7 +60,7 @@
 
       <!-- Super Strength -->   
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="SuperStrength"]/statFactors</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="SuperStrength"]/statFactors</xpath>
         <value>
           <CarryWeight>2</CarryWeight>
           <CarryBulk>2</CarryBulk>  
@@ -69,7 +69,7 @@
 
       <!-- Darkvision -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/VFEAncients.PowerDef[defName="Darkvision"]</xpath>
+        <xpath>Defs/VFEAncients.PowerDef[defName="Darkvision"]</xpath>
         <value>
         <statOffsets>
           <NightVisionEfficiency>1</NightVisionEfficiency>

--- a/Patches/Vanilla Factions Expanded - Ancients/PawnKinds_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/PawnKinds_Spacer.xml
@@ -9,7 +9,7 @@
       <operations>
         
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -30,9 +30,9 @@
         </li>
 
         <li Class="PatchOperationConditional">
-          <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]/skills</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]/skills</xpath>
           <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
+            <xpath>Defs/PawnKindDef[defName="VFEA_AncientSoldierOneAbility" or defName="VFEA_AncientSoldierTwoAbilities" or defName="VFEA_PlayerAncientSoldierOneAbility"]</xpath>
             <value>
               <skills>
                 <li>

--- a/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Factions Expanded - Ancients/ThingDefs_Sentry.xml
@@ -36,7 +36,7 @@
 	    </li>
 
 	    <li Class="PatchOperationAdd">
-	      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
+	      <xpath>Defs/ThingDef[defName="VFEA_Turret_AncientPointDefense"]</xpath>
 	      <value>
 		<fillPercent>0.95</fillPercent>
 	      </value>
@@ -81,7 +81,7 @@
 	    </li>
 
 	    <li Class="PatchOperationReplace">
-	      <xpath>/Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
+	      <xpath>Defs/ThingDef[defName="VFEA_Turret_AncientSecurityTurret"]/fillPercent</xpath>
 	      <value>
 		<fillPercent>0.85</fillPercent>
 	      </value>

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
@@ -20,7 +20,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Javelins"]/ammoTypes</xpath>
+			<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Javelins"]/ammoTypes</xpath>
 			<value>
 				<VFEC_Javelin>Classical_Javelin_Fired</VFEC_Javelin>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
@@ -11,7 +11,7 @@
 
         <!-- === Ammo === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs</xpath>
+          <xpath>Defs</xpath>
           <value>
 
           <CombatExtended.AmmoSetDef>

--- a/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Items_Resource_Stuff.xml
@@ -9,7 +9,7 @@
 
 			<!-- Opium -->
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/HediffDef[defName = "VFEC_OpiumHigh"]/stages/li</xpath>
+				<xpath>Defs/HediffDef[defName = "VFEC_OpiumHigh"]/stages/li</xpath>
 				<value>
 					<statFactors>
 						<Suppressability>0.50</Suppressability>
@@ -19,14 +19,14 @@
 
 			<!-- Bronze -->
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/statBases</xpath>
 				<value>
 					<Bulk>0.03</Bulk>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/categories</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/categories</xpath>
 				<value>
 					<li>Metallic_Weapon</li>
 					<li>Steeled</li>
@@ -34,35 +34,35 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.83</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>1.24</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0</StuffPower_Armor_Heat>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
 				<value>
 					<MeleePenetrationFactor>0.80</MeleePenetrationFactor>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Bronze"]/stuffProps/statFactors</xpath>
 				<value>
 					<Mass>1.1</Mass>
 				</value>
@@ -71,28 +71,28 @@
 			<!-- Tyrian -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.015</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0.044</StuffPower_Armor_Heat>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Tyrian"]/statBases</xpath>
 				<value>
 					<Bulk>0.05</Bulk>
 				</value>

--- a/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/PawnKinds_Misc.xml
@@ -9,7 +9,7 @@
 
       <!-- Increase Legionaire weapon money slightly. -->
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/PawnKindDef[defName="VFEC_Legionnaire"]/weaponMoney</xpath>
+        <xpath>Defs/PawnKindDef[defName="VFEC_Legionnaire"]/weaponMoney</xpath>
         <value>
           <weaponMoney>140~300</weaponMoney>
         </value>
@@ -17,7 +17,7 @@
 
       <!-- Give Auxilaries some javelins. -->
       <li Class="PatchOperationAddModExtension">
-        <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]</xpath>
+        <xpath>Defs/PawnKindDef[defName="VFEC_RepublicAuxilia"]</xpath>
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
@@ -43,7 +43,7 @@
 
       <!-- Give Archers some arrows. -->
       <li Class="PatchOperationAddModExtension">
-        <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicArcher"]</xpath>
+        <xpath>Defs/PawnKindDef[defName="VFEC_RepublicArcher"]</xpath>
         <value>
           <li Class="CombatExtended.LoadoutPropertiesExtension">
             <primaryMagazineCount>
@@ -69,7 +69,7 @@
 
       <!-- Give pawns some packs. -->
       <li Class="PatchOperationAdd">
-      <xpath>/Defs/PawnKindDef[defName="VFEC_RepublicArcher" or defName="VFEC_RepublicAuxilia"]/apparelRequired</xpath>
+      <xpath>Defs/PawnKindDef[defName="VFEC_RepublicArcher" or defName="VFEC_RepublicAuxilia"]/apparelRequired</xpath>
         <value>
           <li>CE_Apparel_TribalBackpack</li>
         </value>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Manned.xml
@@ -9,25 +9,25 @@
 		<operations>
 
 		<li Class="PatchOperationRemove">
-		<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+		<xpath>Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/thingClass</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/thingClass</xpath>
 			<value>
 				<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/fillPercent</xpath>
+		<xpath>Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/fillPercent</xpath>
 			<value>
 				<fillPercent>0.85</fillPercent>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/building/turretBurstCooldownTime</xpath>
+		<xpath>Defs/ThingDef[defName = "VFEC_Turret_Scorpion"]/building/turretBurstCooldownTime</xpath>
 			<value>
 				<turretBurstCooldownTime>1.8</turretBurstCooldownTime>
 			</value>
@@ -65,7 +65,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-		  <xpath>/Defs/ThingDef[defName = "VFEC_TurretGun_Scorpion"]</xpath>
+		  <xpath>Defs/ThingDef[defName = "VFEC_TurretGun_Scorpion"]</xpath>
 		  <value>
 		  	<weaponTags>
 		    	<li>TurretGun</li>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_Shields.xml
@@ -10,7 +10,7 @@
 
 			<!-- Roman Shield (Scutum) -->
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Shield_Heavy"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Shield_Heavy"]</xpath>
 				<value>
 					<ThingDef ParentName="ShieldBase">
 					<defName>VFEC_Shield_Heavy</defName>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsMelee.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsMelee.xml
@@ -10,7 +10,7 @@
 
 		<!--One-handed Tags -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFEC_MeleeWeapon_Spatha" or defName="VFEC_MeleeWeapon_Dagger"]/weaponTags</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEC_MeleeWeapon_Spatha" or defName="VFEC_MeleeWeapon_Dagger"]/weaponTags</xpath>
 			<value>
 				<li>CE_OneHandedWeapon</li>
 			</value>
@@ -18,7 +18,7 @@
 
 		<!-- Spatha -->
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -59,7 +59,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]/statBases</xpath>
 			<value>
 				<Bulk>5</Bulk>
 				<MeleeCounterParryBonus>0.42</MeleeCounterParryBonus>
@@ -67,7 +67,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Spatha"]</xpath>
 			<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.21</MeleeCritChance>
@@ -80,7 +80,7 @@
 		<!-- Dagger (Pugio) -->
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -121,7 +121,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]/statBases</xpath>
 			<value>
 				<Bulk>1</Bulk>
 				<MeleeCounterParryBonus>0.5</MeleeCounterParryBonus>
@@ -129,7 +129,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]</xpath>
+			<xpath>Defs/ThingDef[defName="VFEC_MeleeWeapon_Dagger"]</xpath>
 			<value>
 				<equippedStatOffsets>
 				<MeleeCritChance>0.63</MeleeCritChance>

--- a/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/ThingDefs_WeaponsRanged.xml
@@ -12,41 +12,41 @@
 
 			<!-- This dummy parent just provides a workaround so VFE - Classical can be loaded before CE. -->
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs</xpath>
+				<xpath>Defs</xpath>
 				<value>
 					<ThingDef ParentName="BaseWeaponAndAmmoNeolithic" Name="JavelinBase_VFEC" Abstract="True" />
 				</value>				
 			</li>	
 
 			<li Class="PatchOperationAttributeSet">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<attribute>ParentName</attribute>
 				<value>JavelinBase_VFEC</value>				
 			</li>	
 
 			<li Class="PatchOperationAttributeAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<attribute>Class</attribute>
 				<value>CombatExtended.AmmoDef</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/costList</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]/costList</xpath>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]</xpath>
 				<value>
 					<techLevel>Neolithic</techLevel>			
 				</value>				
 			</li>		
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/recipeMaker</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]/recipeMaker</xpath>
 			</li>
 	
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]/statBases</xpath>
 				<value>
 					<statBases>
 						<MarketValue>7.26</MarketValue>
@@ -63,7 +63,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]/verbs</xpath>
 				<value>
 					<verbs>
 						<li Class="CombatExtended.VerbPropertiesCE">
@@ -79,7 +79,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Javelin"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Javelin"]/tools</xpath>
 				<value>	
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -164,18 +164,18 @@
 			<!-- === Can't remove it entirely without causing errors, but make the mobile "Scorpion" weapon inaccessible. === -->
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Weapon_Scorpion"]/weaponTags</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/minifiedDef</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Turret_Scorpion"]/minifiedDef</xpath>
 				<value>
 					<minifiedDef>MinifiedThing</minifiedDef>			
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFEC_Turret_Scorpion" or defName="VFEC_TurretGun_Scorpion"]/description</xpath>
+				<xpath>Defs/ThingDef[defName="VFEC_Turret_Scorpion" or defName="VFEC_TurretGun_Scorpion"]/description</xpath>
 				<value>
 				  <description>A ballista-like turret capable of firing rapidly when set up and manned. Very effective against enemy infantry.</description>
 				</value>

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
@@ -33,7 +33,7 @@
           <graphicData>
             <texPath>Things/Ammo/Mortar/Charged</texPath>
             <graphicClass>Graphic_StackCount</graphicClass>
-            <drawSize>0.80</drawSize>
+            <drawSize>0.6</drawSize>
           </graphicData>
           <statBases>
             <MarketValue>4.6</MarketValue>
@@ -52,6 +52,7 @@
             <texPath>Things/Projectile/LauncherShot</texPath>
             <graphicClass>Graphic_Single</graphicClass>
             <shaderType>TransparentPostLight</shaderType>
+            <drawSize>(0.5,0.5)</drawSize>
           </graphicData>          
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Thump</damageDef>

--- a/Patches/Vanilla Factions Expanded - Empire/Apparel_Various.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Apparel_Various.xml
@@ -268,6 +268,16 @@
 			</value>
 		</li>
 
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="VFEE_Apparel_JanissaryCuirass"]</xpath>
+			<value>
+				<equippedStatOffsets>
+					<CarryWeight>14</CarryWeight>
+					<CarryBulk>10</CarryBulk>
+				</equippedStatOffsets>
+			</value>
+		</li>
+
 		<li Class="PatchOperationAddModExtension">
 			<xpath>Defs/ThingDef[defName="VFEE_Apparel_JanissaryCuirass"]</xpath>
 			<value>

--- a/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
@@ -11,7 +11,7 @@
       <!-- Striker Turret -->
       <!-- Remove refuelable property -->
       <li Class="PatchOperationRemove">
-        <xpath>Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/comps/li[@Class = "VFEPirates.CompProperties_Fueled"]</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
       </li>
 
       <!-- Replace vanilla thingClass -->
@@ -73,8 +73,8 @@
 
       <!-- Armored Shuttle Turret -->
 
-      <li Class="PatchOperationReplace">
-        <xpath>Defs/ThingDef[defName = "VFEI_TurretArmoredShuttle_CE"]/statBases/ShootingAccuracyTurret</xpath>
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/statBases</xpath>
         <value>
           <ShootingAccuracyTurret>0.99</ShootingAccuracyTurret>
         </value>
@@ -87,10 +87,17 @@
         </value>
       </li>
 
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building/turretBurstCooldownTime</xpath>
+        <value>
+          <turretBurstCooldownTime>2.2</turretBurstCooldownTime>
+        </value>
+      </li>
+
       <li Class="PatchOperationAdd">
         <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building</xpath>
         <value>
-          <turretBurstWarmupTime>3.0</turretBurstWarmupTime>
+          <turretBurstWarmupTime>2.3</turretBurstWarmupTime>
         </value>
       </li>
 
@@ -110,11 +117,11 @@
             </graphicData>
             <soundInteract>Interact_Rifle</soundInteract>
             <statBases>
-              <AccuracyTouch>0.24</AccuracyTouch>
-              <AccuracyShort>0.52</AccuracyShort>
-              <AccuracyMedium>0.57</AccuracyMedium>
-              <AccuracyLong>0.43</AccuracyLong>
-              <RangedWeapon_Cooldown>5.6</RangedWeapon_Cooldown>
+              <AccuracyTouch>0.4</AccuracyTouch>
+              <AccuracyShort>0.65</AccuracyShort>
+              <AccuracyMedium>0.70</AccuracyMedium>
+              <AccuracyLong>0.60</AccuracyLong>
+              <RangedWeapon_Cooldown>1.6</RangedWeapon_Cooldown>
               <DeteriorationRate>0</DeteriorationRate>
               <Mass>80</Mass>
               <Flammability>0</Flammability>
@@ -126,9 +133,9 @@
                 <defaultProjectile>Bullet_ArmoredShuttleTurret_CE</defaultProjectile>
                 <minRange>8.9</minRange>
                 <warmupTime>2.3</warmupTime>
-                <range>78</range>
-                <ticksBetweenBurstShots>4</ticksBetweenBurstShots>
-                <burstShotCount>10</burstShotCount>
+                <range>55</range>
+                <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+                <burstShotCount>6</burstShotCount>
                 <soundCast>Shot_Autocannon</soundCast>
                 <soundCastTail>GunTail_Heavy</soundCastTail>
                 <muzzleFlashScale>12</muzzleFlashScale>
@@ -145,9 +152,9 @@
             </graphicData>
             <projectile>
               <damageDef>Bullet</damageDef>
-              <damageAmountBase>44</damageAmountBase>
-              <speed>206</speed>
-              <armorPenetrationBase>30</armorPenetrationBase>  
+              <damageAmountBase>15</damageAmountBase>
+              <speed>170</speed>
+              <armorPenetrationBase>25</armorPenetrationBase>
             </projectile>
           </ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
@@ -90,7 +90,7 @@
       <li Class="PatchOperationReplace">
         <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building/turretBurstCooldownTime</xpath>
         <value>
-          <turretBurstCooldownTime>2.2</turretBurstCooldownTime>
+          <turretBurstCooldownTime>1.0</turretBurstCooldownTime>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
@@ -11,26 +11,26 @@
       <!-- Striker Turret -->
       <!-- Remove refuelable property -->
       <li Class="PatchOperationRemove">
-        <xpath>/Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/comps/li[@Class = "VFEPirates.CompProperties_Fueled"]</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/comps/li[@Class = "VFEPirates.CompProperties_Fueled"]</xpath>
       </li>
 
       <!-- Replace vanilla thingClass -->
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/thingClass</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/thingClass</xpath>
           <value>
             <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
           </value>
       </li>
 
       <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFEE_Turret_StrikerTurret"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFEE_Turret_StrikerTurret"]/statBases</xpath>
           <value>
             <AimingAccuracy>0.5</AimingAccuracy>
           </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/building/turretBurstCooldownTime</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEE_Turret_StrikerTurret"]/building/turretBurstCooldownTime</xpath>
         <value>
           <turretBurstCooldownTime>1.1</turretBurstCooldownTime>
         </value>
@@ -74,21 +74,21 @@
       <!-- Armored Shuttle Turret -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEI_TurretArmoredShuttle_CE"]/statBases/ShootingAccuracyTurret</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEI_TurretArmoredShuttle_CE"]/statBases/ShootingAccuracyTurret</xpath>
         <value>
           <ShootingAccuracyTurret>0.99</ShootingAccuracyTurret>
         </value>
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building/turretGunDef</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building/turretGunDef</xpath>
         <value>
           <turretGunDef>VFEI_TurretArmoredShuttle_CE</turretGunDef>
         </value>
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building</xpath>
+        <xpath>Defs/ThingDef[defName = "VFEI_ArmoredShuttle"]/building</xpath>
         <value>
           <turretBurstWarmupTime>3.0</turretBurstWarmupTime>
         </value>
@@ -96,7 +96,7 @@
 
       <!-- Vanilla Gauntlet Charge Cannnon -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs</xpath>
+        <xpath>Defs</xpath>
         <value>
 
           <ThingDef ParentName="BaseWeaponTurret">

--- a/Patches/Vanilla Factions Expanded - Empire/PawnKinds_Empire.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/PawnKinds_Empire.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Empire</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[defName="VFEE_Empire_Fighter_Absolver"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>20</min>
+								<max>30</max>
+							</primaryMagazineCount>
+							<sidearms>
+								<li>
+									<generateChance>0.5</generateChance>
+									<sidearmMoney>
+										<min>300</min>
+										<max>500</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+								<li>
+									<generateChance>0.1</generateChance>
+									<sidearmMoney>
+										<min>10</min>
+										<max>100</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>GrenadeSmoke</li>
+									</weaponTags>
+									<magazineCount>
+										<min>1</min>
+										<max>2</max>
+									</magazineCount>
+								</li>
+								<li>
+									<generateChance>0.1</generateChance>
+									<sidearmMoney>
+										<min>10</min>
+										<max>100</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_FlareLauncher</li>
+									</weaponTags>
+									<magazineCount>
+										<min>1</min>
+										<max>3</max>
+									</magazineCount>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/PawnKindDef[defName="VFEE_Empire_Fighter_Absolver"]/specificApparelRequirements</xpath>
+					<value>
+						<li>
+							<bodyPartGroup>Shoulders</bodyPartGroup>
+							<apparelLayer>Backpack</apparelLayer>
+							<stuff>Synthread</stuff>
+							<color>(10, 10, 10)</color>
+						</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/Vanilla Factions Expanded - Empire/RangedSpacer.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/RangedSpacer.xml
@@ -11,7 +11,7 @@
 			<!-- === Tools === -->
 			<li Class="PatchOperationReplace">
 				<xpath>
-					/Defs/ThingDef[
+					Defs/ThingDef[
 						defName = "VEE_Gun_Fletcher" or
 						defName = "VFEE_Gun_ChargeThumper"
 					]/tools

--- a/Patches/Vanilla Factions Expanded - Empire/Scenario_Empire.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Scenario_Empire.xml
@@ -9,7 +9,7 @@
 
       <!-- === Adds ammo to the scenario === -->
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ScenarioDef[defName="VFEE_NewFamily"]/scenario/parts</xpath>
+        <xpath>Defs/ScenarioDef[defName="VFEE_NewFamily"]/scenario/parts</xpath>
         <value>
         <li Class="ScenPart_ScatterThingsAnywhere">
           <def>ScatterThingsAnywhere</def>

--- a/Patches/Vanilla Factions Expanded - Insectoids/Ammo/MadnessShell.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Ammo/MadnessShell.xml
@@ -23,7 +23,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Shell_PsychicWarhead"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Shell_PsychicWarhead"]</xpath>
 
           <value>
             <ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">
@@ -56,7 +56,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Bullet_Shell_PsychicWarhead"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Bullet_Shell_PsychicWarhead"]</xpath>
 
           <value>
             <ThingDef ParentName="Base81mmMortarShell">
@@ -79,7 +79,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
+          <xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_81mmMortarShell"]/ammoTypes</xpath>
 
           <value>
             <VFEI_Shell_PsychicWarhead>VFEI_Bullet_Shell_PsychicWarhead</VFEI_Shell_PsychicWarhead>

--- a/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Boomtick.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Boomtick.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Boomtick === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/BodyDef[defName="VFEI_Boomtick"]//*[def="Shell" or def="Elytra" or def="Pronotum"]</xpath>
+          <xpath>Defs/BodyDef[defName="VFEI_Boomtick"]//*[def="Shell" or def="Elytra" or def="Pronotum"]</xpath>
 
           <value>
             <groups>

--- a/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Scorpionlike.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Scorpionlike.xml
@@ -11,7 +11,7 @@
         <!-- === Scorpion === -->
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/BodyDef[defName="VFEI_ScorpionLike"]//*[
+            Defs/BodyDef[defName="VFEI_ScorpionLike"]//*[
             def="Shell" or 
             def="VFEI_Thorax" or 
             def="Pronotum" or 
@@ -25,7 +25,7 @@
 
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/BodyDef[defName="VFEI_ScorpionLike"]//*[
+            Defs/BodyDef[defName="VFEI_ScorpionLike"]//*[
             def="Shell" or 
             def="VFEI_Thorax" or 
             def="Pronotum" or 

--- a/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Wargling.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Bodies/Bodies_Wargling.xml
@@ -11,7 +11,7 @@
         <!-- === Wargling === -->
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/BodyDef[defName="VFEI_Wargling"]//*[
+            Defs/BodyDef[defName="VFEI_Wargling"]//*[
             def="Shell" or
             def="Elytra" or
             def="Pronotum"]
@@ -24,7 +24,7 @@
 
         <li Class="PatchOperationAdd">
           <xpath>
-            /Defs/BodyDef[defName="VFEI_Wargling"]//*[
+            Defs/BodyDef[defName="VFEI_Wargling"]//*[
             def="Shell" or
             def="Elytra" or
             def="Pronotum" or

--- a/Patches/Vanilla Factions Expanded - Insectoids/Hediffs/Hediffs_Mutations.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Hediffs/Hediffs_Mutations.xml
@@ -10,7 +10,7 @@
       <operations>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/HediffDef[defName="VFEI_VenomGland"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+          <xpath>Defs/HediffDef[defName="VFEI_VenomGland"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 
           <value>
             <tools>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/HediffDef[defName="VFEI_PneumaticClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+          <xpath>Defs/HediffDef[defName="VFEI_PneumaticClaw"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/PawnKindDefs_Humanlikes/PawnKinds_Pirate.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/PawnKindDefs_Humanlikes/PawnKinds_Pirate.xml
@@ -9,11 +9,11 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/PawnKindDef[defName="VFEI_RiotUnit"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEI_RiotUnit"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]</xpath>
         </li>
         
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="VFEI_RiotUnit"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEI_RiotUnit"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <shieldMoney>

--- a/Patches/Vanilla Factions Expanded - Insectoids/Scenario/Scenario.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Scenario/Scenario.xml
@@ -10,12 +10,12 @@
       <operations>
         <!-- === Removes Charge Lance from scenario === -->
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts/li[thingDef="Gun_ChargeLance"]</xpath>
+          <xpath>Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts/li[thingDef="Gun_ChargeLance"]</xpath>
         </li>
 
         <!-- === Increases Charge Rifle count to 3 to replace the CL === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts/li[thingDef="Gun_ChargeRifle"]/count</xpath>
+          <xpath>Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts/li[thingDef="Gun_ChargeRifle"]/count</xpath>
 
           <value>
             <count>3</count>
@@ -24,7 +24,7 @@
 
         <!-- === Adds ammo to the scenario === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts</xpath>
+          <xpath>Defs/ScenarioDef[defName="VFEI_MercenarySquad"]/scenario/parts</xpath>
 
           <value>
             <li Class="ScenPart_StartingThing_Defined">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Items/Items_Resource_Leathers.xml
@@ -62,14 +62,14 @@
 
 		<!-- === Spidersilk === -->
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEI_Spidersilk"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFEI_Spidersilk"]/statBases/StuffPower_Armor_Sharp</xpath>
 			<value>
 				<StuffPower_Armor_Sharp>0.01</StuffPower_Armor_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEI_Spidersilk"]/statBases/StuffPower_Armor_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFEI_Spidersilk"]/statBases/StuffPower_Armor_Blunt</xpath>
 			<value>
 				<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Apparel_Various.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Riot Helmet === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases</xpath>
 
           <value>
             <Bulk>5</Bulk>
@@ -19,7 +19,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>3.5</ArmorRating_Sharp>
@@ -27,7 +27,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>28</ArmorRating_Blunt>
@@ -35,7 +35,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/costList/Steel</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/costList/Steel</xpath>
 
           <value>
             <Steel>55</Steel>
@@ -44,11 +44,11 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/costList/ComponentIndustrial</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]/costList/ComponentIndustrial</xpath>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Apparel_RiotHelmet"]</xpath>
 		<value>
 			  <li Class="CombatExtended.PartialArmorExt">
 				<stats>
@@ -95,7 +95,7 @@
 
         <!-- === Riot Armor === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases</xpath>
 
           <value>
             <Bulk>40</Bulk>
@@ -104,7 +104,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/Mass</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/Mass</xpath>
 
           <value>
             <Mass>20</Mass>
@@ -112,7 +112,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>6</ArmorRating_Sharp>
@@ -120,7 +120,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>36</ArmorRating_Blunt>
@@ -128,7 +128,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/Cloth</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/Cloth</xpath>
 
           <value>
             <Cloth>80</Cloth>
@@ -137,7 +137,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/Steel</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/Steel</xpath>
 
           <value>
             <Steel>80</Steel>
@@ -145,12 +145,12 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/ComponentIndustrial</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/costList/ComponentIndustrial</xpath>
 
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/equippedStatOffsets/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 
           <value>
             <MeleeDodgeChance>-0.15</MeleeDodgeChance>
@@ -158,7 +158,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/apparel/bodyPartGroups</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]/apparel/bodyPartGroups</xpath>
 
           <value>
             <li>Hands</li>
@@ -167,7 +167,7 @@
         </li>
 
 	<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Apparel_RiotArmor"]</xpath>
 		<value>
 			  <li Class="CombatExtended.PartialArmorExt">
 				  <stats>
@@ -226,7 +226,7 @@
 
         <!-- === Riot Shield : Replaced as CE type shield === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Shield_Riot"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Shield_Riot"]</xpath>
           <value>
             <ThingDef ParentName="ShieldBase">
               <defName>VFEI_Shield_Riot</defName>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Weapons_Spacer.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Misc/Weapons_Spacer.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Gun_Plasmacutter"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Gun_Plasmacutter"]/tools</xpath>
 
           <value>
             <tools>
@@ -40,7 +40,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Gun_PlasmaScattergun" or defName="VFE_Gun_Plasmapiercer" or defName="VFE_Gun_PlasmabeamRifle"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Gun_PlasmaScattergun" or defName="VFE_Gun_Plasmapiercer" or defName="VFE_Gun_PlasmabeamRifle"]/tools</xpath>
 
           <value>
             <tools>
@@ -81,7 +81,7 @@
 
         <!-- === Plasma Saw === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Plasmasaw"]/statBases/Mass</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Plasmasaw"]/statBases/Mass</xpath>
 
           <value>
             <Mass>2.8</Mass>
@@ -91,7 +91,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFE_Plasmasaw"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFE_Plasmasaw"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races/Races_Animal_Insect.xml
@@ -11,7 +11,7 @@
 
         <!-- === Queen === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>2.6</MoveSpeed>
             <MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -21,21 +21,21 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>15</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>6</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Queen"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -77,7 +77,7 @@
 
         <!-- === Royal Megaspider === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>4.4</MoveSpeed>
             <MeleeDodgeChance>0.06</MeleeDodgeChance>
@@ -87,28 +87,28 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>14</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>6</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/race/baseHealthScale</xpath>
           <value>
             <baseHealthScale>2.5</baseHealthScale>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_RoyalMegaspider"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -150,7 +150,7 @@
 
         <!-- === Royal Megapede === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>3.3</MoveSpeed>
             <MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -160,35 +160,35 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>25</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>10</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/race/body</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/race/body</xpath>
           <value>
             <body>CE_ArmoredBeetleLikeWithClaw</body>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/race/baseHealthScale</xpath>
           <value>
             <baseHealthScale>3.5</baseHealthScale>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Megapede"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -245,7 +245,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEI_Insectoid_Megapede"]/combatPower</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEI_Insectoid_Megapede"]/combatPower</xpath>
           <value>
             <combatPower>250</combatPower>
           </value>
@@ -253,7 +253,7 @@
 
         <!-- === Gigalocust === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>4.8</MoveSpeed>
             <MeleeDodgeChance>0.07</MeleeDodgeChance>
@@ -263,28 +263,28 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>28</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>11</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/race/baseHealthScale</xpath>
           <value>
             <baseHealthScale>2.1</baseHealthScale>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Gigalocust"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -325,7 +325,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/PawnKindDef[defName="VFEI_Insectoid_Gigalocust"]/combatPower</xpath>
+          <xpath>Defs/PawnKindDef[defName="VFEI_Insectoid_Gigalocust"]/combatPower</xpath>
           <value>
             <combatPower>300</combatPower>
           </value>
@@ -333,7 +333,7 @@
 
         <!-- === Larvae === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>1.5</MoveSpeed>
             <MeleeDodgeChance>0.06</MeleeDodgeChance>
@@ -343,14 +343,14 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/race/baseHealthScale</xpath>
           <value>
             <baseHealthScale>0.2</baseHealthScale>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_Insectoid_Larvae"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Boomtick.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>4.35</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>0.65</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>0.25</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>0.4</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownBoomtick"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Cuterpillar.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Cuterpillar.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.3</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>0.2</baseHealthScale>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownCuterpillar"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigascorpion.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>5.2</MoveSpeed>
@@ -21,7 +21,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>16</ArmorRating_Blunt>
@@ -29,7 +29,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>6</ArmorRating_Sharp>
@@ -37,7 +37,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigascorpion"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigawig.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Gigawig.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.6</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>6</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>3</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigawig"]/tools</xpath>
           
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Megacricket.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Megacricket.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>5.75</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>3</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegacricket"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Milkbeetle.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.5</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>4.65</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>2.25</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMilkbeetle"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Monstrosity.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Monstrosity.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>5.75</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>60</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>20</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
         
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/race/body</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/race/body</xpath>
           
           <value>
             <body>CE_ArmoredBeetleLikeWithClaw</body>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMonstrosity"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Princess.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Princess.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.1</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>15</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>6</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownPrincess"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalLarva.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalLarva.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownRoyalLarva"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownRoyalLarva"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>1.15</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownRoyalLarva"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownRoyalLarva"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_RoyalMaggot.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/MoveSpeed</xpath>
           <value>
             <MoveSpeed>1.15</MoveSpeed>
             <MeleeDodgeChance>0.03</MeleeDodgeChance>
@@ -19,21 +19,21 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>0.3</ArmorRating_Blunt>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/statBases/ArmorRating_Sharp</xpath>
           <value>
             <ArmorRating_Sharp>0.15</ArmorRating_Sharp>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownRoyalMaggot"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Spiderweaver.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Spiderweaver.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>3.6</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>12</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>5</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpiderweaver"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Titanbeetle.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.85</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>26</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>10</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/race/baseHealthScale</xpath>
 
           <value>
             <baseHealthScale>2.75</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownTitanbeetle"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatGigalocust.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>5.2</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>22</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>9</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>2.1</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownGigalocust"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegapede.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>2.8</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>14</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>4.65</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/race/body</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/race/body</xpath>
 
           <value>
             <body>CE_ArmoredBeetleLikeWithClaw</body>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/race/baseHealthScale</xpath>
 
           <value>
             <baseHealthScale>3.45</baseHealthScale>
@@ -52,7 +52,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegapede"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegascarab.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>4.7</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>2.25</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>0.7</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>0.3</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownMegascarab"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegaspider.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatMegaspider.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>4.4</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>10</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>4</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>1.8</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatgrownMegaspider"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_VatSpelopede.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>4.5</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>4</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>2</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>1.2</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownSpelopede"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_Wargling.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>6.0</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>10.8</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWargling"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>3.65</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWargling"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>2</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWargling"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWargling"]/tools</xpath>
           
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/ThingDefs_Races_VatGrown/Races_WorkerAnt.xml
@@ -9,7 +9,7 @@
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/MoveSpeed</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/MoveSpeed</xpath>
 
           <value>
             <MoveSpeed>4.6</MoveSpeed>
@@ -20,7 +20,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/ArmorRating_Blunt</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/ArmorRating_Blunt</xpath>
 
           <value>
             <ArmorRating_Blunt>6</ArmorRating_Blunt>
@@ -28,7 +28,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/ArmorRating_Sharp</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/statBases/ArmorRating_Sharp</xpath>
 
           <value>
             <ArmorRating_Sharp>2.25</ArmorRating_Sharp>
@@ -36,7 +36,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/race/baseHealthScale</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/race/baseHealthScale</xpath>
           
           <value>
             <baseHealthScale>1.3</baseHealthScale>
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEI_VatGrownWorkerAnt"]/tools</xpath>
 
           <value>
             <tools>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/Scenario/Scenario.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/Scenario/Scenario.xml
@@ -10,7 +10,7 @@
 
       <li Class="PatchOperationAdd">
         <xpath>
-          /Defs/ScenarioDef[defName="VFE_TheLoneScavenger"]/scenario/parts
+          Defs/ScenarioDef[defName="VFE_TheLoneScavenger"]/scenario/parts
           </xpath>
         <value>
           <li Class="ScenPart_StartingThing_Defined">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Apparel_Mechanite.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Apparel_Mechanite.xml
@@ -10,28 +10,28 @@
       <operations>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>2</ArmorRating_Sharp>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFE_MechaniteUnderArmor"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>3</ArmorRating_Blunt>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>2</ArmorRating_Sharp>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFE_MechanitePants"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>3</ArmorRating_Blunt>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Mech.xml
@@ -12,7 +12,7 @@
 			<!-- ========== Ship Charge Blaster ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -26,32 +26,32 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/statBases/Mass</xpath>
 				<value>
 					<Mass>300</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeBlasterCannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 				</value>
@@ -88,7 +88,7 @@
 			<!-- ========== Ship Charge Lance ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -102,32 +102,32 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/statBases/Mass</xpath>
 				<value>
 					<Mass>85</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeLanceCannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>1</turretBurstCooldownTime>
 				</value>
@@ -164,7 +164,7 @@
 			<!-- ========== Auto Inferno Cannon ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -178,32 +178,32 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/statBases/Mass</xpath>
 				<value>
 					<Mass>600</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_InfernoLauncherArtillery"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>12.0</turretBurstCooldownTime>
 				</value>
@@ -244,7 +244,7 @@
 			<!-- ========== Auto Mortar ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -258,32 +258,32 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.25</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/statBases/Mass</xpath>
 				<value>
 					<Mass>75</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortarCannon"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]</xpath>
 				<value>
 					<statBases>
 						<SightsEfficiency>0.5</SightsEfficiency>
@@ -294,22 +294,22 @@
 			<!--Test for comps and add if not present-->
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]/comps</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
 					<value>
 						<comps/>
 					</value>
 				</nomatch>
 				<match Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
 					<value>
 					</value>
 				</match>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/comps</xpath>
 				<value>
 					  <li Class="CombatExtended.CompProperties_Charges">
 						<chargeSpeeds>
@@ -325,29 +325,29 @@
 			<!--Test for tags and add if not present-->
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]/weaponTags</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
 					<value>
 						<weaponTags/>
 					</value>
 				</nomatch>
 				<match Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_Gun_AutoMortarCannon"]</xpath>
 					<value>
 					</value>
 				</match>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/weaponTags</xpath>
 				<value>
 					<li>TurretGun</li>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_Gun_AutoMortarCannon"]/verbs</xpath>
 				<value>
 					<verbs>
 					  <li Class="CombatExtended.VerbPropertiesCE">
@@ -374,7 +374,7 @@
 			<!-- ========== Ship Charge Railgun ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -388,32 +388,32 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>2</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/statBases/Mass</xpath>
 				<value>
 					<Mass>800</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.99</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_ChargeRailgun"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>18.0</turretBurstCooldownTime>
 				</value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Buildings_Security_Turrets.xml
@@ -11,7 +11,7 @@
 			<!-- ========== Auto Charge Blaster ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -25,14 +25,14 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/statBases/Mass</xpath>
 				<value>
 					<Mass>80</Mass>
 					<Bulk>80</Bulk>
@@ -40,22 +40,22 @@
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>2.0</turretBurstCooldownTime>
 				</value>
@@ -64,7 +64,7 @@
 			<!-- Price increase because CE HCB is not an equivalent weapon to most other options-->
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/costList/Plasteel</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/costList/Plasteel</xpath>
 				<value>
 					<Plasteel>60</Plasteel>
 					<Steel>205</Steel>
@@ -72,7 +72,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/costList/ComponentIndustrial</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeBlaster"]/costList/ComponentIndustrial</xpath>
 				<value>
 					<ComponentIndustrial>15</ComponentIndustrial>
 				</value>
@@ -117,7 +117,7 @@
 			<!-- ========== Auto Charge Lance ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -131,14 +131,14 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.75</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/statBases/Mass</xpath>
 				<value>
 					<Mass>30</Mass>
 					<Bulk>40</Bulk>
@@ -146,22 +146,22 @@
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoChargeLance"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>1.0</turretBurstCooldownTime>
 				</value>
@@ -206,7 +206,7 @@
 			<!-- ========== Auto Inferno Cannon ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -220,21 +220,21 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.5</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>2.5</turretBurstCooldownTime>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/statBases/Mass</xpath>
 				<value>
 					<Mass>325</Mass>
 					<Bulk>100</Bulk>
@@ -242,15 +242,15 @@
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
@@ -259,7 +259,7 @@
 			<!-- Price increase because CE Inferno cannon is not an equivalent weapon to most other options : Reduced compared to sheet inferno since it bloats the cost too much-->
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/costList/Plasteel</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/costList/Plasteel</xpath>
 				<value>
 					<Plasteel>120</Plasteel>
 					<Steel>140</Steel>
@@ -267,7 +267,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/costList/ComponentIndustrial</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoInfernoCannon"]/costList/ComponentIndustrial</xpath>
 				<value>
 					<ComponentIndustrial>13</ComponentIndustrial>
 				</value>
@@ -313,7 +313,7 @@
 			<!-- ========== Auto Mortar ========== -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/thingClass</xpath>
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/thingClass</xpath>
 				<value>
 					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 				</value>
@@ -327,14 +327,14 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases</xpath>
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.25</AimingAccuracy>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases/Mass</xpath>
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/statBases/Mass</xpath>
 				<value>
 					<Mass>30</Mass>
 					<Bulk>200</Bulk>
@@ -342,29 +342,29 @@
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/fillPercent</xpath>
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/fillPercent</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[@Name="VFE_BaseAutomortarBuilding"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>1</turretBurstCooldownTime>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/costList/Plasteel</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/costList/Plasteel</xpath>
 				<value>
 					<Plasteel>30</Plasteel>
 					<Steel>150</Steel>
@@ -372,14 +372,14 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/costList/ComponentIndustrial</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoMortar"]/costList/ComponentIndustrial</xpath>
 				<value>
 					<ComponentIndustrial>8</ComponentIndustrial>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_AutoMortar"]</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_AutoMortar"]</xpath>
 				<value>
 					<statBases>
 						<SightsEfficiency>0.5</SightsEfficiency>
@@ -390,22 +390,22 @@
 			<!--Test for comps and add if not present-->
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]/comps</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
 					<value>
 						<comps/>
 					</value>
 				</nomatch>
 				<match Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
 					<value>
 					</value>
 				</match>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_AutoMortar"]/comps</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_AutoMortar"]/comps</xpath>
 				<value>
 					  <li Class="CombatExtended.CompProperties_Charges">
 						<chargeSpeeds>
@@ -426,29 +426,29 @@
 			<!--Test for tags and add if not present-->
 			
 			<li Class="PatchOperationConditional">
-				<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]/weaponTags</xpath>
 				<nomatch Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
 					<value>
 						<weaponTags/>
 					</value>
 				</nomatch>
 				<match Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFE_AutoMortar"]</xpath>
 					<value>
 					</value>
 				</match>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "VFE_AutoMortar"]/weaponTags</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_AutoMortar"]/weaponTags</xpath>
 				<value>
 					<li>TurretGun</li>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName = "VFE_AutoMortar"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName = "VFE_AutoMortar"]/verbs</xpath>
 				<value>
 					<verbs>
 					  <li Class="CombatExtended.VerbPropertiesCE">
@@ -475,67 +475,67 @@
 			<!-- ========== Auto Tesla Turret ========== -->
 
 			<li Class="PatchOperationRemove">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoTesla"]</xpath>
 				<value>
 					<fillPercent>0.85</fillPercent>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building</xpath>
 				<value>
 					<turretBurstWarmupTime>4.0</turretBurstWarmupTime>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building/turretBurstCooldownTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Turret_AutoTesla"]/building/turretBurstCooldownTime</xpath>
 				<value>
 					<turretBurstCooldownTime>2</turretBurstCooldownTime>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/statBases/RangedWeapon_Cooldown</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/statBases/RangedWeapon_Cooldown</xpath>
 				<value>
 					<RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/warmupTime</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/warmupTime</xpath>
 				<value>
 					<warmupTime>4.0</warmupTime>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/range</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/range</xpath>
 				<value>
 					<range>45</range>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/minRange</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Gun_AutoTesla"]/verbs/li/minRange</xpath>
 				<value>
 					<minRange>6</minRange>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/projectile/damageAmountBase</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/projectile/damageAmountBase</xpath>
 				<value>
 					<damageAmountBase>10</damageAmountBase>
 				</value>
 			</li>
  
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
+				<xpath>Defs/ThingDef[defName="VFE_Bullet_TeslaProjectile"]/modExtensions/li[@Class="VFEMech.TeslaChainingProps"]/damageDef</xpath>
 				<value>
 					<damageDef>Electrical</damageDef>
 				</value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Weapons_Mech.xml
@@ -21,7 +21,7 @@
     <!-- ========== Inferno spewer description change ========== -->
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_Gun_InfernoSpewerBase"]/description</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_Gun_InfernoSpewerBase"]/description</xpath>
       <value>
         <description>A surprisingly lightweight flamethrower of mechanoid design, while idle the device seems cold as any other, but can immediately heat up to temperatures well above purely human technology. Two undermounted prometheum jelly tanks allow for an ammo capacity big enough for large plumes of liquid flame.</description>
       </value>
@@ -67,7 +67,7 @@
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Gun_CombatMechanoidGun"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Gun_CombatMechanoidGun"]/tools</xpath>
       <value>
         <tools>
         <li Class="CombatExtended.ToolCE">
@@ -125,7 +125,7 @@
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName = "VFE_Gun_RaiderMechanoidGun"]/tools
+      <xpath>Defs/ThingDef[defName = "VFE_Gun_RaiderMechanoidGun"]/tools
       </xpath>
       <value>
         <tools>
@@ -188,7 +188,7 @@
     </li>
         <!-- === Tools === -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name = "VFE_Gun_InfernoSpewerBase"]/tools
+      <xpath>Defs/ThingDef[@Name = "VFE_Gun_InfernoSpewerBase"]/tools
       </xpath>
       <value>
         <tools>
@@ -209,7 +209,7 @@
     <!-- ========== Light Charge Blaster ========== -->
 	
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_Gun_ChargeBlasterLightBase"]/statBases</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_Gun_ChargeBlasterLightBase"]/statBases</xpath>
       <value>
         <statBases>
         <Mass>3.0</Mass>
@@ -225,7 +225,7 @@
     </li>
 	
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_Gun_ChargeBlasterLightBase"]/tools</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_Gun_ChargeBlasterLightBase"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -466,7 +466,7 @@
     <!-- ========== Add the Advanced Thermal Bolt Projector ========== -->
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs</xpath>
+      <xpath>Defs</xpath>
       <value>
         <ThingDef ParentName="BaseGun">
           <defName>VFE_AdvancedThermalBoltProjector</defName>
@@ -595,7 +595,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Gun_AdvancedChargeLance"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Gun_AdvancedChargeLance"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -739,7 +739,7 @@
 	  </li>
 
 	  <li Class="PatchOperationReplace">
-	    <xpath>/Defs/ThingDef[defName="VFE_Gun_AdvancedThumpCannon"]/tools</xpath>
+	    <xpath>Defs/ThingDef[defName="VFE_Gun_AdvancedThumpCannon"]/tools</xpath>
 	    <value>
 	      <tools>
 		<li Class="CombatExtended.ToolCE">
@@ -757,7 +757,7 @@
 	  </li>
 
 	  <li Class="PatchOperationAddModExtension">
-	    <xpath>/Defs/ThingDef[defName="VFE_Gun_AdvancedThumpCannon"]</xpath>
+	    <xpath>Defs/ThingDef[defName="VFE_Gun_AdvancedThumpCannon"]</xpath>
 	    <value>
 	      <li Class="CombatExtended.GunDrawExtension">
 		<DrawSize>1.95,1.95</DrawSize>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -10,9 +10,9 @@
       <operations>
 
 	<li Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]</xpath>
+			<xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -35,14 +35,14 @@
 	<!-- Advanced mechs retain some heat armor to represent sealing of sensitive electronics. Minor improvement to EMP resistance as well-->
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases/ArmorRating_Heat</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases/ArmorRating_Heat</xpath>
       <value>
         <ArmorRating_Heat>0.5</ArmorRating_Heat>
       </value>
     </li>
 
 	<li Class="PatchOperationAdd">
-    <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
+    <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoid"]/statBases</xpath>
       <value>
         <SmokeSensitivity>0</SmokeSensitivity>
         <ArmorRating_Electric>0.10</ArmorRating_Electric>
@@ -53,7 +53,7 @@
     <!-- ========== VFE Advanced Centipede ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -62,7 +62,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases</xpath>
       <value>
         <CarryWeight>260</CarryWeight>
         <CarryBulk>70</CarryBulk>
@@ -77,28 +77,28 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>48</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseBodySize</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>3.0</baseBodySize>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCentipede"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -120,7 +120,7 @@
     <!-- ========== VFE Advanced Scyther/Lancer ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedScyther" or defName="VFE_Mech_AdvancedLancer"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther" or defName="VFE_Mech_AdvancedLancer"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -129,7 +129,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
@@ -143,21 +143,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>7.5</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_AdvancedMechanoidWalker"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>5</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedScyther"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -225,7 +225,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedLancer"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedLancer"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -271,7 +271,7 @@
 	<!-- ========== VFE Advanced Pikeman ========== -->
 
 	<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
@@ -280,7 +280,7 @@
 	</li>
 
 	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/statBases</xpath>
 		<value>
 			<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
 			<ArmorRating_Blunt>18</ArmorRating_Blunt>			
@@ -294,11 +294,11 @@
 	</li>
 
 	<li Class="PatchOperationRemove">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/race/baseHealthScale</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/race/baseHealthScale</xpath>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -320,7 +320,7 @@
    <!-- ========== VFE Advanced Knight ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -329,7 +329,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
@@ -341,21 +341,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>12</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>8</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedKnight"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -401,7 +401,7 @@
    <!-- ========== VFE Advanced Inquisitor ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -410,7 +410,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>50</CarryBulk>
@@ -424,21 +424,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>15</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>10</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -484,7 +484,7 @@
 	<!--CE's blast is way too strong for them dying. Switching it to boomalope-->
 	
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/race/deathActionWorkerClass</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedInquisitor"]/race/deathActionWorkerClass</xpath>
       <value>
         <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
       </value>
@@ -493,7 +493,7 @@
     <!-- ========== VFE Advanced Carpenter ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Quadruped</bodyShape>
@@ -502,7 +502,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases</xpath>
       <value>
         <CarryWeight>400</CarryWeight>
         <CarryBulk>80</CarryBulk>
@@ -514,21 +514,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>48</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedCarpenter"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -550,7 +550,7 @@
     <!-- ==========VFE Advanced Termite ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -559,7 +559,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
       <value>
         <CarryWeight>300</CarryWeight>
         <CarryBulk>60</CarryBulk>
@@ -574,21 +574,21 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
       <value>
         <ArmorRating_Blunt>48</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>22</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_AdvTermite"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Machines.xml
@@ -22,7 +22,7 @@
 	</li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="BaseVFEMachine"]/statBases/ArmorRating_Heat</xpath>
+      <xpath>Defs/ThingDef[@Name="BaseVFEMachine"]/statBases/ArmorRating_Heat</xpath>
       <value>
         <ArmorRating_Heat>0</ArmorRating_Heat>
         <SmokeSensitivity>0</SmokeSensitivity>
@@ -47,14 +47,14 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Raider"]/statBases/MoveSpeed</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Raider"]/statBases/MoveSpeed</xpath>
       <value>
         <MoveSpeed>3.2</MoveSpeed>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Pyro"]/statBases/MoveSpeed</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Pyro"]/statBases/MoveSpeed</xpath>
       <value>
         <MoveSpeed>2.2</MoveSpeed>
       </value>
@@ -62,7 +62,7 @@
 
     <!-- ========== VFE Autocleaner, VFE Autohauler, VFE Autominer, VFE Mobile Turret ========== -->
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -71,7 +71,7 @@
     </li>
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret"or defName="VFE_Mechanoids_Autobroadcaster"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret"or defName="VFE_Mechanoids_Autobroadcaster"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Vehicle</bodyShape>
@@ -80,7 +80,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases</xpath>
       <value>
         <MeleeDodgeChance>0</MeleeDodgeChance>
         <MeleeCritChance>0.01</MeleeCritChance>
@@ -89,7 +89,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Turret"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Turret"]/statBases</xpath>
       <value>
         <CarryWeight>100</CarryWeight>
         <CarryBulk>50</CarryBulk>
@@ -104,21 +104,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>2.5</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autocleaner" or defName="VFE_Mechanoids_Autohauler" or defName="VFE_Mechanoids_Autominer" or defName="VFE_Mechanoids_Turret" or defName="VFE_Mechanoids_Autobroadcaster"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -139,7 +139,7 @@
     <!-- ========== VFE Combat, Riot and Raider Mechs ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -148,7 +148,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>30</CarryBulk>
@@ -164,42 +164,42 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot"]/statBases</xpath>
       <value>
         <MeleeHitChance>6</MeleeHitChance>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Combat"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Combat"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
 	
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Combat"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Combat"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>6</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Pyro" or defName="VFE_Mechanoids_Raider"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Pyro" or defName="VFE_Mechanoids_Raider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>8</ArmorRating_Sharp>
       </value>
     </li>
 	
 	<li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Pyro" or defName="VFE_Mechanoids_Raider"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot" or defName="VFE_Mechanoids_Pyro" or defName="VFE_Mechanoids_Raider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>12</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Combat" or defName="VFE_Mechanoids_Raider" or defName="VFE_Mechanoids_Pyro"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -219,7 +219,7 @@
     </li>
 	
 	<li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Riot"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Riot"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -281,7 +281,7 @@
 	<!-- ========== VFE Strider ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -290,7 +290,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases</xpath>
       <value>
         <CarryWeight>200</CarryWeight>
         <CarryBulk>50</CarryBulk>
@@ -304,21 +304,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>10</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_Autostrider"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -338,7 +338,7 @@
     </li>
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -347,7 +347,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
@@ -358,21 +358,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
 	
 	<li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>6</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mechanoids_AutoMedic"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -10,9 +10,9 @@
       <operations>
 
 	<li Class="PatchOperationConditional">
-		<xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="VFE_Mechanoid"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]</xpath>
+			<xpath>Defs/ThingDef[@Name="VFE_Mechanoid"]</xpath>
 			<value>
 				<comps />
 			</value>
@@ -34,7 +34,7 @@
     <!--Consistency with vanilla mechs-->
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_Mechanoid"]/statBases/ArmorRating_Heat</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_Mechanoid"]/statBases/ArmorRating_Heat</xpath>
       <value>
         <ArmorRating_Heat>0</ArmorRating_Heat>
         <SmokeSensitivity>0</SmokeSensitivity>
@@ -45,7 +45,7 @@
     <!-- ========== VFE Centipede ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -54,7 +54,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases</xpath>
       <value>
         <CarryWeight>250</CarryWeight>
         <CarryBulk>60</CarryBulk>
@@ -69,28 +69,28 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>45</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>20</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseBodySize</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/race/baseBodySize</xpath>
       <value>
         <baseBodySize>3.0</baseBodySize>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Centipede"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Centipede"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -112,7 +112,7 @@
     <!-- ========== VFE Scyther/Lancer ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Scyther" or defName="VFE_Mech_Lancer"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Scyther" or defName="VFE_Mech_Lancer"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -121,7 +121,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
@@ -135,21 +135,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>6</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[@Name="VFE_MechanoidWalker"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>4</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Scyther"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Scyther"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -217,7 +217,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Lancer"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Lancer"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -263,7 +263,7 @@
 	<!-- ========== VFE Pikeman ========== -->
 
 	<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_Pikeman"]</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Pikeman"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
@@ -272,7 +272,7 @@
 	</li>
 
 	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_Pikeman"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Pikeman"]/statBases</xpath>
 		<value>
 			<ArmorRating_Sharp>7</ArmorRating_Sharp>
 			<ArmorRating_Blunt>15</ArmorRating_Blunt>			
@@ -286,11 +286,11 @@
 	</li>
 
 	<li Class="PatchOperationRemove">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_Pikeman"]/race/baseHealthScale</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Pikeman"]/race/baseHealthScale</xpath>
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VFE_Mech_Pikeman"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="VFE_Mech_Pikeman"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -312,7 +312,7 @@
    <!-- ========== Knight ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Knight"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -321,7 +321,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>20</CarryBulk>
@@ -335,21 +335,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>9</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>6</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Knight"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Knight"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -395,7 +395,7 @@
    <!-- ========== Inquisitor ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Humanoid</bodyShape>
@@ -404,7 +404,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases</xpath>
       <value>
         <CarryWeight>50</CarryWeight>
         <CarryBulk>50</CarryBulk>
@@ -418,7 +418,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>12</ArmorRating_Blunt>
         <ArmorRating_Heat>1</ArmorRating_Heat>
@@ -426,14 +426,14 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>8</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -479,7 +479,7 @@
 	<!--CE's blast is way too strong for them dying. Switching it to boomalope-->
 	
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/race/deathActionWorkerClass</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Inquisitor"]/race/deathActionWorkerClass</xpath>
       <value>
         <deathActionWorkerClass>DeathActionWorker_BigExplosion</deathActionWorkerClass>
       </value>
@@ -488,7 +488,7 @@
     <!-- ========== VFE Carpenter and Ancient Carpenter ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>Quadruped</bodyShape>
@@ -497,7 +497,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases</xpath>
       <value>
         <CarryWeight>400</CarryWeight>
         <CarryBulk>80</CarryBulk>
@@ -509,21 +509,21 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases/ArmorRating_Blunt</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases/ArmorRating_Blunt</xpath>
       <value>
         <ArmorRating_Blunt>45</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases/ArmorRating_Sharp</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/statBases/ArmorRating_Sharp</xpath>
       <value>
         <ArmorRating_Sharp>20</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Carpenter" or defName="VFE_AncientMech_AncientCarpenter"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -545,7 +545,7 @@
     <!-- ========== VFE Termite ========== -->
 
     <li Class="PatchOperationAddModExtension">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]</xpath>
       <value>
         <li Class="CombatExtended.RacePropertiesExtensionCE">
           <bodyShape>QuadrupedLow</bodyShape>
@@ -554,7 +554,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
       <value>
         <CarryWeight>300</CarryWeight>
         <CarryBulk>60</CarryBulk>
@@ -569,21 +569,21 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
       <value>
         <ArmorRating_Blunt>40</ArmorRating_Blunt>
       </value>
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/statBases</xpath>
       <value>
         <ArmorRating_Sharp>18</ArmorRating_Sharp>
       </value>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFE_Mech_Termite"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFE_Mech_Termite"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Medieval/PawnKindDefs/VanillaMedieval_PawnKinds.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/PawnKindDefs/VanillaMedieval_PawnKinds.xml
@@ -11,15 +11,15 @@
 				<!-- ========== Add Combat Extended Shields to pawns. =========== -->
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier" or defName="VFEM_Medieval_Knight"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]/shieldMoney</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier" or defName="VFEM_Medieval_Knight"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]/shieldMoney</xpath>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier" or defName="VFEM_Medieval_Knight"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]/shieldTags</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier" or defName="VFEM_Medieval_Knight"]/modExtensions/li[@Class="VFECore.PawnKindDefExtension"]/shieldTags</xpath>
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Footsoldier"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<shieldMoney>
@@ -36,7 +36,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Knight"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Knight"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<shieldMoney>
@@ -54,7 +54,7 @@
 
 				<!-- ========== Give ammo to archer ========== -->
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Bowman"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Bowman"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">
 							<primaryMagazineCount>
@@ -76,7 +76,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Bowman"]</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Bowman"]</xpath>
 					<value>
 						<apparelRequired>
 							<li>CE_Apparel_TribalBackpack</li>
@@ -86,7 +86,7 @@
 
 				<!-- ========== Tweak Squire weapon money. =========== -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/PawnKindDef[defName="VFEM_Medieval_Squire"]/weaponMoney/min</xpath>
+					<xpath>Defs/PawnKindDef[defName="VFEM_Medieval_Squire"]/weaponMoney/min</xpath>
 					<value>
 						<min>120</min>
 					</value>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Apparel.xml
@@ -10,7 +10,7 @@
 
 				<!-- ========== Light Helmet =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/statBases</xpath>
 					<value>
 						<Bulk>3</Bulk>
 						<WornBulk>1</WornBulk>
@@ -18,19 +18,19 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.0</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetLight"]/equippedStatOffsets</xpath>
 				</li>
 
 				<!-- ========== Heavy Helmet =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases</xpath>
 					<value>
 						<Bulk>5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -38,14 +38,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/equippedStatOffsets</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
 							<AimingAccuracy>-0.5</AimingAccuracy>
@@ -55,7 +55,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateHelmetHeavy"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						<stats>
@@ -79,13 +79,13 @@
 				<!-- ========== Jester Hat / Kings Crown / Plague Mask =========== -->
 				<li Class="PatchOperationRemove">
 					<xpath>
-						/Defs/ThingDef[defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask"]/statBases/ArmorRating_Sharp | 
-						/Defs/ThingDef[defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask"]/statBases/ArmorRating_Blunt
+						Defs/ThingDef[defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask"]/statBases/ArmorRating_Sharp | 
+						Defs/ThingDef[defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask"]/statBases/ArmorRating_Blunt
 					</xpath>
 				</li>
 				
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_JesterHat" or defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask" or defName="VFEM_Apparel_DameHat"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_JesterHat" or defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask" or defName="VFEM_Apparel_DameHat"]/statBases</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>1</WornBulk>
@@ -93,14 +93,14 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_JesterHat" or defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask" or defName="VFEM_Apparel_DameHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_JesterHat" or defName="VFEM_Apparel_KingsCrown" or defName="VFEM_Apparel_PlagueMask" or defName="VFEM_Apparel_DameHat"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlagueMask"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlagueMask"]</xpath>
 					<value>
 						<costStuffCount>25</costStuffCount>
 						<stuffCategories>
@@ -110,7 +110,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlagueMask"]/apparel/layers/li[.="Overhead"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlagueMask"]/apparel/layers/li[.="Overhead"]</xpath>
 					<value>
 						<li>StrappedHead</li>
 					</value>
@@ -118,7 +118,7 @@
 
 				<!-- ========== Heavy Plate Armor =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/statBases</xpath>
 					<value>
 						<Bulk>100</Bulk>
 						<WornBulk>12</WornBulk>
@@ -126,25 +126,25 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/equippedStatOffsets/MoveSpeed</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/equippedStatOffsets/MeleeDodgeChance</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/equippedStatOffsets/MeleeDodgeChance</xpath>
 					<value>
 						<MeleeDodgeChance>-0.2</MeleeDodgeChance>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/apparel/bodyPartGroups</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]/apparel/bodyPartGroups</xpath>
 					<value>
 						<li>Hands</li>
 						<li>Feet</li>
@@ -152,7 +152,7 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_PlateArmorHeavy"]</xpath>
 					<value>
 					  <li Class="CombatExtended.PartialArmorExt">
 						  <stats>
@@ -211,7 +211,7 @@
 
 				<!-- ========== Tabard =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_Tabard"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_Tabard"]/statBases</xpath>
 					<value>
 						<Bulk>4</Bulk>
 						<WornBulk>1</WornBulk>
@@ -219,7 +219,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_Tabard"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_Tabard"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
 					</value>
@@ -227,7 +227,7 @@
 
 				<!-- ========== Jester Outfit / Dame Dress =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_JesterOutfit" or defName="VFEM_Apparel_DameDress"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_JesterOutfit" or defName="VFEM_Apparel_DameDress"]/statBases</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>1</WornBulk>
@@ -235,7 +235,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_JesterOutfit" or defName="VFEM_Apparel_DameDress"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_JesterOutfit" or defName="VFEM_Apparel_DameDress"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
 					</value>
@@ -243,7 +243,7 @@
 
 				<!-- ========== King's Robes =========== -->
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_KingsRobes"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_KingsRobes"]/statBases</xpath>
 					<value>
 						<Bulk>2</Bulk>
 						<WornBulk>1.5</WornBulk>
@@ -251,7 +251,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Apparel_KingsRobes"]/statBases/StuffEffectMultiplierArmor</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Apparel_KingsRobes"]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
 						<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 					</value>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Items.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Items.xml
@@ -9,21 +9,21 @@
 	<operations>
 
 	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="VFEM_RawGrapes"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VFEM_RawGrapes"]/statBases</xpath>
 		<value>
 			<Bulk>0.014</Bulk>
 		</value>
 	</li>
 
 	<li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName="VFEM_Wine"]/statBases</xpath>
+		<xpath>Defs/ThingDef[defName="VFEM_Wine"]/statBases</xpath>
 		<value>
 			<Bulk>1.5</Bulk>
 		</value>
 	</li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFEM_Wine"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFEM_Wine"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
@@ -11,7 +11,7 @@
 
         <!-- === Ammo === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs</xpath>
+          <xpath>Defs</xpath>
           <value>
 
           <CombatExtended.AmmoSetDef>
@@ -115,7 +115,7 @@
 
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFEM_Bow_HeavyCrossbow"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFEM_Bow_HeavyCrossbow"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Shields.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Shields.xml
@@ -11,7 +11,7 @@
 
 				<!-- Kite Shield -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Shield_Kite"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Shield_Kite"]</xpath>
 					<value>
 						 <ThingDef ParentName="ShieldBase">
 							<defName>VFEM_Shield_Kite</defName>
@@ -94,7 +94,7 @@
 
 				<!-- Heater Shield -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_Shield_Heater"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_Shield_Heater"]</xpath>
 					<value>
 						 <ThingDef ParentName="ShieldBase">
 							<defName>VFEM_Shield_Heater</defName>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Weapons.xml
@@ -11,7 +11,7 @@
 				
 				<!-- Heavy Mace -->	
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -41,7 +41,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeCritChance>1.5</MeleeCritChance>
@@ -52,7 +52,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/statBases</xpath>
 					<value>
 						<Bulk>4.5</Bulk>
 						<MeleeCounterParryBonus>.53</MeleeCounterParryBonus>
@@ -60,7 +60,7 @@
 				</li>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>/Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/stuffCategories</xpath>
+                    <xpath>Defs/ThingDef[defName="VFEM_MeleeWeapon_HeavyMace"]/stuffCategories</xpath>
                     <value>
                     <stuffCategories>
                         <li>Steeled</li>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -120,7 +120,7 @@
       <li Class="PatchOperationAdd">
         <xpath>/Defs/ThingDef[@Name = "VFEP_CrashedShip"]/building</xpath>
         <value>
-          <turretBurstWarmupTime>3.0</turretBurstWarmupTime>
+          <turretBurstWarmupTime>2.3</turretBurstWarmupTime>
         </value>
       </li>
 
@@ -139,8 +139,8 @@
             <statBases>
               <AccuracyTouch>0.9</AccuracyTouch>
               <AccuracyShort>0.85</AccuracyShort>
-              <AccuracyMedium>0.75</AccuracyMedium>
-              <AccuracyLong>0.60</AccuracyLong>
+              <AccuracyMedium>0.60</AccuracyMedium>
+              <AccuracyLong>0.40</AccuracyLong>
               <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
               <DeteriorationRate>0</DeteriorationRate>
               <Mass>5</Mass>
@@ -153,15 +153,14 @@
               <li>
                 <verbClass>Verb_Shoot</verbClass>
                 <defaultProjectile>VFEP_Bullet_GauntletChargeCanon</defaultProjectile>
-                <warmupTime>3</warmupTime>
+                <warmupTime>2.3</warmupTime>
                 <range>62</range>
-                <minRange>13</minRange>
-                <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-                <burstShotCount>4</burstShotCount>
+                <minRange>8.9</minRange>
+                <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
+                <burstShotCount>3</burstShotCount>
                 <soundCast>VFEP_Shot_GauntletCannon</soundCast>
                 <soundCastTail>GunTail_Light</soundCastTail>
                 <muzzleFlashScale>9</muzzleFlashScale>
-                <consumeFuelPerShot>1</consumeFuelPerShot>
               </li>
             </verbs>
           </ThingDef>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -120,7 +120,7 @@
       <li Class="PatchOperationAdd">
         <xpath>/Defs/ThingDef[@Name = "VFEP_CrashedShip"]/building</xpath>
         <value>
-          <turretBurstWarmupTime>2.3</turretBurstWarmupTime>
+          <turretBurstWarmupTime>3.0</turretBurstWarmupTime>
         </value>
       </li>
 
@@ -139,8 +139,8 @@
             <statBases>
               <AccuracyTouch>0.9</AccuracyTouch>
               <AccuracyShort>0.85</AccuracyShort>
-              <AccuracyMedium>0.60</AccuracyMedium>
-              <AccuracyLong>0.40</AccuracyLong>
+              <AccuracyMedium>0.75</AccuracyMedium>
+              <AccuracyLong>0.60</AccuracyLong>
               <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
               <DeteriorationRate>0</DeteriorationRate>
               <Mass>5</Mass>
@@ -153,14 +153,15 @@
               <li>
                 <verbClass>Verb_Shoot</verbClass>
                 <defaultProjectile>VFEP_Bullet_GauntletChargeCanon</defaultProjectile>
-                <warmupTime>2.3</warmupTime>
+                <warmupTime>3</warmupTime>
                 <range>62</range>
-                <minRange>8.9</minRange>
-                <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-                <burstShotCount>3</burstShotCount>
+                <minRange>13</minRange>
+                <ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+                <burstShotCount>4</burstShotCount>
                 <soundCast>VFEP_Shot_GauntletCannon</soundCast>
                 <soundCastTail>GunTail_Light</soundCastTail>
                 <muzzleFlashScale>9</muzzleFlashScale>
+                <consumeFuelPerShot>1</consumeFuelPerShot>
               </li>
             </verbs>
           </ThingDef>

--- a/Patches/Vanilla Factions Expanded - Settlers/Drugs/Alcohol_Chemshine.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/Drugs/Alcohol_Chemshine.xml
@@ -30,7 +30,7 @@
 
         <!-- === Addictivines === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Chemshine"]/comps/li[@Class="CompProperties_Drug"]/addictiveness</xpath>
+          <xpath>Defs/ThingDef[defName="Chemshine"]/comps/li[@Class="CompProperties_Drug"]/addictiveness</xpath>
 
           <value>
             <addictiveness>0.05</addictiveness>
@@ -38,7 +38,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Chemshine"]/comps/li[@Class="CompProperties_Drug"]/minToleranceToAddict</xpath>
+          <xpath>Defs/ThingDef[defName="Chemshine"]/comps/li[@Class="CompProperties_Drug"]/minToleranceToAddict</xpath>
 
           <value>
             <minToleranceToAddict>0.05</minToleranceToAddict>

--- a/Patches/Vanilla Factions Expanded - Settlers/PawnKindDefs/PawnKinds_Bandits.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/PawnKindDefs/PawnKinds_Bandits.xml
@@ -11,7 +11,7 @@
 
         <!-- === Bandit === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="Bandit"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="Bandit"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -40,7 +40,7 @@
 
         <!-- === Bounty Hunter === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="BountyHunter"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="BountyHunter"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -70,14 +70,14 @@
         <!-- === Outlaw === -->
         <!-- We'll add this as a secondary -->
         <li Class="PatchOperationConditional">
-            <xpath>/Defs/PawnKindDef[defName="Outlaw"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
+            <xpath>Defs/PawnKindDef[defName="Outlaw"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
             <match Class="PatchOperationRemove">
-                <xpath>/Defs/PawnKindDef[defName="Outlaw"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
+                <xpath>Defs/PawnKindDef[defName="Outlaw"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
             </match>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="Outlaw"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="Outlaw"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -106,7 +106,7 @@
 
         <!-- === Gunslinger | Bandit Leader === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="Gunslinger" or defName="BanditLeader"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="Gunslinger" or defName="BanditLeader"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>

--- a/Patches/Vanilla Factions Expanded - Settlers/PawnKindDefs/PawnKinds_Settlers.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/PawnKindDefs/PawnKinds_Settlers.xml
@@ -11,14 +11,14 @@
         <!-- === Settler === -->
         <!-- We'll add this as a secondary -->
         <li Class="PatchOperationConditional">
-            <xpath>/Defs/PawnKindDef[defName="Settler"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
+            <xpath>Defs/PawnKindDef[defName="Settler"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
             <match Class="PatchOperationRemove">
-                <xpath>/Defs/PawnKindDef[defName="Settler"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
+                <xpath>Defs/PawnKindDef[defName="Settler"]/weaponTags/li[.="GrenadeDestructive"]</xpath>
             </match>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="Settler"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="Settler"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -47,7 +47,7 @@
 
         <!-- === Deputy | Militia | Frontier Trader === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="Deputy" or defName="Militia" or defName="Frontier_Trader" or defName="Sheriff" or defName="Mayor"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="Deputy" or defName="Militia" or defName="Frontier_Trader" or defName="Sheriff" or defName="Mayor"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>

--- a/Patches/Vanilla Factions Expanded - Settlers/Scenarios/Scenarios_Classic.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/Scenarios/Scenarios_Classic.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Dynamine Count === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ScenarioDef[defName="VFES_Bandits"]/scenario/parts/li[thingDef="VFES_Weapon_GrenadeDynamite"]</xpath>
+          <xpath>Defs/ScenarioDef[defName="VFES_Bandits"]/scenario/parts/li[thingDef="VFES_Weapon_GrenadeDynamite"]</xpath>
 
           <value>
             <li Class="ScenPart_StartingThing_Defined">
@@ -23,7 +23,7 @@
 
         <!-- === Add ammo to scenario === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ScenarioDef[defName="VFES_Bandits"]/scenario/parts</xpath>
+          <xpath>Defs/ScenarioDef[defName="VFES_Bandits"]/scenario/parts</xpath>
 
           <value>
             <li Class="ScenPart_StartingThing_Defined">

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Buildings/TurretGatlingGun.xml
@@ -48,7 +48,7 @@
         <!-- == thingClass == -->
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/thingClass</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/thingClass</xpath>
           <value>
             <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
           </value>
@@ -57,28 +57,28 @@
         <!-- == Remove stuff == -->
       
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Flickable"]</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/comps/li[@Class="CompProperties_Flickable"]</xpath>
         </li>
 
          <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/stuffCategories</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/stuffCategories</xpath>
         </li>
 
          <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/costStuffCount</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/costStuffCount</xpath>
         </li>
 
         <!-- == costList == -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]</xpath>
           <value>
             <costList>
               <Steel>325</Steel>
@@ -89,7 +89,7 @@
 
         <!-- == fillPercent == -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/fillPercent</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/fillPercent</xpath>
           <value>
             <fillPercent>0.85</fillPercent>
           </value>
@@ -97,7 +97,7 @@
 
         <!-- == turretBurstCooldownTime == -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/building/turretBurstCooldownTime</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/building/turretBurstCooldownTime</xpath>
           <value>
             <turretBurstCooldownTime>1.1</turretBurstCooldownTime>
           </value>
@@ -105,7 +105,7 @@
 
         <!-- == ShootingAccuracy === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="Turret_GatlingGun"]/statBases/ShootingAccuracyTurret</xpath>
+          <xpath>Defs/ThingDef[defName="Turret_GatlingGun"]/statBases/ShootingAccuracyTurret</xpath>
           <value>
             <ShootingAccuracyTurret>0.35</ShootingAccuracyTurret>
           </value>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Apparel_Headgear.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Bandana === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Bandana"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Bandana"]/statBases</xpath>
 
           <value>
             <Bulk>1</Bulk>
@@ -19,7 +19,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Bandana"]/statBases/StuffEffectMultiplierArmor</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Bandana"]/statBases/StuffEffectMultiplierArmor</xpath>
 
           <value>
             <StuffEffectMultiplierArmor>1</StuffEffectMultiplierArmor>
@@ -27,7 +27,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Bandana"]/apparel/layers</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Bandana"]/apparel/layers</xpath>
 
           <value>
             <layers>
@@ -37,7 +37,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Bandana"]/equippedStatOffsets</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Bandana"]/equippedStatOffsets</xpath>
 
           <value>
             <SmokeSensitivity>-0.1</SmokeSensitivity>
@@ -46,7 +46,7 @@
 
         <!-- === Sombrero === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Sombrero"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Sombrero"]/statBases</xpath>
 
           <value>
             <Bulk>5</Bulk>
@@ -55,7 +55,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_Sombrero"]/statBases/StuffEffectMultiplierArmor</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_Sombrero"]/statBases/StuffEffectMultiplierArmor</xpath>
 
           <value>
             <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
@@ -64,7 +64,7 @@
 
         <!-- === Flat Cap === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_FlatCap"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_FlatCap"]/statBases</xpath>
 
           <value>
             <Bulk>2</Bulk>
@@ -73,7 +73,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Headgear_FlatCap"]/statBases/StuffEffectMultiplierArmor</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Headgear_FlatCap"]/statBases/StuffEffectMultiplierArmor</xpath>
 
           <value>
             <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrial.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrial.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName ="VFES_Gun_DoubleActionRevolver"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName ="VFES_Gun_DoubleActionRevolver"]/tools</xpath>
 
           <value>
             <tools>
@@ -40,7 +40,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun" or defName="VFES_Gun_HuntingRifle"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun" or defName="VFES_Gun_HuntingRifle"]/tools</xpath>
 
           <value>
             <tools>
@@ -100,6 +100,7 @@
           </costList>
 
           <Properties>
+            <recoilAmount>2.5</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_44Magnum_FMJ</defaultProjectile>
@@ -130,7 +131,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VFES_Gun_DoubleActionRevolver"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Gun_DoubleActionRevolver"]</xpath>
 
           <value>
             <li Class="CombatExtended.GunDrawExtension">
@@ -161,6 +162,7 @@
           </costList>
 
           <Properties>
+            <recoilAmount>3.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
@@ -189,7 +191,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun"]</xpath>
 
           <value>
             <li Class="CombatExtended.GunDrawExtension">
@@ -220,6 +222,7 @@
           </costList>
 
           <Properties>
+            <recoilAmount>1.5</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_303British_FMJ</defaultProjectile>
@@ -251,7 +254,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Gun_DoubleBarreledShotgun"]</xpath>
 
           <value>
             <li Class="CombatExtended.GunDrawExtension">

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedIndustrialGrenades.xml
@@ -47,7 +47,7 @@
 
         <!-- == Weapon == -->
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
         </li>
@@ -57,7 +57,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
           <value>
             <thingClass>CombatExtended.AmmoThing</thingClass>
             <stackLimit>75</stackLimit>
@@ -66,9 +66,9 @@
         </li>
 
         <li Class="PatchOperationConditional">
-          <xpath>/Defs/ThingDef[defName = "VFES_Weapon_GrenadeDynamite"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName = "VFES_Weapon_GrenadeDynamite"]/comps</xpath>
           <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[defName = "VFES_Weapon_GrenadeDynamite"]</xpath>
+            <xpath>Defs/ThingDef[defName = "VFES_Weapon_GrenadeDynamite"]</xpath>
             <value>
               <comps />
             </value>
@@ -76,7 +76,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]/comps</xpath>
           <value>
             <li Class="CombatExtended.CompProperties_ExplosiveCE">
               <explosiveDamageType>Bomb</explosiveDamageType>
@@ -88,7 +88,7 @@
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Weapon_GrenadeDynamite"]</xpath>
           <attribute>Class</attribute>
           <value>CombatExtended.AmmoDef</value>
         </li>

--- a/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
+++ b/Patches/Vanilla Factions Expanded - Settlers/ThingDefs_Misc/Weapons/RangedMedieval.xml
@@ -38,13 +38,13 @@
 
         <!-- == Weapon == -->
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
         </li>
         
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>       
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>       
           <value>
             <thingCategories>
               <li>WeaponsRanged</li>
@@ -53,26 +53,26 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/costStuffCount</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/costStuffCount</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/stuffCategories</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/stuffCategories</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/recipeMaker</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/recipeMaker</xpath>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/graphicData</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/graphicData</xpath>
           <value>
             <color>(105,105,105)</color>
           </value>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
           <value>
             <thingClass>CombatExtended.AmmoThing</thingClass>
             <stackLimit>75</stackLimit>
@@ -81,15 +81,15 @@
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]</xpath>
           <attribute>Class</attribute>
           <value>CombatExtended.AmmoDef</value>
         </li>
 
         <li Class="PatchOperationConditional">
-          <xpath>/Defs/ThingDef[defName = "VFES_Tomahawk"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName = "VFES_Tomahawk"]/comps</xpath>
           <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[defName = "VFES_Tomahawk"]</xpath>
+            <xpath>Defs/ThingDef[defName = "VFES_Tomahawk"]</xpath>
             <value>
               <comps />
             </value>
@@ -121,7 +121,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VFES_Tomahawk"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VFES_Tomahawk"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Apparel_Misc.xml
@@ -10,7 +10,7 @@
 
 		<!-- Torch Belt -->
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VFEV_Apparel_TorchBelt"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VFEV_Apparel_TorchBelt"]/verbs</xpath>
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">
@@ -35,7 +35,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEV_Apparel_TorchBelt"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Apparel_TorchBelt"]/statBases</xpath>
 			<value>
 				<Bulk>0</Bulk>     
 			</value>
@@ -223,7 +223,7 @@
 
 		<!-- Orbital Targeter - Mjollnir -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEV_OrbitalTargeterMjollnir"]</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_OrbitalTargeterMjollnir"]</xpath>
 			<value>
 				<statBases>
 					<Bulk>0</Bulk>

--- a/Patches/Vanilla Factions Expanded - Vikings/PawnKindDefs_Vikings.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/PawnKindDefs_Vikings.xml
@@ -10,7 +10,7 @@
 
 		<!-- Vikings -->
 		<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/PawnKindDef[defName="VFEV_Raider"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="VFEV_Raider"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
@@ -31,7 +31,7 @@
 		</li>
 
 		<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/PawnKindDef[defName="VFEV_Archer"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="VFEV_Archer"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>
@@ -53,7 +53,7 @@
 
 		<!-- Special -->
 		<li Class="PatchOperationAddModExtension">
-		<xpath>/Defs/PawnKindDef[defName="VFEV_VikingLegend"]</xpath>
+		<xpath>Defs/PawnKindDef[defName="VFEV_VikingLegend"]</xpath>
 		<value>
 			<li Class="CombatExtended.LoadoutPropertiesExtension">
 			<primaryMagazineCount>

--- a/Patches/Vanilla Factions Expanded - Vikings/ThingDef_Items.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/ThingDef_Items.xml
@@ -10,14 +10,14 @@
 
 		<!-- Add Bulk to items. -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFEV_Honey"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEV_Honey"]/statBases</xpath>
 			<value>
 				<Bulk>0.05</Bulk>
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFEV_Sweetroll"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEV_Sweetroll"]/statBases</xpath>
 			<value>
 				<Bulk>0.25</Bulk>
 			</value>
@@ -26,14 +26,14 @@
 		<!-- Give Mead Bulk and Melee tools. -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFEV_Mead"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEV_Mead"]/statBases</xpath>
 			<value>
 				<Bulk>3.5</Bulk>
 			</value>
 		</li>
 
 	        <li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Mead"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Mead"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -61,7 +61,7 @@
 		</li>
 		
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFEV_Mead"]</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Mead"]</xpath>
 			<value>
 				<equippedStatOffsets>
 					<MeleeCritChance>0.1</MeleeCritChance>
@@ -73,14 +73,14 @@
 
 		<!-- Give Lothurr Antler Bulk and Melee tools. -->
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFEV_LothurrAntler"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEV_LothurrAntler"]/statBases</xpath>
 			<value>
 				<Bulk>8</Bulk>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName = "VFEV_LothurrAntler"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName = "VFEV_LothurrAntler"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -110,21 +110,21 @@
 
 		<!-- Patch leathers. -->
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/statBases/StuffPower_Armor_Sharp</xpath>
 			<value>
 				<StuffPower_Armor_Sharp>0.75</StuffPower_Armor_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/statBases/StuffPower_Armor_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/statBases/StuffPower_Armor_Blunt</xpath>
 			<value>
 				<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
 			</value>
 		</li>
 
 		<li Class="PatchOperationConditional">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/stuffProps/categories</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/stuffProps/categories</xpath>
 			<nomatch Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/stuffProps</xpath>
 				<value>
@@ -134,7 +134,7 @@
 				</value>
 			</nomatch>
 			<match Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/stuffProps/categories</xpath>
+				<xpath>Defs/ThingDef[defName="VFEV_Leather_Fenrir"]/stuffProps/categories</xpath>
 				<value>
 					<li>SoftArmor</li>
 				</value>
@@ -142,28 +142,28 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Lothurr"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Lothurr"]/statBases/StuffPower_Armor_Sharp</xpath>
 			<value>
 				<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Lothurr"]/statBases/StuffPower_Armor_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Lothurr"]/statBases/StuffPower_Armor_Blunt</xpath>
 			<value>
 				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Njorun"]/statBases/StuffPower_Armor_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Njorun"]/statBases/StuffPower_Armor_Sharp</xpath>
 			<value>
 				<StuffPower_Armor_Sharp>0.2</StuffPower_Armor_Sharp>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFEV_Leather_Njorun"]/statBases/StuffPower_Armor_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="VFEV_Leather_Njorun"]/statBases/StuffPower_Armor_Blunt</xpath>
 			<value>
 				<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 			</value>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Crypto.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Crypto.xml
@@ -11,7 +11,7 @@
     <!-- === Light Crypto Axe === -->
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -41,7 +41,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/statBases</xpath>
       <value>
         <Bulk>4</Bulk>
         <MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
@@ -49,7 +49,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoLightAxe"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoLightAxe"]</xpath>
       <value>
       <equippedStatOffsets>
         <MeleeCritChance>0.23</MeleeCritChance>
@@ -60,7 +60,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/weaponTags</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoLightAxe"]/weaponTags</xpath>
       <value>
         <li>CE_OneHandedWeapon</li>
       </value>
@@ -69,7 +69,7 @@
     <!-- === Heavy Crypto Axe === -->
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -99,7 +99,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]/statBases</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]/statBases</xpath>
       <value>
         <Bulk>8</Bulk>
         <MeleeCounterParryBonus>1</MeleeCounterParryBonus>
@@ -107,7 +107,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]</xpath>
+      <xpath>Defs/ThingDef[defName="VFEV_CryptoHeavyAxe"]</xpath>
       <value>
       <equippedStatOffsets>
         <MeleeCritChance>0.26</MeleeCritChance>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -80,7 +80,7 @@
       <!-- === Bearded Axe === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -110,7 +110,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/statBases</xpath>
         <value>
           <Bulk>4</Bulk>
           <MeleeCounterParryBonus>0.20</MeleeCounterParryBonus>
@@ -118,7 +118,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]</xpath>
         <value>
         <equippedStatOffsets>
           <MeleeCritChance>0.03</MeleeCritChance>
@@ -129,7 +129,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/weaponTags</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_BeardedAxe"]/weaponTags</xpath>
         <value>
           <li>CE_OneHandedWeapon</li>
         </value>
@@ -138,7 +138,7 @@
       <!-- === Dane Axe === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -168,7 +168,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]/statBases</xpath>
         <value>
           <Bulk>8</Bulk>
           <MeleeCounterParryBonus>1</MeleeCounterParryBonus>
@@ -176,7 +176,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]</xpath>
+        <xpath>Defs/ThingDef[defName="VFE_MeleeWeapon_DaneAxe"]</xpath>
         <value>
         <equippedStatOffsets>
           <MeleeCritChance>0.06</MeleeCritChance>

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -73,7 +73,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-		  <xpath>/Defs/ThingDef[defName = "VFES_Gun_BallistaTurret"]/weaponTags</xpath>
+		  <xpath>Defs/ThingDef[defName = "VFES_Gun_BallistaTurret"]/weaponTags</xpath>
 		  <value>
 		    <li>TurretGun</li>
 		  </value>
@@ -162,41 +162,41 @@
 		<!-- ========== Catapult - Base ========== -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Catapult"]/building</xpath>
 			<value>
 				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
 			</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstWarmupTime</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstWarmupTime</xpath>
 			<value>
 				<turretBurstWarmupTime>1</turretBurstWarmupTime>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstCooldownTime</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstCooldownTime</xpath>
 			<value>
 				<turretBurstCooldownTime>1</turretBurstCooldownTime>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/inspectorTabs</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Catapult"]/inspectorTabs</xpath>
 		</li>
 
 		<!-- ========== Catapult - Weapon ========== -->			
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFES_Artillery_Catapult"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Artillery_Catapult"]/statBases</xpath>
 			<value>
 			  <SightsEfficiency>0.5</SightsEfficiency>
 			</value>
 		</li>
 	  
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/comps</xpath>
+			<xpath>Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/comps</xpath>
 			<value>
 			  <li Class="CombatExtended.CompProperties_Charges">
 				<chargeSpeeds>
@@ -215,7 +215,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/verbs</xpath>
+			<xpath>Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/verbs</xpath>
 			<value>
 				<verbs>
 				  <li Class="CombatExtended.VerbPropertiesCE">
@@ -239,7 +239,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-		  <xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/weaponTags</xpath>
+		  <xpath>Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/weaponTags</xpath>
 		  <value>
 		    <li>TurretGun</li>
 		  </value>
@@ -248,32 +248,32 @@
 		<!-- ========== Artillery - Base ========== -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Artillery"]/statBases</xpath>
 			<value>
 				<Mass>5500</Mass>
 			</value>
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Artillery"]/building</xpath>
 			<value>
 				<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
 			</value>
 		</li>
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/buildingTags</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/buildingTags</xpath>
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/turretBurstWarmupTime</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/turretBurstWarmupTime</xpath>
 			<value>
 				<turretBurstWarmupTime>1</turretBurstWarmupTime>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/turretBurstCooldownTime</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Turret_Artillery"]/building/turretBurstCooldownTime</xpath>
 			<value>
 				<turretBurstCooldownTime>1</turretBurstCooldownTime>
 			</value>
@@ -282,14 +282,14 @@
 		<!-- ========== Artillery - Weapon ========== -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="VFES_Artillery_Weapon"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="VFES_Artillery_Weapon"]/statBases</xpath>
 			<value>
 			  <SightsEfficiency>0.5</SightsEfficiency>
 			</value>
 		</li>
 	  
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/comps</xpath>
+			<xpath>Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/comps</xpath>
 			<value>
 			  <li Class="CombatExtended.CompProperties_Charges">
 				<chargeSpeeds>
@@ -308,7 +308,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/verbs</xpath>
+			<xpath>Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/verbs</xpath>
 			<value>
 				<verbs>
 				  <li Class="CombatExtended.VerbPropertiesCE">
@@ -332,7 +332,7 @@
 		</li>
 	
 		<li Class="PatchOperationReplace">
-		  <xpath>/Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/weaponTags</xpath>
+		  <xpath>Defs/ThingDef[defName = "VFES_Artillery_Weapon"]/weaponTags</xpath>
 		  <value>
 		    <weaponTags>
 		      <li>Artillery_BaseDestroyer</li>
@@ -343,7 +343,7 @@
 		<!-- ========== Mortar - Long Range Artillery ========== -->
 	  
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Turret_Mortar"]</xpath>
+			<xpath>Defs/ThingDef[defName = "Turret_Mortar"]</xpath>
 			<value>
 				<comps>
 					<li Class="VFESecurity.CompProperties_LongRangeArtillery">

--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Sentry.xml
@@ -344,7 +344,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFES_Turret_AutocannonDouble"]/researchPrerequisites</xpath>
+			<xpath>Defs/ThingDef[defName = "VFES_Turret_AutocannonDouble"]/researchPrerequisites</xpath>
 			<value>
 				<li>CE_HeavyTurret</li>      
 			</value>

--- a/Patches/Vanilla Genetics Expanded/Items_Resources.xml
+++ b/Patches/Vanilla Genetics Expanded/Items_Resources.xml
@@ -86,7 +86,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="GR_HybridSilk"]/stuffProps/categories</xpath>
+        <xpath>Defs/ThingDef[defName="GR_HybridSilk"]/stuffProps/categories</xpath>
         <value>
           <li>SoftArmor</li>
         </value>
@@ -109,7 +109,7 @@
       </li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="GR_HybridChitin"]/stuffProps</xpath>
+        <xpath>Defs/ThingDef[defName="GR_HybridChitin"]/stuffProps</xpath>
         <value>
           <categories>
             <li>SoftArmor</li>

--- a/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Items_Resource_Stuff.xml.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Items_Resource_Stuff.xml.xml
@@ -15,14 +15,14 @@
 			<!--Boomthread -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.16</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomthread"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
 				</value>

--- a/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Patch_Projectiles.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Patch_Projectiles.xml
@@ -15,7 +15,7 @@
 			<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[
+				<xpath>Defs/ThingDef[
 				defName="AA_Bullet_TinyVenomBarb" or
 				defName="AA_HugeQuill" or
 				defName="AA_ExplodingWeb"
@@ -30,7 +30,7 @@
 			<!-- =============== Now defining Projectiles in CE Procedure ============= -->
 						
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_Bullet_TinyVenomBarb"]/projectile</xpath>
+				<xpath>Defs/ThingDef[defName="AA_Bullet_TinyVenomBarb"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
@@ -44,7 +44,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_HugeQuill"]/projectile</xpath>
+				<xpath>Defs/ThingDef[defName="AA_HugeQuill"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>
@@ -58,7 +58,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="AA_ExplodingWeb"]/projectile</xpath>
+				<xpath>Defs/ThingDef[defName="AA_ExplodingWeb"]/projectile</xpath>
 				<value>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<flyOverhead>false</flyOverhead>

--- a/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Patch_VerbShoot.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/AlphaAnimals_Patch_VerbShoot.xml
@@ -13,7 +13,7 @@
 			<operations>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -34,7 +34,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -55,7 +55,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/verbs</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Needlechicken"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Genetics Expanded/Mods/CosmicHorror_Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/CosmicHorror_Items_Resource_Stuff.xml
@@ -15,21 +15,21 @@
 			<!--GR_EldritchWool -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.12</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.05</StuffPower_Armor_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Heat</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWool"]/statBases/StuffPower_Armor_Heat</xpath>
 				<value>
 					<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
 				</value>
@@ -38,14 +38,14 @@
 			<!--Shiftskin -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Shiftskin"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Shiftskin"]/statBases/StuffPower_Armor_Sharp</xpath>
 				<value>
 					<StuffPower_Armor_Sharp>0.18</StuffPower_Armor_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Shiftskin"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Shiftskin"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.08</StuffPower_Armor_Blunt>
 				</value>

--- a/Patches/Vanilla Genetics Expanded/Mods/Dinosauria_Items_Resource_Stuff.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/Dinosauria_Items_Resource_Stuff.xml
@@ -15,7 +15,7 @@
 			<!--DinoFeatherWool -->
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_DinoFeatherWool"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_DinoFeatherWool"]/statBases/StuffPower_Armor_Blunt</xpath>
 				<value>
 					<StuffPower_Armor_Blunt>0.24</StuffPower_Armor_Blunt>
 				</value>

--- a/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_AlphaHybridCE.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_AlphaHybridCE.xml
@@ -13,7 +13,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_BearBug"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_BearBug"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_BearBug"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.09</MeleeDodgeChance>
 				<MeleeCritChance>0.4</MeleeCritChance>
@@ -31,20 +31,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_BearBug"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_BearBug"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_BearBug"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -76,7 +76,7 @@
 			
 			<!-- Boomspider -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -85,7 +85,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]/statBases</xpath>
 				<value>
 				<AimingAccuracy>0.65</AimingAccuracy>
 			    <ShootingAccuracyPawn>0.65</ShootingAccuracyPawn> 
@@ -96,20 +96,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomalisk"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomalisk"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -169,7 +169,7 @@
 			
 			<!-- Chicken Cactus -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Needlechicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -178,7 +178,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Needlechicken"]/statBases</xpath>
 				<value>
 				<AimingAccuracy>0.3</AimingAccuracy>
 			                <ShootingAccuracyPawn>0.3</ShootingAccuracyPawn> 
@@ -188,7 +188,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Needlechicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Needlechicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -223,7 +223,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beetlefleet"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -232,7 +232,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beetlefleet"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.24</MeleeCritChance>
@@ -242,7 +242,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Beetlefleet"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beetlefleet"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -266,7 +266,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Groundffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Groundffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -275,7 +275,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Groundffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Groundffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.08</MeleeDodgeChance>
 				<MeleeCritChance>0.4</MeleeCritChance>
@@ -283,7 +283,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Groundffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Groundffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -350,7 +350,7 @@
 			
 			<!-- Birdlizard -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_MeadowLizard"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -359,7 +359,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_MeadowLizard"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.5</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -368,7 +368,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_MeadowLizard"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_MeadowLizard"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -424,7 +424,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_AnimusHare"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -433,14 +433,14 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_AnimusHare"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.48</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_AnimusHare"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_AnimusHare"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -463,7 +463,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -472,7 +472,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases</xpath>
 				<value>
 				<AimingAccuracy>0.9</AimingAccuracy>
 			                <ShootingAccuracyPawn>0.9</ShootingAccuracyPawn> 
@@ -484,21 +484,21 @@
 
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Nighthrumbo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Nighthrumbo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -540,7 +540,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WolfShrimp"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -549,7 +549,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WolfShrimp"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>1</MeleeDodgeChance>
 				<MeleeCritChance>0.21</MeleeCritChance>
@@ -559,14 +559,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WolfShrimp"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_WolfShrimp"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WolfShrimp"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_Dino_HybridCE.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_Dino_HybridCE.xml
@@ -13,7 +13,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spinobear"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spinobear"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.09</MeleeDodgeChance>
 					<MeleeCritChance>0.42</MeleeCritChance>
@@ -31,7 +31,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Spinobear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spinobear"]/tools</xpath>
 				<value>
 					<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -99,7 +99,7 @@
 			
 			<!-- Boomspider -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Parasaurolope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Parasaurolope"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -108,7 +108,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Parasaurolope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Parasaurolope"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.37</MeleeCritChance>
@@ -117,7 +117,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Parasaurolope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Parasaurolope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -136,7 +136,7 @@
 			
 			<!-- Chicken Cactus -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickennathus"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickennathus"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -145,7 +145,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickennathus"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickennathus"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.8</MeleeDodgeChance>
 					<MeleeCritChance>0.07</MeleeCritChance>
@@ -153,7 +153,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickennathus"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickennathus"]/tools</xpath>
 				<value>
 					<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -196,7 +196,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Diplobeetle"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -205,7 +205,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Diplobeetle"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.12</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -214,21 +214,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Diplobeetle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Diplobeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Diplobeetle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Diplobeetle"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -275,7 +275,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Triceraffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Triceraffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -284,7 +284,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Triceraffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Triceraffalo"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
 					<MeleeCritChance>0.4</MeleeCritChance>
@@ -292,7 +292,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Triceraffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Triceraffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -321,7 +321,7 @@
 			
 			<!-- Birdlizard -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Raptortoise"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Raptortoise"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -330,7 +330,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Raptortoise"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Raptortoise"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
 					<MeleeCritChance>0.23</MeleeCritChance>
@@ -339,7 +339,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Raptortoise"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Raptortoise"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -416,7 +416,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Stegothrumbo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Stegothrumbo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -425,7 +425,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Stegothrumbo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Stegothrumbo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.48</MeleeDodgeChance>
 				<MeleeCritChance>0.64</MeleeCritChance>
@@ -433,7 +433,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Stegothrumbo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Stegothrumbo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -475,7 +475,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Velociwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -484,7 +484,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Velociwolf"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
 					<MeleeCritChance>0.14</MeleeCritChance>
@@ -493,7 +493,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Velociwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Velociwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_HorrorHybrid.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_HorrorHybrid.xml
@@ -13,7 +13,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -22,7 +22,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.15</MeleeDodgeChance>
 				<MeleeCritChance>0.51</MeleeCritChance>
@@ -33,7 +33,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -86,7 +86,7 @@
 			
 			<!-- Boomspawn -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBoomalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Humanoid</bodyShape>
@@ -95,7 +95,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBoomalope"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.13</MeleeDodgeChance>
 					<MeleeCritChance>0.27</MeleeCritChance>
@@ -104,7 +104,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchBoomalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchBoomalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -143,7 +143,7 @@
 			
 			<!-- EldritchChickens -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchChicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -152,7 +152,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchChicken"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
 					<MeleeCritChance>0.03</MeleeCritChance>
@@ -160,7 +160,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchChicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchChicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -187,7 +187,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchInsectoid"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -196,7 +196,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.18</MeleeCritChance>
@@ -205,21 +205,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchInsectoid"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchInsectoid"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchInsectoid"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -257,7 +257,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchMuffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -266,7 +266,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchMuffalo"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.1</MeleeDodgeChance>
 					<MeleeCritChance>0.47</MeleeCritChance>
@@ -274,7 +274,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchMuffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchMuffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -312,7 +312,7 @@
 			
 			<!-- Eldritch Snake -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchReptile"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Serpentine</bodyShape>
@@ -321,7 +321,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchReptile"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.5</MeleeDodgeChance>
 					<MeleeCritChance>0.04</MeleeCritChance>
@@ -330,7 +330,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchReptile"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchReptile"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -368,7 +368,7 @@
 
 			<!-- Eldritch Thrumbo -->			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchThrumbo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -377,7 +377,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.84</MeleeCritChance>
@@ -387,21 +387,21 @@
 
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchThrumbo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>22</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchThrumbo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchThrumbo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -443,7 +443,7 @@
 
 			<!-- Eldritch Wolf -->			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -452,7 +452,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWolf"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>0.21</MeleeCritChance>
@@ -461,21 +461,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWolf"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWolf"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_EldritchWolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_EldritchWolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -506,7 +506,7 @@
 
 			<!-- Eldritch Cat -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Cathulhu"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Cathulhu"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -515,7 +515,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Cathulhu"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Cathulhu"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.36</MeleeDodgeChance>
 					<MeleeCritChance>0.30</MeleeCritChance>
@@ -524,14 +524,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Cathulhu"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Cathulhu"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Cathulhu"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Cathulhu"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>7</ArmorRating_Blunt>
 				</value>

--- a/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_MegaHybrid.xml
+++ b/Patches/Vanilla Genetics Expanded/Mods/Races_Animal_MegaHybrid.xml
@@ -15,7 +15,7 @@
 			<!-- Rhinobear -->	
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Elasmobearium"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Elasmobearium"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -24,7 +24,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.84</MeleeCritChance>
@@ -33,20 +33,20 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Elasmobearium"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.35</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Elasmobearium"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Elasmobearium"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -126,7 +126,7 @@
 			<!-- Boomaphant -->	
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomnotherium"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomnotherium"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -135,7 +135,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomnotherium"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomnotherium"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.8</MeleeCritChance>
@@ -144,7 +144,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomnotherium"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomnotherium"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>2</ArmorRating_Blunt>
 					<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
@@ -152,7 +152,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomnotherium"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomnotherium"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -206,7 +206,7 @@
 			<!-- Chickenlodon -->
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlodon"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlodon"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -215,7 +215,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlodon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlodon"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.47</MeleeDodgeChance>
 				<MeleeCritChance>0.4</MeleeCritChance>
@@ -224,7 +224,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlodon"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlodon"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -291,7 +291,7 @@
 			<!-- Giant Mantis -->			
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mantistanis"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mantistanis"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -300,7 +300,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mantistanis"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mantistanis"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.33</MeleeDodgeChance>
 				<MeleeCritChance>0.33</MeleeCritChance>
@@ -309,7 +309,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mantistanis"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mantistanis"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -386,7 +386,7 @@
 			<!-- Paraceramuffalo-->	
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Paraceramuffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Paraceramuffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -395,7 +395,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.88</MeleeCritChance>
@@ -404,20 +404,20 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
 				<value>
 					<ArmorRating_Blunt>4</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Paraceramuffalo"]/statBases</xpath>
 				<value>
 					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Paraceramuffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Paraceramuffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -467,7 +467,7 @@
 			<!-- cowlizard -->
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardochs"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardochs"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -476,7 +476,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardochs"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardochs"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.5</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -485,7 +485,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardochs"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardochs"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -538,7 +538,7 @@
 			<!-- Rodent -->
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Doedicoon"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Doedicoon"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -547,7 +547,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Doedicoon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Doedicoon"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.3</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -556,21 +556,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Doedicoon"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Doedicoon"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Doedicoon"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Doedicoon"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>2.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Doedicoon"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Doedicoon"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -622,7 +622,7 @@
 			<!-- Thrumbo Dino -->	
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumdraeodon"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumdraeodon"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -631,7 +631,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.78</MeleeCritChance>
@@ -640,21 +640,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumdraeodon"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>21</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumdraeodon"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumdraeodon"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -709,7 +709,7 @@
 			<!-- Wooly Wolf -->
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_WoolyWolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WoolyWolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -718,7 +718,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_WoolyWolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WoolyWolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.47</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -729,7 +729,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_WoolyWolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_WoolyWolf"]/tools</xpath>
 				<value>
 					<tools>
 

--- a/Patches/Vanilla Genetics Expanded/Patch_Items_Drugs.xml
+++ b/Patches/Vanilla Genetics Expanded/Patch_Items_Drugs.xml
@@ -11,7 +11,7 @@
 		<!--GR_FeatherdustJoint -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_FeatherdustJoint"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FeatherdustJoint"]/statBases</xpath>
 			<value>
 				<Bulk>0.12</Bulk>
 			</value>
@@ -20,7 +20,7 @@
 		<!--GR_ElectroEgg -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_ElectroEgg"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ElectroEgg"]/statBases</xpath>
 			<value>
 				<Bulk>0.10</Bulk>
 			</value>
@@ -29,7 +29,7 @@
 		<!--GR_PoisonAmpoule -->
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_PoisonAmpoule"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_PoisonAmpoule"]/statBases</xpath>
 			<value>
 				<Bulk>0.05</Bulk>
 			</value>

--- a/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
+++ b/Patches/Vanilla Genetics Expanded/Patch_Projectiles.xml
@@ -11,11 +11,11 @@
 		<!-- ============== Changing Projectile's thingClass to CE ones ================ -->
 
 		<li Class="PatchOperationRemove">
-			<xpath>/Defs/ThingDef[@Name="GR_BaseAnimalProjectile"]/projectile/flyOverhead</xpath>
+			<xpath>Defs/ThingDef[@Name="GR_BaseAnimalProjectile"]/projectile/flyOverhead</xpath>
 		</li>	
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[
+			<xpath>Defs/ThingDef[
 			defName="GR_SniperFlechette" or
 			defName="GR_RazorProjectile" or
 			defName="GR_Laser" or
@@ -34,7 +34,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[
+			<xpath>Defs/ThingDef[
 			@Name="GR_BaseAnimalProjectile" or
 			defName="GR_Proj_ThrownSac" or
 			defName="GR_IncendiaryMote" or
@@ -54,7 +54,7 @@
 		<!-- =============== Now defining Projectiles in CE Procedure ============= -->
 					
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_SniperFlechette"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_SniperFlechette"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -68,7 +68,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_RazorProjectile"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_RazorProjectile"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -82,7 +82,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Laser"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Laser"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -95,7 +95,7 @@
 		</li>
 		
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Disintegrator"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Disintegrator"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -114,7 +114,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_StunBolt"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_StunBolt"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -128,7 +128,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_PoisonBlast"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_PoisonBlast"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -142,7 +142,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_HairballProjectile"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_HairballProjectile"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -155,7 +155,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_GreatHairballProjectile"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_GreatHairballProjectile"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -168,7 +168,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Web"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Web"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -182,7 +182,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_CryoBlast"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_CryoBlast"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -194,7 +194,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_PoisonBreath"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_PoisonBreath"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -206,7 +206,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Proj_ThrownSac"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Proj_ThrownSac"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>12</speed>
@@ -223,7 +223,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_SmokeBomb"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_SmokeBomb"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>18</speed>
@@ -241,7 +241,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_PlasmaBurst"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_PlasmaBurst"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>31</speed>
@@ -257,7 +257,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_FireSpit"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_FireSpit"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>10</speed>
@@ -274,7 +274,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_IncendiaryMote"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_IncendiaryMote"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>16</speed>
@@ -292,7 +292,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Warhead"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Warhead"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<speed>60</speed>
@@ -316,7 +316,7 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Distortion"]/projectile</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Distortion"]/projectile</xpath>
 			<value>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<flyOverhead>false</flyOverhead>
@@ -334,7 +334,7 @@
 		</li>
 
 		<li Class="PatchOperationAdd">
-			<xpath>/Defs</xpath>
+			<xpath>Defs</xpath>
 			<value>
 				<ThingDef ParentName="BaseBullet">
 					<defName>GR_PoisonBreathAnimated_CE</defName>

--- a/Patches/Vanilla Genetics Expanded/Patch_VerbShoot.xml
+++ b/Patches/Vanilla Genetics Expanded/Patch_VerbShoot.xml
@@ -11,7 +11,7 @@
 				<!-- Archocentipede -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -45,7 +45,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -67,7 +67,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Spidercat"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -89,7 +89,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Catalope"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Catalope"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -112,7 +112,7 @@
 
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -134,7 +134,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Boomsnake"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -156,7 +156,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Chickenlizard"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -178,7 +178,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Muffalokomodo"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -200,7 +200,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Spidersnake"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -222,7 +222,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Snakecat"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Snakecat"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -244,7 +244,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Crocorse"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Crocorse"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -266,7 +266,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Thrumbolizard"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -287,7 +287,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Wolfalope"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -310,7 +310,7 @@
 				<!-- Mechas -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechabear"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -332,7 +332,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechalope"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -354,7 +354,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -376,7 +376,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -398,7 +398,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -420,7 +420,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mecharat"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -442,7 +442,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -464,7 +464,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechawolf"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -486,7 +486,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -511,7 +511,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechacat"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">
@@ -533,7 +533,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="GR_Mechamime"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="GR_Mechamime"]/verbs</xpath>
 						<value>
 							<verbs>
 								<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ArchoCentipede.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>3</AimingAccuracy>
 					<ShootingAccuracyPawn>5</ShootingAccuracyPawn> 
@@ -31,20 +31,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>500</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>50</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ArchotechCentipede"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ArchotechCentipede"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_AvianHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_AvianHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenbear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenbear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.09</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenbear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenbear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -60,7 +60,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -69,7 +69,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -78,7 +78,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -111,7 +111,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -120,7 +120,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.08</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -129,7 +129,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -154,7 +154,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -163,7 +163,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.12</MeleeCritChance>
@@ -172,7 +172,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -204,7 +204,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenrabbit"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -213,7 +213,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenrabbit"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.04</MeleeCritChance>
@@ -222,7 +222,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenrabbit"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenrabbit"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -255,7 +255,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickencat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -264,7 +264,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickencat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.04</MeleeCritChance>
@@ -274,7 +274,7 @@
 			
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickencat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickencat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -307,7 +307,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Turkeyman"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Turkeyman"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -316,7 +316,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Turkeyman"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Turkeyman"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.04</MeleeCritChance>
@@ -326,7 +326,7 @@
 			
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Turkeyman"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Turkeyman"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_BoomHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_BoomHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomabear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomabear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.08</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -26,7 +26,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomabear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomabear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -58,7 +58,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomachicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -67,7 +67,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomachicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.08</MeleeCritChance>
@@ -75,7 +75,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomachicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomachicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -107,7 +107,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -116,7 +116,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.05</MeleeDodgeChance>
 				<MeleeCritChance>0.20</MeleeCritChance>
@@ -125,7 +125,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -141,7 +141,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -150,7 +150,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.15</MeleeCritChance>
@@ -159,7 +159,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -192,7 +192,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsquirrel"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -201,7 +201,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsquirrel"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.03</MeleeCritChance>
@@ -209,7 +209,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsquirrel"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsquirrel"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -251,7 +251,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomcat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomcat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -260,7 +260,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomcat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomcat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.15</MeleeCritChance>
@@ -269,7 +269,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomcat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomcat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -302,7 +302,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Booman"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Booman"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -311,7 +311,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Booman"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Booman"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -321,7 +321,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Booman"]/tools</xpath> 
+				<xpath>Defs/ThingDef[defName="GR_Booman"]/tools</xpath> 
 				<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_CanineHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_CanineHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.26</MeleeDodgeChance>
 				<MeleeCritChance>0.14</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -85,7 +85,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -94,7 +94,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.14</MeleeCritChance>
@@ -103,7 +103,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -169,7 +169,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfchicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -178,7 +178,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfchicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.26</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -187,7 +187,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfchicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfchicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -253,7 +253,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -262,7 +262,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.08</MeleeDodgeChance>
 				<MeleeCritChance>0.22</MeleeCritChance>
@@ -271,7 +271,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -303,7 +303,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbeaver"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -312,7 +312,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbeaver"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.26</MeleeDodgeChance>
 				<MeleeCritChance>0.1</MeleeCritChance>
@@ -321,7 +321,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfbeaver"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfbeaver"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -387,7 +387,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfcat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -396,7 +396,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfcat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.3</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -405,7 +405,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfcat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfcat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ColossalHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ColossalHybrids.xml
@@ -10,7 +10,7 @@
 	
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -19,7 +19,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.8</MeleeCritChance>
@@ -28,21 +28,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbear"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -98,7 +98,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -107,7 +107,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.06</MeleeDodgeChance>
 				<MeleeCritChance>0.5</MeleeCritChance>
@@ -116,21 +116,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbalope"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbalope"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -183,7 +183,7 @@
 			</li>
 		
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -192,7 +192,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.5</MeleeCritChance>
@@ -201,21 +201,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -260,7 +260,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -269,7 +269,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.04</MeleeDodgeChance>
 				<MeleeCritChance>0.65</MeleeCritChance>
@@ -278,21 +278,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>15</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -337,7 +337,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -346,7 +346,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.35</MeleeDodgeChance>
 				<MeleeCritChance>0.55</MeleeCritChance>
@@ -355,21 +355,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbochicken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -420,7 +420,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -429,7 +429,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.44</MeleeDodgeChance>
 				<MeleeCritChance>0.56</MeleeCritChance>
@@ -438,21 +438,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbocat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbocat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -504,7 +504,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumborat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -513,7 +513,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumborat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.64</MeleeCritChance>
@@ -522,7 +522,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumborat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumborat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -678,7 +678,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbospider"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -687,7 +687,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbospider"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.09</MeleeDodgeChance>
 					<MeleeCritChance>0.78</MeleeCritChance>
@@ -697,21 +697,21 @@
 
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbospider"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbospider"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbospider"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -735,7 +735,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbolizard"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -744,7 +744,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbolizard"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.08</MeleeDodgeChance>
 					<MeleeCritChance>0.7</MeleeCritChance>
@@ -753,7 +753,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Thrumbolizard"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Thrumbolizard"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_EquineHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_EquineHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearhorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearhorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -93,7 +93,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomhorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomhorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -161,7 +161,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenhorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenhorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -229,7 +229,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomhorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomhorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -238,7 +238,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Cathorse"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Cathorse"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.27</MeleeDodgeChance>
 				<MeleeCritChance>0.50</MeleeCritChance>
@@ -247,7 +247,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Cathorse"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Cathorse"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -448,7 +448,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Muffalohorse"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Muffalohorse"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.17</MeleeDodgeChance>
 				<MeleeCritChance>0.25</MeleeCritChance>
@@ -457,7 +457,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Muffalohorse"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Muffalohorse"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -507,7 +507,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Crocorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Crocorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -566,7 +566,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -575,7 +575,7 @@
 			</li>	
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.18</MeleeCritChance>
@@ -586,21 +586,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Spiderhorse"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Spiderhorse"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -629,7 +629,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Hurseman"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Hurseman"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_FelineHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_FelineHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catbear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catbear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catbear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catbear"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.2</MeleeDodgeChance>
 					<MeleeCritChance>0.11</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catbear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catbear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -85,7 +85,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -94,7 +94,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.02</MeleeCritChance>
@@ -105,7 +105,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -137,7 +137,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catchicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -146,7 +146,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catchicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.01</MeleeCritChance>
@@ -155,7 +155,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catchicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catchicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -187,7 +187,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -196,7 +196,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.06</MeleeCritChance>
@@ -205,7 +205,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -237,7 +237,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catrabbit"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -246,7 +246,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catrabbit"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.01</MeleeCritChance>
@@ -255,7 +255,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catrabbit"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catrabbit"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -320,7 +320,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -329,7 +329,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.07</MeleeCritChance>
@@ -338,7 +338,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Catwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Catwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_HumanoidHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_HumanoidHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Manbear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manbear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Humanoid</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Manbear"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manbear"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.15</MeleeDodgeChance>
 				<MeleeCritChance>0.01</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Manbear"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manbear"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -79,7 +79,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Manffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -146,7 +146,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Manffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -155,7 +155,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Manffalo"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manffalo"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.17</MeleeDodgeChance>
 				<MeleeCritChance>0.25</MeleeCritChance>
@@ -164,7 +164,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Manffalo"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manffalo"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -192,7 +192,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Manalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manalope"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -201,7 +201,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Manalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manalope"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.3</MeleeDodgeChance>
 					<MeleeCritChance>0.01</MeleeCritChance>
@@ -210,7 +210,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Manalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Manalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -238,7 +238,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-			<xpath>/Defs/ThingDef[defName="GR_Manwolf"]</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manwolf"]</xpath>
 			<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
@@ -247,7 +247,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Manwolf"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manwolf"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.75</MeleeCritChance>
@@ -256,7 +256,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Manwolf"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Manwolf"]/tools</xpath>
 			<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">
@@ -332,7 +332,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mancat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mancat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Humanoid</bodyShape>
@@ -341,7 +341,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_Mancat"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Mancat"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.27</MeleeDodgeChance>
 				<MeleeCritChance>0.25</MeleeCritChance>
@@ -350,7 +350,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_Mancat"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_Mancat"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_InsectoidHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_InsectoidHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearscarab"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearscarab"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.05</MeleeDodgeChance>
 				<MeleeCritChance>0.3</MeleeCritChance>
@@ -26,21 +26,21 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearscarab"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearscarab"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearscarab"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -72,7 +72,7 @@
 			</li>
 		
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boombeetle"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -81,7 +81,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/statBases</xpath>
 				<value>
 				<AimingAccuracy>0.65</AimingAccuracy>
 			    <ShootingAccuracyPawn>0.65</ShootingAccuracyPawn> 
@@ -92,21 +92,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.8</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boombeetle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boombeetle"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -138,7 +138,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenspider"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -147,7 +147,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenspider"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.24</MeleeDodgeChance>
 				<MeleeCritChance>0.05</MeleeCritChance>
@@ -156,21 +156,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenspider"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenspider"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenspider"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -195,7 +195,7 @@
 
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalopede"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -204,7 +204,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalopede"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.03</MeleeDodgeChance>
 					<MeleeCritChance>0.4</MeleeCritChance>
@@ -213,20 +213,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalopede"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalopede"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalopede"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -250,7 +250,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfscarab"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -259,7 +259,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfscarab"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.28</MeleeCritChance>
@@ -268,21 +268,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfscarab"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfscarab"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfscarab"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -314,7 +314,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidercat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -323,7 +323,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidercat"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.75</AimingAccuracy>
 					<ShootingAccuracyPawn>0.75</ShootingAccuracyPawn> 
@@ -334,21 +334,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidercat"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Spidercat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidercat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MechanoidHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MechanoidHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechabear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechabear"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -29,20 +29,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechabear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechabear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechabear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -74,7 +74,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -83,7 +83,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechalope"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -94,20 +94,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>16</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechalope"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>8</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -123,7 +123,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechachicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -132,7 +132,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>2.6</AimingAccuracy>
 					<ShootingAccuracyPawn>2.6</ShootingAccuracyPawn> 
@@ -143,20 +143,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>1</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechachicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechachicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -172,7 +172,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaspider"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -181,7 +181,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1.6</AimingAccuracy>
 					<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
@@ -192,20 +192,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>25</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaspider"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaspider"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -221,7 +221,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -230,7 +230,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -241,21 +241,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>28</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>11</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamuffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamuffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -271,7 +271,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mecharat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -280,7 +280,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mecharat"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.8</AimingAccuracy>
 					<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn> 
@@ -291,20 +291,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>0.6</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mecharat"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>0.6</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mecharat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mecharat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -320,7 +320,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -329,7 +329,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1.6</AimingAccuracy>
 					<ShootingAccuracyPawn>1.6</ShootingAccuracyPawn> 
@@ -340,20 +340,20 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>58</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>23</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechaturtle"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechaturtle"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -369,7 +369,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechawolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -378,7 +378,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechawolf"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -389,21 +389,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>15</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechawolf"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechawolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechawolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -435,7 +435,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -444,7 +444,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -455,21 +455,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechathrumbo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechathrumbo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -494,7 +494,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechacat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -503,7 +503,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechacat"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>1</AimingAccuracy>
 					<ShootingAccuracyPawn>1</ShootingAccuracyPawn> 
@@ -514,21 +514,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>15</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechacat"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>7.5</ArmorRating_Sharp>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechacat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechacat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -569,14 +569,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechahorse"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechahorse"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>2.75</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechahorse"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechahorse"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>3.85</ArmorRating_Blunt>
 				</value>
@@ -660,7 +660,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamime"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamime"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Humanoid</bodyShape>
@@ -669,7 +669,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamime"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamime"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -678,21 +678,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamime"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamime"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>3.5</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamime"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamime"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>5.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Mechamime"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Mechamime"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MuffaloHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_MuffaloHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalobear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalobear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.38</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalobear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalobear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -43,7 +43,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalochicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -52,7 +52,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalochicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -61,7 +61,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalochicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalochicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -85,7 +85,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -94,7 +94,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -103,7 +103,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -119,7 +119,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalowolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -128,7 +128,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalowolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.33</MeleeCritChance>
@@ -137,7 +137,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalowolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalowolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -162,7 +162,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalocat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -171,7 +171,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalocat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -180,7 +180,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalocat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalocat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -196,7 +196,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalorat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -205,7 +205,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalorat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -214,7 +214,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalorat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalorat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Paragons.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_Paragons.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.6</MeleeCritChance>
@@ -29,7 +29,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -95,7 +95,7 @@
 			</li>		
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBoomalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBoomalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -104,7 +104,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBoomalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBoomalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.04</MeleeDodgeChance>
 				<MeleeCritChance>0.22</MeleeCritChance>
@@ -113,7 +113,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonBoomalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonBoomalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -129,7 +129,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonChicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonChicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -138,14 +138,14 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonChicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonChicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.09</MeleeDodgeChance>
 				<MeleeCritChance>0.02</MeleeCritChance>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonChicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonChicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -178,7 +178,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonMuffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonMuffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -187,7 +187,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonMuffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonMuffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.01</MeleeDodgeChance>
 				<MeleeCritChance>0.5</MeleeCritChance>
@@ -198,14 +198,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonMuffalo"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonMuffalo"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>4.6</MoveSpeed>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonMuffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonMuffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -221,7 +221,7 @@
 			</li>
 		
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonWolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonWolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -230,14 +230,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonWolf"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonWolf"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>7.1</MoveSpeed>
 				</value>
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonWolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonWolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.45</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -246,7 +246,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonWolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonWolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -304,7 +304,7 @@
 			</li>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonIguana"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonIguana"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -313,7 +313,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonIguana"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonIguana"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.22</MeleeCritChance>
@@ -322,14 +322,14 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonIguana"]/statBases/MoveSpeed</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonIguana"]/statBases/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>4</MoveSpeed>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonIguana"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonIguana"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -570,7 +570,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonRat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonRat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -579,7 +579,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonRat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonRat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.5</MeleeDodgeChance>
 				<MeleeCritChance>0.02</MeleeCritChance>
@@ -588,7 +588,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonRat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonRat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -630,7 +630,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_ParagonHumanoid"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_ParagonHumanoid"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Humanoid</bodyShape>
@@ -639,7 +639,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonHumanoid"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonHumanoid"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.2</MeleeDodgeChance>
 				<MeleeCritChance>0.20</MeleeCritChance>
@@ -648,7 +648,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonHumanoid"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonHumanoid"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -806,7 +806,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases</xpath>
 			<value>
 				<MeleeDodgeChance>0.03</MeleeDodgeChance>
 				<MeleeCritChance>0.30</MeleeCritChance>
@@ -815,21 +815,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases/ArmorRating_Blunt</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases/ArmorRating_Blunt</xpath>
 			<value>
 				<ArmorRating_Blunt>18</ArmorRating_Blunt>
 			</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases/ArmorRating_Sharp</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonInsectoid"]/statBases/ArmorRating_Sharp</xpath>
 			<value>
 				<ArmorRating_Sharp>8.5</ArmorRating_Sharp>
 			</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-			<xpath>/Defs/ThingDef[defName="GR_ParagonInsectoid"]/tools</xpath>
+			<xpath>Defs/ThingDef[defName="GR_ParagonInsectoid"]/tools</xpath>
 			<value>
 				<tools>
 				<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ReptileHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_ReptileHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearodile"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearodile"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.05</MeleeDodgeChance>
 				<MeleeCritChance>0.43</MeleeCritChance>
@@ -29,7 +29,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearodile"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearodile"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -95,7 +95,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsnake"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Serpentine</bodyShape>
@@ -104,7 +104,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsnake"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.5</MeleeDodgeChance>
 				<MeleeCritChance>0.33</MeleeCritChance>
@@ -113,7 +113,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Boomsnake"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Boomsnake"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -145,7 +145,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlizard"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Birdlike</bodyShape>
@@ -154,7 +154,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlizard"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.07</MeleeCritChance>
@@ -163,7 +163,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Chickenlizard"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Chickenlizard"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -197,7 +197,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalokomodo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -206,7 +206,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalokomodo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.06</MeleeDodgeChance>
 				<MeleeCritChance>0.4</MeleeCritChance>
@@ -217,7 +217,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Muffalokomodo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Muffalokomodo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -241,7 +241,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidersnake"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Serpentine</bodyShape>
@@ -250,7 +250,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidersnake"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.45</MeleeDodgeChance>
 				<MeleeCritChance>0.07</MeleeCritChance>
@@ -259,7 +259,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Spidersnake"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Spidersnake"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -283,7 +283,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfsnake"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -292,7 +292,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfsnake"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.3</MeleeCritChance>
@@ -302,7 +302,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Wolfsnake"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Wolfsnake"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -375,7 +375,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Snakecat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Serpentine</bodyShape>
@@ -384,7 +384,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Snakecat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.5</MeleeDodgeChance>
 				<MeleeCritChance>0.25</MeleeCritChance>
@@ -393,7 +393,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Snakecat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Snakecat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -427,7 +427,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardman"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardman"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Birdlike</bodyShape>
@@ -436,7 +436,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardman"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardman"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.31</MeleeCritChance>
@@ -445,7 +445,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Lizardman"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Lizardman"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_RodentHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_RodentHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Molebear"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Molebear"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Molebear"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Molebear"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.18</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Molebear"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Molebear"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -93,7 +93,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Squirralope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -102,7 +102,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Squirralope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.1</MeleeDodgeChance>
 				<MeleeCritChance>0.15</MeleeCritChance>
@@ -111,7 +111,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Squirralope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Squirralope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -136,7 +136,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitchicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -145,7 +145,7 @@
 			</li>
 					
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitchicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.25</MeleeDodgeChance>
 				<MeleeCritChance>0.02</MeleeCritChance>
@@ -154,7 +154,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitchicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitchicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -179,7 +179,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Ratffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Ratffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>QuadrupedLow</bodyShape>
@@ -188,7 +188,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Ratffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Ratffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.22</MeleeDodgeChance>
 				<MeleeCritChance>0.03</MeleeCritChance>
@@ -197,7 +197,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Ratffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Ratffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -222,7 +222,7 @@
 			</li>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beaverwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -231,7 +231,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beaverwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.18</MeleeDodgeChance>
 				<MeleeCritChance>0.15</MeleeCritChance>
@@ -240,7 +240,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Beaverwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Beaverwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -306,7 +306,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitcat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -315,7 +315,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitcat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.23</MeleeDodgeChance>
 				<MeleeCritChance>0.27</MeleeCritChance>
@@ -324,7 +324,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Rabbitcat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Rabbitcat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_UrsineHybrids.xml
+++ b/Patches/Vanilla Genetics Expanded/ThingDefs_Races/Races_Animal_UrsineHybrids.xml
@@ -9,7 +9,7 @@
 			<operations>
 	
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearalope"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -18,7 +18,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearalope"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.09</MeleeDodgeChance>
 				<MeleeCritChance>0.25</MeleeCritChance>
@@ -27,7 +27,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearalope"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearalope"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -93,7 +93,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearchicken"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -102,7 +102,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearchicken"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.12</MeleeDodgeChance>
 				<MeleeCritChance>0.07</MeleeCritChance>
@@ -111,7 +111,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearchicken"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearchicken"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -177,7 +177,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearffalo"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -186,7 +186,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearffalo"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.07</MeleeDodgeChance>
 				<MeleeCritChance>0.3</MeleeCritChance>
@@ -195,7 +195,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearffalo"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearffalo"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -261,7 +261,7 @@
 			</li>
 			
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearwolf"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -270,7 +270,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearwolf"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.3</MeleeDodgeChance>
 				<MeleeCritChance>0.2</MeleeCritChance>
@@ -279,7 +279,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearwolf"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearwolf"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -345,7 +345,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearmole"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -354,7 +354,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearmole"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.3</MeleeDodgeChance>
 				<MeleeCritChance>0.16</MeleeCritChance>
@@ -363,7 +363,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearmole"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearmole"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -428,7 +428,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearcat"]</xpath>
 				<value>
 				<li Class="CombatExtended.RacePropertiesExtensionCE">
 					<bodyShape>Quadruped</bodyShape>
@@ -437,7 +437,7 @@
 			</li>
 						
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearcat"]/statBases</xpath>
 				<value>
 				<MeleeDodgeChance>0.35</MeleeDodgeChance>
 				<MeleeCritChance>0.23</MeleeCritChance>
@@ -446,7 +446,7 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearcat"]/tools</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearcat"]/tools</xpath>
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
@@ -512,7 +512,7 @@
 			</li>
 
 			<li Class="PatchOperationAddModExtension">
-				<xpath>/Defs/ThingDef[defName="GR_Bearman"]</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearman"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
@@ -521,7 +521,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName="GR_Bearman"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="GR_Bearman"]/statBases</xpath>
 				<value>
 					<MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1</MeleeCritChance>
@@ -531,7 +531,7 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>/Defs/ThingDef[defName="GR_Bearman"]/tools</xpath> 
+				<xpath>Defs/ThingDef[defName="GR_Bearman"]/tools</xpath> 
 				<value>
 				<tools>
 					<li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectile_Shoot.xml
@@ -11,7 +11,7 @@
 				<!-- ================= Setting it so that the Animal is shooting using CE code ================= -->
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="VDE_AwakenedDryad_Spitter"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">
@@ -31,7 +31,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VDE_Dryad_Spitter"]/verbs</xpath>
+					<xpath>Defs/ThingDef[defName="VDE_Dryad_Spitter"]/verbs</xpath>
 					<value>
 						<verbs>
 							<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectiles.xml
+++ b/Patches/Vanilla Ideology Expanded - Dryads/DamageDefs/Animal_Projectiles.xml
@@ -11,7 +11,7 @@
 				<!-- ================= Setting it so that the Animal is shooting using CE code ================= -->
 	
 						<li Class="PatchOperationAdd">
-							<xpath>/Defs/ThingDef[defName="VDE_AcidBolt"]</xpath>
+							<xpath>Defs/ThingDef[defName="VDE_AcidBolt"]</xpath>
 							<value>
 								<thingClass>CombatExtended.BulletCE</thingClass>
 							</value>				
@@ -20,7 +20,7 @@
 				
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VDE_AcidBolt"]/projectile</xpath>
+					<xpath>Defs/ThingDef[defName="VDE_AcidBolt"]/projectile</xpath>
 					<value>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<flyOverhead>false</flyOverhead>

--- a/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
+++ b/Patches/Vanilla Psycasts Expanded/ThingDefs_Misc/Apparel_Patch.xml
@@ -96,7 +96,7 @@
             </li>
 
             <li Class="PatchOperationAddModExtension">
-               <xpath>/Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]</xpath>
+               <xpath>Defs/ThingDef[defName="VPE_Apparel_PlateArmorPrestige"]</xpath>
                <value>
                   <li Class="CombatExtended.PartialArmorExt">
                      <stats>

--- a/Patches/Vanilla Storytellers Expanded - Perry Persistent/PawnKinds_ManInCoat.xml
+++ b/Patches/Vanilla Storytellers Expanded - Perry Persistent/PawnKinds_ManInCoat.xml
@@ -10,7 +10,7 @@
       <operations>
         <!-- ===Man in coat === -->
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/PawnKindDef[defName="VSE_ManInTheCoat"]</xpath>
+          <xpath>Defs/PawnKindDef[defName="VSE_ManInTheCoat"]</xpath>
           <value>
             <li Class="CombatExtended.LoadoutPropertiesExtension">
               <primaryMagazineCount>
@@ -22,14 +22,14 @@
         </li>
         
       <li Class="PatchOperationReplace">
-			<xpath>/Defs/PawnKindDef[defName="VSE_ManInTheCoat"]/invNutrition</xpath>
+			<xpath>Defs/PawnKindDef[defName="VSE_ManInTheCoat"]/invNutrition</xpath>
 				<value>
 					<invNutrition>6</invNutrition>
 				</value>
 			</li>
 
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/PawnKindDef[defName="VSE_ManInTheCoat"]/apparelRequired</xpath>
+        <xpath>Defs/PawnKindDef[defName="VSE_ManInTheCoat"]/apparelRequired</xpath>
         <value>
           <li>CE_Apparel_Backpack</li>		
         </value>

--- a/Patches/Vanilla Storytellers Expanded - Winston Waves/Modifiers/Modifiers.xml
+++ b/Patches/Vanilla Storytellers Expanded - Winston Waves/Modifiers/Modifiers.xml
@@ -11,7 +11,7 @@
 
         <!-- === Charge For Everyone === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/VSEWW.ModifierDef[defName="VSEWW_ChargeForEveryone"]/allowedWeaponDef/li[contains(.,"Gun_ChargeLance")]</xpath>
+          <xpath>Defs/VSEWW.ModifierDef[defName="VSEWW_ChargeForEveryone"]/allowedWeaponDef/li[contains(.,"Gun_ChargeLance")]</xpath>
           <value>
             <li MayRequire="CETeam.CombatExtendedGuns">CE_Gun_ChargeLMG</li>
             <li MayRequire="CETeam.CombatExtendedGuns">CE_Gun_ChargeSniperRifle</li>

--- a/Patches/Vanilla Storytellers Expanded - Winston Waves/Rewards/Rewards.xml
+++ b/Patches/Vanilla Storytellers Expanded - Winston Waves/Rewards/Rewards.xml
@@ -13,14 +13,14 @@
 
         <!-- === Good Reward === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_GoodResourceDrop"]/description</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_GoodResourceDrop"]/description</xpath>
           <value>
 		    <description>Cargo pods drop 500 wood, 500 steel, 30 components, 200 plasteel, 10 FSX and 10 Prometheum</description>
           </value>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_GoodResourceDrop"]/items</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_GoodResourceDrop"]/items</xpath>
           <value>
 		    <li>
 			  <thing>FSX</thing>
@@ -35,14 +35,14 @@
 
         <!-- === Excellent Reward === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_ExcellentResourceDrop"]/description</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_ExcellentResourceDrop"]/description</xpath>
           <value>
 		    <description>Cargo pods drop 1000 wood, 1000 steel, 60 components, 20 advanced components, 300 plasteel, 25 FSX and 25 Prometheum</description>
           </value>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_ExcellentResourceDrop"]/items</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_ExcellentResourceDrop"]/items</xpath>
           <value>
 		    <li>
 			  <thing>FSX</thing>
@@ -57,14 +57,14 @@
 
         <!-- === Legendary Reward === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_LegendaryResourceDrop"]/description</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_LegendaryResourceDrop"]/description</xpath>
           <value>
 		    <description>Cargo pods drop 3000 wood, 3000 steel, 100 components, 50 advanced components, 500 plasteel, 100 FSX and 100 Prometheum</description>
           </value>
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/VSEWW.RewardDef[defName="VSEWW_LegendaryResourceDrop"]/items</xpath>
+          <xpath>Defs/VSEWW.RewardDef[defName="VSEWW_LegendaryResourceDrop"]/items</xpath>
           <value>
 		    <li>
 			  <thing>FSX</thing>

--- a/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Coilguns/RangedSpacer.xml
@@ -16,7 +16,7 @@
       <!-- === Tools === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName ="VWE_Gun_GaussMagnum"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName ="VWE_Gun_GaussMagnum"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -45,7 +45,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VWE_Gun_GaussRifle"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName = "VWE_Gun_GaussRifle"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -84,7 +84,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWE_Gun_GaussLance"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWE_Gun_GaussLance"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -113,6 +113,7 @@
           <RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
         </statBases>
         <Properties>
+          <recoilAmount>3.0</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_CoilGun_Magnum</defaultProjectile>
@@ -188,6 +189,7 @@
           <RangedWeapon_Cooldown>0.86</RangedWeapon_Cooldown>
         </statBases>
         <Properties>
+          <recoilAmount>2.0</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_CoilGun_Lance</defaultProjectile>

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Coilguns.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Coilguns.xml
@@ -16,7 +16,7 @@
       <!-- === Tools === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWEFT_Gun_GaussRevolver"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWEFT_Gun_GaussRevolver"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -45,7 +45,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWEFT_Gun_GaussRepeater"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWEFT_Gun_GaussRepeater"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -95,6 +95,7 @@
           <RangedWeapon_Cooldown>0.51</RangedWeapon_Cooldown>
         </statBases>
         <Properties>
+          <recoilAmount>3.0</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_CoilGun_Magnum</defaultProjectile>
@@ -106,8 +107,8 @@
         </Properties>
         <AmmoUser>
           <magazineSize>6</magazineSize>
-					<reloadOneAtATime>true</reloadOneAtATime>
-					<reloadTime>0.95</reloadTime>
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<reloadTime>0.95</reloadTime>
           <ammoSet>AmmoSet_GaussRevolver_HR</ammoSet>
         </AmmoUser>
         <FireModes>
@@ -130,6 +131,7 @@
           <RangedWeapon_Cooldown>0.77</RangedWeapon_Cooldown>
         </statBases>
         <Properties>
+          <recoilAmount>2.0</recoilAmount>
           <verbClass>CombatExtended.Verb_ShootCE</verbClass>
           <hasStandardCommand>True</hasStandardCommand>
           <defaultProjectile>Bullet_CoilGun_Rifle</defaultProjectile>
@@ -141,8 +143,8 @@
         </Properties>
         <AmmoUser>
           <magazineSize>12</magazineSize>
-					<reloadOneAtATime>true</reloadOneAtATime>
-					<reloadTime>1</reloadTime>          
+			<reloadOneAtATime>true</reloadOneAtATime>
+			<reloadTime>1</reloadTime>          
           <ammoSet>AmmoSet_GaussRepeater_HR</ammoSet>
         </AmmoUser>
         <FireModes>
@@ -160,4 +162,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-HeavyWeapons.xml
@@ -2,13 +2,13 @@
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
-					<mods>
-						<li>Vanilla Weapons Expanded - Frontier</li>
-					</mods>
+			<mods>
+				<li>Vanilla Weapons Expanded - Frontier</li>
+			</mods>
 		<match Class="PatchOperationFindMod">
-					<mods>
-						<li>Vanilla Weapons Expanded - Heavy Weapons</li>
-					</mods>
+			<mods>
+				<li>Vanilla Weapons Expanded - Heavy Weapons</li>
+			</mods>
 					
 			<match Class="PatchOperationSequence">
 				<operations>
@@ -17,7 +17,7 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/tools
+            Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/tools
           </xpath>
           <value>
             <tools>
@@ -37,7 +37,7 @@
 
         <!-- === Handheld Gatling Gun === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/costList/ComponentIndustrial</xpath>
+          <xpath>Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]/costList/ComponentIndustrial</xpath>
           <value>
             <ComponentIndustrial>14</ComponentIndustrial>  
           </value>
@@ -82,7 +82,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]</xpath>
+          <xpath>Defs/ThingDef[defName = "VWEFT_Gun_HandheldGatlingGun"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.3,1.3</DrawSize>
@@ -97,4 +97,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Laser.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Laser.xml
@@ -16,7 +16,7 @@
       <!-- === Tools === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWEFT_Gun_SalvagedLaserRevolver"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWEFT_Gun_SalvagedLaserRevolver"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -45,7 +45,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWEFT_Gun_SalvagedLaserRepeater" or defName="VWEFT_Gun_SalvagedLaserHuntingRifle"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWEFT_Gun_SalvagedLaserRepeater" or defName="VWEFT_Gun_SalvagedLaserHuntingRifle"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -86,7 +86,7 @@
       <!-- === Remove VWE Overheating Gizmo === -->
 
       <li Class="PatchOperationRemove">
-        <xpath>/Defs/ThingDef[
+        <xpath>Defs/ThingDef[
         defName = "VWEFT_Gun_SalvagedLaserRevolver" or 
         defName = "VWEFT_Gun_SalvagedLaserRepeater" or        
         defName = "VWEFT_Gun_SalvagedLaserHuntingRifle"

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier-Quickdraw.xml
@@ -15,7 +15,7 @@
               
         <!-- ========== Melee Tools ========== -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWEFT_Gun_Derringer"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWEFT_Gun_Derringer"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -44,7 +44,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWEFT_Gun_LeverActionShotgun"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWEFT_Gun_LeverActionShotgun"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -94,6 +94,7 @@
             <Bulk>1.23</Bulk>
           </statBases>
           <Properties>
+            <recoilAmount>2.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_41RimfireHR_FMJ</defaultProjectile>
@@ -134,6 +135,7 @@
             <Bulk>9.97</Bulk>
           </statBases>
           <Properties>
+            <recoilAmount>2.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>true</hasStandardCommand>
             <defaultProjectile>Bullet_12GaugeHR_Buck</defaultProjectile>
@@ -164,4 +166,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
+++ b/Patches/Vanilla Weapons Expanded - Frontier/Weapons_Frontier.xml
@@ -10,7 +10,7 @@
 
   <!-- ========== Melee Tools ========== -->
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[
+    <xpath>Defs/ThingDef[
     defName="VWEFT_Gun_HeavyRevolver" or
     defName="VWEFT_Gun_VolcanicPistol" or
     defName="VWEFT_Gun_FrontierPistol"
@@ -43,7 +43,7 @@
   </li>
 
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[defName="VWEFT_Gun_RollingBlockRifle" or defName="VWEFT_Gun_RepeatingShotgun"]/tools</xpath>
+    <xpath>Defs/ThingDef[defName="VWEFT_Gun_RollingBlockRifle" or defName="VWEFT_Gun_RepeatingShotgun"]/tools</xpath>
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
@@ -83,7 +83,7 @@
 
   <!-- Crafting Recipes -->
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[
+    <xpath>Defs/ThingDef[
     defName="VWEFT_Gun_HeavyRevolver" or
     defName="VWEFT_Gun_VolcanicPistol" or
     defName="VWEFT_Gun_FrontierPistol"
@@ -94,7 +94,7 @@
   </li>
 
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[defName = "VWEFT_Gun_RepeatingShotgun"]/costList/ComponentIndustrial</xpath>
+    <xpath>Defs/ThingDef[defName = "VWEFT_Gun_RepeatingShotgun"]/costList/ComponentIndustrial</xpath>
     <value>
       <ComponentIndustrial>3</ComponentIndustrial>  
     </value>
@@ -112,6 +112,7 @@
       <Bulk>3.75</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>2.2</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_44MagnumHR_FMJ</defaultProjectile>
@@ -151,6 +152,7 @@
       <Bulk>3.80</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>1.5</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_25ACPHR_FMJ</defaultProjectile>
@@ -191,13 +193,14 @@
 			<Bulk>3.12</Bulk>
 		</statBases>
 		<Properties>
+			<recoilAmount>2.5</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_763x25mmMauserHR_FMJ</defaultProjectile>
 			<warmupTime>0.6</warmupTime>
 			<range>12</range>
-      <soundCast>Shot_Autopistol</soundCast>
-      <soundCastTail>GunTail_Light</soundCastTail>
+			<soundCast>Shot_Autopistol</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
 			<muzzleFlashScale>9</muzzleFlashScale>
 		</Properties>
 		<AmmoUser>
@@ -227,6 +230,7 @@
       <Bulk>12.80</Bulk>
     </statBases>
     <Properties>
+      <recoilAmount>2.0</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_4570GovHR_FMJ</defaultProjectile>
@@ -263,6 +267,7 @@
       <SightsEfficiency>1</SightsEfficiency>
     </statBases>
     <Properties>
+      <recoilAmount>3.0</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_12GaugeHR_Buck</defaultProjectile>
@@ -289,4 +294,3 @@
 	</Operation>
 
 </Patch>
-

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs-NonLethal.xml
@@ -15,7 +15,7 @@
 
 		<!-- Tear Gas Grenade Belt -->
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/costList</xpath>
 		<value>
 			<costList>
 			<VWE_TearGasGrenade>5</VWE_TearGasGrenade>
@@ -24,14 +24,14 @@
 		</li>	
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeTearGasBelt"]/verbs</xpath>
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
+++ b/Patches/Vanilla Weapons Expanded - Grenades/Apparel_Packs.xml
@@ -10,7 +10,7 @@
 
 		<!-- Frag Grenade Belt -->
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/costList</xpath>
 		<value>
 			<costList>
 				<Weapon_GrenadeFrag>5</Weapon_GrenadeFrag>
@@ -19,14 +19,14 @@
 		</li>	
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeFragBelt"]/verbs</xpath>
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">
@@ -55,7 +55,7 @@
 
 		<!-- Molotov Belt -->
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/costList</xpath>
 		<value>
 			<costList>		
 				<Weapon_GrenadeMolotov>5</Weapon_GrenadeMolotov>
@@ -64,14 +64,14 @@
 		</li>		
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeMolotovBelt"]/verbs</xpath>
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">
@@ -100,7 +100,7 @@
 
 		<!-- EMP Grenade Belt -->
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/costList</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/costList</xpath>
 		<value>
 			<costList>		
 				<Weapon_GrenadeEMP>5</Weapon_GrenadeEMP>
@@ -109,14 +109,14 @@
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/comps/li[@Class="CompProperties_Reloadable"]/ammoCountToRefill</xpath>
 		<value>
 			<ammoCountPerCharge>1</ammoCountPerCharge>
 		</value>
 		</li>
 
 		<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/verbs</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Apparel_GrenadeEMPBelt"]/verbs</xpath>
 		<value>
 			<verbs>
 				<li Class="CombatExtended.VerbPropertiesCE">

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/Apparel_Packs.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/Apparel_Packs.xml
@@ -9,7 +9,7 @@
       <operations>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Apparel_Exoframe"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Apparel_Exoframe"]/statBases</xpath>
           <value>
             <Bulk>35</Bulk>
             <WornBulk>12</WornBulk>
@@ -17,7 +17,7 @@
         </li>
 
          <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Apparel_Exoframe"]/equippedStatOffsets/CarryingCapacity</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Apparel_Exoframe"]/equippedStatOffsets/CarryingCapacity</xpath>
           <value>
             <CarryWeight>55</CarryWeight>
           </value>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/RangedIndustrialHeavy.xml
@@ -11,7 +11,7 @@
         <!-- === verbClass === -->
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName = "VWE_Gun_Autocannon" or
               defName = "VWE_Gun_HandheldMortar" or
               defName = "VWE_Gun_HeavyFlamer" or
@@ -27,7 +27,7 @@
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName = "VWE_Gun_Autocannon" or
               defName = "VWE_Gun_HandheldMortar" or
               defName = "VWE_Gun_HeavyFlamer" or
@@ -90,14 +90,14 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_Autocannon"]/recipeMaker/researchPrerequisite</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_Autocannon"]/recipeMaker/researchPrerequisite</xpath>
           <value>
             <researchPrerequisite>CE_TurretHeavyWeapons</researchPrerequisite>
           </value>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_Autocannon"]</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_Autocannon"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.3,1.3</DrawSize>
@@ -117,6 +117,7 @@
             <RangedWeapon_Cooldown>1.5</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
+            <recoilAmount>5.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_60mmMortarShell_HE</defaultProjectile>
@@ -141,7 +142,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_HandheldMortar"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_HandheldMortar"]/comps</xpath>
           <value>
             <li Class="CombatExtended.CompProperties_Charges">
               <chargeSpeeds>
@@ -155,7 +156,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_HandheldMortar"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_HandheldMortar"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.3,1.3</DrawSize>
@@ -177,6 +178,7 @@
             <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
           </statBases>
           <Properties>
+            <recoilAmount>3.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_30x173mmNATO_AP</defaultProjectile>
@@ -199,14 +201,14 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_UraniumSlugRifle"]/recipeMaker/researchPrerequisite</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_UraniumSlugRifle"]/recipeMaker/researchPrerequisite</xpath>
           <value>
             <researchPrerequisite>CE_TurretHeavyWeapons</researchPrerequisite>
           </value>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_UraniumSlugRifle"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_UraniumSlugRifle"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.4,1.4</DrawSize>
@@ -257,7 +259,7 @@
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_HeavyFlamer"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_HeavyFlamer"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.3,1.3</DrawSize>
@@ -310,14 +312,14 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_SwarmMissileLauncher"]/recipeMaker/researchPrerequisite</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_SwarmMissileLauncher"]/recipeMaker/researchPrerequisite</xpath>
           <value>
             <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
           </value>
         </li>
 
         <li Class="PatchOperationAddModExtension">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_SwarmMissileLauncher"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_SwarmMissileLauncher"]</xpath>
           <value>
             <li Class="CombatExtended.GunDrawExtension">
               <DrawSize>1.3,1.3</DrawSize>

--- a/Patches/Vanilla Weapons Expanded - Laser/PawnKinds.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/PawnKinds.xml
@@ -10,7 +10,7 @@
 	
 		<!-- ========== Give ammo to Mercenary Marine ========== -->
 		<li Class="PatchOperationAddModExtension">
-		  <xpath>/Defs/PawnKindDef[defName="Mercenary_Marine"]</xpath>
+		  <xpath>Defs/PawnKindDef[defName="Mercenary_Marine"]</xpath>
 		  <value>
 		    <li Class="CombatExtended.LoadoutPropertiesExtension">
 		  	<primaryMagazineCount>

--- a/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
+++ b/Patches/Vanilla Weapons Expanded - Laser/RangedSpacer.xml
@@ -19,7 +19,7 @@
       <!-- === Tools === -->
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName = "VWEL_Gun_LaserPistol" or defName = "VWEL_Gun_SalvagedLaserPistol"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName = "VWEL_Gun_LaserPistol" or defName = "VWEL_Gun_SalvagedLaserPistol"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -48,7 +48,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[
+        <xpath>Defs/ThingDef[
         defName = "VWEL_Gun_LaserSMG" or
         defName = "VWEL_Gun_LaserRifle" or
         defName = "VWEL_Gun_LaserShotgun" or
@@ -95,7 +95,7 @@
       </li>
 
       <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWEL_Gun_LaserMinigun" or defName = "VWEL_Gun_TeslaGun"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWEL_Gun_LaserMinigun" or defName = "VWEL_Gun_TeslaGun"]/tools</xpath>
         <value>
           <tools>
             <li Class="CombatExtended.ToolCE">
@@ -115,7 +115,7 @@
       <!-- === Remove VWE Overheating Gizmo === -->
 
       <li Class="PatchOperationRemove">
-        <xpath>/Defs/ThingDef[
+        <xpath>Defs/ThingDef[
         defName = "VWEL_Gun_LaserPistol" or 
         defName = "VWEL_Gun_SalvagedLaserPistol" or        
         defName = "VWEL_Gun_LaserSMG" or

--- a/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
+++ b/Patches/Vanilla Weapons Expanded - Makeshift/RangedIndustrial.xml
@@ -10,7 +10,7 @@
 
 		<li Class="PatchOperationReplace">
 			<xpath>
-				/Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/tools
+				Defs/ThingDef[defName = "VWE_Gun_MakeshiftPistol"]/tools
 			</xpath>
 			<value>
 			<tools>
@@ -41,7 +41,7 @@
 
 		<li Class="PatchOperationReplace">
 			<xpath>
-				/Defs/ThingDef[
+				Defs/ThingDef[
 					defName = "VWE_Gun_MakeshiftSMG" or
 					defName = "VWE_Gun_MakeshiftRifle" or
 					defName = "VWE_Gun_MakeshiftLMG" or
@@ -96,6 +96,7 @@
 				<Bulk>2.62</Bulk>
 			</statBases>
 			<Properties>
+				<recoilAmount>2.75</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Grenades.xml
@@ -11,14 +11,14 @@
         <!-- === Tear Gas Grenade === -->
         <!-- == Projectile == -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]</xpath>
           <value>
             <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/projectile</xpath>
+          <xpath>Defs/ThingDef[defName="VWENL_Projectile_TearGasGrenade"]/projectile</xpath>
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>VWENL_TearGas</damageDef>
@@ -40,7 +40,7 @@
 
         <!-- == Grenade == -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
           <value>
             <thingClass>CombatExtended.AmmoThing</thingClass>
             <stackLimit>75</stackLimit>
@@ -49,7 +49,7 @@
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_TearGasGrenade"]</xpath>
           <attribute>Class</attribute>
           <value>CombatExtended.AmmoDef</value>
         </li>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Melee.xml
@@ -10,7 +10,7 @@
 
         <!-- === Baton === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/statBases</xpath>
           <value>
             <Bulk>2.75</Bulk>
             <MeleeCounterParryBonus>0.9</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.17</MeleeCritChance>
@@ -29,14 +29,14 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/weaponTags</xpath>
           <value>
             <li>CE_OneHandedWeapon</li>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_StunBaton"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/NonLethal_Ranged.xml
@@ -11,7 +11,7 @@
 	<!-- === Tools === -->
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Gun_Taser" or defName="VWE_Gun_RubberBulletPistol"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Gun_Taser" or defName="VWE_Gun_RubberBulletPistol"]/tools</xpath>
 		<value>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -40,7 +40,7 @@
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName = "VWE_Gun_DartGun"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName = "VWE_Gun_DartGun"]/tools</xpath>
 		<value>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -79,7 +79,7 @@
 	</li>
 
 	<li Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName="VWE_Gun_TearGasLauncher"]/tools</xpath>
+		<xpath>Defs/ThingDef[defName="VWE_Gun_TearGasLauncher"]/tools</xpath>
 		<value>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -145,6 +145,7 @@
 		<Bulk>2.10</Bulk>
 	</statBases>
 	<Properties>
+		<recoilAmount>2.0</recoilAmount>
 		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		<hasStandardCommand>true</hasStandardCommand>
 		<defaultProjectile>Bullet_43cal_NL</defaultProjectile>
@@ -185,6 +186,7 @@
       <ComponentIndustrial>5</ComponentIndustrial>
 	</costList>
 	<Properties>
+		<recoilAmount>1.2</recoilAmount>
 		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 		<hasStandardCommand>true</hasStandardCommand>
 		<defaultProjectile>Bullet_DartRifle_NL</defaultProjectile>
@@ -220,6 +222,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<Properties>
+			<recoilAmount>2.3</recoilAmount>
 			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
 			<defaultProjectile>Bullet_40x46mmGrenade_CN</defaultProjectile>

--- a/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
+++ b/Patches/Vanilla Weapons Expanded - Quickdraw/Weapons_Quickdraw.xml
@@ -10,7 +10,7 @@
 
   <!-- ========== Melee Tools ========== -->
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[defName="VWE_Gun_AutomaticPistol"]/tools</xpath>
+    <xpath>Defs/ThingDef[defName="VWE_Gun_AutomaticPistol"]/tools</xpath>
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
@@ -39,7 +39,7 @@
   </li>
 
   <li Class="PatchOperationReplace">
-    <xpath>/Defs/ThingDef[defName="VWE_Gun_PDW" or defName="VWE_Gun_BullpupRifle" or defName="VWE_Gun_BullpupDMR"]/tools</xpath>
+    <xpath>Defs/ThingDef[defName="VWE_Gun_PDW" or defName="VWE_Gun_BullpupRifle" or defName="VWE_Gun_BullpupDMR"]/tools</xpath>
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
@@ -121,7 +121,7 @@
 
   <!-- Name -->
   <li Class='PatchOperationReplace'>
-    <xpath>/Defs/ThingDef[defName='VWE_Gun_PDW']/label</xpath> 
+    <xpath>Defs/ThingDef[defName='VWE_Gun_PDW']/label</xpath> 
     <value>
       <label>P90</label>
     </value>
@@ -140,6 +140,7 @@
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
     </statBases>
     <Properties>
+      <recoilAmount>1.46</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
@@ -151,7 +152,6 @@
       <soundCastTail>GunTail_Medium</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
       <recoilPattern>Regular</recoilPattern>
-      <recoilAmount>1.46</recoilAmount>
     </Properties>
     <AmmoUser>
       <magazineSize>30</magazineSize>
@@ -173,7 +173,7 @@
 
   <!-- Name -->
   <li Class='PatchOperationReplace'>
-    <xpath>/Defs/ThingDef[defName='VWE_Gun_BullpupRifle']/label</xpath>
+    <xpath>Defs/ThingDef[defName='VWE_Gun_BullpupRifle']/label</xpath>
     <value>
       <label>FAMAS</label>
     </value>
@@ -192,6 +192,7 @@
       <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
     </statBases>
     <Properties>
+      <recoilAmount>2.0</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
@@ -220,7 +221,7 @@
 
   <!-- Name -->
   <li Class='PatchOperationReplace'>
-    <xpath>/Defs/ThingDef[defName='VWE_Gun_BullpupDMR']/label</xpath>
+    <xpath>Defs/ThingDef[defName='VWE_Gun_BullpupDMR']/label</xpath>
     <value>
       <label>Bullpup DMR</label>
     </value>
@@ -239,6 +240,7 @@
       <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
     </statBases>
     <Properties>
+      <recoilAmount>2.74</recoilAmount>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
       <defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
@@ -249,8 +251,7 @@
       <soundCast>Shot_Autopistol</soundCast>
       <soundCastTail>GunTail_Light</soundCastTail>
       <muzzleFlashScale>9</muzzleFlashScale>
-      <recoilPattern>Regular</recoilPattern>
-      <recoilAmount>2.74</recoilAmount>      
+      <recoilPattern>Regular</recoilPattern>    
     </Properties>
     <AmmoUser>
       <magazineSize>17</magazineSize>
@@ -271,16 +272,14 @@
 
   <!-- Name -->
   <li Class='PatchOperationReplace'>
-    <xpath>/Defs/ThingDef[defName='VWE_Gun_AutomaticPistol']/label</xpath>
+    <xpath>Defs/ThingDef[defName='VWE_Gun_AutomaticPistol']/label</xpath>
     <value>
       <label>Glock 18</label>
     </value>
   </li>
-
 
 			</operations>		
 		</match>
 	</Operation>
 
 </Patch>
-

--- a/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Melee_Neolithic.xml
@@ -118,7 +118,7 @@
     <!-- === Tribal Axe === -->
 
     <li Class="PatchOperationReplace">
-        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/tools</xpath>
+        <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/tools</xpath>
         <value>
         <tools>
             <li Class="CombatExtended.ToolCE">
@@ -148,7 +148,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/statBases</xpath>
+        <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/statBases</xpath>
         <value>
         <Bulk>4</Bulk>
         <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
@@ -156,7 +156,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]</xpath>
+        <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]</xpath>
         <value>
         <equippedStatOffsets>
           <MeleeCritChance>0.10</MeleeCritChance>
@@ -167,7 +167,7 @@
     </li>
 
     <li Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/weaponTags</xpath>
+        <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_TribalAxe"]/weaponTags</xpath>
         <value>
             <li>CE_OneHandedWeapon</li>
         </value>

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -37,7 +37,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_Sling"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Sling"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">
@@ -57,7 +57,7 @@
     <!-- === Throwing Shard === -->
     <!-- == Projectile == -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_FlyingShard"]</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_FlyingShard"]</xpath>
       <value>
         <ThingDef ParentName="BasePilumProjectile">
           <defName>VWE_FlyingShard</defName>
@@ -82,7 +82,7 @@
 
     <!-- == Weapon == -->
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/graphicData</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/graphicData</xpath>
       <value>
         <graphicData>
           <texPath>Things/Projectile/ShardThrown</texPath>
@@ -92,13 +92,13 @@
     </li>
 
     <li Class="PatchOperationAttributeSet">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
       <attribute>ParentName</attribute>
       <value>BaseWeapon</value>
     </li>
     
     <li Class="PatchOperationAdd">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath> 
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath> 
       <value>
         <thingCategories>
           <li>WeaponsRanged</li>
@@ -107,19 +107,19 @@
     </li>
 
     <li Class="PatchOperationRemove">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/recipeMaker</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/recipeMaker</xpath>
     </li>
 
     <li Class="PatchOperationRemove">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/costStuffCount</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/costStuffCount</xpath>
     </li>
 
     <li Class="PatchOperationRemove">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/stuffCategories</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/stuffCategories</xpath>
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/smeltable</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/smeltable</xpath>
       <value>
         <thingClass>CombatExtended.AmmoThing</thingClass>
         <stackLimit>75</stackLimit>
@@ -129,7 +129,7 @@
     </li>
 
     <li Class="PatchOperationAttributeSet">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]</xpath>
       <attribute>Class</attribute>
       <value>CombatExtended.AmmoDef</value>
     </li>
@@ -158,7 +158,7 @@
     </li>
 
     <li Class="PatchOperationReplace">
-      <xpath>/Defs/ThingDef[defName="VWE_Throwing_Shards"]/tools</xpath>
+      <xpath>Defs/ThingDef[defName="VWE_Throwing_Shards"]/tools</xpath>
       <value>
         <tools>
           <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Grenades.xml
@@ -11,7 +11,7 @@
         <!-- === Remove Flashbang / Smoke as they're redundant === -->
         <li Class="PatchOperationRemove">
           <xpath>
-          /Defs/ThingDef[
+          Defs/ThingDef[
             defName = "VWE_Projectile_FlashGrenade" or 
             defName = "VWE_Projectile_SmokeGrenade" or
             defName = "VWE_FlashGrenade" or

--- a/Patches/Vanilla Weapons Expanded/Industrial_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Melee.xml
@@ -10,7 +10,7 @@
 
         <!-- === Baton === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/statBases</xpath>
           <value>
             <Bulk>2.75</Bulk>
             <MeleeCounterParryBonus>0.9</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.17</MeleeCritChance>
@@ -29,7 +29,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/weaponTags</xpath>
           <value>
             <li>CE_Sidearm_Melee</li>
             <li>CE_OneHandedWeapon</li>
@@ -37,7 +37,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Baton"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -67,7 +67,7 @@
 
         <!-- === Combat Knife === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/statBases</xpath>
           <value>
             <Bulk>1.25</Bulk>
             <MeleeCounterParryBonus>0.30</MeleeCounterParryBonus>
@@ -75,7 +75,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.10</MeleeCritChance>
@@ -86,7 +86,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/weaponTags</xpath>
           <value>
             <li>CE_Sidearm_Melee</li>
             <li>CE_OneHandedWeapon</li>
@@ -94,7 +94,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_CombatKnife"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -136,7 +136,7 @@
 
         <!-- === Shovel === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/statBases</xpath>
           <value>
             <Bulk>5</Bulk>
             <MeleeCounterParryBonus>0.56</MeleeCounterParryBonus>
@@ -144,7 +144,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/equippedStatOffsets</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/equippedStatOffsets</xpath>
           <value>
             <MeleeCritChance>0.22</MeleeCritChance>
             <MeleeParryChance>0.20</MeleeParryChance>
@@ -153,7 +153,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Shovel"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Industrial_Ranged.xml
@@ -10,7 +10,7 @@
 
 				<!-- === Tools === -->
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VWE_Bow_Compound"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Bow_Compound"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -27,7 +27,7 @@
 
 				<li Class="PatchOperationReplace">
 					<xpath>
-						/Defs/ThingDef[
+						Defs/ThingDef[
 							defName = "VWE_CombatHandgun" or 
 							defName = "VWE_Gun_HandCannon" or 
 							defName = "VWE_Gun_LightSMG" or
@@ -64,7 +64,7 @@
 
 				<li Class="PatchOperationReplace">
 					<xpath>
-						/Defs/ThingDef[
+						Defs/ThingDef[
 							defName = "VWE_Gun_AntiMaterialRifle" or
 							defName = "VWE_Gun_SemiAutomaticRifle" or
 							defName = "VWE_Gun_BattleRifle" or
@@ -115,7 +115,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VWE_Gun_RocketLauncher"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Gun_RocketLauncher"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -133,7 +133,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<xpath>/Defs/ThingDef[defName="VWE_Gun_FireExtinguisher"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="VWE_Gun_FireExtinguisher"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -198,6 +198,7 @@
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>2.5</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
@@ -240,6 +241,7 @@
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>2.5</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_357Magnum_FMJ</defaultProjectile>
@@ -329,6 +331,7 @@
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.39</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
@@ -339,7 +342,6 @@
 						<soundCast>VWE_Shot_SMG</soundCast>
 						<soundCastTail>GunTail_Light</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>1.39</recoilAmount>
 					</Properties>
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
@@ -375,6 +377,7 @@
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>3.5</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
@@ -418,17 +421,17 @@
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>2.12</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
 						<warmupTime>1.1</warmupTime>
-						<range>48</range>
+						<range>51</range>
 						<soundCast>VWE_Shot_BattleRifle</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>2.12</recoilAmount>
 					</Properties>
 					<AmmoUser>
 						<magazineSize>20</magazineSize>
@@ -465,17 +468,17 @@
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.53</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
 						<burstShotCount>6</burstShotCount>
 						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
 						<warmupTime>1.1</warmupTime>
-						<range>44</range>
+						<range>48</range>
 						<soundCast>Shot_AssaultRifle</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>1.53</recoilAmount>
 					</Properties>
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
@@ -512,6 +515,7 @@
 						<ComponentIndustrial>5</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.53</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
@@ -522,7 +526,6 @@
 						<soundCast>VWE_Shot_ServiceRifle</soundCast>
 						<soundCastTail>GunTail_Medium</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>1.53</recoilAmount>
 					</Properties>
 					<AmmoUser>
 						<magazineSize>30</magazineSize>
@@ -559,6 +562,7 @@
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.75</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -598,11 +602,12 @@
 						<ComponentIndustrial>2</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.75</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_44-40Winchester_FMJ</defaultProjectile>
 						<warmupTime>1.1</warmupTime>
-						<range>48</range>
+						<range>31</range>
 						<soundCast>VWE_Shot_LeverActionRifle</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
@@ -638,6 +643,7 @@
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>2.5</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
@@ -683,6 +689,7 @@
 						<ComponentIndustrial>4</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.94</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
@@ -727,6 +734,7 @@
 						<ComponentIndustrial>6</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>1.49</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
@@ -737,8 +745,6 @@
 						<soundCast>Shot_Minigun</soundCast>
 						<soundCastTail>GunTail_Heavy</soundCastTail>
 						<muzzleFlashScale>9</muzzleFlashScale>
-						<recoilAmount>1.49</recoilAmount>
-						<recoilPattern>Regular</recoilPattern>
 						<targetParams>
 							<canTargetLocations>true</canTargetLocations>
 						</targetParams>
@@ -825,6 +831,7 @@
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>0.85</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>True</hasStandardCommand>
 						<defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
@@ -835,7 +842,6 @@
 						<minRange>3</minRange>
 						<soundCast>VWE_Shot_Flamethrower</soundCast>
 						<muzzleFlashScale>0</muzzleFlashScale>
-						<recoilAmount>0.85</recoilAmount>
 						<ai_IsBuildingDestroyer>True</ai_IsBuildingDestroyer>
 						<targetParams>
 							<canTargetLocations>True</canTargetLocations>
@@ -877,6 +883,7 @@
 						<ComponentIndustrial>3</ComponentIndustrial>
 					</costList>
 					<Properties>
+						<recoilAmount>2.93</recoilAmount>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
 						<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
@@ -885,7 +892,6 @@
 						<minRange>5</minRange>
 						<soundCast>VWE_Shot_GrenadeLauncher</soundCast>
 						<muzzleFlashScale>14</muzzleFlashScale>
-						<recoilAmount>2.93</recoilAmount>
 						<ai_IsBuildingDestroyer>True</ai_IsBuildingDestroyer>
 						<ignorePartialLoSBlocker>True</ignorePartialLoSBlocker>
 						<targetParams>

--- a/Patches/Vanilla Weapons Expanded/Medieval_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Melee.xml
@@ -10,7 +10,7 @@
 
         <!-- === Battle Axe === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]/statBases</xpath>
           <value>
             <Bulk>13</Bulk>
             <MeleeCounterParryBonus>1.5</MeleeCounterParryBonus>
@@ -18,7 +18,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.3</MeleeCritChance>
@@ -29,7 +29,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_BattleAxe"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -71,7 +71,7 @@
 
         <!-- === Halberd === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]/statBases</xpath>
           <value>
             <Bulk>13</Bulk>
             <MeleeCounterParryBonus>1.08</MeleeCounterParryBonus>
@@ -79,7 +79,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]</xpath>
           <value>
             <equippedStatOffsets>
               <MeleeCritChance>0.2</MeleeCritChance>
@@ -90,7 +90,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Halberd"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -132,7 +132,7 @@
 
         <!-- === Hammer === -->
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/statBases</xpath>
           <value>
             <Bulk>3.75</Bulk>
             <MeleeCounterParryBonus>0.06</MeleeCounterParryBonus>
@@ -140,7 +140,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/equippedStatOffsets</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/equippedStatOffsets</xpath>
           <value>
             <MeleeCritChance>0.45</MeleeCritChance>
             <MeleeParryChance>0.11</MeleeParryChance>
@@ -149,14 +149,14 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/weaponTags</xpath>
           <value>
             <li>CE_OneHandedWeapon</li>
           </value>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Hammer"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Medieval_Ranged.xml
@@ -10,7 +10,7 @@
 
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Bow_Crossbow"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Bow_Crossbow"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -26,7 +26,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_Flintlock"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_Flintlock"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -55,7 +55,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName = "VWE_Gun_Musket"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Gun_Musket"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -136,7 +136,7 @@
           - Has to be replaced in vanilla too 
         -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_Flintlock"]/verbs/li/verbClass</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_Flintlock"]/verbs/li/verbClass</xpath>
           <value>
             <verbClass>Verb_Shoot</verbClass>
           </value>
@@ -189,7 +189,7 @@
           - Has to be replaced in vanilla too 
         -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_Musket"]/verbs/li/verbClass</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_Musket"]/verbs/li/verbClass</xpath>
           <value>
             <verbClass>Verb_Shoot</verbClass>
           </value>
@@ -238,7 +238,7 @@
         <!-- === Throwing Knives === -->
         <!-- == Projectile == -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_FlyingBlade"]/projectile</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_FlyingBlade"]/projectile</xpath>
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>RangedStab</damageDef>
@@ -265,13 +265,13 @@
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
         </li>
         
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath> 
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath> 
           <value>
             <thingCategories>
               <li>WeaponsRanged</li>
@@ -280,20 +280,20 @@
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/recipeMaker</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/recipeMaker</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/costStuffCount</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/costStuffCount</xpath>
         </li>
 
         <li Class="PatchOperationRemove">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/stuffCategories</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/stuffCategories</xpath>
         </li>
 
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
           <value>
             <thingClass>CombatExtended.AmmoThing</thingClass>
             <stackLimit>75</stackLimit>
@@ -305,7 +305,7 @@
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]</xpath>
           <attribute>Class</attribute>
           <value>CombatExtended.AmmoDef</value>
         </li>
@@ -336,7 +336,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Knives"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Knives"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -424,7 +424,7 @@
 
         <!-- Tools -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Tool_Whip"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Tool_Whip"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Melee.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Melee.xml
@@ -10,7 +10,7 @@
 
         <!-- === Axe === -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -40,7 +40,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/statBases</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/statBases</xpath>
           <value>
             <Bulk>4</Bulk>
             <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
@@ -48,7 +48,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/equippedStatOffsets</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/equippedStatOffsets</xpath>
           <value>
             <MeleeCritChance>0.10</MeleeCritChance>
             <MeleeParryChance>0.15</MeleeParryChance>
@@ -57,7 +57,7 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/weaponTags</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_MeleeWeapon_Axe"]/weaponTags</xpath>
           <value>
             <li>CE_OneHandedWeapon</li>
           </value>

--- a/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Neolithic_Ranged.xml
@@ -63,7 +63,7 @@
         <!-- === Throwing Rock === -->
         <!-- == Projectile == -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Rock"]/projectile</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Rock"]/projectile</xpath>
           <value>
             <projectile Class="CombatExtended.ProjectilePropertiesCE">
               <damageDef>Blunt</damageDef>
@@ -77,13 +77,13 @@
 
         <!-- == Weapon == -->
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
           <attribute>ParentName</attribute>
           <value>BaseWeapon</value>
         </li>
         
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
           <value>
             <thingCategories>
               <li>WeaponsRanged</li>
@@ -93,14 +93,14 @@
 
         <li Class="PatchOperationRemove">
           <xpath>
-            /Defs/ThingDef[defName="VWE_Throwing_Rocks"]/recipeMaker |
-            /Defs/ThingDef[defName="VWE_Throwing_Rocks"]/costStuffCount |
-            /Defs/ThingDef[defName="VWE_Throwing_Rocks"]/stuffCategories
+            Defs/ThingDef[defName="VWE_Throwing_Rocks"]/recipeMaker |
+            Defs/ThingDef[defName="VWE_Throwing_Rocks"]/costStuffCount |
+            Defs/ThingDef[defName="VWE_Throwing_Rocks"]/stuffCategories
           </xpath>
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/smeltable</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]/smeltable</xpath>
           <value>
             <thingClass>CombatExtended.AmmoThing</thingClass>
             <stackLimit>75</stackLimit>
@@ -110,22 +110,22 @@
         </li>
 
         <li Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/graphicData</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]/graphicData</xpath>
           <value>
             <color>(158,153,135)</color>
           </value>
         </li>
 
         <li Class="PatchOperationAttributeSet">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]</xpath>
           <attribute>Class</attribute>
           <value>CombatExtended.AmmoDef</value>
         </li>
 
         <li Class="PatchOperationConditional">
-          <xpath>/Defs/ThingDef[defName = "VWE_Throwing_Rocks"]/comps</xpath>
+          <xpath>Defs/ThingDef[defName = "VWE_Throwing_Rocks"]/comps</xpath>
           <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef[defName = "VWE_Throwing_Rocks"]</xpath>
+            <xpath>Defs/ThingDef[defName = "VWE_Throwing_Rocks"]</xpath>
             <value>
               <comps />
             </value>
@@ -158,7 +158,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Throwing_Rocks"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Throwing_Rocks"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">

--- a/Patches/Vanilla Weapons Expanded/ResearchProjects.xml
+++ b/Patches/Vanilla Weapons Expanded/ResearchProjects.xml
@@ -11,7 +11,7 @@
         <!-- === Prerequisite Replacement === -->
         <!-- == Laser Targeting Systems == -->
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ResearchProjectDef[defName="VWE_LaserTargetingSystems"]/prerequisites</xpath>
+          <xpath>Defs/ResearchProjectDef[defName="VWE_LaserTargetingSystems"]/prerequisites</xpath>
           <value>
             <prerequisites>
               <li>CE_AdvancedLaunchers</li>
@@ -23,7 +23,7 @@
         <!-- === Remove Unused Research Defs === -->
         <li Class="PatchOperationRemove">
           <xpath>
-            /Defs/ResearchProjectDef[
+            Defs/ResearchProjectDef[
               defName="VWE_HeavyWeapons" or
               defName="VWE_DesignatedMarksmanRifle" or
               defName="VWE_Flamethrower" or

--- a/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
+++ b/Patches/Vanilla Weapons Expanded/Spacer_Ranged.xml
@@ -10,7 +10,7 @@
         <!-- === Tools === -->
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName ="VWE_Gun_ChargePistol" or 
               defName = "VWE_Gun_ChargeSMG"]/tools
           </xpath>
@@ -43,7 +43,7 @@
 
         <li Class="PatchOperationReplace">
           <xpath>
-            /Defs/ThingDef[
+            Defs/ThingDef[
               defName = "VWE_Gun_ChargeShotgun" or
               defName = "VWE_Gun_ChargeSniperRifle" or
               defName = "VWE_Gun_ChargeLMG" or
@@ -88,7 +88,7 @@
         </li>
 
         <li Class="PatchOperationReplace">
-          <xpath>/Defs/ThingDef[defName="VWE_Gun_ChargeRocketLauncher"]/tools</xpath>
+          <xpath>Defs/ThingDef[defName="VWE_Gun_ChargeRocketLauncher"]/tools</xpath>
           <value>
             <tools>
               <li Class="CombatExtended.ToolCE">
@@ -124,6 +124,7 @@
             <ComponentIndustrial>2</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>3.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
@@ -136,12 +137,14 @@
             <muzzleFlashScale>9</muzzleFlashScale>
           </Properties>
           <AmmoUser>
-            <magazineSize>14</magazineSize>
+            <magazineSize>12</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aiAimMode>AimedShot</aiAimMode>
+            <aiAimMode>Snapshot</aiAimMode>
+            <aiUseBurstMode>True</aiUseBurstMode>
+            <aimedBurstShotCount>2</aimedBurstShotCount>
           </FireModes>
           <weaponTags>
             <li>SpacerGun</li>
@@ -169,6 +172,7 @@
             <ComponentIndustrial>10</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>1.20</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
@@ -179,10 +183,9 @@
             <soundCast>VWE_Shot_ChargeSMG</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
-            <recoilAmount>1.20</recoilAmount>
           </Properties>
           <AmmoUser>
-            <magazineSize>35</magazineSize>
+            <magazineSize>30</magazineSize>
             <reloadTime>4</reloadTime>
             <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
           </AmmoUser>
@@ -215,6 +218,7 @@
             <ComponentIndustrial>10</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>3.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_12GaugeCharged</defaultProjectile>
@@ -229,7 +233,9 @@
             <reloadTime>4.5</reloadTime>
             <ammoSet>AmmoSet_12GaugeCharged</ammoSet>
           </AmmoUser>
-          <FireModes />
+          <FireModes>
+            <aiAimMode>Snapshot</aiAimMode>
+          </FireModes>
           <weaponTags>
             <li>SpacerGun</li>
             <li>CE_AI_AssaultWeapon</li>
@@ -256,6 +262,7 @@
             <ComponentIndustrial>12</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>1.5</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_8x35mmCharged_Triple</defaultProjectile>
@@ -301,6 +308,7 @@
             <ComponentIndustrial>10</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>1.16</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
             <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
@@ -311,14 +319,13 @@
             <soundCast>Shot_ChargeBlaster</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
-            <recoilAmount>1.16</recoilAmount>
             <recoilPattern>Mounted</recoilPattern>
             <targetParams>
               <canTargetLocations>True</canTargetLocations>
             </targetParams>
           </Properties>
           <AmmoUser>
-            <magazineSize>100</magazineSize>
+            <magazineSize>200</magazineSize>
             <reloadTime>7.8</reloadTime>
             <ammoSet>AmmoSet_6x24mmCharged</ammoSet>
           </AmmoUser>
@@ -340,41 +347,40 @@
           <defName>VWE_Gun_ChargeMinigun</defName>
           <statBases>
             <WorkToMake>75500</WorkToMake>
-            <Mass>32.0</Mass>
-            <Bulk>28.0</Bulk>
+            <Mass>20.0</Mass>
+            <Bulk>12.0</Bulk>
             <SwayFactor>1.35</SwayFactor>
             <ShotSpread>0.10</ShotSpread>
             <SightsEfficiency>1</SightsEfficiency>
             <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
           </statBases>
           <costList>
-            <Steel>125</Steel>
-            <Plasteel>55</Plasteel>
-            <Chemfuel>20</Chemfuel>
+            <Steel>120</Steel>
+            <Plasteel>40</Plasteel>
+            <Chemfuel>15</Chemfuel>
             <ComponentIndustrial>15</ComponentIndustrial>
           </costList>
           <Properties>
+            <recoilAmount>1.0</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
+            <defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
             <burstShotCount>50</burstShotCount>
-            <ticksBetweenBurstShots>1</ticksBetweenBurstShots>
+            <ticksBetweenBurstShots>2</ticksBetweenBurstShots>
             <warmupTime>2.5</warmupTime>
             <range>62</range>
             <soundCast>VWE_Shot_ChargeMinigun</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
             <muzzleFlashScale>9</muzzleFlashScale>
-            <recoilAmount>1.24</recoilAmount>
-            <recoilPattern>Regular</recoilPattern>
           </Properties>
           <AmmoUser>
             <magazineSize>500</magazineSize>
             <reloadTime>9.2</reloadTime>
-            <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
+            <ammoSet>AmmoSet_8x35mmCharged</ammoSet>
           </AmmoUser>
           <FireModes>
-            <aiAimMode>SuppressFire</aiAimMode>
-            <aimedBurstShotCount>20</aimedBurstShotCount>
+            <aiAimMode>Snapshot</aiAimMode>
+            <aimedBurstShotCount>25</aimedBurstShotCount>
           </FireModes>
           <weaponTags>
             <li>SpacerGun</li>

--- a/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
+++ b/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds_Royalty.xml
@@ -81,6 +81,11 @@
   	</value>
   </Operation>
 
+  <!--removed gunlink-->
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Janissary"]/specificApparelRequirements/li[1]</xpath>
+  </Operation>
+
   <Operation Class="PatchOperationAddModExtension">
   	<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Janissary"]</xpath>
   	<value>
@@ -150,7 +155,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/PawnKindDef[defName ="Empire_Fighter_Cataphract"]/weaponTags</xpath>
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/weaponTags</xpath>
     <value>
         <li>Minigun</li>
     </value>
@@ -158,7 +163,7 @@
 
   <!--removed gunlink-->
   <Operation Class="PatchOperationRemove">
-    <xpath>Defs/PawnKindDef[defName ="Empire_Fighter_Cataphract"]/specificApparelRequirements/li[1]</xpath>
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/specificApparelRequirements/li[1]</xpath>
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
@@ -214,7 +219,7 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>Defs/PawnKindDef[defName ="Empire_Fighter_Grenadier"]/weaponTags</xpath>
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]/weaponTags</xpath>
     <value>
         <weaponTags>
             <li>GunHeavy</li>
@@ -318,18 +323,36 @@
   <!-- ========== Add Loadbearing Gear to Imperial Fighters ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/apparelRequired</xpath>
+    <xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]/specificApparelRequirements</xpath>
       <value>
-        <li>CE_Apparel_Backpack</li>
+        <li>
+          <bodyPartGroup>Shoulders</bodyPartGroup>
+          <apparelLayer>Backpack</apparelLayer>
+          <stuff>Cloth</stuff>
+        </li>
       </value>
    </Operation>
- 
-   <Operation Class="PatchOperationAdd">
-    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]/apparelRequired</xpath>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/specificApparelRequirements</xpath>
       <value>
-        <li>CE_Apparel_Backpack</li>
+        <li>
+          <bodyPartGroup>Shoulders</bodyPartGroup>
+          <apparelLayer>Backpack</apparelLayer>
+          <stuff>Synthread</stuff>
+        </li>
       </value>
    </Operation>
- 
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/PawnKindDef[@Name="StellicGuardBase"]/specificApparelRequirements</xpath>
+      <value>
+        <li>
+          <bodyPartGroup>Shoulders</bodyPartGroup>
+          <apparelLayer>Backpack</apparelLayer>
+          <stuff>Hyperweave</stuff>
+        </li>
+      </value>
+   </Operation>
 
 </Patch>


### PR DESCRIPTION
## Changes

- Updated VE mod patches with recoil values added to the semi-auto guns. Rechambered the charged minigun in 8x35mm as its the spacer counterpart to the base game minigun.
- Updated several mod patches with `/Defs` switched to `Defs`. The rest of the patches will follow after this PR is merged.
- Fixed and updated VFE-Empire's patch.
- Tweaked the helmet generation behavior of janissaries and implemented a more robust solution for the backpack generation on empire fighter pawns

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
