### PR TITLE
Psycho's description typo fix

### DIFF
--- a/Defs/Drugs/Psychite_Psycho.xml
+++ b/Defs/Drugs/Psychite_Psycho.xml
@@ -4,7 +4,7 @@
   <ThingDef ParentName="MakeableDrugBase">
     <defName>Psycho</defName>
     <label>psycho</label>
-    <description>A coarse, powdery preparation of concentrated psychite. When snorted, it produces an intense feeling of euphoria and invigoration, dramatically reducing the user's perception of pain and sharpening their senses for a short time. The high is followed by an equally intense and very unpleasant crash. Owing to its high potency and crude preparation, psycho is even more dangerous and addictive than other drugs derived from psychoid leave.\n\nMany tribal warriors take psycho before entering battle, heightening their senses and allowing them to briefly ignore otherwise incapacitating wounds.</description>
+    <description>A coarse, powdery preparation of concentrated psychite. When snorted, it produces an intense feeling of euphoria and invigoration, dramatically reducing the user's perception of pain and sharpening their senses for a short time. The high is followed by an equally intense and very unpleasant crash. Owing to its high potency and crude preparation, psycho is even more dangerous and addictive than other drugs derived from psychoid leaves.\n\nMany tribal warriors take psycho before entering battle, heightening their senses and allowing them to briefly ignore otherwise incapacitating wounds.</description>
     <descriptionHyperlinks>
       <HediffDef>PsychoHigh</HediffDef>
       <HediffDef>PsychiteTolerance</HediffDef>


### PR DESCRIPTION
## Changes

- Fixed a typo in the item description.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
