### PR TITLE
Misc tweaks

### DIFF
--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -235,8 +235,8 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationSharp>5</armorPenetrationSharp>
-				<armorPenetrationBlunt>21.6</armorPenetrationBlunt>
-				<speed>147</speed>
+				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
+				<speed>148</speed>
 			</projectile>
 		</ThingDef>
 
@@ -244,10 +244,10 @@
 			<defName>Bullet_556x45mmNATO_AP_SB</defName>
 			<label>5.56mm NATO bullet (AP)</label>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageAmountBase>7</damageAmountBase>
+				<damageAmountBase>8</damageAmountBase>
 				<armorPenetrationSharp>10</armorPenetrationSharp>
-				<armorPenetrationBlunt>21.6</armorPenetrationBlunt>
-				<speed>147</speed>
+				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
+				<speed>148</speed>
 			</projectile>
 		</ThingDef>
 
@@ -257,8 +257,8 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>15</damageAmountBase>
 				<armorPenetrationSharp>3</armorPenetrationSharp>
-				<armorPenetrationBlunt>21.6</armorPenetrationBlunt>
-				<speed>147</speed>
+				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
+				<speed>148</speed>
 			</projectile>
 		</ThingDef>
 
@@ -266,16 +266,16 @@
 			<defName>Bullet_556x45mmNATO_Incendiary_SB</defName>
 			<label>5.56mm NATO bullet (AP-I)</label>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<damageAmountBase>7</damageAmountBase>
+				<damageAmountBase>8</damageAmountBase>
 				<armorPenetrationSharp>10</armorPenetrationSharp>
-				<armorPenetrationBlunt>21.6</armorPenetrationBlunt>
+				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
 				<secondaryDamage>
 					<li>
 						<def>Flame_Secondary</def>
 						<amount>5</amount>
 					</li>
 				</secondaryDamage>
-				<speed>147</speed>
+				<speed>148</speed>
 			</projectile>
 		</ThingDef>
 		
@@ -285,14 +285,14 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationSharp>5</armorPenetrationSharp>
-				<armorPenetrationBlunt>21.6</armorPenetrationBlunt>
+				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
 				<secondaryDamage>
 					<li>
 						<def>Bomb_Secondary</def>
 						<amount>7</amount>
 					</li>
 				</secondaryDamage>
-				<speed>147</speed>
+				<speed>148</speed>
 			</projectile>
 		</ThingDef>
 
@@ -302,8 +302,8 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>6</damageAmountBase>
 				<armorPenetrationSharp>17.5</armorPenetrationSharp>
-				<armorPenetrationBlunt>27.96</armorPenetrationBlunt>
-				<speed>220</speed>
+				<armorPenetrationBlunt>28.42</armorPenetrationBlunt>
+				<speed>222</speed>
 			</projectile>
 		</ThingDef>
 

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -145,7 +145,7 @@
 		<label>8.6mm Blackout bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>8.6mm Blackout bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -175,7 +175,7 @@
 		<label>8.6mm Blackout bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
-		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -191,7 +191,7 @@
 		<label>8.6mm Blackout bullet (AP-HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>21</damageAmountBase>
-		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
 		  <armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		  <secondaryDamage>
 				<li>
@@ -207,7 +207,7 @@
 		<label>8.6mm Blackout bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>11</damageAmountBase>
-		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
+		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>101.58</armorPenetrationBlunt>
 		  <speed>203</speed>
 		</projectile>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -411,7 +411,7 @@
 					<factorGood>1</factorGood>
 					<factorExcellent>1</factorExcellent>
 					<factorMasterwork>1.05</factorMasterwork>
-					<factorLegendary>1.1</factorLegendary>
+					<factorLegendary>1.15</factorLegendary>
 				</li>
 			</parts>
 		</value>


### PR DESCRIPTION
## Changes

- Increased the armor penetration values of 8.6 BO by 1mm.
- Increased the bonus damage dealt by legendary guns from x1.1 to x1.15, the ratio was off.
- Increased the velocity of the SB 5.56 ammoset to go around the rounding stuff going on in the projectile spreadsheet, the AP round's damage was only 6m/s away from being 8 instead of 7.

https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1198674278

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
