### PR TITLE
Tweak Warcasket autorifle and slug rifle

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Ranged_Warcaskets.xml
@@ -74,13 +74,13 @@
             <RangedWeapon_Cooldown>0.47</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
-            <recoilAmount>1.65</recoilAmount>
+            <recoilAmount>1.99</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
+            <defaultProjectile>Bullet_20x82mmMauser_AP</defaultProjectile>
             <burstShotCount>3</burstShotCount>
             <ticksBetweenBurstShots>10</ticksBetweenBurstShots>
-            <warmupTime>1.3</warmupTime>
+            <warmupTime>1.1</warmupTime>
             <range>60</range>
             <soundCast>Shot_Autocannon</soundCast>
             <soundCastTail>GunTail_Medium</soundCastTail>
@@ -89,7 +89,7 @@
           <AmmoUser>
             <magazineSize>30</magazineSize>
             <reloadTime>4.9</reloadTime>
-            <ammoSet>AmmoSet_50BMG</ammoSet>
+            <ammoSet>AmmoSet_20x82mmMauser</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiUseBurstMode>true</aiUseBurstMode>
@@ -109,10 +109,10 @@
             <RangedWeapon_Cooldown>0.60</RangedWeapon_Cooldown>
           </statBases>
           <Properties>
-            <recoilAmount>2.24</recoilAmount>
+            <recoilAmount>3.19</recoilAmount>
             <verbClass>CombatExtended.Verb_ShootCE</verbClass>
             <hasStandardCommand>True</hasStandardCommand>
-            <defaultProjectile>Bullet_20x102mmNATO_AP</defaultProjectile>
+            <defaultProjectile>Bullet_25x137mmNATO_AP</defaultProjectile>
             <warmupTime>1.6</warmupTime>
             <range>68</range>
             <soundCast>Shot_TurretSniper</soundCast>
@@ -122,7 +122,7 @@
           <AmmoUser>
             <magazineSize>10</magazineSize>
             <reloadTime>4.0</reloadTime>
-            <ammoSet>AmmoSet_20x102mmNATO</ammoSet>
+            <ammoSet>AmmoSet_25x137mmNATO</ammoSet>
           </AmmoUser>
           <FireModes>
             <aiAimMode>AimedShot</aiAimMode>


### PR DESCRIPTION
## Changes

- Both weapons dealt slightly less damage than their turret version in vanilla, it was not fair to chamber them in such smaller cartridges. Rechambered the autorifle in 20mm mauser (a proper autocannon cartridge) and the slug rifle back in 25mm nato.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
