### PR TITLE
Explosion damage resistance tweaks

### DIFF
--- a/Biotech/Patches/ThingDefs_Items/Items_BiotechGeneral.xml
+++ b/Biotech/Patches/ThingDefs_Items/Items_BiotechGeneral.xml
@@ -1,6 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+	<!-- Mech boss drops explosion resistance -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="MechResourceBase"]</xpath>
+		<value>
+			<damageMultipliers>
+				<li>
+					<damageDef>Bomb</damageDef>
+					<multiplier>0.25</multiplier>
+				</li>
+				<li>
+					<damageDef>Thermobaric</damageDef>
+					<multiplier>0.1</multiplier>
+				</li>
+				<li>
+					<damageDef>Thump</damageDef>
+					<multiplier>0.5</multiplier>
+				</li>
+			</damageMultipliers>
+		</value>
+	</Operation>
+
   <!-- Food -->
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[defName="HemogenPack"]/statBases</xpath>

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -103,6 +103,19 @@
           </FireModes>        
       </li>
 
+	<!-- Make the crashed ships don't destroy each other upon crashing -->
+	<li Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name = "VFEP_CrashedShip"]</xpath>
+		<value>
+			<damageMultipliers>
+				<li>
+					<damageDef>Bomb</damageDef>
+					<multiplier>0.1</multiplier>
+				</li>
+			</damageMultipliers>
+		</value>
+	</li>
+
       <li Class="PatchOperationReplace">
         <xpath>Defs/ThingDef[@Name = "VFEP_CrashedShip"]/statBases/ShootingAccuracyTurret</xpath>
         <value>


### PR DESCRIPTION
## Changes

- Made the mech boss loot items resistant to explosion damage sources so that they don't get deleted right after being dropped.
- Made the crashed gauntlet ships from VFE-Pirates resistant to their own explosions upon landing so that they don't destroy each other.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (working as intended