### PR TITLE
Giddy-Up 2 compatibility patch

### DIFF
--- a/Patches/Giddy-Up 2/Job_Patch.xml
+++ b/Patches/Giddy-Up 2/Job_Patch.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Giddy-Up 2</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/JobDef[defName="ReloadWeapon"]</xpath>
+					<value>
+						<li Class="GiddyUp.CanDoMounted"/>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -214,6 +214,7 @@ Frontline - Trenches (Continued)    |
 Frontline - Additional Guns for Trenches (Continued)    |
 Fuck it Unboomas Your Lope |
 Gas Traps And Shells	|
+Giddy-Up 2    |
 Gimmicks    |
 Gimmicks (Continued)    |
 Girls' Frontline Apparel Pack	|


### PR DESCRIPTION
## Changes

- Made pawns be able to reload weapons while mounted, without the patch pawns have to dismount and reload. Also pawns are forced to dismount when the reload job is started.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Working as intended)
