### PR TITLE
add What's That Mod load order rule

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -39,12 +39,12 @@
 		<li>SteveZero.FullArmorHandsFeet</li>
 		<li>Dingo.GrenadeFixRearmed</li>
 		<li>automatic.gunplay</li>
-		<li>co.uk.epicguru.whatsthatmod</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>
 		<li>Rah.RVTE</li>
 		<li>miho.fortifiedoutremer</li>		
+		<li>co.uk.epicguru.whatsthatmod</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>

--- a/About/About.xml
+++ b/About/About.xml
@@ -39,6 +39,7 @@
 		<li>SteveZero.FullArmorHandsFeet</li>
 		<li>Dingo.GrenadeFixRearmed</li>
 		<li>automatic.gunplay</li>
+		<li>co.uk.epicguru.whatsthatmod</li>
 	</incompatibleWith>
 	<loadBefore>
 		<li>Atlas.AndroidTiers</li>


### PR DESCRIPTION
## Changes

- What it says on the tin. It has to be loaded after CE otherwise it breaks the Give Ammo system.

## References

- https://steamcommunity.com/sharedfiles/filedetails/?id=2258431182

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Playtested a colony (Breaks the system when loaded before CE and not if loaded after)
