### PR TITLE
Fix VFE-Empire's ammo speeds

### DIFF
--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
@@ -57,6 +57,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Thump</damageDef>
             <damageAmountBase>8</damageAmountBase>
+            <speed>60</speed>
             <armorPenetrationSharp>0</armorPenetrationSharp>
             <armorPenetrationBlunt>0</armorPenetrationBlunt>
             <explosionRadius>1.5</explosionRadius>

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
@@ -55,6 +55,7 @@
           </graphicData>  
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageAmountBase>6</damageAmountBase>
+            <speed>150</speed>
             <damageDef>VFEE_Fletcher</damageDef>
             <armorPenetrationSharp>16</armorPenetrationSharp>
             <armorPenetrationBlunt>36</armorPenetrationBlunt>


### PR DESCRIPTION
## Changes

- What it says on the tin, the two newly added ammo were missing a speed node in their projectile defs.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
