### PR TITLE
Tweak the Nearsighted and Unstoppable genes

### DIFF
--- a/Biotech/Patches/GeneDefs/GeneDefs_Misc.xml
+++ b/Biotech/Patches/GeneDefs/GeneDefs_Misc.xml
@@ -5,6 +5,7 @@
     <xpath>Defs/GeneDef[defName="Nearsighted"]/statFactors</xpath>
     <value>
       <statFactors>
+        <ShootingAccuracyPawn>0.75</ShootingAccuracyPawn>
         <AimingAccuracy>0.5</AimingAccuracy>
       </statFactors>
     </value>
@@ -19,12 +20,10 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationReplace">
+  <Operation Class="PatchOperationAdd">
     <xpath>Defs/GeneDef[defName="Unstoppable"]/statFactors</xpath>
     <value>
-      <statFactors>
-        <Suppressability>0</Suppressability>
-      </statFactors>
+      <Suppressability>0</Suppressability>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes

- Tweaked the Nearsighted gene to retain its weapon handling penalty as aiming accuracy does not do much on its own.
- Tweaked the patch for the Unstoppable gene to retain the removed stagger effect upon the pawn being hit as the stagger effect still works in melee.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
