### PR TITLE
Tweak ATR mech's melee tool

### DIFF
--- a/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
@@ -525,7 +525,7 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>left fist</label>
 								<capacities>
-									<li>Blunt</li>
+									<li>Demolish</li>
 								</capacities>
 								<power>80</power>
 								<cooldownTime>3.07</cooldownTime>
@@ -535,7 +535,7 @@
 							<li Class="CombatExtended.ToolCE">
 								<label>right fist</label>
 								<capacities>
-									<li>Blunt</li>
+									<li>Demolish</li>
 								</capacities>
 								<power>80</power>
 								<cooldownTime>3.07</cooldownTime>


### PR DESCRIPTION
## Changes

- As of ATR ver. 1.2.11, mechs do Demolish damage instead of Blunt. Adjusted the patch to account for that.

## References

- https://github.com/RWDevathon/Android-Tiers-Reforged/commit/6ba88ebb5131aef0bc4e299b6b5f8f9fc9d10f23#diff-a366102bfac3f60313f36e006c8bdeb73faf8c11f68ebe8c7209773275b5d70f

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors