### PR TITLE
Patch VFE-Empire's deserter pawnkind

### DIFF
--- a/Patches/Vanilla Factions Expanded - Empire/PawnKinds.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/PawnKinds.xml
@@ -9,6 +9,44 @@
 			<operations>
 
 				<li Class="PatchOperationAddModExtension">
+					<xpath>Defs/PawnKindDef[@Name="VFEE_DeserterBase"]</xpath>
+					<value>
+						<li Class="CombatExtended.LoadoutPropertiesExtension">
+							<primaryMagazineCount>
+								<min>4</min>
+								<max>6</max>
+							</primaryMagazineCount>
+							<sidearms>
+								<li>
+									<generateChance>0.5</generateChance>
+									<sidearmMoney>
+										<min>300</min>
+										<max>500</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>CE_Sidearm_Melee</li>
+									</weaponTags>
+								</li>
+								<li>
+									<generateChance>0.15</generateChance>
+									<sidearmMoney>
+										<min>10</min>
+										<max>100</max>
+									</sidearmMoney>
+									<weaponTags>
+										<li>GrenadeSmoke</li>
+									</weaponTags>
+									<magazineCount>
+										<min>1</min>
+										<max>2</max>
+									</magazineCount>
+								</li>
+							</sidearms>
+						</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/PawnKindDef[defName="VFEE_Empire_Fighter_Absolver"]</xpath>
 					<value>
 						<li Class="CombatExtended.LoadoutPropertiesExtension">


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- Patched the parent def as it has many child defs derived from it that have the same weapon set up.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony