### PR TITLE
Update the incendiary ammo and housekeeping

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -98,12 +98,10 @@
     <label>incendiary bolt</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>6.5</explosionRadius>
+      <damageAmountBase>6</damageAmountBase>
+      <explosionRadius>4.5</explosionRadius>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-      <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+      <preExplosionSpawnChance>0.2</preExplosionSpawnChance>
       <ai_IsIncendiary>true</ai_IsIncendiary>
     </projectile>
   </ThingDef>
@@ -116,8 +114,6 @@
       <explosionRadius>2.0</explosionRadius>
       <damageDef>Thermobaric</damageDef>
       <damageAmountBase>48</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
@@ -133,8 +129,6 @@
       <suppressionFactor>0.0</suppressionFactor>
       <dangerFactor>0.0</dangerFactor>
       <explosionRadius>3</explosionRadius>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>

--- a/Defs/Ammo/Advanced/66mmThermalBolt.xml
+++ b/Defs/Ammo/Advanced/66mmThermalBolt.xml
@@ -84,9 +84,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <damageAmountBase>6</damageAmountBase>
       <explosionRadius>4.9</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -75,9 +75,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <damageAmountBase>9</damageAmountBase>
       <speed>60</speed>
       <flyOverhead>false</flyOverhead>
       <explosionRadius>5.9</explosionRadius>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -77,7 +77,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>47.45</MarketValue>
+			<MarketValue>57.78</MarketValue>
 		</statBases>
 		<ammoClass>BurstingShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Bursting</cookOffProjectile>
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>39.18</MarketValue>
+			<MarketValue>41.72</MarketValue>
 		</statBases>
 		<ammoClass>FireShell</ammoClass>
 		<cookOffProjectile>Bullet_CannonBall_Incendiary</cookOffProjectile>
@@ -107,7 +107,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>5.56</MarketValue>
+			<MarketValue>26.18</MarketValue>
 		</statBases>
 		<ammoClass>Grapeshot</ammoClass>
 	</ThingDef>
@@ -172,12 +172,10 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>91</speed>
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<damageAmountBase>6</damageAmountBase>
 			<explosionRadius>4.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 		</projectile>
 	</ThingDef>
@@ -227,18 +225,16 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>82</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>2</explosionRadius>
+			<damageAmountBase>142</damageAmountBase>
+			<explosionRadius>2.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 		<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-				<Fragment_Large>19</Fragment_Large>
-				<Fragment_Small>9</Fragment_Small>
+				<Fragment_Large>17</Fragment_Large>
+				<Fragment_Small>22</Fragment_Small>
 			</fragments>
 		</li>
 		</comps>
@@ -254,10 +250,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
-			<explosionRadius>1.5</explosionRadius>
+			<damageAmountBase>6</damageAmountBase>
+			<explosionRadius>4.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
@@ -314,7 +308,7 @@
 				<li>FSX</li>
 			</thingDefs>
 			</filter>
-			<count>4</count>
+			<count>9</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -326,7 +320,7 @@
 		<products>
 		<Ammo_CannonBall_Bursting>5</Ammo_CannonBall_Bursting>
 		</products>
-		<workAmount>10600</workAmount>
+		<workAmount>11400</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -350,7 +344,7 @@
 				<li>Prometheum</li>
 			</thingDefs>
 			</filter>
-			<count>5</count>
+			<count>2</count>
 		</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -362,7 +356,7 @@
 		<products>
 		<Ammo_CannonBall_Incendiary>5</Ammo_CannonBall_Incendiary>
 		</products>
-		<workAmount>9000</workAmount>
+		<workAmount>8600</workAmount>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -371,7 +365,7 @@
 		<description>Craft 5 grape shot cannon shells.</description>
 		<jobString>Making grape shot cannon shells.</jobString>
 		<researchPrerequisite>CE_Gunpowder</researchPrerequisite>
-		<workAmount>8600</workAmount>
+		<workAmount>6600</workAmount>
 		<ingredients>
 		<li>
 			<filter>

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -121,8 +121,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<explosionRadius>9</explosionRadius>
+			<damageAmountBase>12</damageAmountBase>
+			<explosionRadius>6.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
 			<soundExplode>MortarBomb_Explode</soundExplode>

--- a/Defs/Ammo/Rocket/RPO.xml
+++ b/Defs/Ammo/Rocket/RPO.xml
@@ -40,8 +40,8 @@
     <label>RPO-Z grenade</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <explosionRadius>12.5</explosionRadius>
+      <damageAmountBase>21</damageAmountBase>
+      <explosionRadius>9.5</explosionRadius>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.5</preExplosionSpawnChance>
       <soundExplode>MortarIncendiary_Explode</soundExplode>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -66,7 +66,7 @@
 			<drawSize>0.90</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>144.04</MarketValue>
+			<MarketValue>128.17</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_HE</detonateProjectile>
@@ -81,7 +81,7 @@
 		</graphicData>
 		<statBases>
 		  <Mass>21</Mass>
-		  <MarketValue>128</MarketValue>
+		  <MarketValue>128.54</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_HEAT_directfire</detonateProjectile>
@@ -93,10 +93,9 @@
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Howitzer/INC</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
-			<drawSize>0.90</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>117.37</MarketValue>
+			<MarketValue>101.5</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_Incendiary</detonateProjectile>
@@ -108,10 +107,9 @@
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Howitzer/EMP</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
-			<drawSize>0.90</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>237.87</MarketValue>
+			<MarketValue>222</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 	</ThingDef>
@@ -122,10 +120,9 @@
 		<graphicData>
 			<texPath>Things/Ammo/Cannon/Howitzer/SMK</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
-			<drawSize>0.90</drawSize>
 		</graphicData>
 		<statBases>
-			<MarketValue>114.2</MarketValue>
+			<MarketValue>101.5</MarketValue>
 		</statBases>
 		<ammoClass>Smoke</ammoClass>
 		<detonateProjectile>Bullet_105mmHowitzerShell_Smoke</detonateProjectile>
@@ -162,7 +159,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>216</damageAmountBase>
+			<damageAmountBase>217</damageAmountBase>
 			<explosionRadius>3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -186,9 +183,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<damageAmountBase>15</damageAmountBase>
 			<explosionRadius>7</explosionRadius>
 			<flyOverhead>true</flyOverhead>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -214,7 +209,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageDef>EMP</damageDef>
-		  <damageAmountBase>216</damageAmountBase>
+		  <damageAmountBase>217</damageAmountBase>
 		  <armorPenetrationSharp>0</armorPenetrationSharp>
 		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <flyOverhead>true</flyOverhead>
@@ -233,8 +228,6 @@
 		  <damageDef>Smoke</damageDef>
 		  <suppressionFactor>0.0</suppressionFactor>
 		  <dangerFactor>0.0</dangerFactor>
-		  <armorPenetrationSharp>0</armorPenetrationSharp>
-		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>8.5</explosionRadius>
 		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
@@ -328,12 +321,10 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<damageAmountBase>15</damageAmountBase>
 			<explosionRadius>7</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 		  </projectile>
 		  <comps>
@@ -394,7 +385,7 @@
 		<label>make 105mm HE Howitzer shells x2</label>
 		<description>Craft 2 105mm HE Howitzer shells.</description>
 		<jobString>Making 105mm HE Howitzer shells.</jobString>
-		<workAmount>11600</workAmount>
+		<workAmount>10000</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -402,7 +393,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>76</count>
+				<count>60</count>
 			</li>
 			<li>
 				<filter>
@@ -462,7 +453,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -482,7 +473,7 @@
 		<label>make 105mm Incendiary Howitzer shells x2</label>
 		<description>Craft 2 105mm Incendiary Howitzer shells.</description>
 		<jobString>Making 105mm Incendiary Howitzer shells.</jobString>
-		<workAmount>10000</workAmount>
+		<workAmount>8400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -490,7 +481,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>66</count>
+				<count>60</count>
 			</li>
 			<li>
 				<filter>
@@ -506,7 +497,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>3</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -527,7 +518,7 @@
 		<description>Craft 2 105mm EMP Howitzer shells.</description>
 		<jobString>Making 105mm EMP Howitzer shells.</jobString>
 		<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
-		<workAmount>13600</workAmount>
+		<workAmount>12000</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -535,7 +526,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>76</count>
+				<count>60</count>
 			</li>
 			<li>
 				<filter>
@@ -543,7 +534,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>10</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -562,7 +553,7 @@
 		<label>make 105mm Smoke Howitzer shells x2</label>
 		<description>Craft 2 105mm Smoke Howitzer shells.</description>
 		<jobString>Making 105mm Smoke Howitzer shells.</jobString>
-		<workAmount>9600</workAmount>
+		<workAmount>8400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -570,7 +561,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>76</count>
+				<count>60</count>
 			</li>
 			<li>
 				<filter>
@@ -586,7 +577,7 @@
 				<li>Prometheum</li>
 				</thingDefs>
 			</filter>
-			<count>2</count>
+			<count>3</count>
 			</li>
 		</ingredients>
 			<fixedIngredientFilter>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -48,7 +48,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>151.46</MarketValue>
+			<MarketValue>157.92</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_120mmCannonShell_HEAT</detonateProjectile>
@@ -62,7 +62,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>198.99</MarketValue>
+			<MarketValue>188.92</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_120mmCannonShell_HE</detonateProjectile>
@@ -146,7 +146,7 @@
 		<label>make 120mm HEAT cannon shells x2</label>
 		<description>Craft 2 120mm HEAT cannon shells.</description>
 		<jobString>Making 120mm HEAT cannon shells.</jobString>
-		<workAmount>33200</workAmount>
+		<workAmount>13000</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -190,7 +190,7 @@
 		<label>make 120mm HE cannon shells x2</label>
 		<description>Craft 2 120mm HE cannon shells.</description>
 		<jobString>Making 120mm HE cannon shells.</jobString>
-		<workAmount>42400</workAmount>
+		<workAmount>15400</workAmount>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -78,7 +78,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>333.53</MarketValue>
+			<MarketValue>283.1</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeIncendiary</ammoClass>
 		<detonateProjectile>Bullet_155mmHowitzerShell_Incendiary</detonateProjectile>
@@ -165,13 +165,11 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<damageAmountBase>31</damageAmountBase>
 			<explosionRadius>9.5</explosionRadius>
 			<flyOverhead>true</flyOverhead>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
+			<preExplosionSpawnChance>0.3</preExplosionSpawnChance>
 			<soundExplode>MortarIncendiary_Explode</soundExplode>
 		</projectile>
 		<comps>
@@ -194,8 +192,6 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageDef>EMP</damageDef>
 		  <damageAmountBase>452</damageAmountBase>
-		  <armorPenetrationSharp>0</armorPenetrationSharp>
-		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <flyOverhead>true</flyOverhead>
 		  <explosionRadius>9.5</explosionRadius>
 		</projectile>
@@ -212,8 +208,6 @@
 		  <damageDef>Smoke</damageDef>
 		  <suppressionFactor>0.0</suppressionFactor>
 		  <dangerFactor>0.0</dangerFactor>
-		  <armorPenetrationSharp>0</armorPenetrationSharp>
-		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>10.5</explosionRadius>
 		  <flyOverhead>true</flyOverhead>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
@@ -276,9 +270,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>PrometheumFlame</damageDef>
-			<damageAmountBase>0</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<damageAmountBase>31</damageAmountBase>
 			<explosionRadius>9.5</explosionRadius>
 			<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.20</preExplosionSpawnChance>
@@ -304,8 +296,6 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageDef>EMP</damageDef>
 		  <damageAmountBase>452</damageAmountBase>
-		  <armorPenetrationSharp>0</armorPenetrationSharp>
-		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>9.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -321,8 +311,6 @@
 		  <damageDef>Smoke</damageDef>
 		  <suppressionFactor>0.0</suppressionFactor>
 		  <dangerFactor>0.0</dangerFactor>
-		  <armorPenetrationSharp>0</armorPenetrationSharp>
-		  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 		  <explosionRadius>10.5</explosionRadius>
 		  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 		  <soundExplode>Explosion_EMP</soundExplode>
@@ -342,7 +330,7 @@
 		<label>make 155mm HE Howitzer shells x1</label>
 		<description>Craft 1 155mm HE Howitzer shells.</description>
 		<jobString>Making 155mm HE Howitzer shells.</jobString>
-		<workAmount>15400</workAmount>
+		<workAmount>17400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -358,7 +346,7 @@
 						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
-				<count>1</count>
+				<count>2</count>
 			</li>
 			<li>
 				<filter>
@@ -386,7 +374,7 @@
 		<label>make 155mm Incendiary Howitzer shells x1</label>
 		<description>Craft 155mm Incendiary Howitzer shell.</description>
 		<jobString>Making 155mm Incendiary Howitzer shell.</jobString>
-		<workAmount>10000</workAmount>
+		<workAmount>12600</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -410,7 +398,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>5</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -431,7 +419,7 @@
 		<description>Craft 155mm EMP Howitzer shell.</description>
 		<jobString>Making 155mm EMP Howitzer shell.</jobString>
 		<researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
-		<workAmount>13600</workAmount>
+		<workAmount>18400</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -466,7 +454,7 @@
 		<label>make 155mm Smoke Howitzer shells x1</label>
 		<description>Craft 155mm Smoke Howitzer shell.</description>
 		<jobString>Making 155mm Smoke Howitzer shell.</jobString>
-		<workAmount>9600</workAmount>
+		<workAmount>11400</workAmount>
 		<ingredients>
 			<li>
 				<filter>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -15,6 +15,9 @@
     <label>50mm type 89 mortar shells</label>
     <ammoTypes>
       <Ammo_50mmType89MortarShell_HE>Bullet_50mmType89MortarShell_HE</Ammo_50mmType89MortarShell_HE>
+      <Ammo_50mmType89MortarShell_Incendiary>Bullet_50mmType89MortarShell_Incendiary</Ammo_50mmType89MortarShell_Incendiary>
+      <Ammo_50mmType89MortarShell_EMP>Bullet_50mmType89MortarShell_EMP</Ammo_50mmType89MortarShell_EMP>
+      <Ammo_50mmType89MortarShell_Smoke>Bullet_50mmType89MortarShell_Smoke</Ammo_50mmType89MortarShell_Smoke>  
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 	
@@ -29,6 +32,10 @@
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_TableMachining</li>
     </tradeTags>
+    <statBases>
+	  <Mass>0.9</Mass>
+	  <Bulk>0.87</Bulk>
+    </statBases>
     <stackLimit>25</stackLimit>
     <cookOffFlashScale>20</cookOffFlashScale>
     <cookOffSound>MortarBomb_Explode</cookOffSound>
@@ -42,27 +49,55 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>20.8</MarketValue>
-	  <Mass>0.104</Mass>
-	  <Bulk>0.793</Bulk>
+      <MarketValue>21.1</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
-    <comps>
-		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-			<damageAmountBase>42</damageAmountBase>
-			<explosiveDamageType>Bomb</explosiveDamageType>
-			<explosiveRadius>2</explosiveRadius>
-			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-		  </li>
-		  <li Class="CombatExtended.CompProperties_Fragments">
-			<fragments>
-          <Fragment_Large>3</Fragment_Large>
-          <Fragment_Small>12</Fragment_Small>
-			</fragments>
-		  </li>
-    </comps>
+	<detonateProjectile>Bullet_50mmType89MortarShell_HE</detonateProjectile>
   </ThingDef>
-	
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50mmType89MortarShellBase">
+    <defName>Ammo_50mmType89MortarShell_Incendiary</defName>
+    <label>50mm type 89 mortar shell (Incendiary)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>19.5</MarketValue>
+    </statBases>
+    <ammoClass>GrenadeIncendiary</ammoClass>
+	<detonateProjectile>Bullet_50mmType89MortarShell_Incendiary</detonateProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50mmType89MortarShellBase">
+    <defName>Ammo_50mmType89MortarShell_EMP</defName>
+    <label>50mm type 89 mortar shell (EMP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/EMP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>29.97</MarketValue>
+    </statBases>
+    <ammoClass>GrenadeEMP</ammoClass>
+	<detonateProjectile>Bullet_50mmType89MortarShell_EMP</detonateProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50mmType89MortarShellBase">
+    <defName>Ammo_50mmType89MortarShell_Smoke</defName>
+    <label>50mm type 89 mortar shell (Smoke)</label>
+    <generateAllowChance>0</generateAllowChance>
+    <graphicData>
+      <texPath>Things/Ammo/Mortar/Smoke</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>18.24</MarketValue>
+    </statBases>
+    <ammoClass>Smoke</ammoClass>
+	<detonateProjectile>Bullet_50mmType89MortarShell_Smoke</detonateProjectile>
+  </ThingDef>
+
 	<!-- ================== Projectiles ================== -->
 
 	<ThingDef Name="Base50mmType89MortarShell" ParentName="BaseExplosiveBullet" Abstract="true">
@@ -89,7 +124,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
       <damageAmountBase>42</damageAmountBase>
-      <explosionRadius>2</explosionRadius>
+      <explosionRadius>1.5</explosionRadius>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <ai_IsIncendiary>true</ai_IsIncendiary>
@@ -103,7 +138,65 @@
 		  </li>
 		</comps>
 	</ThingDef>
-  
+
+  <ThingDef ParentName="Base50mmType89MortarShell">
+    <defName>Bullet_50mmType89MortarShell_Incendiary</defName>
+    <label>50mm type 89 mortar shell (Incendiary)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Incendiary</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>PrometheumFlame</damageDef>
+      <damageAmountBase>6</damageAmountBase>
+      <explosionRadius>4.5</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+      <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+      <soundExplode>MortarIncendiary_Explode</soundExplode>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base50mmType89MortarShell">
+    <defName>Bullet_50mmType89MortarShell_EMP</defName>
+    <label>50mm type 89 mortar shell (EMP)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/EMP</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>EMP</damageDef>
+      <damageAmountBase>42</damageAmountBase>
+      <flyOverhead>true</flyOverhead>
+      <explosionRadius>2.5</explosionRadius>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base50mmType89MortarShell">
+    <defName>Bullet_50mmType89MortarShell_Smoke</defName>
+    <label>50mm type 89 mortar shell (Smoke)</label>
+    <graphicData>
+      <texPath>Things/Projectile/Mortar/Smoke</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Smoke</damageDef>
+      <suppressionFactor>0.0</suppressionFactor>
+      <dangerFactor>0.0</dangerFactor>
+      <explosionRadius>3</explosionRadius>
+      <flyOverhead>true</flyOverhead>
+      <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
+      <soundExplode>Explosion_EMP</soundExplode>
+      <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
+      <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <postExplosionGasType>BlindSmoke</postExplosionGasType>
+      <preExplosionSpawnChance>1</preExplosionSpawnChance>
+      <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+      <explosionEffect>ExtinguisherExplosion</explosionEffect>
+    </projectile>
+  </ThingDef>
+
+
 	<!-- ==================== Recipes ========================== -->
 
   <RecipeDef ParentName="AmmoRecipeBase">
@@ -149,5 +242,129 @@
       <Ammo_50mmType89MortarShell_HE>5</Ammo_50mmType89MortarShell_HE>
     </products>
   </RecipeDef>
-	
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_50mmType89MortarShell_Incendiary</defName>
+    <label>make 50mm type 89 incendiary mortar shells x5</label>
+    <description>Craft 5 50mm type 89 incendiary mortar shells.</description>
+    <jobString>Making 50mm type 89 incendiary mortar shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50mmType89MortarShell_Incendiary>5</Ammo_50mmType89MortarShell_Incendiary>
+    </products>
+    <workAmount>3000</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_50mmType89MortarShell_EMP</defName>
+    <label>make 50mm type 89 EMP mortar shells x5</label>
+    <description>Craft 5 50mm type 89 EMP mortar shells.</description>
+    <jobString>Making 50mm type 89 EMP mortar shells.</jobString>
+    <researchPrerequisite>MicroelectronicsBasics</researchPrerequisite>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50mmType89MortarShell_EMP>5</Ammo_50mmType89MortarShell_EMP>
+    </products>
+    <workAmount>3400</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_50mmType89MortarShell_Smoke</defName>
+    <label>make 50mm type 89 smoke mortar shells x5</label>
+    <description>Craft 5 50mm type 89 smoke mortar shells.</description>
+    <jobString>Making 50mm type 89 smoke mortar shells.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ComponentIndustrial</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>1</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+        <li>ComponentIndustrial</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50mmType89MortarShell_Smoke>5</Ammo_50mmType89MortarShell_Smoke>
+    </products>
+    <workAmount>2600</workAmount>
+  </RecipeDef>
+
 </Defs>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -114,7 +114,7 @@
       <MarketValue>22.20</MarketValue>
     </statBases>
     <ammoClass>Smoke</ammoClass>
-	<detonateProjectile>Bullet_60mmMortarShell_60mmMortar_Smoke</detonateProjectile>
+	<detonateProjectile>Bullet_60mmMortarShell_Smoke</detonateProjectile>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -17,7 +17,7 @@
       <Shell_60mmMortar_Incendiary>Bullet_60mmMortarShell_Incendiary</Shell_60mmMortar_Incendiary>
       <Shell_60mmMortar_EMP>Bullet_60mmMortarShell_EMP</Shell_60mmMortar_EMP>
       <Shell_60mmMortar_Firefoam>Bullet_60mmMortarShell_Firefoam</Shell_60mmMortar_Firefoam>
-      <Shell_60mmMortar_Smoke>Bullet_60mmMortarShell_60mmMortar_Smoke</Shell_60mmMortar_Smoke>         
+      <Shell_60mmMortar_Smoke>Bullet_60mmMortarShell_Smoke</Shell_60mmMortar_Smoke>         
     </ammoTypes>
   </CombatExtended.AmmoSetDef>
 
@@ -37,18 +37,15 @@
       <li>Ammo60mmMortarShells</li>
     </thingCategories>
     <stackLimit>25</stackLimit>
-    <cookOffFlashScale>30</cookOffFlashScale>
-    <cookOffSound>MortarBomb_Explode</cookOffSound>
-  </ThingDef>
-
-  <ThingDef Class="CombatExtended.AmmoDef" Name="60mmMortarShellBaseCraftableBase" ParentName="60mmMortarShellBase" Abstract="True">
     <tradeTags>
       <li>CE_AutoEnableTrade</li>
       <li>CE_AutoEnableCrafting_TableMachining</li>
     </tradeTags>
+    <cookOffFlashScale>30</cookOffFlashScale>
+    <cookOffSound>MortarBomb_Explode</cookOffSound>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
     <defName>Shell_60mmMortar_HE</defName>
     <label>60mm mortar shell (HE)</label>
     <graphicData>
@@ -62,7 +59,7 @@
     <detonateProjectile>Bullet_60mmMortarShell_HE</detonateProjectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
     <defName>Shell_60mmMortar_Incendiary</defName>
     <label>60mm mortar shell (Incendiary)</label>
     <graphicData>
@@ -73,20 +70,10 @@
       <MarketValue>23.47</MarketValue>
     </statBases>
     <ammoClass>GrenadeIncendiary</ammoClass>
-    <comps>
-	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>0</damageAmountBase>
-		<explosiveDamageType>PrometheumFlame</explosiveDamageType>
-		<explosiveRadius>4.5</explosiveRadius>
-		<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-		<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
-		<explosionSound>MortarIncendiary_Explode</explosionSound>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-	  </li>
-    </comps>
+    <detonateProjectile>Bullet_60mmMortarShell_Incendiary</detonateProjectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
     <defName>Shell_60mmMortar_EMP</defName>
     <label>60mm mortar shell (EMP)</label>
     <graphicData>
@@ -97,16 +84,10 @@
       <MarketValue>46.94</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
-    <comps>
-	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>17</damageAmountBase>
-		<explosiveDamageType>Bomb</explosiveDamageType>
-		<explosiveRadius>3.5</explosiveRadius>
-	  </li>
-    </comps>
+    <detonateProjectile>Bullet_60mmMortarShell_EMP</detonateProjectile>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
     <defName>Shell_60mmMortar_Firefoam</defName>
     <label>60mm mortar shell (Foam)</label>
     <generateAllowChance>0</generateAllowChance>
@@ -119,19 +100,9 @@
     </statBases>
     <ammoClass>FoamFuel</ammoClass>
     <detonateProjectile>Bullet_60mmMortarShell_Firefoam</detonateProjectile>
-    <comps>
-	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>3.5</damageAmountBase>
-		<explosiveDamageType>Extinguish</explosiveDamageType>
-		<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
-		<postExplosionSpawnChance>1</postExplosionSpawnChance>
-		<postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
-		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-	  </li>
-    </comps>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
     <defName>Shell_60mmMortar_Smoke</defName>
     <label>60mm mortar shell (Smoke)</label>
     <generateAllowChance>0</generateAllowChance>
@@ -141,22 +112,9 @@
     </graphicData>
     <statBases>
       <MarketValue>22.20</MarketValue>
-      <Mass>4.1</Mass>
-      <Bulk>10.01</Bulk>
     </statBases>
     <ammoClass>Smoke</ammoClass>
 	<detonateProjectile>Bullet_60mmMortarShell_60mmMortar_Smoke</detonateProjectile>
-    <comps>
-      <li Class="CompProperties_Explosive">
-        <explosiveRadius>4.5</explosiveRadius>
-        <explosiveDamageType>Smoke</explosiveDamageType>
-        <startWickHitPointsPercent>0.7</startWickHitPointsPercent>
-        <postExplosionGasType>BlindSmoke</postExplosionGasType>
-        <preExplosionSpawnChance>1</preExplosionSpawnChance>
-        <explodeOnKilled>True</explodeOnKilled>
-        <wickTicks>30~60</wickTicks>
-      </li>
-    </comps>
   </ThingDef>
 
   <!-- ================== Projectiles ================== -->
@@ -188,8 +146,6 @@
       <damageDef>Bomb</damageDef>
       <explosionRadius>2</explosionRadius>	  
       <damageAmountBase>76</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <flyOverhead>true</flyOverhead>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -214,9 +170,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <damageAmountBase>6</damageAmountBase>
       <explosionRadius>4.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -235,8 +189,6 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>EMP</damageDef>
       <damageAmountBase>76</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <flyOverhead>true</flyOverhead>
       <explosionRadius>3.5</explosionRadius>
     </projectile>
@@ -253,9 +205,7 @@
       <damageDef>Extinguish</damageDef>
       <suppressionFactor>0.0</suppressionFactor>
       <dangerFactor>0.0</dangerFactor>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>7</explosionRadius>
+      <explosionRadius>3.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
       <soundExplode>Explosion_EMP</soundExplode>
@@ -270,7 +220,7 @@
   </ThingDef>
 
   <ThingDef ParentName="Base60mmMortarShell">
-    <defName>Bullet_60mmMortarShell_60mmMortar_Smoke</defName>
+    <defName>Bullet_60mmMortarShell_Smoke</defName>
     <label>60mm mortar shell (Smoke)</label>
     <graphicData>
       <texPath>Things/Projectile/Mortar/Smoke</texPath>
@@ -280,8 +230,6 @@
       <damageDef>Smoke</damageDef>
       <suppressionFactor>0.0</suppressionFactor>
       <dangerFactor>0.0</dangerFactor>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <explosionRadius>4.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
@@ -480,7 +428,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>42</count>
+        <count>20</count>
       </li>
       <li>
         <filter>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -49,8 +49,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<Mass>9.62</Mass>
-			<MarketValue>64.28</MarketValue>
+			<MarketValue>61.1</MarketValue>
 		</statBases>
 		<ammoClass>RocketHEAT</ammoClass>
 		<detonateProjectile>Bullet_762x385mmRCannonShell_HEAT</detonateProjectile>
@@ -188,7 +187,7 @@
 		<label>make 76.2x385mmR HEAT cannon shells x5</label>
 		<description>Craft 5 76.2x385mmR HEAT cannon shells.</description>
 		<jobString>Making 76.2x385mmR HEAT cannon shells.</jobString>
-		<workAmount>13400</workAmount>
+		<workAmount>12600</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -196,7 +195,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>98</count>
+				<count>90</count>
 			</li>
 			<li>
 				<filter>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -84,8 +84,8 @@
     </graphicData>
     <statBases>
       <MarketValue>42.34</MarketValue>
-      <Mass>4.1</Mass>
-      <Bulk>10.01</Bulk>
+      <Mass>5.65</Mass>
+      <Bulk>9.0</Bulk>
     </statBases>
     <ammoClass>GrenadeIncendiary</ammoClass>
     <comps>
@@ -274,8 +274,6 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
       <damageAmountBase>156</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <explosionRadius>2.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundExplode>MortarBomb_Explode</soundExplode>
@@ -301,9 +299,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <damageAmountBase>11</damageAmountBase>
       <explosionRadius>6.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -322,8 +318,6 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>EMP</damageDef>
       <damageAmountBase>156</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <flyOverhead>true</flyOverhead>
       <explosionRadius>5.5</explosionRadius>
     </projectile>
@@ -340,9 +334,7 @@
       <damageDef>Extinguish</damageDef>
       <suppressionFactor>0.0</suppressionFactor>
       <dangerFactor>0.0</dangerFactor>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>9.5</explosionRadius>
+      <explosionRadius>5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
       <soundExplode>Explosion_EMP</soundExplode>
@@ -367,8 +359,6 @@
       <damageDef>Smoke</damageDef>
       <suppressionFactor>0.0</suppressionFactor>
       <dangerFactor>0.0</dangerFactor>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
       <explosionRadius>6</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/30x64mmFuelCell-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/30x64mmFuelCell-Punched.xml
@@ -100,12 +100,10 @@
 							<label>incendiary bolt (Punched)</label>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>PrometheumFlame</damageDef>
-								<damageAmountBase>20</damageAmountBase>
-								<armorPenetrationSharp>20</armorPenetrationSharp>
-								<armorPenetrationBlunt>20</armorPenetrationBlunt>
+								<damageAmountBase>10</damageAmountBase>
 								<explosionRadius>6.5</explosionRadius>
 								<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-								<preExplosionSpawnChance>0.15</preExplosionSpawnChance>
+								<preExplosionSpawnChance>0.25</preExplosionSpawnChance>
 								<ai_IsIncendiary>true</ai_IsIncendiary>
 							</projectile>
 						</ThingDef>
@@ -117,8 +115,6 @@
 								<explosionRadius>2.0</explosionRadius>
 								<damageDef>Thermobaric</damageDef>
 								<damageAmountBase>64</damageAmountBase>
-								<armorPenetrationSharp>20</armorPenetrationSharp>
-								<armorPenetrationBlunt>20</armorPenetrationBlunt>
 								<soundExplode>MortarBomb_Explode</soundExplode>
 								<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 								<ai_IsIncendiary>true</ai_IsIncendiary>
@@ -131,8 +127,6 @@
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Extinguish</damageDef>
 								<explosionRadius>6.5</explosionRadius>
-								<armorPenetrationSharp>0</armorPenetrationSharp>
-								<armorPenetrationBlunt>0</armorPenetrationBlunt>
 								<postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
 								<preExplosionSpawnChance>1</preExplosionSpawnChance>
 							</projectile>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -238,9 +238,9 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<explosionRadius>1</explosionRadius>
 				<damageDef>PrometheumFlame</damageDef>
-				<damageAmountBase>10</damageAmountBase>
+				<damageAmountBase>11</damageAmountBase>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
-				<preExplosionSpawnChance>0.8</preExplosionSpawnChance>
+				<preExplosionSpawnChance>0.75</preExplosionSpawnChance>
 				<speed>12</speed>
 				<ai_IsIncendiary>true</ai_IsIncendiary>
 				<screenShakeFactor>0</screenShakeFactor>

--- a/Patches/LF Red Dawn/82mmMortar.xml
+++ b/Patches/LF Red Dawn/82mmMortar.xml
@@ -90,7 +90,7 @@
     <ammoClass>GrenadeIncendiary</ammoClass>
     <comps>
 	  <li Class="CombatExtended.CompProperties_ExplosiveCE">
-		<damageAmountBase>0</damageAmountBase>
+		<damageAmountBase>11</damageAmountBase>
 		<explosiveDamageType>PrometheumFlame</explosiveDamageType>
 		<explosiveRadius>5</explosiveRadius>
         <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -235,10 +235,8 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
-      <damageAmountBase>0</damageAmountBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <explosionRadius>9.5</explosionRadius>
+      <damageAmountBase>11</damageAmountBase>
+      <explosionRadius>6.5</explosionRadius>
       <flyOverhead>true</flyOverhead>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.15</preExplosionSpawnChance>

--- a/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
+++ b/Patches/Not Only Just A Cannon/Patch_Cannon_Ammo.xml
@@ -274,9 +274,7 @@
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>PrometheumFlame</damageDef>
-				<damageAmountBase>0</damageAmountBase>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<armorPenetrationBlunt>45.454</armorPenetrationBlunt>
+				<damageAmountBase>35</damageAmountBase>
 				<explosionRadius>2.8</explosionRadius>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
@@ -602,9 +600,7 @@
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>PrometheumFlame</damageDef>
-				<damageAmountBase>0</damageAmountBase>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<armorPenetrationBlunt>45.454</armorPenetrationBlunt>
+				<damageAmountBase>35</damageAmountBase>
 				<explosionRadius>2.8</explosionRadius>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>0.5</preExplosionSpawnChance>

--- a/Patches/Orassans/Ammo/ChemicalCompoundOE.xml
+++ b/Patches/Orassans/Ammo/ChemicalCompoundOE.xml
@@ -158,8 +158,6 @@
          <projectile Class="CombatExtended.ProjectilePropertiesCE">
            <damageDef>AprometheumFlame</damageDef>
            <damageAmountBase>12</damageAmountBase>
-           <armorPenetrationSharp>0</armorPenetrationSharp>
-           <armorPenetrationBlunt>0</armorPenetrationBlunt>
            <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
            <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
            <soundExplode>CE_FlamethrowerExplosion</soundExplode>

--- a/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
+++ b/Patches/Paniel the Automata/Ammo/Ammo_Paniel.xml
@@ -421,9 +421,7 @@
 					  <speed>9</speed>
 					  <gravityFactor>5</gravityFactor>
 					  <damageDef>PrometheumFlame</damageDef>
-					  <damageAmountBase>0</damageAmountBase>
-					  <armorPenetrationSharp>0</armorPenetrationSharp>
-					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
+					  <damageAmountBase>6</damageAmountBase>
 					  <explosionRadius>4.5</explosionRadius>
 					  <flyOverhead>true</flyOverhead>
 					  <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
@@ -444,8 +442,6 @@
 					  <gravityFactor>5</gravityFactor>
 					  <damageDef>EMP</damageDef>
 					  <damageAmountBase>76</damageAmountBase>
-					  <armorPenetrationSharp>0</armorPenetrationSharp>
-					  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 					  <flyOverhead>true</flyOverhead>
 					  <explosionRadius>3.5</explosionRadius>
 					</projectile>

--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -458,8 +458,6 @@
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>Bomb</damageDef>
 			  <damageAmountBase>156</damageAmountBase>
-			  <armorPenetrationSharp>0</armorPenetrationSharp>
-			  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 			  <explosionRadius>2.5</explosionRadius>
 			  <flyOverhead>false</flyOverhead>
 			  <soundExplode>MortarBomb_Explode</soundExplode>
@@ -487,10 +485,8 @@
 			  <speed>32</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>PrometheumFlame</damageDef>
-			  <damageAmountBase>0</damageAmountBase>
-			  <armorPenetrationSharp>0</armorPenetrationSharp>
-			  <armorPenetrationBlunt>0</armorPenetrationBlunt>
-			  <explosionRadius>9.5</explosionRadius>
+			  <damageAmountBase>6</damageAmountBase>
+			  <explosionRadius>6.5</explosionRadius>
 			  <flyOverhead>false</flyOverhead>
 			  <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 			  <preExplosionSpawnChance>0.15</preExplosionSpawnChance>
@@ -510,8 +506,6 @@
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>EMP</damageDef>
 			  <damageAmountBase>156</damageAmountBase>
-			  <armorPenetrationSharp>0</armorPenetrationSharp>
-			  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 			  <flyOverhead>false</flyOverhead>
 			  <explosionRadius>5.5</explosionRadius>
 			</projectile>
@@ -530,9 +524,7 @@
 			  <damageDef>Extinguish</damageDef>
 			  <suppressionFactor>0.0</suppressionFactor>
 			  <dangerFactor>0.0</dangerFactor>
-			  <armorPenetrationSharp>0</armorPenetrationSharp>
-			  <armorPenetrationBlunt>0</armorPenetrationBlunt>
-			  <explosionRadius>9.5</explosionRadius>
+			  <explosionRadius>5</explosionRadius>
 			  <flyOverhead>false</flyOverhead>
 			  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			  <soundExplode>Explosion_EMP</soundExplode>
@@ -559,8 +551,6 @@
 			  <damageDef>Smoke</damageDef>
 			  <suppressionFactor>0.0</suppressionFactor>
 			  <dangerFactor>0.0</dangerFactor>
-			  <armorPenetrationSharp>0</armorPenetrationSharp>
-			  <armorPenetrationBlunt>0</armorPenetrationBlunt>
 			  <explosionRadius>6</explosionRadius>
 			  <flyOverhead>false</flyOverhead>
 			  <soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -308,7 +308,7 @@
                         </projectile>
                         <comps>
                             <li Class="CombatExtended.CompProperties_ExplosiveCE">
-                                <damageAmountBase>0</damageAmountBase>
+                                <damageAmountBase>5</damageAmountBase>
                                 <explosiveDamageType>PrometheumFlame</explosiveDamageType>
                                 <explosiveRadius>6.5</explosiveRadius>
                                 <explosionSound>MortarBomb_Explode</explosionSound>

--- a/Patches/Turret Collection/TurretCollection_CE_Patch_Turrets.xml
+++ b/Patches/Turret Collection/TurretCollection_CE_Patch_Turrets.xml
@@ -31,7 +31,7 @@
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
 							<damageDef>PrometheumFlame</damageDef>
-							<damageAmountBase>0</damageAmountBase>
+							<damageAmountBase>10</damageAmountBase>
 							<explosionRadius>8</explosionRadius>
 							<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 							<preExplosionSpawnChance>0.5</preExplosionSpawnChance>

--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/Bolter.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/Bolter.xml
@@ -141,9 +141,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>PrometheumFlame</damageDef>
-				<damageAmountBase>0</damageAmountBase>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<armorPenetrationBlunt>0</armorPenetrationBlunt>
+				<damageAmountBase>3</damageAmountBase>
 				<explosionRadius>0.5</explosionRadius>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>

--- a/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
+++ b/Patches/Warcaskets - Adeptus Astartes/Ammo/HeavyBolter.xml
@@ -141,9 +141,7 @@
 			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>PrometheumFlame</damageDef>
-				<damageAmountBase>0</damageAmountBase>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<armorPenetrationBlunt>0</armorPenetrationBlunt>
+				<damageAmountBase>5</damageAmountBase>
 				<explosionRadius>1.5</explosionRadius>
 				<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
 				<preExplosionSpawnChance>0.7</preExplosionSpawnChance>


### PR DESCRIPTION
## Additions

- Added the missing ammo types to the 50mm type 89 mortar shells.

## Changes

- Updated some outdated values in the shell ammo type defs.
- Added a flat prometheum flame damage to incendiary (explosive) ammo types.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- As it is currently, the prometheum soak hediff is not stacking (with the altered ammo types in this PR) at all and the severity does not go up no matter how many times the hediff-causer projectile hits a target, which makes these ammo types very lackluster on that front. The RM2 flamethrower and molotovs are good because they deal raw prometheum flame damage. This change was made by giving a 10% damage multiplier and 15% to Incendiary and Fire bomb damage types respectively instead of the current 0%, 15% for the Fire bomb damage type means roughly the same 10 (now 11) prometheum flame damage for molotovs.

## Alternatives

- Firefoam shells had x2 the explosion radius contrary to the sheet, we could either adjust the sheet accordingly if the x2 values are intended (which I doubt) or keep the fixed values.
- We could go higher on the damage for something like the 30mm fuel cells but the auto-generated values seem ok.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
