### PR TITLE
Patch RH2 Utilitarian

### DIFF
--- a/Patches/RH2 Faction - Utilitarian/Utilitarian_Apparel.xml
+++ b/Patches/RH2 Faction - Utilitarian/Utilitarian_Apparel.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[RH2] Faction: Utilitarian</li>
+		</mods>
+			
+			<match Class="PatchOperationSequence">
+				<operations>       
+
+					<!-- Ranged Shield Belt -->
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="RHApparel_RangedShieldBelt_TitanCorp"]/statBases/EnergyShieldRechargeRate</xpath>
+						<value>
+							<EnergyShieldRechargeRate>0.15</EnergyShieldRechargeRate>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[defName="RHApparel_RangedShieldBelt_TitanCorp"]/statBases/EnergyShieldEnergyMax</xpath>
+						<value>
+							<EnergyShieldEnergyMax>0.75</EnergyShieldEnergyMax>
+						</value>
+					</li>
+
+					<!-- Power Armor Helmets -->
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/statBases</xpath>
+						<value>
+						  <Bulk>6</Bulk>
+						  <WornBulk>1</WornBulk>
+						  <NightVisionEfficiency_Apparel>0.75</NightVisionEfficiency_Apparel>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/statBases/Flammability</xpath>
+						<value>
+						  <Flammability>0</Flammability>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/statBases/Mass</xpath>
+						<value>
+						  <Mass>6.6</Mass>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/statBases/ArmorRating_Sharp</xpath>
+						<value>
+						  <ArmorRating_Sharp>22</ArmorRating_Sharp>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+						<value>
+						  <ArmorRating_Blunt>50</ArmorRating_Blunt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
+						<value>
+							<AimingAccuracy>0.15</AimingAccuracy>
+							<SmokeSensitivity>-1</SmokeSensitivity>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/costList/Plasteel</xpath>
+						<value>
+						  <Plasteel>120</Plasteel>
+						  <DevilstrandCloth>25</DevilstrandCloth>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]/apparel/layers</xpath>
+						<value>
+						  <li>OnHead</li>
+						  <li>StrappedHead</li>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAddModExtension">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_VectorHelmet_UTIL1PowerArmor" or
+							defName="RHApparel_PrimeHelmet_UTIL2PowerArmor" or
+							defName="RHApparel_OmicronHelmet_UTIL3PowerArmor" or
+							defName="RHApparel_HelixHelmet_UTIL4PowerArmor"]</xpath>
+						<value>
+						  <li Class="CombatExtended.PartialArmorExt">
+							<stats>
+								<li>
+									<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+									<parts>
+										<li>Eye</li>
+									</parts>
+								</li>
+								<li>
+									<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+									<parts>
+										<li>Eye</li>
+									</parts>
+								</li>
+							</stats>
+						  </li>
+						</value>
+					</li>
+
+					<!-- Power Armor Suits -->
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases</xpath>
+						<value>
+							<Bulk>100</Bulk>
+							<WornBulk>15</WornBulk>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases/MaxHitPoints</xpath>
+						<value>
+							<MaxHitPoints>600</MaxHitPoints>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases/Mass</xpath>
+						<value>
+							<Mass>80</Mass>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases/Flammability</xpath>
+						<value>
+							<Flammability>0</Flammability>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases/ArmorRating_Sharp</xpath>
+						<value>
+							<ArmorRating_Sharp>26</ArmorRating_Sharp>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+						<value>
+							<ArmorRating_Blunt>56</ArmorRating_Blunt>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/costList</xpath>
+						<value>
+							<DevilstrandCloth>50</DevilstrandCloth>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/equippedStatOffsets</xpath>
+						<value>
+							<CarryWeight>100</CarryWeight>
+							<CarryBulk>20</CarryBulk>
+							<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAdd">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/apparel/bodyPartGroups</xpath>
+						<value>
+							<li>Hands</li>
+							<li>Feet</li>
+						</value>
+					</li>
+
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/costList/Plasteel</xpath>
+						<value>
+							<Plasteel>220</Plasteel>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationReplace">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]/costList/Uranium</xpath>
+						<value>
+							<Uranium>60</Uranium>
+						</value>
+					</li>
+
+					<li Class="PatchOperationAddModExtension">
+						<xpath>Defs/ThingDef[
+							defName="RHApparel_Vector_UTIL1PowerArmor" or
+							defName="RHApparel_Prime_UTIL2PowerArmor" or
+							defName="RHApparel_Omicron_UTIL3PowerArmor" or
+							defName="RHApparel_Helix_UTIL4PowerArmor"]</xpath>
+						<value>
+						  <li Class="CombatExtended.PartialArmorExt">
+							  <stats>		  				  
+								  <li>
+									<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+									<parts>
+										<li>Hand</li>
+									</parts>
+								  </li>
+								  <li>
+									<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+									<parts>
+										<li>Hand</li>
+									</parts>
+								  </li>
+							  </stats>
+						  </li>
+						</value>
+					</li>
+
+				</operations>
+			</match>
+	</Operation>
+
+</Patch>

--- a/Patches/RH2 Faction - Utilitarian/Utilitarian_Gun.xml
+++ b/Patches/RH2 Faction - Utilitarian/Utilitarian_Gun.xml
@@ -3,14 +3,14 @@
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
-			<li>[RH2] Faction: Bounty Hunters</li>
+			<li>[RH2] Faction: Utilitarian</li>
 		</mods>
 			
 			<match Class="PatchOperationSequence">
 				<operations>       
 
 					<li Class="PatchOperationReplace">
-						<xpath>Defs/ThingDef[defName="RHGun_DOOM3_PlasmaGun"]/tools</xpath>
+						<xpath>Defs/ThingDef[defName="RNGun_DOOM3_MG88Enforcer"]/tools</xpath>
 						<value>
 						  <tools>
 							<li Class="CombatExtended.ToolCE">
@@ -49,33 +49,34 @@
 					</li>
 
 					<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
-						<defName>RHGun_DOOM3_PlasmaGun</defName>
+						<defName>RNGun_DOOM3_MG88Enforcer</defName>
 						<statBases>
-							<Bulk>7.5</Bulk>
-							<SwayFactor>1.27</SwayFactor>
-							<ShotSpread>0.07</ShotSpread>
-							<SightsEfficiency>1.1</SightsEfficiency>
-							<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+							<Bulk>7.0</Bulk>
+							<SwayFactor>1.15</SwayFactor>
+							<ShotSpread>0.05</ShotSpread>
+							<SightsEfficiency>1.0</SightsEfficiency>
+							<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
 						</statBases>
 						<Properties>
-							<recoilAmount>1.25</recoilAmount>
+							<recoilAmount>2.25</recoilAmount>
 							<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 							<hasStandardCommand>True</hasStandardCommand>
-							<defaultProjectile>Bullet_PlasmaCellRifle</defaultProjectile>
+							<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
 							<burstShotCount>6</burstShotCount>
 							<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
-							<warmupTime>1.2</warmupTime>
-							<range>62</range>
-							<soundCast>RHShot_DOOM3_PlasmaGunShot</soundCast>
-							<soundCastTail>GunTail_Medium</soundCastTail>
+							<warmupTime>1.1</warmupTime>
+							<range>51</range>
+							<soundCast>RHShot_DOOM3_MG88EnforcerShot</soundCast>
+							<soundCastTail>GunTail_Light</soundCastTail>
 							<muzzleFlashScale>9</muzzleFlashScale>
 						</Properties>
 						<AmmoUser>
 							<magazineSize>60</magazineSize>
-							<reloadTime>4.9</reloadTime>
-							<ammoSet>AmmoSet_PlasmaCellRifle</ammoSet>
+							<reloadTime>4.5</reloadTime>
+							<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 						</AmmoUser>
 						<FireModes>
+							<aiUseBurstMode>TRUE</aiUseBurstMode>
 							<aiAimMode>AimedShot</aiAimMode>
 							<aimedBurstShotCount>3</aimedBurstShotCount>
 						</FireModes>

--- a/Patches/RH2 Faction - Utilitarian/Utilitarian_Pawnkinds.xml
+++ b/Patches/RH2 Faction - Utilitarian/Utilitarian_Pawnkinds.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[RH2] Faction: Utilitarian</li>
+		</mods>
+			
+			<match Class="PatchOperationSequence">
+				<operations>  
+
+					<li Class="PatchOperationAddModExtension">
+						<xpath>Defs/PawnKindDef[
+							@Name="RH2_DOOMUtilitarian_Base" or
+							@Name="RH2_Utilitarian_SpecialBase" or
+							@Name="RH2_Utilitarian_FNGBase" or
+							@Name="RH2_Utilitarian_BossBase"
+						]</xpath>
+						<value>
+							<li Class="CombatExtended.LoadoutPropertiesExtension">
+								<primaryMagazineCount>
+									<min>3</min>
+									<max>5</max>
+								</primaryMagazineCount>
+							</li>
+						</value>
+					</li>
+
+				</operations>
+			</match>
+	</Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -43,6 +43,7 @@ Mod |
 [RH2] Faction: Bounty Hunters   |
 [RH2] Faction: Task Force 141   |
 [RH2] Faction: The Rangers  |
+[RH2] Faction: Utilitarian  |
 [RH2] Faction: V.O.I.D.	|
 [RH2] Rimmu-Nation² - Clothing	|
 [RH2] Rimmu-Nation² - Security  |


### PR DESCRIPTION
## Additions

- What it says on the tin, the stats and values are the same as the RH2 Bounty Hunters mod.

## Changes

- Removed a redundant mass node in Bounty Hunters' weapon patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
