### PR TITLE
Tend priority accounts for stabilized wounds.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/HediffComp_Stabilize.cs
@@ -49,6 +49,18 @@ namespace CombatExtended
                 return Mathf.Clamp01(mod);
             }
         }
+        public float StabilizedBleed  //returns the amount by which stabilization has reduced bleeding rate
+        {
+            get
+            {
+                float unstabilizedBleedRate = parent.Severity * parent.def.injuryProps.bleedRate;
+                if (parent.Part != null)
+                {
+                    unstabilizedBleedRate *= parent.Part.def.bleedRate;
+                }
+                return unstabilizedBleedRate * (1 - BleedModifier);
+            }
+        }
 
         public void Stabilize(Pawn medic, Medicine medicine)
         {

--- a/Source/CombatExtended/Harmony/Harmony_HediffTendPriority.cs
+++ b/Source/CombatExtended/Harmony/Harmony_HediffTendPriority.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using HarmonyLib;
+using Verse;
+using RimWorld;
+using UnityEngine;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(Hediff), "TendPriority", MethodType.Getter)]
+    class Harmony_HediffTendPriority
+    {
+        internal static bool Prefix(Hediff __instance, ref float __result)
+        {
+            //copied from Verse
+            float severityHeuristic = 0f;
+            HediffStage curStage = __instance.CurStage;
+            if (curStage != null && curStage.lifeThreatening)
+            {
+                severityHeuristic = Mathf.Max(severityHeuristic, 1f);
+            }
+
+            //If injury is stabilised, increase priority
+            HediffComp_Stabilize comp = (__instance as HediffWithComps)?.TryGetComp<HediffComp_Stabilize>() ?? null;
+            if (comp != null)
+            {
+                severityHeuristic = Mathf.Max(severityHeuristic, __instance.BleedRate * 1.5f + comp.StabilizedBleed * 0.3f);
+            }
+            else
+            {
+                severityHeuristic = Mathf.Max(severityHeuristic, __instance.BleedRate * 1.5f);
+            }
+            HediffComp_TendDuration hediffComp_TendDuration = __instance.TryGetComp<HediffComp_TendDuration>();
+            if (hediffComp_TendDuration != null && hediffComp_TendDuration.TProps.severityPerDayTended < 0f)
+            {
+                severityHeuristic = Mathf.Max(severityHeuristic, 0.025f);
+            }
+            __result = severityHeuristic;
+            return false;
+        }
+
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_HediffTendPriority.cs
+++ b/Source/CombatExtended/Harmony/Harmony_HediffTendPriority.cs
@@ -12,33 +12,13 @@ namespace CombatExtended.HarmonyCE
     [HarmonyPatch(typeof(Hediff), "TendPriority", MethodType.Getter)]
     class Harmony_HediffTendPriority
     {
-        internal static bool Prefix(Hediff __instance, ref float __result)
+        internal static void Postfix(Hediff __instance, ref float __result)
         {
-            //copied from Verse
-            float severityHeuristic = 0f;
-            HediffStage curStage = __instance.CurStage;
-            if (curStage != null && curStage.lifeThreatening)
-            {
-                severityHeuristic = Mathf.Max(severityHeuristic, 1f);
-            }
-
-            //If injury is stabilised, increase priority
             HediffComp_Stabilize comp = (__instance as HediffWithComps)?.TryGetComp<HediffComp_Stabilize>() ?? null;
             if (comp != null)
             {
-                severityHeuristic = Mathf.Max(severityHeuristic, __instance.BleedRate * 1.5f + comp.StabilizedBleed * 0.3f);
+                __result = Mathf.Max(__result, __instance.BleedRate * 1.5f + comp.StabilizedBleed * 0.3f);
             }
-            else
-            {
-                severityHeuristic = Mathf.Max(severityHeuristic, __instance.BleedRate * 1.5f);
-            }
-            HediffComp_TendDuration hediffComp_TendDuration = __instance.TryGetComp<HediffComp_TendDuration>();
-            if (hediffComp_TendDuration != null && hediffComp_TendDuration.TProps.severityPerDayTended < 0f)
-            {
-                severityHeuristic = Mathf.Max(severityHeuristic, 0.025f);
-            }
-            __result = severityHeuristic;
-            return false;
         }
 
     }


### PR DESCRIPTION
## Additions

- Stabilized wounds are now tended before bruises/cracks/burns.

## Changes

- Patched Hediff.TendPriority to return a value of a fraction of the normal bleed rate for stabilized bleeding

## Reasoning

- Stabilized wounds that will start bleeding should be treated before bruises
- Patch to tendPriority was easy to implement

## Alternatives

- Patch the tend job to not use a simple list sorted by a single number.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long) 5 minutes, checked tend priorities on Hediff debug tooltips
