### PR TITLE
Better ammouser dev button

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -846,7 +846,7 @@ namespace CombatExtended
 
                     Command_Action devSetAmmoToMaxCommandGizmo = new Command_Action
                     {
-                        action = delegate { CurMagCount = MagSize; },
+                        action = delegate { CurrentAmmo = SelectedAmmo; CurMagCount = MagSize; },
                         defaultLabel = "DEV: Set ammo to max"
                     };
                     yield return devSetAmmoToMaxCommandGizmo;

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -574,7 +574,8 @@ namespace CombatExtended
 
         private void DoOutOfAmmoAction()
         {
-            if (this.parent.def.weaponTags.Contains("NoSwitch"))
+            //Don't stow weapon for player pawns when in god mode
+            if (this.parent.def.weaponTags.Contains("NoSwitch") || (DebugSettings.godMode && Wielder != null && (Wielder.IsColonistPlayerControlled || Wielder.IsColonyMech)))
             {
                 return;
             }

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -427,6 +427,13 @@ namespace CombatExtended
         /// </summary>
         public void TryStartReload()
         {
+            //Don't reload when changing player pawn ammo in god mode
+            if (DebugSettings.godMode && Wielder != null && (Wielder.IsColonistPlayerControlled || Wielder.IsColonyMech) && selectedAmmo != CurrentAmmo)
+            {
+                return;
+            }
+
+
             if (Wielder?.jobs.curDriver is IJobDriver_Tactical)
             {
                 return;
@@ -574,7 +581,7 @@ namespace CombatExtended
 
         private void DoOutOfAmmoAction()
         {
-            //Don't stow weapon for player pawns when in god mode
+            //Don't stow weapon for player pawns when in god mode, can be ammoying when testing single shot weapons.
             if (this.parent.def.weaponTags.Contains("NoSwitch") || (DebugSettings.godMode && Wielder != null && (Wielder.IsColonistPlayerControlled || Wielder.IsColonyMech)))
             {
                 return;

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
@@ -126,7 +126,7 @@ namespace CombatExtended
 
                         // If we have no inventory available (e.g. manned turret), add all possible ammo types to the selection
                         // Otherwise, iterate through all suitable ammo types and check if they're in our inventory
-                        if (user.CompInventory?.ammoList?.Any(x => x.def == ammoDef) ?? true)
+                        if ((user.CompInventory?.ammoList?.Any(x => x.def == ammoDef) ?? true) || DebugSettings.godMode)
                         {
                             if (!ammoClassAmounts.ContainsKey(ammoClass))
                             {

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
@@ -125,6 +125,7 @@ namespace CombatExtended
                         var ammoClass = ammoDef.ammoClass;
 
                         // If we have no inventory available (e.g. manned turret), add all possible ammo types to the selection
+                        // Or if we're in god mode. 
                         // Otherwise, iterate through all suitable ammo types and check if they're in our inventory
                         if ((user.CompInventory?.ammoList?.Any(x => x.def == ammoDef) ?? true) || DebugSettings.godMode)
                         {


### PR DESCRIPTION
## Changes

-Make "DEV: Set ammo to max" change currently using ammo to the selected ammo in reload gizmo
-Make reload gizmo show all ammo types when in god mode
-Do not stow weapon for player pawn when out of ammo and in god mode

## Reasoning

so that we don't have to spawn the ammo when testing non default ammo.

## Alternatives

Find and spawn corresponding ammo every time when testing something not FMJ, as convenient as pre-dev buttons.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (5 minutes with god mode on and off)
