### PR TITLE
Make rocket sustainer less an ear rape

### DIFF
--- a/Defs/SoundDefs/World_Sustainers_RPG.xml
+++ b/Defs/SoundDefs/World_Sustainers_RPG.xml
@@ -23,6 +23,11 @@
           <min>0.9576087</min>
           <max>1.084783</max>
         </pitchRange>
+        <distRange>
+          <min>0</min>
+          <max>50</max>
+        </distRange>
+        <muteWhenPaused>True</muteWhenPaused>
       </li>
     </subSounds>
   </SoundDef>
@@ -49,8 +54,14 @@
           <min>0.9576087</min>
           <max>1.084783</max>
         </pitchRange>
+        <distRange>
+          <min>0</min>
+          <max>50</max>
+        </distRange>
+        <muteWhenPaused>True</muteWhenPaused>
       </li>
     </subSounds>
   </SoundDef>
+
 
 </Defs>


### PR DESCRIPTION
## Changes

-Rocket sustainers now pause when game paused

## Reasoning

-The rocket motor sustainer is driving me mad when I pause the game with a rocket mid-flight

## Alternatives

-Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (Firing LAWs here and there)
