### PR TITLE
Change the minammocount from 10 to 1.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
 
         public FloatRange primaryMagazineCount = FloatRange.Zero;
         public AttachmentOption primaryAttachments;
-        public int minAmmoCount = 10;
+        public int minAmmoCount = 1;
 
         public FloatRange shieldMoney = FloatRange.Zero;
         public List<string> shieldTags;

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -256,12 +256,6 @@ namespace CombatExtended
                 if (gun.TryGetComp<CompEquippable>().PrimaryVerb.verbProps.verbClass == typeof(Verb_ShootCEOneUse))
                 {
                     thingToAdd = gun.def;   // For one-time use weapons such as grenades, add duplicates instead of ammo
-                    if (minAmmoSpawned == 10)
-                    {
-                        //don't spawn 10 (the default value) of single-use weapons,
-                        //unless the xml patcher explicitly set a different value
-                        minAmmoSpawned = 1;
-                    }
                 }
                 else
                 {

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
 
         public FloatRange primaryMagazineCount = FloatRange.Zero;
         public AttachmentOption primaryAttachments;
-        public int minAmmoCount = 1;
+        public int minAmmoCount;
 
         public FloatRange shieldMoney = FloatRange.Zero;
         public List<string> shieldTags;


### PR DESCRIPTION
## Changes
- Change the default `minAmmoCount` from 10 to 1.
- Remove a check that applied if the minAmmoCount prescribed was using the default of 10.

## Reasoning
The `minAmmoCount` determines the absolute minimum amount of ammo a pawnkind will spawn with, overriding the amount spawned by the pawn's loadout if it is smaller. With 10 as the default value, it will apply to any and all pawnkinds that don't have a `minAmmoCount` otherwise prescribed to them.

Given the wide range of different weapons these pawns may be armed with, it's not desirable to force them to spawn with this much ammo across the board. While 10 is perfectly reasonable for a pawn spawning with a bow or a musket, it's potentially too much for a pawn spawning with a rocket launcher or similarly heavy weapon--they might be assigned something like 4 - 6 reloads via a loadout. Overriding that loadout amount may not be desirable, and we'd prefer to avoid the added work necessary to avoid it.

Since we already have an absolute minimum default ammo count created by the pawnkind autopatcher that gives 2 - 3 magazines, I think it would be overall less work to prescribe a low, safe value (`1`, in this case) to `minAmmoCount `, and manually add it in xml to pawnkinds that need it. Used in concert with `AmmoGenCountOverride` from #2288, I think `minAmmoCount` provides a useful backstop for edge cases--such as a civilian pawn armed with a double-barrel shotgun who would only get 4 - 6 rounds from their loadout. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
