### PR TITLE
Fix ubgl faction check

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -170,7 +170,7 @@ namespace CombatExtended
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            if (_compEq.Holder?.Faction == Faction.OfPlayer || DebugSettings.godMode)
+            if (CompEq.Holder?.Faction == Faction.OfPlayer || DebugSettings.godMode)
             {
                 if (CompAmmo.Props.ammoSet == CompPropsAmmo.ammoSet)
                 {

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmosetSwitcher.cs
@@ -170,37 +170,40 @@ namespace CombatExtended
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            if (CompAmmo.Props.ammoSet == CompPropsAmmo.ammoSet)
+            if (_compEq.Holder?.Faction == Faction.OfPlayer || DebugSettings.godMode)
             {
-                yield return new Command_Action
+                if (CompAmmo.Props.ammoSet == CompPropsAmmo.ammoSet)
                 {
-
-                    defaultLabel = "CE_SwitchAmmmoSetToUnderBarrel".Translate(),
-                    icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload"),
-                    defaultDesc = "CE_UBGLStats".Translate() +
-                    "\n " + "WarmupTime".Translate() + ": " + Props.verbPropsUnderBarrel.warmupTime
-                    + "\n " + "Range".Translate() + ": " + Props.verbPropsUnderBarrel.range
-                    + "\n " + "CE_AmmoSet".Translate() + ": " + Props.propsUnderBarrel.ammoSet.label
-                    + "\n " + "CE_MagazineSize".Translate() + ": " + Props.propsUnderBarrel.magazineSize
-                    ,
-                    action = delegate
+                    yield return new Command_Action
                     {
-                        SwitchToUB();
-                    }
-                };
-            }
-            else
-            {
-                yield return new Command_Action
+
+                        defaultLabel = "CE_SwitchAmmmoSetToUnderBarrel".Translate(),
+                        icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload"),
+                        defaultDesc = "CE_UBGLStats".Translate() +
+                        "\n " + "WarmupTime".Translate() + ": " + Props.verbPropsUnderBarrel.warmupTime
+                        + "\n " + "Range".Translate() + ": " + Props.verbPropsUnderBarrel.range
+                        + "\n " + "CE_AmmoSet".Translate() + ": " + Props.propsUnderBarrel.ammoSet.label
+                        + "\n " + "CE_MagazineSize".Translate() + ": " + Props.propsUnderBarrel.magazineSize
+                        ,
+                        action = delegate
+                        {
+                            SwitchToUB();
+                        }
+                    };
+                }
+                else
                 {
-
-                    defaultLabel = "CE_SwitchAmmmoSetToNormalRifle".Translate(),
-                    icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload"),
-                    action = delegate
+                    yield return new Command_Action
                     {
-                        SwithToB();
-                    }
-                };
+
+                        defaultLabel = "CE_SwitchAmmmoSetToNormalRifle".Translate(),
+                        icon = ContentFinder<Texture2D>.Get("UI/Buttons/Reload"),
+                        action = delegate
+                        {
+                            SwithToB();
+                        }
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
## Changes

-Make UBGL gizmo only appear on player pawns (or in god mode)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (5 seconds)
