### PR TITLE
Null checks and fallbacks for unpatched weapons

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Keys.xml
+++ b/Languages/ChineseSimplified/Keyed/Keys.xml
@@ -101,6 +101,6 @@
   <CE_EnableTutorEnable>启用教程助手</CE_EnableTutorEnable>
   <CE_EnableTutorDisable>我了解风险</CE_EnableTutorDisable>
 
-  <!--<CE_ReloadedMote>重新装填完成！</CE_ReloadedMote>-->
-
+  <CE_UnpatchedWeapon>这把武器未进行CE适配，将会以原版机制工作。请和负责适配的人或者CE组联系。</CE_UnpatchedWeapon>
+  <CE_UnpatchedWeaponShort>未CE适配</CE_UnpatchedWeaponShort>
 </LanguageData>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -3,7 +3,7 @@
 
   <!-- Tabs -->
 
-  <TabAttachments>Attachm.</TabAttachments>    
+  <TabAttachments>Attachm.</TabAttachments>
 
   <!-- Billing -->
 
@@ -24,7 +24,7 @@
   <CE_HoldFireLabel>Hold fire</CE_HoldFireLabel>
   <CE_ToggleFireModeDesc>Toggle fire mode.</CE_ToggleFireModeDesc>
   <CE_ToggleAimModeDesc>Toggle aim mode.</CE_ToggleAimModeDesc>
-  
+
   <!-- Bipod system -->
   <CE_Bipod_Set_Up>Bipod IS set up</CE_Bipod_Set_Up>
   <CE_Bipod_Not_Set_Up>Bipod IS NOT set up</CE_Bipod_Not_Set_Up>
@@ -131,13 +131,15 @@
   <CE_EnableTutorText>CE adds several tutorial entries on subjects such as how the armor mechanics work and how not to die from Centipedes. It is recommended first time players enable the learning helper.</CE_EnableTutorText>
   <CE_EnableTutorEnable>Enable learning helper</CE_EnableTutorEnable>
   <CE_EnableTutorDisable>I know the risk</CE_EnableTutorDisable>
-  
+
   <!-- Assign menu -->
   <CE_UpdateLoadoutNow>Rearm</CE_UpdateLoadoutNow>
 
   <!-- Uncompiled dev build popup -->
   <CE_UncompiledDevBuild>Uncompiled CE dev build\n\nYou're running a development build of Combat Extended that is not intended for gameplay purposes, this will create a large amount of errors if you attempt to play a colony.\n\nEither download an official CE release from GitHub's Releases section, or if you need the latest development snapshot for testing purposes, get it from the link below.</CE_UncompiledDevBuild>
   <CE_GetCompiledDevBuild>Get development snapshot</CE_GetCompiledDevBuild>
-  <CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>  
+  <CE_ContinueAnyway>Continue anyway</CE_ContinueAnyway>
 
+  <CE_UnpatchedWeapon>This weapon is yet patched for CE, while it will behave in vanilla way as fallback, please contact a patcher for compatibility patches.</CE_UnpatchedWeapon>
+  <CE_UnpatchedWeaponShort>Not patched for CE</CE_UnpatchedWeaponShort>
 </LanguageData>

--- a/Source/CombatExtended/CombatExtended/AmmoUtility.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoUtility.cs
@@ -23,8 +23,8 @@ namespace CombatExtended
             var props = projectileDef?.projectile as ProjectilePropertiesCE;
             if (props == null)
             {
-                Log.Error("CE tried getting projectile readout with null props");
-                return "";
+                Log.Warning("CE tried getting projectile readout with null props");
+                return "CE_UnpatchedWeaponShort".Translate();
             }
 
             var stringBuilder = new StringBuilder();

--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -57,7 +57,7 @@ namespace CombatExtended
 
             if (primaryWeapon != null)
             {
-                maxWeaponPen = primaryWeapon.def.tools.Select(x => x as ToolCE).Max(x => x.armorPenetrationSharp) * primaryWeapon.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
+                maxWeaponPen = primaryWeapon.def.tools.Max(x => { ToolCE y = x as ToolCE; return y == null ? 0f : y.armorPenetrationSharp; }) * primaryWeapon.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
             }
 
             if (PawnParent.skills.GetSkill(SkillDefOf.Melee).Level < 16 && PawnParent.skills.GetSkill(SkillDefOf.Melee).Level > 7)

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
@@ -51,24 +51,34 @@ namespace CombatExtended
                                                    (100 * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
                                                    (100 * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
             stringBuilder.AppendLine("");
-
-            foreach (ToolCE tool in tools)
+            foreach (Tool tool in tools)
             {
-                var adjustedToolDamage = GetAdjustedDamage(tool, req.Thing);
-                var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => tool.capacities.Contains(d.requiredCapacity));
-                var maneuverString = "(";
-                foreach (var maneuver in maneuvers)
+                if (tool is ToolCE toolCE)
                 {
-                    maneuverString += maneuver.ToString() + "/";
+                    var adjustedToolDamage = GetAdjustedDamage(toolCE, req.Thing);
+                    var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => toolCE.capacities.Contains(d.requiredCapacity));
+                    var maneuverString = "(";
+                    foreach (var maneuver in maneuvers)
+                    {
+                        maneuverString += maneuver.ToString() + "/";
+                    }
+                    maneuverString = maneuverString.TrimmedToLength(maneuverString.Length - 1) + ")";
+                    stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + toolCE.ToString() + " " + maneuverString);
+                    stringBuilder.AppendLine("    " + "CE_DescBaseDamage".Translate() + ": " + toolCE.power.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+                    stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
+                    stringBuilder.AppendLine(string.Format("    " + "StatsReport_FinalValue".Translate() + ": {0} - {1}",
+                                                           (adjustedToolDamage * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
+                                                           (adjustedToolDamage * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
+                    stringBuilder.AppendLine();
                 }
-                maneuverString = maneuverString.TrimmedToLength(maneuverString.Length - 1) + ")";
-                stringBuilder.AppendLine("  " + "Tool".Translate() + ": " + tool.ToString() + " " + maneuverString);
-                stringBuilder.AppendLine("    " + "CE_DescBaseDamage".Translate() + ": " + tool.power.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-                stringBuilder.AppendLine("    " + "CE_AdjustedForWeapon".Translate() + ": " + adjustedToolDamage.ToStringByStyle(ToStringStyle.FloatMaxTwo));
-                stringBuilder.AppendLine(string.Format("    " + "StatsReport_FinalValue".Translate() + ": {0} - {1}",
-                                                       (adjustedToolDamage * skilledDamageVariationMin).ToStringByStyle(ToStringStyle.FloatMaxTwo),
-                                                       (adjustedToolDamage * skilledDamageVariationMax).ToStringByStyle(ToStringStyle.FloatMaxTwo)));
-                stringBuilder.AppendLine();
+                else
+                {
+                    if (DebugSettings.godMode)
+                    {
+                        Log.Error($"Trying to get stat MeleeDamage from {req.Def.defName} which has no support for Combat Extended.");
+                    }
+                    stringBuilder.AppendLine("CE_UnpatchedWeapon".Translate());
+                }
             }
             return stringBuilder.ToString();
         }
@@ -96,8 +106,11 @@ namespace CombatExtended
             }
             if (tools.Any(x => !(x is ToolCE)))
             {
-                Log.Error($"Trying to get stat MeleeDamage from {optionalReq.Def.defName} which has no support for Combat Extended.");
-                return "";
+                if (DebugSettings.godMode)
+                {
+                    Log.Error($"Trying to get stat MeleeDamage from {optionalReq.Def.defName} which has no support for Combat Extended.");
+                }
+                return "CE_UnpatchedWeaponShort".Translate();
             }
 
             float lowestDamage = Int32.MaxValue;


### PR DESCRIPTION
## Changes

-Fixed melee targeting break unpatched melee.
-Made several predefined red letter for unpatched weapons only show when in god mod (you know I love god mod checks).
-Added null checks here and there to eliminate NRE red letters.
-Made melee and ranged info panel statworkers display "unpatched for ce" message if not patched.

## Reasoning

-We're only a few null and type checks away from vanilla compat, really.
-Normal players has red-letter-phobia. Only those red letters that means the game fucked should be shown to normal people. Unpatched weapons are not. So I made them only display when god mode is turned on, showing error message to those that it mattered.

## Alternatives

CE compat when?

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (beating pawns with unpatched gun, ranged and melee)
