### PR TITLE
Checks shield's blunt armor after sharp damage deflection

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -150,7 +150,8 @@ namespace CombatExtended
                             shieldAbsorbed = true;
                             //Priority: Left Arm > Right Arm > Left Shoulder
                             //It seems that losing left shoulder makes shield unequippable, so no need to add a null check (for now)
-                            BodyPartRecord PartToHit = pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbCore).First(x => x.IsInGroup(CE_BodyPartGroupDefOf.LeftArm) || x.IsInGroup(CE_BodyPartGroupDefOf.RightArm));
+                            //FirstOrFallback returns null when nothing satisfies, effectively brings the program into the if statement
+                            BodyPartRecord PartToHit = pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbCore).FirstOrFallback(x => x.IsInGroup(CE_BodyPartGroupDefOf.LeftArm) || x.IsInGroup(CE_BodyPartGroupDefOf.RightArm));
                             if (PartToHit == null)
                             {
                                 PartToHit = pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbSegment).First(x => x.IsInGroup(CE_BodyPartGroupDefOf.LeftShoulder));

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -143,12 +143,19 @@ namespace CombatExtended
 
                             return dinfo;
                         }
-                        //Blunt damage penetrated the shield, apply the damage to right arm
+                        //Blunt damage penetrated the shield, apply the damage to left arm
+                        //Could add a check for having weapon equipped, if not, pawns should be able to hold the shield with both arms, increasing their defence
                         else
                         {
                             shieldAbsorbed = true;
-                            //I'm not sure whether pawn having no arms is able to use the shield
-                            dinfo.SetHitPart(pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbCore).Where(x => x.IsInGroup(CE_BodyPartGroupDefOf.RightArm)).First());
+                            //Priority: Left Arm > Right Arm > Left Shoulder
+                            //It seems that losing left shoulder makes shield unequippable, so no need to add a null check (for now)
+                            BodyPartRecord PartToHit = pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbCore).First(x => x.IsInGroup(CE_BodyPartGroupDefOf.LeftArm) || x.IsInGroup(CE_BodyPartGroupDefOf.RightArm));
+                            if (PartToHit == null)
+                            {
+                                PartToHit = pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbSegment).First(x => x.IsInGroup(CE_BodyPartGroupDefOf.LeftShoulder));
+                            }
+                            dinfo.SetHitPart(PartToHit);
                             dinfo.SetAmount(dmgAmount);
                             // Apply secondary damage to shield
                             if (dinfo.Weapon?.projectile is ProjectilePropertiesCE props && !props.secondaryDamage.NullOrEmpty())

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -126,9 +126,13 @@ namespace CombatExtended
                             {
                                 foreach (var sec in props.secondaryDamage)
                                 {
-                                    if (shield.Destroyed || !Rand.Chance(sec.chance))
+                                    if (shield.Destroyed)
                                     {
                                         break;
+                                    }
+                                    if (!Rand.Chance(sec.chance))
+                                    {
+                                        continue;
                                     }
                                     var secDinfo = sec.GetDinfo();
                                     var pen = secDinfo.ArmorPenetrationInt; //GetPenetrationValue(originalDinfo);
@@ -151,9 +155,13 @@ namespace CombatExtended
                             {
                                 foreach (var sec in props.secondaryDamage)
                                 {
-                                    if (shield.Destroyed || !Rand.Chance(sec.chance))
+                                    if (shield.Destroyed)
                                     {
                                         break;
+                                    }
+                                    if (!Rand.Chance(sec.chance))
+                                    {
+                                        continue;
                                     }
                                     var secDinfo = sec.GetDinfo();
                                     var pen = secDinfo.ArmorPenetrationInt; //GetPenetrationValue(originalDinfo);

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -15,6 +15,7 @@ namespace CombatExtended
         private const float PenetrationRandVariation = 0.05f;    // Armor penetration will be randomized by +- this amount
         private const float SoftArmorMinDamageFactor = 0.2f;    // Soft body armor will always take at least original damage * this number from sharp attacks
         private const float SpikeTrapAPModifierBlunt = 0.65f;
+        private const float BulletImpactForceMultiplier = 0.05f; //Bullet has less mass => less impluse comparing to melee => less Blunt penetration
 
         #endregion
 
@@ -115,6 +116,8 @@ namespace CombatExtended
                         }
                         // Hit was deflected, convert damage type
                         dinfo = GetDeflectDamageInfo(dinfo, hitPart, ref dmgAmount, ref penAmount);
+                        //Applies multiplier to bullet.
+                        penAmount *= dinfo.Weapon?.IsMeleeWeapon ?? false ? 1.0f : BulletImpactForceMultiplier;
                         //Check if converted blunt damage could penetrate the shield
                         if (!TryPenetrateArmor(dinfo.Def, shield.GetStatValue(dinfo.Def.armorCategory.armorRatingStat), ref penAmount, ref dmgAmount))
                         {

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -15,7 +15,7 @@ namespace CombatExtended
         private const float PenetrationRandVariation = 0.05f;    // Armor penetration will be randomized by +- this amount
         private const float SoftArmorMinDamageFactor = 0.2f;    // Soft body armor will always take at least original damage * this number from sharp attacks
         private const float SpikeTrapAPModifierBlunt = 0.65f;
-        private const float BulletImpactForceMultiplier = 0.05f; //Bullet has less mass => less impluse comparing to melee => less Blunt penetration
+        private const float BulletImpactForceMultiplier = 0.2f; //Bullet has less mass => less impluse comparing to melee => less Blunt penetration
 
         #endregion
 

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -101,30 +101,69 @@ namespace CombatExtended
                             }
                         }
                     }
+
                     // Try to penetrate the shield
                     if (blockedByShield && !TryPenetrateArmor(dinfo.Def, shield.GetStatValue(dinfo.Def.armorCategory.armorRatingStat), ref penAmount, ref dmgAmount, shield))
                     {
-                        shieldAbsorbed = true;
-                        armorDeflected = true;
-                        dinfo.SetAmount(0);
-
-                        // Apply secondary damage to shield
-                        if (dinfo.Weapon?.projectile is ProjectilePropertiesCE props && !props.secondaryDamage.NullOrEmpty())
+                        //Deflected by sharp armor, check for blunt armor
+                        if (dinfo.Def.armorCategory.armorRatingStat == StatDefOf.ArmorRating_Sharp)
                         {
-                            foreach (var sec in props.secondaryDamage)
+                            if (deflectionComp != null)
                             {
-                                if (shield.Destroyed || !Rand.Chance(sec.chance))
-                                {
-                                    break;
-                                }
-                                var secDinfo = sec.GetDinfo();
-                                var pen = secDinfo.ArmorPenetrationInt; //GetPenetrationValue(originalDinfo);
-                                var dmg = (float)secDinfo.Amount;
-                                TryPenetrateArmor(secDinfo.Def, shield.GetStatValue(secDinfo.Def.armorCategory.armorRatingStat), ref pen, ref dmg, shield);
+                                deflectionComp.deflectedSharp = true;
                             }
                         }
+                        // Hit was deflected, convert damage type
+                        dinfo = GetDeflectDamageInfo(dinfo, hitPart, ref dmgAmount, ref penAmount);
+                        //Check if converted blunt damage could penetrate the shield
+                        if (!TryPenetrateArmor(dinfo.Def, shield.GetStatValue(dinfo.Def.armorCategory.armorRatingStat), ref penAmount, ref dmgAmount))
+                        {
+                            shieldAbsorbed = true;
+                            armorDeflected = true;
+                            dinfo.SetAmount(0);
+                            // Apply secondary damage to shield
+                            if (dinfo.Weapon?.projectile is ProjectilePropertiesCE props && !props.secondaryDamage.NullOrEmpty())
+                            {
+                                foreach (var sec in props.secondaryDamage)
+                                {
+                                    if (shield.Destroyed || !Rand.Chance(sec.chance))
+                                    {
+                                        break;
+                                    }
+                                    var secDinfo = sec.GetDinfo();
+                                    var pen = secDinfo.ArmorPenetrationInt; //GetPenetrationValue(originalDinfo);
+                                    var dmg = (float)secDinfo.Amount;
+                                    TryPenetrateArmor(secDinfo.Def, shield.GetStatValue(secDinfo.Def.armorCategory.armorRatingStat), ref pen, ref dmg, shield);
+                                }
+                            }
 
-                        return dinfo;
+                            return dinfo;
+                        }
+                        //Blunt damage penetrated the shield, apply the damage to right arm
+                        else
+                        {
+                            shieldAbsorbed = true;
+                            //I'm not sure whether pawn having no arms is able to use the shield
+                            dinfo.SetHitPart(pawn.health.hediffSet.GetNotMissingParts(depth: BodyPartDepth.Outside, tag: BodyPartTagDefOf.ManipulationLimbCore).Where(x => x.IsInGroup(CE_BodyPartGroupDefOf.RightArm)).First());
+                            dinfo.SetAmount(dmgAmount);
+                            // Apply secondary damage to shield
+                            if (dinfo.Weapon?.projectile is ProjectilePropertiesCE props && !props.secondaryDamage.NullOrEmpty())
+                            {
+                                foreach (var sec in props.secondaryDamage)
+                                {
+                                    if (shield.Destroyed || !Rand.Chance(sec.chance))
+                                    {
+                                        break;
+                                    }
+                                    var secDinfo = sec.GetDinfo();
+                                    var pen = secDinfo.ArmorPenetrationInt; //GetPenetrationValue(originalDinfo);
+                                    var dmg = (float)secDinfo.Amount;
+                                    TryPenetrateArmor(secDinfo.Def, shield.GetStatValue(secDinfo.Def.armorCategory.armorRatingStat), ref pen, ref dmg, shield);
+                                }
+                            }
+                            return dinfo;
+                        }
+
                     }
                 }
 
@@ -217,7 +256,6 @@ namespace CombatExtended
                     return dinfo;
                 }
             }
-
             // Applies blunt damage from partial penetrations.
             if (isSharp && (dinfo.Amount > dmgAmount))
             {

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartGroupDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_BodyPartGroupDefOf.cs
@@ -13,6 +13,8 @@ namespace CombatExtended
     {
         public static BodyPartGroupDef CoveredByNaturalArmor;
         public static BodyPartGroupDef RightArm;
+        public static BodyPartGroupDef LeftArm;
+        public static BodyPartGroupDef LeftShoulder;
         public static BodyPartGroupDef OutsideSquishy;
     }
 }


### PR DESCRIPTION
## Changes

- Shield now behaves similar to apparel, will double-check for its blunt armor when deflecting sharp attack

## References

Links to the associated issues or other related pull requests, e.g.
- Contributes towards #2412

## Reasoning

Why did you choose to implement things this way, e.g.

- Currently shield totally ignores its blunt armor when blocking sharp attack, rendering this stat somewhat useless (I really doubt any blunt weapon other than zeus hammer could overwhelm its blunt armor)
- It's reasonable that deflecting a bullet won't cause any damage, but this applies to melee too

## Alternatives

Describe alternative implementations you have considered, e.g.

- Can add additional checks for different behavior towards ranged sharp and melee sharp attack
- Or could add a new stat for "perfect deflection" which relates to the pawn's melee or other stats
- Or just adjust shield's blunt armor, but that's way more harder to balance I guess

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (kept shooting legendary plasteel ballistic shield with 762x51 sabot for half an hour)
