### PR TITLE
Fix for berserk pawn endless reload (issue 2411)

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -165,7 +165,10 @@ namespace CombatExtended
 
             // setup fail states, if something goes wrong with the pawn performing the reload, the weapon, or something else that we want to fail on.
             this.FailOnDespawnedOrNull(indReloader);
-            this.FailOnMentalState(indReloader);
+            if (pawn.MentalStateDef != MentalStateDefOf.Berserk && pawn.MentalStateDef != MentalStateDefOf.BerserkMechanoid)
+            {
+                this.FailOnMentalState(indReloader);
+            }
             this.FailOnDestroyedOrNull(indWeapon);
             this.FailOn(HasNoGunOrAmmo);
 


### PR DESCRIPTION
Fix berserk pawns endless reloading bug

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony 8 hours
