### PR TITLE
Remove the butcher product patch of AA's Aerofleet

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aerofleet.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Aerofleet.xml
@@ -26,13 +26,6 @@
 				</value>
 			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="AA_Aerofleet"]/butcherProducts</xpath>
-				<value>
-					<FSX>1</FSX>
-				</value>
-			</li>
-
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="AA_Aerofleet"]/tools</xpath>
 				<value>


### PR DESCRIPTION
## Changes

- What it says on the tin, the animal no longer has a unique butherProduct node in xml.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
