### PR TITLE
Danger behavior adjustments

### DIFF
--- a/Source/CombatExtended/CombatExtended/DangerTracker.cs
+++ b/Source/CombatExtended/CombatExtended/DangerTracker.cs
@@ -82,7 +82,7 @@ namespace CombatExtended
                 }
                 if (reduceOverDistance)
                 {
-                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / (radius* radius)) * 0.5f);
+                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / (radius * radius)) * 0.5f);
                 }
                 IncreaseAt(cell, (int)Mathf.Ceil(dangerAmount));
 

--- a/Source/CombatExtended/CombatExtended/DangerTracker.cs
+++ b/Source/CombatExtended/CombatExtended/DangerTracker.cs
@@ -82,7 +82,7 @@ namespace CombatExtended
                 }
                 if (reduceOverDistance)
                 {
-                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / (radius * radius)) * 0.5f);
+                    dangerAmount *= Mathf.Clamp01(1 - ((pos.ToVector3() - cell.ToVector3()).sqrMagnitude / (radius * radius)) * 0.1f);
                 }
                 IncreaseAt(cell, (int)Mathf.Ceil(dangerAmount));
 

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
         private const float maxCoverDist = 10f; // Maximum distance to run for cover to;
 
         public const float linearDangerAmountFactor = 0.2f; // The coefficient for linear danger amount when calculating cell cover attractiveness
-        public const float squaredDangerAmountFactor = 0.008f; // The coefficient for squared danger amount when calculating cell cover attractiveness
+        public const float squaredDangerAmountFactor = 0.01f; // The coefficient for squared danger amount when calculating cell cover attractiveness
         private const float pathCostFactor = 2f; // How important is the distance to travel
         private const float obstaclePathCostFactor = 2f; // How important is travelling over a path that has mantling or doors involved
         private const float distanceFromThreatFactor = 0.5f; // How important is the distance change from the new cell to the shooter position versus the current cell to the shooter position

--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -97,7 +97,7 @@ namespace CombatExtended
             }
             if (this.IsHashIntervalTick(120))
             {
-                DangerTracker?.Notify_SmokeAt(Position);
+                DangerTracker?.Notify_SmokeAt(Position, density / MaxDensity);
             }
 
             base.Tick();


### PR DESCRIPTION
## Changes
1. Danger becomes less important with better initial cell cover rating;
2. Pawns will no longer even consider pathing to other sides of impassable terrain when running for cover, though will still consider mantling over cover (and, additionally, moving trough doors) as a worse path;
3. Pawns will prefer to move away from their suppressor's location, however this preference is smaller than the distance cost.
4. Danger generated by explosives by default falls over distance, being around x0.5 at the edges;
5. Smoke now sets danger at a cell depending on the concentration instead of increasing it by a flat value.

## References
1., 2., 3. and 4. Reported cases of "pawns doing stupid things when running for cover";
5. #2414.

## Reasoning
1., 2., 3., 4., 5. Can't be bothered, really, just reread the References.

## Testing
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)

## Additional material
- https://www.desmos.com/calculator/keunktjnqw (Image may not be representative of the current formula)
![image](https://user-images.githubusercontent.com/34545746/229308716-80a7ad50-57af-494e-aac0-b2496c396046.png)