### PR TITLE
Armor degrade min amount

### DIFF
--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -1,450 +1,452 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-	<!-- ========== General ========== -->
+  <!-- ========== General ========== -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="Flammability"]</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_Flammability</workerClass>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="Flammability"]</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_Flammability</workerClass>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="Flammability"]/category</xpath>
-		<value>
-			<category>Basics</category>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="Flammability"]/category</xpath>
+    <value>
+      <category>Basics</category>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="Mass"]/parts</xpath>
-		<value>
-			<li Class="CombatExtended.StatPart_LoadedAmmo"/>
-			<li Class="CombatExtended.StatPart_Attachments"/>			
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="Mass"]/parts</xpath>
+    <value>
+      <li Class="CombatExtended.StatPart_LoadedAmmo"/>
+      <li Class="CombatExtended.StatPart_Attachments"/>
+    </value>
+  </Operation>
 
-	<!-- ========== Apparel ========== -->
+  <!-- ========== Apparel ========== -->
 
-	<!-- Armor Cap -->
+  <!-- Armor Cap -->
 
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/maxValue</xpath>
-	</Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>Defs/StatDef[@Name="ArmorRatingBase"]/maxValue</xpath>
+  </Operation>
 
-	<!-- Armor Rating -->
-	
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_ArmorPartial</workerClass>
-		</value>
-	</Operation>
+  <!-- Armor Rating -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
-		<value>
-			<li Class="CombatExtended.StatPart_QualityConditional">
-			  <factorAwful>0.6</factorAwful>
-			  <factorPoor>0.8</factorPoor>
-			  <factorNormal>1</factorNormal>
-			  <factorGood>1.15</factorGood>
-			  <factorExcellent>1.3</factorExcellent>
-			  <factorMasterwork>1.5</factorMasterwork>
-			  <factorLegendary>1.75</factorLegendary>
-			</li>
-			<li Class="StatPart_Health">
-			  <curve>
-			    <points>
-			      <li>(0.0, 0.0)</li>
-			      <li>(0.5, 0.5)</li>
-			      <li>(0.8, 1.0)</li>
-			    </points>
-			  </curve>
-			</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[@Name="ArmorRatingBase"]</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_ArmorPartial</workerClass>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="ArmorRating_Sharp"]</xpath>
-		<value>
-			<toStringStyle>FloatMaxTwo</toStringStyle>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
+    <value>
+      <li Class="CombatExtended.StatPart_MechDurability"/>
+      <li Class="CombatExtended.StatPart_QualityConditional">
+        <factorAwful>0.6</factorAwful>
+        <factorPoor>0.8</factorPoor>
+        <factorNormal>1</factorNormal>
+        <factorGood>1.15</factorGood>
+        <factorExcellent>1.3</factorExcellent>
+        <factorMasterwork>1.5</factorMasterwork>
+        <factorLegendary>1.75</factorLegendary>
+      </li>
+      <li Class="StatPart_Health">
+        <curve>
+          <points>
+            <li>(0.0, 0.0)</li>
+            <li>(0.5, 0.5)</li>
+            <li>(0.8, 1.0)</li>
+          </points>
+        </curve>
+      </li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="ArmorRating_Blunt"]</xpath>
-		<value>
-			<toStringStyle>FloatMaxThree</toStringStyle>
-		</value>
-	</Operation>
-	
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="StuffPower_Armor_Blunt" or defName="StuffPower_Armor_Sharp"]/toStringStyle</xpath>
-		<value>
-			<toStringStyle>FloatMaxThree</toStringStyle>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="ArmorRating_Sharp"]</xpath>
+    <value>
+      <toStringStyle>FloatMaxTwo</toStringStyle>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="ArmorRating_Blunt" or defName="StuffPower_Armor_Blunt"]</xpath>
-		<value>
-			<formatString>{0} MPa</formatString>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="ArmorRating_Blunt"]</xpath>
+    <value>
+      <toStringStyle>FloatMaxThree</toStringStyle>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="ArmorRating_Sharp" or defName="StuffPower_Armor_Sharp"]</xpath>
-		<value>
-			<formatString>{0} mm RHA</formatString>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="StuffPower_Armor_Blunt" or defName="StuffPower_Armor_Sharp"]/toStringStyle</xpath>
+    <value>
+      <toStringStyle>FloatMaxThree</toStringStyle>
+    </value>
+  </Operation>
 
-	<!-- Armor Descriptions -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="ArmorRating_Blunt" or defName="StuffPower_Armor_Blunt"]</xpath>
+    <value>
+      <formatString>{0} MPa</formatString>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ArmorRating_Sharp"]/description</xpath>
-		<value>
-			<description>Mitigation effect on sharp damage such as bullets, knife stabs, and animal bites.\n\nThis armor rating is compared against an attack's armor penetration, with deflection occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8mm RHA armor is hit by a 10mm RHA projectile, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers. If an attack is deflected, it's converted to blunt, the damage is recalculated based off the base blunt armor penetration and the ratio of pre-deflecton sharp armor penetration to base sharp penetration, and is checked against the apparel's blunt armor rating. If an attack penetrated with some of its damage blocked, then additional blunt damage is applied based off the attack's base blunt penetration influenced by the ratio of blocked damage and blocked armor penetration to base damage and base armor penetration.</description>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="ArmorRating_Sharp" or defName="StuffPower_Armor_Sharp"]</xpath>
+    <value>
+      <formatString>{0} mm RHA</formatString>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ArmorRating_Blunt"]/description</xpath>
-		<value>
-			<description>Mitigation effect on blunt-force damage such as maces, explosions, and animal hoofs.\n\nThis armor rating is compared against an attack's armor penetration, with no damage occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8 MPa armor is hit by a 10 MPa impact, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers.</description>
-		</value>
-	</Operation>
+  <!-- Armor Descriptions -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ArmorRating_Heat"]/description</xpath>
-		<value>
-			<description>Percentage reduction of damage from extreme heat such as fire and incendiary explosions.\n\nHaving a value of 100% or above makes the creature immune to all flame damage in that body region.</description>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ArmorRating_Sharp"]/description</xpath>
+    <value>
+      <description>Mitigation effect on sharp damage such as bullets, knife stabs, and animal bites.\n\nThis armor rating is compared against an attack's armor penetration, with deflection occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8mm RHA armor is hit by a 10mm RHA projectile, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers. If an attack is deflected, it's converted to blunt, the damage is recalculated based off the base blunt armor penetration and the ratio of pre-deflecton sharp armor penetration to base sharp penetration, and is checked against the apparel's blunt armor rating. If an attack penetrated with some of its damage blocked, then additional blunt damage is applied based off the attack's base blunt penetration influenced by the ratio of blocked damage and blocked armor penetration to base damage and base armor penetration.</description>
+    </value>
+  </Operation>
 
-	<!-- ========== Pawn stats ========== -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ArmorRating_Blunt"]/description</xpath>
+    <value>
+      <description>Mitigation effect on blunt-force damage such as maces, explosions, and animal hoofs.\n\nThis armor rating is compared against an attack's armor penetration, with no damage occurring if armor is the higher stat. Otherwise, damage is reduced based on the ratio of armor to AP (e.g: if a 8 MPa armor is hit by a 10 MPa impact, the armor will block 80% of the damage). The internal formula is:\n\nModifiedAP=InitialAP - ArmorRating\nModifiedDamage=InitialDamage * (ModifiedAP / InitialAP)\n\nThese reductions apply for each layer the attack goes through, lowering its ability to penetrate and damage subsequent layers.</description>
+    </value>
+  </Operation>
 
-	<!-- Melee Hit Chance -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ArmorRating_Heat"]/description</xpath>
+    <value>
+      <description>Percentage reduction of damage from extreme heat such as fire and incendiary explosions.\n\nHaving a value of 100% or above makes the creature immune to all flame damage in that body region.</description>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeHitChance"]/postProcessCurve/points</xpath>
-		<value>
-			<points>
-				<li>(-20, 0.10)</li>
-				<li>(-10, 0.20)</li>
-				<li>(0, 0.60)</li>
-				<li>(10, 0.90)</li>
-				<li>(20, 1.00)</li>
-			</points>
-		</value>
-	</Operation>
+  <!-- ========== Pawn stats ========== -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeHitChance"]/noSkillOffset</xpath>
-		<value>
-			<noSkillOffset>6.7</noSkillOffset>
-		</value>
-	</Operation>
+  <!-- Melee Hit Chance -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="MeleeHitChance"]/parts</xpath>
-		<value>
-			<li Class="CombatExtended.StatPart_Bulk" />
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeHitChance"]/postProcessCurve/points</xpath>
+    <value>
+      <points>
+        <li>(-20, 0.10)</li>
+        <li>(-10, 0.20)</li>
+        <li>(0, 0.60)</li>
+        <li>(10, 0.90)</li>
+        <li>(20, 1.00)</li>
+      </points>
+    </value>
+  </Operation>
 
-	<!-- Melee Dodge Chance -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeHitChance"]/noSkillOffset</xpath>
+    <value>
+      <noSkillOffset>6.7</noSkillOffset>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
-			<maxValue>3.2</maxValue>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="MeleeHitChance"]/parts</xpath>
+    <value>
+      <li Class="CombatExtended.StatPart_Bulk" />
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/defaultBaseValue</xpath>
-		<value>
-			<defaultBaseValue>1</defaultBaseValue>
-		</value>
-	</Operation>
+  <!-- Melee Dodge Chance -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/skillNeedOffsets</xpath>
-		<value>
-		    <skillNeedFactors>
-		      <li Class="SkillNeed_BaseBonus">
-			<skill>Melee</skill>
-			<baseValue>0.05</baseValue>
-			<bonusPerLevel>0.0175</bonusPerLevel>
-		      </li>
-		    </skillNeedFactors>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
+      <maxValue>3.2</maxValue>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/capacityOffsets</xpath>
-		<value>
-		    <capacityFactors>
-		      <li>
-			<capacity>Moving</capacity>
-			<weight>1</weight>
-		      </li>
-		      <li>
-			<capacity>Sight</capacity>
-			<weight>0.7</weight>
-			<max>1</max>
-		      </li>
-		    </capacityFactors>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]/defaultBaseValue</xpath>
+    <value>
+      <defaultBaseValue>1</defaultBaseValue>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/postProcessCurve</xpath>
-		<value>
-		    <postProcessCurve>
-		      <points>
-			<li>(0.0, 0.0)</li>
-			<li>(0.3, 0.3)</li>
-			<li>(0.6, 0.45)</li>
-			<li>(1.2, 0.6)</li>
-			<li>(2.4, 0.75)</li>
-			<li>(3.2, 0.8)</li>
-		      </points>
-		    </postProcessCurve>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]/skillNeedOffsets</xpath>
+    <value>
+      <skillNeedFactors>
+        <li Class="SkillNeed_BaseBonus">
+          <skill>Melee</skill>
+          <baseValue>0.05</baseValue>
+          <bonusPerLevel>0.0175</bonusPerLevel>
+        </li>
+      </skillNeedFactors>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeDodgeChance"]/displayPriorityInCategory</xpath>
-		<value>
-			<displayPriorityInCategory>99</displayPriorityInCategory>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]/capacityOffsets</xpath>
+    <value>
+      <capacityFactors>
+        <li>
+          <capacity>Moving</capacity>
+          <weight>1</weight>
+        </li>
+        <li>
+          <capacity>Sight</capacity>
+          <weight>0.7</weight>
+          <max>1</max>
+        </li>
+      </capacityFactors>
+    </value>
+  </Operation>
 
-	<!-- Shooting Accuracy -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]/postProcessCurve</xpath>
+    <value>
+      <postProcessCurve>
+        <points>
+          <li>(0.0, 0.0)</li>
+          <li>(0.3, 0.3)</li>
+          <li>(0.6, 0.45)</li>
+          <li>(1.2, 0.6)</li>
+          <li>(2.4, 0.75)</li>
+          <li>(3.2, 0.8)</li>
+        </points>
+      </postProcessCurve>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/label</xpath>
-		<value>
-			<label>weapon handling</label>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeDodgeChance"]/displayPriorityInCategory</xpath>
+    <value>
+      <displayPriorityInCategory>99</displayPriorityInCategory>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
-		<match Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
-		</match>
-	</Operation>
+  <!-- Shooting Accuracy -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/description</xpath>
-		<value>
-			<description>How well a shooter can hold a gun steady when aiming and compensate for recoil.\n\nThe total sway is calculated as:\n(4.5 - weapon handling) * weapon sway factor\n\nThe recoil per shot is determined by multiplying this value against the weapon's inherent recoil amount and increases after every shot in a burst.</description>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/label</xpath>
+    <value>
+      <label>weapon handling</label>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]</xpath>
-		<value>
-			<maxValue>13</maxValue>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+    <match Class="PatchOperationRemove">
+      <xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+    </match>
+  </Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
-		<match Class="PatchOperationRemove">
-			<xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
-		</match>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/description</xpath>
+    <value>
+      <description>How well a shooter can hold a gun steady when aiming and compensate for recoil.\n\nThe total sway is calculated as:\n(4.5 - weapon handling) * weapon sway factor\n\nThe recoil per shot is determined by multiplying this value against the weapon's inherent recoil amount and increases after every shot in a burst.</description>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationSequence"> <!-- compatibility with any mod that redefines ShootingAccuracy and changes SkillNeed back to the traditional pre-A17 values per skill level (e.g. Shooting Skill Rebalanced) -->
-		<success>Always</success>
-		<operations>
-			<li Class="PatchOperationTest">
-				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
-				<value>
-					<li Class="SkillNeed_BaseBonus" />
-				</value>
-			</li>
-		</operations>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]</xpath>
+    <value>
+      <maxValue>13</maxValue>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_BaseBonus"]</xpath>
-		<value>
-			<li Class="SkillNeed_BaseBonus">
-			  <skill>Shooting</skill>
-			  <baseValue>1</baseValue>
-			  <bonusPerLevel>0.2</bonusPerLevel>
-			</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
+    <match Class="PatchOperationRemove">
+      <xpath>Defs/ThingDef[defName="ShootingAccuracyPawn"]/workerClass</xpath>
+    </match>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/capacityOffsets</xpath>
-		<value>
-			<capacityOffsets>
-				<li>
-					<capacity>Manipulation</capacity>
-					<scale>1.6</scale>
-				</li>
-			</capacityOffsets>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationSequence">
+    <!-- compatibility with any mod that redefines ShootingAccuracy and changes SkillNeed back to the traditional pre-A17 values per skill level (e.g. Shooting Skill Rebalanced) -->
+    <success>Always</success>
+    <operations>
+      <li Class="PatchOperationTest">
+        <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
+      </li>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_Direct"]</xpath>
+        <value>
+          <li Class="SkillNeed_BaseBonus" />
+        </value>
+      </li>
+    </operations>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/postProcessCurve</xpath>
-		<value>
-			<postProcessCurve>
-			  <points>
-			    <li>(0.0, 0.0)</li>
-			    <li>(2.0, 2.0)</li>
-			    <li>(3.0, 2.5)</li>
-			    <li>(4.0, 2.75)</li>
-			    <li>(5.0, 2.875)</li>
-			    <li>(13, 4.5)</li>
-			  </points>
-			</postProcessCurve>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/skillNeedOffsets/li[@Class="SkillNeed_BaseBonus"]</xpath>
+    <value>
+      <li Class="SkillNeed_BaseBonus">
+        <skill>Shooting</skill>
+        <baseValue>1</baseValue>
+        <bonusPerLevel>0.2</bonusPerLevel>
+      </li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/noSkillOffset</xpath>
-		<value>
-			<noSkillFactor>2.6</noSkillFactor>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/capacityOffsets</xpath>
+    <value>
+      <capacityOffsets>
+        <li>
+          <capacity>Manipulation</capacity>
+          <scale>1.6</scale>
+        </li>
+      </capacityOffsets>
+    </value>
+  </Operation>
 
-	<!-- Aiming Delay Factor -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/postProcessCurve</xpath>
+    <value>
+      <postProcessCurve>
+        <points>
+          <li>(0.0, 0.0)</li>
+          <li>(2.0, 2.0)</li>
+          <li>(3.0, 2.5)</li>
+          <li>(4.0, 2.75)</li>
+          <li>(5.0, 2.875)</li>
+          <li>(13, 4.5)</li>
+        </points>
+      </postProcessCurve>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
-		<value>
-		    <maxValue>2.0</maxValue>
-		    <skillNeedFactors>
-		      <li Class="SkillNeed_Direct">
-			<skill>Shooting</skill>
-			<valuesPerLevel>
-			  <li>1.25</li>
-			  <li>1.2</li>
-			  <li>1.17</li>
-			  <li>1.15</li>
-			  <li>1.12</li>
-			  <li>1.09</li>
-			  <li>1.06</li>
-			  <li>1.03</li>
-			  <li>1.0</li>
-			  <li>0.98</li>
-			  <li>0.96</li>
-			  <li>0.94</li>
-			  <li>0.92</li>
-			  <li>0.90</li>
-			  <li>0.88</li>
-			  <li>0.86</li>
-			  <li>0.84</li>
-			  <li>0.82</li>
-			  <li>0.80</li>
-			  <li>0.78</li>
-			  <li>0.75</li>
-			</valuesPerLevel>
-		      </li>
-		    </skillNeedFactors>
-		    <capacityFactors>
-		      <li>
-			<capacity>Manipulation</capacity>
-			<weight>1</weight>
-			<useReciprocal>true</useReciprocal>
-		      </li>
-		      <li>
-			<capacity>Sight</capacity>
-			<weight>0.7</weight>
-			<useReciprocal>true</useReciprocal>
-		      </li>
-		    </capacityFactors>
-		    <postProcessCurve>
-		      <points>
-			<li>(0.01, 0.5)</li>
-			<li>(0.75, 0.75)</li>
-			<li>(1.0, 1.0)</li>
-			<li>(1.25, 1.25)</li>
-			<li>(2.0, 1.5)</li>
-		      </points>
-		    </postProcessCurve>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="ShootingAccuracyPawn"]/noSkillOffset</xpath>
+    <value>
+      <noSkillFactor>2.6</noSkillFactor>
+    </value>
+  </Operation>
 
-	<!-- Move speed -->
+  <!-- Aiming Delay Factor -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="MoveSpeed"]</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="AimingDelayFactor"]</xpath>
+    <value>
+      <maxValue>2.0</maxValue>
+      <skillNeedFactors>
+        <li Class="SkillNeed_Direct">
+          <skill>Shooting</skill>
+          <valuesPerLevel>
+            <li>1.25</li>
+            <li>1.2</li>
+            <li>1.17</li>
+            <li>1.15</li>
+            <li>1.12</li>
+            <li>1.09</li>
+            <li>1.06</li>
+            <li>1.03</li>
+            <li>1.0</li>
+            <li>0.98</li>
+            <li>0.96</li>
+            <li>0.94</li>
+            <li>0.92</li>
+            <li>0.90</li>
+            <li>0.88</li>
+            <li>0.86</li>
+            <li>0.84</li>
+            <li>0.82</li>
+            <li>0.80</li>
+            <li>0.78</li>
+            <li>0.75</li>
+          </valuesPerLevel>
+        </li>
+      </skillNeedFactors>
+      <capacityFactors>
+        <li>
+          <capacity>Manipulation</capacity>
+          <weight>1</weight>
+          <useReciprocal>true</useReciprocal>
+        </li>
+        <li>
+          <capacity>Sight</capacity>
+          <weight>0.7</weight>
+          <useReciprocal>true</useReciprocal>
+        </li>
+      </capacityFactors>
+      <postProcessCurve>
+        <points>
+          <li>(0.01, 0.5)</li>
+          <li>(0.75, 0.75)</li>
+          <li>(1.0, 1.0)</li>
+          <li>(1.25, 1.25)</li>
+          <li>(2.0, 1.5)</li>
+        </points>
+      </postProcessCurve>
+    </value>
+  </Operation>
 
-	<!-- Work speed -->
+  <!-- Move speed -->
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/StatDef[defName="WorkSpeedGlobal"]</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_WorkSpeedGlobal</workerClass>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="MoveSpeed"]</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_MoveSpeed</workerClass>
+    </value>
+  </Operation>
 
-	<!-- Tweak the Ranged Weapon Damage Multiplier -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
-		<value>
-			<parts>
-				<li Class="StatPart_Quality">
-					<factorAwful>0.9</factorAwful>
-					<factorPoor>1</factorPoor>
-					<factorNormal>1</factorNormal>
-					<factorGood>1</factorGood>
-					<factorExcellent>1</factorExcellent>
-					<factorMasterwork>1.05</factorMasterwork>
-					<factorLegendary>1.15</factorLegendary>
-				</li>
-			</parts>
-		</value>
-	</Operation>
+  <!-- Work speed -->
 
-	<!-- Melee DPS -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/workerClass</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_MeleeDamageAverage</workerClass>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/StatDef[defName="WorkSpeedGlobal"]</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_WorkSpeedGlobal</workerClass>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/displayPriorityInCategory</xpath>
-		<value>
-			<displayPriorityInCategory>6</displayPriorityInCategory>
-		</value>
-	</Operation>
+  <!-- Tweak the Ranged Weapon Damage Multiplier -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="RangedWeapon_DamageMultiplier"]/parts</xpath>
+    <value>
+      <parts>
+        <li Class="StatPart_Quality">
+          <factorAwful>0.9</factorAwful>
+          <factorPoor>1</factorPoor>
+          <factorNormal>1</factorNormal>
+          <factorGood>1</factorGood>
+          <factorExcellent>1</factorExcellent>
+          <factorMasterwork>1.05</factorMasterwork>
+          <factorLegendary>1.15</factorLegendary>
+        </li>
+      </parts>
+    </value>
+  </Operation>
 
-	<!-- Melee AP -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/workerClass</xpath>
-		<value>
-			<workerClass>CombatExtended.StatWorker_MeleeArmorPenetration</workerClass>
-		</value>
-	</Operation>
+  <!-- Melee DPS -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/workerClass</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_MeleeDamageAverage</workerClass>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/toStringStyle</xpath>
-		<value>
-			<toStringStyle>FloatTwo</toStringStyle>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageDPS"]/displayPriorityInCategory</xpath>
+    <value>
+      <displayPriorityInCategory>6</displayPriorityInCategory>
+    </value>
+  </Operation>
+
+  <!-- Melee AP -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/workerClass</xpath>
+    <value>
+      <workerClass>CombatExtended.StatWorker_MeleeArmorPenetration</workerClass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/StatDef[defName="MeleeWeapon_AverageArmorPenetration"]/toStringStyle</xpath>
+    <value>
+      <toStringStyle>FloatTwo</toStringStyle>
+    </value>
+  </Operation>
 
 </Patch>

--- a/Patches/Core/Stats/Stats.xml
+++ b/Patches/Core/Stats/Stats.xml
@@ -45,7 +45,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/StatDef[@Name="ArmorRatingBase"]/parts/li[@Class="StatPart_Quality"]</xpath>
     <value>
-      <li Class="CombatExtended.StatPart_MechDurability"/>
+      <li Class="CombatExtended.StatPart_NaturalArmorDurability"/>
       <li Class="CombatExtended.StatPart_QualityConditional">
         <factorAwful>0.6</factorAwful>
         <factorPoor>0.8</factorPoor>

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -1,104 +1,104 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Human"]</xpath>
-		<value>
-			<li Class="CombatExtended.RacePropertiesExtensionCE">
-				<bodyShape>Humanoid</bodyShape>
-			</li>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAddModExtension">
+    <xpath>Defs/ThingDef[defName="Human"]</xpath>
+    <value>
+      <li Class="CombatExtended.RacePropertiesExtensionCE">
+        <bodyShape>Humanoid</bodyShape>
+      </li>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Human"]/statBases</xpath>
-		<value>
-			<MeleeDodgeChance>1</MeleeDodgeChance>
-			<MeleeCritChance>1</MeleeCritChance>
-			<MeleeParryChance>1</MeleeParryChance>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Human"]/statBases</xpath>
+    <value>
+      <MeleeDodgeChance>1</MeleeDodgeChance>
+      <MeleeCritChance>1</MeleeCritChance>
+      <MeleeParryChance>1</MeleeParryChance>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Human"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>left fist</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>1.26</cooldownTime>
-					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>right fist</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>1.26</cooldownTime>
-					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>teeth</label>
-					<capacities>
-					  <li>Bite</li>
-					</capacities>
-					<power>1</power>
-					<cooldownTime>2</cooldownTime>
-					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-					<chanceFactor>0.07</chanceFactor>
-					<soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
-					<soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
-					<armorPenetrationSharp>0.15</armorPenetrationSharp>
-					<armorPenetrationBlunt>1.0</armorPenetrationBlunt>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>head</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>2</power>
-					<cooldownTime>4.49</cooldownTime>
-					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>0.625</armorPenetrationBlunt>
-				</li>
-			</tools>
-		</value>
-	</Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Human"]/tools</xpath>
+    <value>
+      <tools>
+        <li Class="CombatExtended.ToolCE">
+          <label>left fist</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>1</power>
+          <cooldownTime>1.26</cooldownTime>
+          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>right fist</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>1</power>
+          <cooldownTime>1.26</cooldownTime>
+          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>teeth</label>
+          <capacities>
+            <li>Bite</li>
+          </capacities>
+          <power>1</power>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+          <chanceFactor>0.07</chanceFactor>
+          <soundMeleeHit>Pawn_Melee_HumanBite_Hit</soundMeleeHit>
+          <soundMeleeMiss>Pawn_Melee_HumanBite_Miss</soundMeleeMiss>
+          <armorPenetrationSharp>0.15</armorPenetrationSharp>
+          <armorPenetrationBlunt>1.0</armorPenetrationBlunt>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>head</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>2</power>
+          <cooldownTime>4.49</cooldownTime>
+          <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+          <chanceFactor>0.2</chanceFactor>
+          <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+        </li>
+      </tools>
+    </value>
+  </Operation>
 
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Human"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Human"]</xpath>
-			<value>
-				<comps />
-			</value>
-		</nomatch>
-	</Operation>
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName="Human"]/comps</xpath>
+    <nomatch Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Human"]</xpath>
+      <value>
+        <comps />
+      </value>
+    </nomatch>
+  </Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Human"]/comps</xpath>
-		<value>
-			<li>
-			  <compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<!-- <li>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Human"]/comps</xpath>
+    <value>
+      <li>
+        <compClass>CombatExtended.CompPawnGizmo</compClass>
+      </li>
+      <!-- <li>
 				<compClass>CombatExtended.CompArmorDurability</compClass>
 			</li> -->
-			<li Class="CombatExtended.CompProperties_Suppressable" />
-			<li>
-			  <compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-		</value>
-	</Operation>
+      <li Class="CombatExtended.CompProperties_Suppressable" />
+      <li>
+        <compClass>CombatExtended.CompAmmoGiver</compClass>
+      </li>
+    </value>
+  </Operation>
 
-	<!-- <Operation Class="PatchOperationAddModExtension"> 
+  <!-- <Operation Class="PatchOperationAddModExtension"> 
 		<xpath>Defs/ThingDef[defName="Human"]</xpath>
 		<value>
 			<li Class="CombatExtended.MechArmorDurabilityExt">
@@ -115,6 +115,11 @@
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>500</MaxOverHeal>
+        <MinArmorPct>0.25</MinArmorPct> The default minimal armor percentage for all armor kinds. Will be overriden by any below
+        <MinArmorValueSharp>14</MinArmorValueSharp>
+        <MinArmorValueBlunt>30</MinArmorValueBlunt>
+        <MinArmorValueHeat>0.2</MinArmorValueHeat>
+        <MinArmorValueElectric>0.1</MinArmorValueElectric>
 			</li>
 		</value>
 	</Operation> -->

--- a/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Humanlike.xml
@@ -88,20 +88,7 @@
       <li>
         <compClass>CombatExtended.CompPawnGizmo</compClass>
       </li>
-      <!-- <li>
-				<compClass>CombatExtended.CompArmorDurability</compClass>
-			</li> -->
-      <li Class="CombatExtended.CompProperties_Suppressable" />
-      <li>
-        <compClass>CombatExtended.CompAmmoGiver</compClass>
-      </li>
-    </value>
-  </Operation>
-
-  <!-- <Operation Class="PatchOperationAddModExtension"> 
-		<xpath>Defs/ThingDef[defName="Human"]</xpath>
-		<value>
-			<li Class="CombatExtended.MechArmorDurabilityExt">
+      <!-- <li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>500</Durability>
 				<Regenerates>true</Regenerates>
 				<RegenInterval>600</RegenInterval>
@@ -120,9 +107,13 @@
         <MinArmorValueBlunt>30</MinArmorValueBlunt>
         <MinArmorValueHeat>0.2</MinArmorValueHeat>
         <MinArmorValueElectric>0.1</MinArmorValueElectric>
-			</li>
-		</value>
-	</Operation> -->
+			</li> -->
+      <li Class="CombatExtended.CompProperties_Suppressable" />
+      <li>
+        <compClass>CombatExtended.CompAmmoGiver</compClass>
+      </li>
+    </value>
+  </Operation>
 
 </Patch>
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -100,7 +100,7 @@ namespace CombatExtended
 
     public class CompArmorDurability : ThingComp
     {
-        public MechArmorDurabilityExt durabilityProps => this.parent.def.GetModExtension<MechArmorDurabilityExt>();
+        public CompProperties_ArmorDurability durabilityProps => props as CompProperties_ArmorDurability;
 
         public float maxDurability => durabilityProps.Durability;
 
@@ -221,8 +221,12 @@ namespace CombatExtended
         }
     }
 
-    public class MechArmorDurabilityExt : DefModExtension
+    public class CompProperties_ArmorDurability : CompProperties
     {
+        public CompProperties_ArmorDurability()
+        {
+            compClass = typeof(CompArmorDurability);
+        }
         public float Durability;
 
         public bool Regenerates;

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -135,9 +135,16 @@ namespace CombatExtended
             base.PostPostMake();
         }
 
+        public override void PostSpawnSetup(bool respawningAfterLoad)
+        {
+            regens = durabilityProps.Regenerates;
+            base.PostSpawnSetup(respawningAfterLoad);
+        }
+
         public override void PostExposeData()
         {
-            Scribe_Values.Look<bool>(ref regens, "regens", false);
+            Scribe_Values.Look(ref curDurability, "curDurability");
+            Scribe_Values.Look(ref timer, "timer");
             base.PostExposeData();
         }
 
@@ -148,7 +155,6 @@ namespace CombatExtended
 
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
-            Log.Message(dinfo.ToString());
             base.PostPreApplyDamage(dinfo, out absorbed);
             if (curDurability > 0)
             {

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -249,6 +249,8 @@ namespace CombatExtended
 
         public float MinArmorValueHeat = -1;
 
+        public float MinArmorValueElectric = -1;
+
         public float MinArmorPct = 0.25f;
     }
 

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -144,13 +144,13 @@ namespace CombatExtended
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
-            if (curDurability < 0)
-            {
-                curDurability = 0;
-            }
-            else
+            if (curDurability > 0)
             {
                 curDurability -= dinfo.Amount;
+                if (curDurability < 0)
+                {
+                    curDurability = 0;
+                }
             }
         }
 
@@ -242,6 +242,14 @@ namespace CombatExtended
         public bool CanOverHeal;
 
         public float MaxOverHeal;
+
+        public float MinArmorValueSharp = -1;
+
+        public float MinArmorValueBlunt = -1;
+
+        public float MinArmorValueHeat = -1;
+
+        public float MinArmorPct = 0.25f;
     }
 
     public class JobDriver_RepairNaturalArmor : JobDriver

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -141,6 +141,11 @@ namespace CombatExtended
             base.PostExposeData();
         }
 
+        public override string CompInspectStringExtra()
+        {
+            return "Armor durability: " + curDurability.ToString() + "/" + maxDurability.ToString() + " (" + curDurabilityPercent.ToStringPercent() + ")";
+        }
+
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);

--- a/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompArmorDurability.cs
@@ -148,6 +148,7 @@ namespace CombatExtended
 
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
+            Log.Message(dinfo.ToString());
             base.PostPreApplyDamage(dinfo, out absorbed);
             if (curDurability > 0)
             {

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_StatDefOf.cs
@@ -55,6 +55,6 @@ namespace CombatExtended
 
         public static StatDef Suppressability;
 
-
+        public static StatDef ArmorRating_Electric;
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_MechDurability.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_MechDurability.cs
@@ -36,7 +36,7 @@ namespace CombatExtended
 
                 float minArmor = getMinArmor(comp, val);
 
-                val *= comp.curDurabilityPercent;
+                val -= (val - minArmor) * (1 - comp.curDurabilityPercent);
 
                 if (val < minArmor) { val = minArmor; }
             }

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_MechDurability.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_MechDurability.cs
@@ -16,6 +16,7 @@ namespace CombatExtended
             if (parentStat == StatDefOf.ArmorRating_Sharp) { return comp.durabilityProps.MinArmorValueSharp; }
             if (parentStat == StatDefOf.ArmorRating_Blunt) { return comp.durabilityProps.MinArmorValueBlunt; }
             if (parentStat == StatDefOf.ArmorRating_Heat) { return comp.durabilityProps.MinArmorValueHeat; }
+            if (parentStat == CE_StatDefOf.ArmorRating_Electric) { return comp.durabilityProps.MinArmorValueElectric; }
             return -1;
         }
 

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
@@ -28,17 +28,19 @@ namespace CombatExtended
 
         public override void TransformValue(StatRequest req, ref float val)
         {
-
-            var comp = (req.Thing?.TryGetComp<CompArmorDurability>() ?? null);
-            if (comp != null)
+            if (val != 0)
             {
-                var mech = (Pawn)req.Thing;
+                var comp = (req.Thing?.TryGetComp<CompArmorDurability>() ?? null);
+                if (comp != null)
+                {
+                    var mech = (Pawn)req.Thing;
 
-                float minArmor = getMinArmor(comp, val);
+                    float minArmor = getMinArmor(comp, val);
 
-                val -= (val - minArmor) * (1 - comp.curDurabilityPercent);
+                    val -= (val - minArmor) * (1 - comp.curDurabilityPercent);
 
-                if (val < minArmor) { val = minArmor; }
+                    if (val < minArmor) { val = minArmor; }
+                }
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
+++ b/Source/CombatExtended/CombatExtended/StatParts/StatPart_NaturalArmorDurability.cs
@@ -9,7 +9,7 @@ using Verse;
 namespace CombatExtended
 {
 
-    public class StatPart_MechDurability : StatPart
+    public class StatPart_NaturalArmorDurability : StatPart
     {
         float getMinArmorExplicit(CompArmorDurability comp)
         {


### PR DESCRIPTION
## Additions

Natural armor degration now has a minimal value.
Several new fields in MechArmorDurabilityExt:
MinArmorPct as the general min armor percentage for all armor categories, if no explicit values are given. Default at 0.25

MinArmorValueSharp/Blunt/Heat/Electric as the explicit min value for each armor category. These overrides MinArmorPct in their respective category. Value below 0 deactivates it. Default at -1 (deactivated)

## Changes

Removed the hardcoded statpart add which seems to break statdefof.
Used traditional xml patching instead

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (a dozen runs shooting at centipedes)
