### PR TITLE
Add the mechanoid version of the minigun

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_Ranged.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Ranged.xml
@@ -319,10 +319,6 @@
     <techLevel>Spacer</techLevel>
     <tradeability>None</tradeability>
     <destroyOnDrop>true</destroyOnDrop>
-    <weaponTags>
-      <li>MechanoidGunIndirect</li>
-      <li>NoSwitch</li>
-    </weaponTags>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
@@ -360,6 +356,10 @@
         <aiUseBurstMode>FALSE</aiUseBurstMode>
       </li>
     </comps>
+    <weaponTags>
+      <li>MechanoidGunIndirect</li>
+      <li>NoSwitch</li>
+    </weaponTags>
     <tools>
       <li Class="CombatExtended.ToolCE">
         <label>barrel</label>
@@ -473,6 +473,79 @@
         <DrawOffset>0.0,0.0</DrawOffset>
       </li>
     -->
+    </modExtensions>
+  </ThingDef>
+
+  <!-- ==================== Minigun (Mechanoid) ==================== -->
+
+  <ThingDef ParentName="BaseGun">
+    <defName>CE_MechanoidMinigun</defName>
+    <label>minigun</label>
+    <description>A multi-barrel machine gun. It looks menacing with its long barrels and once it starts firing it fires very fast. Where most self-loading guns are powered by the energy from the gunpowder, the minigun uses an electric motor powered by the mechanoid it's mounted on to rapidly cycle cartridges through the weapon.</description>
+    <relicChance>0</relicChance>
+    <graphicData>
+      <texPath>Things/Item/Equipment/WeaponRanged/Minigun</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <soundInteract>Interact_Rifle</soundInteract>
+    <statBases>
+      <SightsEfficiency>1</SightsEfficiency>
+      <ShotSpread>0.01</ShotSpread>
+      <SwayFactor>1.25</SwayFactor>
+      <Bulk>12.0</Bulk>
+      <Mass>30.0</Mass>
+      <RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
+      <MarketValue>1250</MarketValue>
+    </statBases>
+    <techLevel>Spacer</techLevel>
+    <tradeability>None</tradeability>
+    <destroyOnDrop>true</destroyOnDrop>
+    <verbs>
+      <li Class="CombatExtended.VerbPropertiesCE">
+        <recoilAmount>0.55</recoilAmount>
+        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <hasStandardCommand>true</hasStandardCommand>
+        <defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+        <warmupTime>2.3</warmupTime>
+        <range>68</range>
+        <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+        <burstShotCount>50</burstShotCount>
+        <soundCast>Shot_Minigun</soundCast>
+        <soundCastTail>GunTail_Medium</soundCastTail>
+        <muzzleFlashScale>9</muzzleFlashScale>
+      </li>
+    </verbs>
+    <comps>
+      <li Class="CombatExtended.CompProperties_AmmoUser">
+        <magazineSize>250</magazineSize>
+        <reloadTime>9.2</reloadTime>
+        <ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+      </li>
+      <li Class="CombatExtended.CompProperties_FireModes">
+        <aiAimMode>Snapshot</aiAimMode>
+        <aimedBurstShotCount>25</aimedBurstShotCount>
+      </li>
+    </comps>
+    <weaponTags>
+      <li>MechanoidMinigun</li>
+      <li>NoSwitch</li>
+    </weaponTags>
+    <tools>
+      <li Class="CombatExtended.ToolCE">
+        <label>barrel</label>
+        <capacities>
+          <li>Blunt</li>
+        </capacities>
+        <power>10</power>
+        <cooldownTime>2.44</cooldownTime>
+        <armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+        <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+      </li>
+    </tools>
+    <modExtensions>
+      <li Class="CombatExtended.ThingDefExtensionCE">
+        <MenuHidden>True</MenuHidden>
+      </li>
     </modExtensions>
   </ThingDef>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -890,7 +890,6 @@
     </FireModes>
     <weaponTags>
       <li>CE_AI_Suppressive</li>
-      <li>NoSwitch</li>
     </weaponTags>    
   </Operation>
 

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -48,6 +48,13 @@
     </value>
   </Operation>
 
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/PawnKindDef[defName="Mech_CentipedeGunner"]/weaponTags</xpath>
+    <value>
+      <weaponTags>MechanoidMinigun</weaponTags>
+    </value>
+  </Operation>
+
   <!-- ========== Base Mechanoid ========== -->
 
   <Operation Class="PatchOperationAdd">


### PR DESCRIPTION
## Additions

- What it says on the tin.

## References

- https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037

## Reasoning

- Currently the gunner centipede uses the normal handheld minigun that because of it being set up to be hip-fired, it has a high sway value which makes the gun very inaccurate and veers of its aim mid-shooting. This makes it very undesirable as a weapon in the hands of a centipede. This PR adds a fixed version of the minigun with appropriate mass and longer barrel length to make the weapon a potent tool in the hands of the centipede gunner.

## Alternatives

- The current mechanoid minigun is still chambered in 7.62x51mm, one could chamber it in .338 Norma to make it compete a bit better with the Heavy Charge Blaster chambered in the almighty 12x64mm. This'd bridge the vast gap in firepower to some extent.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
