### PR TITLE
Integrated multi-round ammo

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -62,6 +62,24 @@ namespace CombatExtended
                 return (int)parent.GetStatValue(CE_StatDefOf.MagazineCapacity);
             }
         }
+
+        public int CurAmmoCount
+        {
+            get
+            {
+                return currentAmmoInt.ammoCount;
+            }
+        }
+
+        public int MagAmmoCount
+        {
+            get
+            {
+                Log.Message(CurAmmoCount.ToString()); Log.Message((MagSize / CurAmmoCount).ToString());
+                return MagSize / CurAmmoCount;
+            }
+        }
+
         public int MagSizeOverride
         {
             get
@@ -534,20 +552,20 @@ namespace CombatExtended
 
             // Add remaining ammo back to inventory
             Thing ammoThing = ThingMaker.MakeThing(currentAmmoInt);
-            ammoThing.stackCount = curMagCountInt;
+            ammoThing.stackCount = curMagCountInt / CurAmmoCount;
             bool doDrop = false;
-
             if (CompInventory != null)
             {
-                doDrop = (curMagCountInt != CompInventory.container.TryAdd(ammoThing, ammoThing.stackCount));    // TryAdd should report how many ammoThing.stackCount it stored.
+                doDrop = (curMagCountInt / CurAmmoCount) != CompInventory.container.TryAdd(ammoThing, ammoThing.stackCount);    // TryAdd should report how many ammoThing.stackCount it stored.
             }
             else
             {
                 doDrop = true;    // Inventory was null so no place to shift the ammo besides the ground.
             }
-
+            Log.Message(doDrop.ToString());
             if (doDrop)
             {
+                Log.Message(ammoThing.stackCount.ToString());
                 // NOTE: If we get here from ThingContainer.TryAdd() it will have modified the ammoThing.stackCount to what it couldn't take.
                 //Thing outThing;
                 if (!GenThing.TryDropAndSetForbidden(ammoThing, Position, Map, ThingPlaceMode.Near, out droppedAmmo, turret.Faction != Faction.OfPlayer))
@@ -556,7 +574,6 @@ namespace CombatExtended
                                               "Unable to drop ", ammoThing.LabelCap, " on the ground, thing was destroyed."));
                 }
             }
-
             // don't forget to set the clip to empty...
             CurMagCount = 0;
 
@@ -681,29 +698,29 @@ namespace CombatExtended
                 currentAmmoInt = (AmmoDef)ammoThing.def;
 
                 // If there's more ammo in inventory than the weapon can hold, or if there's greater than 1 bullet in inventory if reloading one at a time
-                if ((Props.reloadOneAtATime ? 1 : MagSize) < ammoThing.stackCount)
+                if ((Props.reloadOneAtATime ? 1 : MagAmmoCount) < ammoThing.stackCount)
                 {
                     if (Props.reloadOneAtATime)
                     {
-                        newMagCount = curMagCountInt + 1;
+                        newMagCount = curMagCountInt + CurAmmoCount;
                         ammoThing.stackCount--;
                     }
                     else
                     {
                         newMagCount = MagSize;
-                        ammoThing.stackCount -= MagSize;
+                        ammoThing.stackCount -= MagAmmoCount;
                     }
                 }
 
                 // If there's less ammo in inventory than the weapon can hold, or if there's only one bullet left if reloading one at a time
                 else
                 {
-                    int newAmmoCount = ammoThing.stackCount;
+                    int newAmmoCount = ammoThing.stackCount * CurAmmoCount;
                     if (turret != null)     //Turrets are reloaded without unloading the mag first (if using same ammo type), to support very high capacity magazines
                     {
                         newAmmoCount += curMagCountInt;
                     }
-                    newMagCount = Props.reloadOneAtATime ? curMagCountInt + 1 : newAmmoCount;
+                    newMagCount = Props.reloadOneAtATime ? curMagCountInt + CurAmmoCount : newAmmoCount;
                     if (ammoFromInventory)
                     {
                         CompInventory.container.Remove(ammoThing);

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -23,6 +23,7 @@ namespace CombatExtended
         public bool isMortarAmmo = false;
 
         public int ammoCount = 1;
+        public ThingDef partialUnloadAmmoDef = null;
 
         public List<string> ammoTags;
 
@@ -131,6 +132,18 @@ namespace CombatExtended
                 }
 
                 description = stringBuilder.ToString().TrimEndNewlines();
+            }
+        }
+
+        public override IEnumerable<string> ConfigErrors()
+        {
+            foreach (string s in base.ConfigErrors())
+            {
+                yield return s;
+            }
+            if (HasComp(typeof(CompReloadable)) && stackLimit > 1)
+            {
+                yield return "has compreloadable and a stack limit higher than 1. this is not recommended.";
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -22,6 +22,8 @@ namespace CombatExtended
         // mortar ammo should still availabe when the ammo system is off
         public bool isMortarAmmo = false;
 
+        public int ammoCount = 1;
+
         public List<string> ammoTags;
 
         private List<DefHyperlink> originalHyperlinks;


### PR DESCRIPTION
easier than I thought, which scares me. I probably missed something but idk.
I'll see if I can do something with comprefuelable/reloadable

## Additions

ammoCount field in ammodef. when this ammo is used, the ammoCount amount of shots will be added into the gun magazine per ammo item.

partialUnloadAmmoDef is used to handle, well, partial unloads, when there're remainders after dividing.

if CompReloadable is found on ammo def, another ammo item with a charge amount of the remainder will be given. Otherwise if partialUnloadAmmoDef is not empty, remainder amounts of it will be given. if both are not present, remainder will be wasted.

Say, a gun with 30 round capacity and each ammo item has an ammoCount of 15. it'll take 2 ammo to reload it. and when you unload the gun at 26 round remaining, you only get one ammo pack back.
if the ammo has partial unload ammo def, you'll get one ammo pack and 11 loose bullets back.
If the ammo has reloadable, you'll be given one full ammo pack and another with 11/15 charge

* Note that for compreloadable to work properly, your gun have to be load one at once, and your ammo need a stack limit of exactly 1.

## To Do List

-I'm still thinking should I remove the comp reloadable support, since it's rather restricted. Or I leave it as-is in case someone wants is

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
