### PR TITLE
Separate the normal from explosive ammo of 20x42mm

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -56,7 +56,7 @@
     </statBases>
     <tradeTags>
 	  <li>CE_AutoEnableTrade</li>
-	  <li>CE_AutoEnableCrafting_TableMachining</li>
+	  <li>CE_AutoEnableCrafting</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo20x42mmGrenades</li>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -2,6 +2,13 @@
 <Defs>
 
 	<ThingCategoryDef>
+		<defName>Ammo20x42mmCartridges</defName>
+		<label>20x42mm Cartridge</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<ThingCategoryDef>
 		<defName>Ammo20x42mmGrenades</defName>
 		<label>20x42mm Grenade</label>
 		<parent>AmmoGrenades</parent>
@@ -26,6 +33,21 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
+  <ThingDef Class="CombatExtended.AmmoDef" Name="20x42mmCartridgeBase" ParentName="MediumAmmoBase" Abstract="True">
+    <description>Specialized cartridge developed for use in shoulder-fired grenade launchers.</description>
+    <statBases>
+	  <Mass>0.162</Mass>
+	  <Bulk>0.1</Bulk>
+    </statBases>
+    <tradeTags>
+	  <li>CE_AutoEnableTrade</li>
+	  <li>CE_AutoEnableCrafting</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo20x42mmCartridges</li>
+    </thingCategories>
+  </ThingDef>
+
   <ThingDef Class="CombatExtended.AmmoDef" Name="20x42mmGrenadeBase" ParentName="MediumAmmoBase" Abstract="True">
     <description>Specialized grenade developed for use in shoulder-fired grenade launchers.</description>
     <statBases>
@@ -33,8 +55,8 @@
 	  <Bulk>0.1</Bulk>
     </statBases>
     <tradeTags>
-    	<li>CE_AutoEnableTrade</li>
-    	<li>CE_AutoEnableCrafting_TableMachining</li>
+	  <li>CE_AutoEnableTrade</li>
+	  <li>CE_AutoEnableCrafting_TableMachining</li>
     </tradeTags>
     <thingCategories>
       <li>Ammo20x42mmGrenades</li>
@@ -42,10 +64,9 @@
     <cookOffFlashScale>20</cookOffFlashScale>
   </ThingDef>
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmCartridgeBase">
     <defName>Ammo_20x42mm_AP</defName>
     <label>20x42mm (AP)</label>
-    <description>Specialized cartridge developed for use in shoulder-fired grenade launchers.</description>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/AP</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -57,10 +78,9 @@
 	<detonateProjectile>Bullet_20x42mm_AP</detonateProjectile>
   </ThingDef> 
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmCartridgeBase">
     <defName>Ammo_20x42mm_Incendiary</defName>
     <label>20x42mm (AP-I)</label>
-    <description>Specialized cartridge developed for use in shoulder-fired grenade launchers.</description>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -72,10 +92,9 @@
 	<detonateProjectile>Bullet_20x42mm_Incendiary</detonateProjectile>
   </ThingDef> 
 
-  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmGrenadeBase">
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="20x42mmCartridgeBase">
     <defName>Ammo_20x42mm_APHE</defName>
     <label>20x42mm (AP-HE)</label>
-    <description>Specialized cartridge developed for use in shoulder-fired grenade launchers.</description>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
## Changes

- What it says on the tin, the normal cartridges were grouped together with the grenades and were made at the machining table, this PR puts them in the loading bench similar to other normal ammo separate from the grenade ammo types.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors