### PR TITLE
Fix the RevolverShotgun generic ammoset

### DIFF
--- a/Defs/Ammo/GENERIC/Generics_Misc.xml
+++ b/Defs/Ammo/GENERIC/Generics_Misc.xml
@@ -11,9 +11,9 @@
             <Ammo_PistolMagnum_AP>Bullet_45Colt_AP</Ammo_PistolMagnum_AP>
             <Ammo_PistolMagnum_HP>Bullet_45Colt_HP</Ammo_PistolMagnum_HP>
             <Ammo_Shotgun_Buck>Bullet_410Bore_Buck</Ammo_Shotgun_Buck>
-			<Ammo_Shotgun_Slug>Bullet_410Bore_Slug</Ammo_Shotgun_Slug>
-			<Ammo_Shotgun_Beanbag>Bullet_410Bore_Beanbag</Ammo_Shotgun_Beanbag>
-			<Ammo_Shotgun_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_Shotgun_ElectroSlug>
+            <Ammo_Shotgun_Slug>Bullet_410Bore_Slug</Ammo_Shotgun_Slug>
+            <Ammo_Shotgun_Beanbag>Bullet_410Bore_Beanbag</Ammo_Shotgun_Beanbag>
+            <Ammo_Shotgun_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_Shotgun_ElectroSlug>
         </ammoTypes>
     </CombatExtended.AmmoSetDef>
 

--- a/Defs/Ammo/GENERIC/Generics_Misc.xml
+++ b/Defs/Ammo/GENERIC/Generics_Misc.xml
@@ -11,6 +11,10 @@
             <Ammo_PistolMagnum_AP>Bullet_45Colt_AP</Ammo_PistolMagnum_AP>
             <Ammo_PistolMagnum_HP>Bullet_45Colt_HP</Ammo_PistolMagnum_HP>
             <Ammo_Shotgun_Buck>Bullet_410Bore_Buck</Ammo_Shotgun_Buck>
+			<Ammo_Shotgun_Slug>Bullet_410Bore_Slug</Ammo_Shotgun_Slug>
+			<Ammo_Shotgun_Beanbag>Bullet_410Bore_Beanbag</Ammo_Shotgun_Beanbag>
+			<Ammo_Shotgun_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_Shotgun_ElectroSlug>
         </ammoTypes>
     </CombatExtended.AmmoSetDef>
+
 </Defs>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -34,7 +34,10 @@
 			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
-			<Ammo_410Bore_Buck>Bullet_410Bore_Buck</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
+			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
+			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>
+			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug_SB</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
 		<similarTo>AmmoSet_RevolverShotgun</similarTo>
 	</CombatExtended.AmmoSetDef>

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -19,7 +19,7 @@
 			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag</Ammo_410Bore_Beanbag>
 			<Ammo_410Bore_ElectroSlug>Bullet_410Bore_ElectroSlug</Ammo_410Bore_ElectroSlug>
 		</ammoTypes>
-		<similarTo>AmmoSet_RevolverShotgun</similarTo>
+		<similarTo>AmmoSet_Shotgun</similarTo>
 	</CombatExtended.AmmoSetDef>
 
 	<CombatExtended.AmmoSetDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, it lacked the newly added .410 ammo types.
- Changed the normal .410 shotgun ammoset to be similar to Shotgun generic ammoset.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
