### PR TITLE
Rim-Effect Patches: Updates, Fixes, Housekeeping

### DIFF
--- a/Patches/Rim-Effect Core/Apparel_ME.xml
+++ b/Patches/Rim-Effect Core/Apparel_ME.xml
@@ -7,70 +7,105 @@
 		<match Class="PatchOperationSequence">
 			<operations>
 
- <li Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="RE_Apparel_Fatigues"]/statBases/StuffEffectMultiplierArmor</xpath>
-    <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
-    </value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_Fatigues"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+					<Bulk>5</Bulk>
+					<WornBulk>1.5</WornBulk>
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceDressJacket"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<Bulk>3</Bulk>
-			<WornBulk>1</WornBulk>
-			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>0.04</ArmorRating_Sharp>
-		</value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceDressJacket"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
+					<ArmorRating_Sharp>0.04</ArmorRating_Sharp>
+				</value>
+			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceDressJacket"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.04</ArmorRating_Blunt>
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceDressJacket"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>0.04</ArmorRating_Blunt>
-		</value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_FormalShirt"]/costStuffCount</xpath>
+				<value>
+					<costStuffCount>40</costStuffCount>
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Apparel_FormalShirt"]/costStuffCount</xpath>
-		<value>
-			<costStuffCount>40</costStuffCount>
-		</value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_FormalShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+					<Bulk>1</Bulk>
+					<WornBulk>0.5</WornBulk>  
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="RE_Apparel_FormalShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
-    <value>
-		  <StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>	  
-    </value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_FormalJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>3</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>	  
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-    <xpath>Defs/ThingDef[defName="RE_Apparel_FormalJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
-    <value>
-		  <Bulk>3</Bulk>
-		  <WornBulk>1</WornBulk>
-		  <StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>	  
-    </value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_BattleUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>2</WornBulk>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
+					<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
+				</value>
+			</li>
 
- <li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Apparel_BattleUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
-		<value>
-			<Bulk>5</Bulk>
-			<WornBulk>2</WornBulk>
-			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>0.75</ArmorRating_Sharp>
-		</value>
- </li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_BattleUniform"]/statBases</xpath>
+				<value>
+					<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+				</value>
+			</li>
 
- <li Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="RE_Apparel_BattleUniform"]/statBases</xpath>
-		<value>
-			<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
-		</value>
- </li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceOfficerHat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<Bulk>1</Bulk>
+					<WornBulk>0</WornBulk>
+					<ArmorRating_Sharp>0.02</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_AllianceOfficerHat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.03</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_ScienceUniform"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>2</WornBulk>
+					<ArmorRating_Sharp>0.08</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RE_Apparel_ScienceUniform"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.12</ArmorRating_Blunt>
+				</value>
+			</li>
 
 			</operations>
 		</match>

--- a/Patches/Rim-Effect Core/Armor_ME.xml
+++ b/Patches/Rim-Effect Core/Armor_ME.xml
@@ -788,7 +788,9 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="RE_Apparel_SpectreVisor"]/statBases</xpath>
 					<value>
-      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
+      					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>
+						<Bulk>1</Bulk>
+						<WornBulk>0</WornBulk> 
 					</value>
 				</li>
 
@@ -796,8 +798,8 @@
 					<xpath>Defs/ThingDef[defName="RE_Apparel_SpectreVisor"]/equippedStatOffsets</xpath>
 					<value>
 						<equippedStatOffsets>
-      							<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
-      							<AimingAccuracy>0.4</AimingAccuracy>
+							<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
+							<AimingAccuracy>0.4</AimingAccuracy>
 						</equippedStatOffsets>
 					</value>
 				</li>

--- a/Patches/Rim-Effect Core/ME_Machine.xml
+++ b/Patches/Rim-Effect Core/ME_Machine.xml
@@ -11,145 +11,131 @@
 		<xpath>Defs</xpath>
 		<value>
 
-  <ThingDef ParentName="BaseGunWithQuality">
-    <defName>ME_LokiPistol</defName>
-    <label>Loki Pistol</label>
-    <description>A specialised M3 predator pistol used by LOKI mechs, does not appear to use thermal clips. Do not under any circumstance tell your mech to drop its weapon.</description>
-    <graphicData>
-      <texPath>Things/Item/Equipment/WeaponRanged/AlliancePistol</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <soundInteract>RE_Interact_Predator</soundInteract>
-    <statBases>
-      <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.13</ShotSpread>
-      <SwayFactor>0.88</SwayFactor>
-      <Bulk>1.75</Bulk>
-      <Mass>0.8</Mass>
-      <RangedWeapon_Cooldown>0.1</RangedWeapon_Cooldown>
-    </statBases>
-    <techLevel>Ultra</techLevel>
-    <relicChance>0</relicChance>
-    <tradeability>None</tradeability>
-    <destroyOnDrop>true</destroyOnDrop>    
-    <weaponTags>
-      <li>LokiGun</li>  
-    </weaponTags>
-    <verbs>
-	  <li Class="CombatExtended.VerbPropertiesCE">
-		<verbClass>CombatExtended.Verb_ShootCE</verbClass>
-		<hasStandardCommand>true</hasStandardCommand>
-		<defaultProjectile>Bullet_Predator</defaultProjectile>
-		<warmupTime>0.5</warmupTime>
-		<range>18</range>
-		<burstShotCount>1</burstShotCount>
-        		<soundCast>RE_Shot_Predator</soundCast>
-        		<soundCastTail>GunTail_Light</soundCastTail>
-        		<muzzleFlashScale>9</muzzleFlashScale>
-	  </li>
-    </verbs>
-    <comps>
-      <li Class="CombatExtended.CompProperties_AmmoUser">
-        <magazineSize>15</magazineSize>
-        <reloadTime>2.5</reloadTime>
-      </li>
-      <li Class="CombatExtended.CompProperties_FireModes">
-        <aiUseBurstMode>FALSE</aiUseBurstMode>
-      </li>
-    </comps>
-    <tools>
-        <li Class="CombatExtended.ToolCE">
-          <label>grip</label>
-          <capacities>
-            <li>Blunt</li>
-          </capacities>
-          <power>4</power>
-          <cooldownTime>1.54</cooldownTime>
-          <chanceFactor>1.5</chanceFactor>
-          <armorPenetrationBlunt>0.75</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-        </li>
-        <li Class="CombatExtended.ToolCE">
-          <label>muzzle</label>
-          <capacities>
-            <li>Poke</li>
-          </capacities>
-          <power>3</power>
-          <cooldownTime>1.54</cooldownTime>
-          <armorPenetrationBlunt>0.75</armorPenetrationBlunt>
-          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-        </li>
-    </tools>
-    <modExtensions>
-      <li Class="CombatExtended.GunDrawExtension">
-        <DrawSize>1.0,1.0</DrawSize>
-        <DrawOffset>0.0,0.0</DrawOffset>
-      </li>
-    </modExtensions>
-  </ThingDef>
+			<ThingDef ParentName="BaseGunWithQuality">
+				<defName>ME_LokiPistol</defName>
+				<label>Loki Pistol</label>
+				<description>A specialised M3 predator pistol used by LOKI mechs, does not appear to use thermal clips. Do not under any circumstance tell your mech to drop its weapon.</description>
+				<graphicData>
+				<texPath>Things/Item/Equipment/WeaponRanged/AlliancePistol</texPath>
+				<graphicClass>Graphic_Single</graphicClass>
+				</graphicData>
+				<soundInteract>RE_Interact_Predator</soundInteract>
+				<statBases>
+				<SightsEfficiency>1</SightsEfficiency>
+				<ShotSpread>0.13</ShotSpread>
+				<SwayFactor>0.88</SwayFactor>
+				<Bulk>1.75</Bulk>
+				<Mass>0.8</Mass>
+				<RangedWeapon_Cooldown>0.1</RangedWeapon_Cooldown>
+				</statBases>
+				<techLevel>Ultra</techLevel>
+				<relicChance>0</relicChance>
+				<tradeability>None</tradeability>
+				<destroyOnDrop>true</destroyOnDrop>    
+				<weaponTags>
+				<li>LokiGun</li>  
+				</weaponTags>
+				<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_Predator</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>18</range>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>RE_Shot_Predator</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</li>
+				</verbs>
+				<comps>
+				<li Class="CombatExtended.CompProperties_AmmoUser">
+					<magazineSize>15</magazineSize>
+					<reloadTime>2.5</reloadTime>
+				</li>
+				<li Class="CombatExtended.CompProperties_FireModes">
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+				</li>
+				</comps>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+					<label>grip</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>4</power>
+					<cooldownTime>1.54</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>3</power>
+					<cooldownTime>1.54</cooldownTime>
+					<armorPenetrationBlunt>0.75</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+					</li>
+				</tools>
+				<modExtensions>
+				<li Class="CombatExtended.GunDrawExtension">
+					<DrawSize>1.0,1.0</DrawSize>
+					<DrawOffset>0.0,0.0</DrawOffset>
+				</li>
+				</modExtensions>
+			</ThingDef>
+
 		</value>
 		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Mechanoids_LOKIBase"]/costList</xpath>
-		<value>
-    			<costList>
-      				<Steel>40</Steel>
-	  			<Plasteel>40</Plasteel>
-      				<RE_PrefabComponent>7</RE_PrefabComponent>
-	  			<ComponentSpacer>4</ComponentSpacer>
-    			</costList>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="RE_Mechanoids_LOKIBase"]/costList</xpath>
+			<value>
+				<costList>
+					<Steel>40</Steel>
+					<Plasteel>40</Plasteel>
+					<RE_PrefabComponent>7</RE_PrefabComponent>
+					<ComponentSpacer>4</ComponentSpacer>
+				</costList>
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Mechanoids_LOKIBase"]/comps/li[@Class ="VFE.Mechanoids.CompProperties_MachineChargingStation"]</xpath>
-		<value>
-	  	<li Class="VFE.Mechanoids.CompProperties_MachineChargingStation">
-		<pawnToSpawn>RE_Mechanoids_LOKI</pawnToSpawn>
-		<allowedWorkTypes>
-		</allowedWorkTypes>
-		<extraChargingPower>1000</extraChargingPower>
-		<spawnWithWeapon>ME_LokiPistol</spawnWithWeapon>
-		<hoursToRecharge>20</hoursToRecharge>
-	  	</li>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="RE_Mechanoids_LOKIBase"]/comps/li[@Class ="VFE.Mechanoids.CompProperties_MachineChargingStation"]/spawnWithWeapon</xpath>
+			<value>
+				<spawnWithWeapon>ME_LokiPistol</spawnWithWeapon>
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/costList</xpath>
-		<value>
-    			<costList>
-      				<Steel>300</Steel>
-	  			<Plasteel>300</Plasteel>
-	  			<Uranium>60</Uranium>
-      				<RE_PrefabComponent>25</RE_PrefabComponent>
-	  			<ComponentSpacer>16</ComponentSpacer>
-    			</costList>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/costList</xpath>
+			<value>
+				<costList>
+					<Steel>300</Steel>
+					<Plasteel>300</Plasteel>
+					<Uranium>60</Uranium>
+					<RE_PrefabComponent>25</RE_PrefabComponent>
+					<ComponentSpacer>16</ComponentSpacer>
+				</costList>
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/constructionSkillPrerequisite</xpath>
-		<value>
-    			<constructionSkillPrerequisite>12</constructionSkillPrerequisite>
-		</value>
-	</li>
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/constructionSkillPrerequisite</xpath>
+			<value>
+				<constructionSkillPrerequisite>12</constructionSkillPrerequisite>
+			</value>
+		</li>
 
-	<li Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/comps/li[@Class ="VFE.Mechanoids.CompProperties_MachineChargingStation"]</xpath>
-		<value>
-	  	<li Class="VFE.Mechanoids.CompProperties_MachineChargingStation">
-		<pawnToSpawn>RE_Mechanoids_YMIR</pawnToSpawn>
-		<allowedWorkTypes>
-		</allowedWorkTypes>
-		<extraChargingPower>4400</extraChargingPower>
-		<spawnWithWeapon>RE_YMIRMassAccelerator</spawnWithWeapon>
-		<hoursToRecharge>48</hoursToRecharge>
-	  	</li>
-		</value>
-	</li>
-
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="RE_Mechanoids_YMIRBase"]/comps/li[@Class ="VFE.Mechanoids.CompProperties_MachineChargingStation"]/spawnWithWeapon</xpath>
+			<value>
+				<spawnWithWeapon>RE_YMIRMassAccelerator</spawnWithWeapon>
+			</value>
+		</li>
 
 		</operations>
 		</match>

--- a/Patches/Rim-Effect Core/Mech_Weapons.xml
+++ b/Patches/Rim-Effect Core/Mech_Weapons.xml
@@ -47,7 +47,6 @@
 		    </value>
 		  </li>
 
-
 			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 			<defName>RE_YMIRMassAccelerator</defName>
 			  <statBases>
@@ -85,7 +84,6 @@
 			</weaponTags>
 			</li>
 			
-
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Rim-Effect N7/Armor_N7.xml
+++ b/Patches/Rim-Effect N7/Armor_N7.xml
@@ -295,21 +295,11 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/apparel/immuneToToxGasExposure</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/apparel</xpath>
-						<value>
-							<immuneToToxGasExposure>true</immuneToToxGasExposure>
-						</value>
-					</nomatch>
-				</li>
-
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/equippedStatOffsets/ToxicSensitivity</xpath>
+					<xpath>Defs/ThingDef[defName="REN7_Apparel_N7Helmet"]/equippedStatOffsets/ToxicResistance</xpath>
 					<value>
 						<AimingDelayFactor>-0.075</AimingDelayFactor>
-						<ToxicEnvironmentResistance>0.5</ToxicEnvironmentResistance>
+						<ToxicEnvironmentResistance>1</ToxicEnvironmentResistance>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</value>
 				</li>
@@ -482,7 +472,7 @@
 						<Bulk>8</Bulk>
 						<WornBulk>2.5</WornBulk>
 						<Mass>6</Mass>
-      						<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
+      					<NightVisionEfficiency_Apparel>0.6</NightVisionEfficiency_Apparel>      
 					</value>
 				</li>
 


### PR DESCRIPTION
## Changes
Did some work on the Rim-Effect patches.
- Fixed some failing patch operations.
- Added some missing Bulk values for apparel, so that the autopatcher no longer messes with them.
- Simplified a couple of operations.
- Whitespace clean-up and other housekeeping.

## Reasoning
The Rim-Effect Core and N7 mods updated recently, so the patches needed some adjustment.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
