### PR TITLE
Fix Gas Traps and Shells' patch

### DIFF
--- a/Patches/Gas Traps and Shells/Patch_60mm.xml
+++ b/Patches/Gas Traps and Shells/Patch_60mm.xml
@@ -25,7 +25,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_ToxicGas</defName>
 					<label>60mm mortar shell (Toxic)</label>
 					<graphicData>
@@ -60,7 +60,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_RageGas</defName>
 					<label>60mm mortar shell (Rage)</label>
 					<graphicData>
@@ -95,7 +95,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_TearGas</defName>
 					<label>60mm mortar shell (Tear)</label>
 					<graphicData>
@@ -130,7 +130,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_SleepGas</defName>
 					<label>60mm mortar shell (Sleep)</label>
 					<graphicData>
@@ -165,7 +165,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_FearGas</defName>
 					<label>60mm mortar shell (Fear)</label>
 					<graphicData>
@@ -200,7 +200,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs</xpath>
 				<value>
-					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBaseCraftableBase">
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="60mmMortarShellBase">
 					<defName>Shell_60mmMortar_AcidGas</defName>
 					<label>60mm mortar shell (Acid)</label>
 					<graphicData>


### PR DESCRIPTION
## Changes

- What it says on the tin, the parentName for the patched-in 60mm shells was incorrect.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
