### PR TITLE
fix some save-load bugs

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -426,7 +426,6 @@ namespace CombatExtended
         {
             base.ExposeData();
 
-            Log.Message(this.ThingID);
             if (Scribe.mode == LoadSaveMode.Saving && launcher != null && launcher.Destroyed)
             {
                 launcher = null;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -1267,13 +1267,9 @@ namespace CombatExtended
                 float dangerAmount = 0f;
                 var dir = new float?(origin.AngleTo(Vec2Position()));
 
-                Log.Message("1");
                 // Opt-out for things without explosionRadius
                 if (def.projectile.explosionRadius > 0f)
                 {
-                    Log.Message("2");
-                    Log.Message(Map.ToString());
-                    Log.Message(explodePos.ToString());
                     GenExplosionCE.DoExplosion(
                         explodePos.ToIntVec3(),
                         Map,

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -426,6 +426,7 @@ namespace CombatExtended
         {
             base.ExposeData();
 
+            Log.Message(this.ThingID);
             if (Scribe.mode == LoadSaveMode.Saving && launcher != null && launcher.Destroyed)
             {
                 launcher = null;
@@ -448,16 +449,9 @@ namespace CombatExtended
             Scribe_Values.Look<bool>(ref logMisses, "logMisses", true);
             Scribe_Values.Look<bool>(ref castShadow, "castShadow", true);
 
+            //To fix landed grenades sl problem
+            Scribe_Values.Look(ref impactPosition, "impactPosition");
             // To insure saves don't get affected..
-            Thing target = null;
-            if (Scribe.mode != LoadSaveMode.Saving)
-            {
-                Scribe_References.Look<Thing>(ref target, "intendedTarget");
-                if (target != null)
-                {
-                    intendedTarget = new LocalTargetInfo(target);
-                }
-            }
         }
         #endregion
 
@@ -1273,9 +1267,13 @@ namespace CombatExtended
                 float dangerAmount = 0f;
                 var dir = new float?(origin.AngleTo(Vec2Position()));
 
+                Log.Message("1");
                 // Opt-out for things without explosionRadius
                 if (def.projectile.explosionRadius > 0f)
                 {
+                    Log.Message("2");
+                    Log.Message(Map.ToString());
+                    Log.Message(explodePos.ToString());
                     GenExplosionCE.DoExplosion(
                         explodePos.ToIntVec3(),
                         Map,

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -18,6 +18,7 @@ namespace CombatExtended
         }
         public override void Tick()
         {
+            Log.Message(ExactPosition.ToString());
             base.Tick();
             if (this.ticksToDetonation > 0)
             {

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -18,7 +18,6 @@ namespace CombatExtended
         }
         public override void Tick()
         {
-            Log.Message(ExactPosition.ToString());
             base.Tick();
             if (this.ticksToDetonation > 0)
             {


### PR DESCRIPTION
## Reasoning

the removed code in projectileCE's exposeData is causing redletters when a projectile aimed at ground is saved and loaded.

Added scribe for impactPosition because the lack of it caused grenades fail to detonate if they're saved and loaded when landed.

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
