### PR TITLE
Fix a bug when swapping weapons

### DIFF
--- a/Source/CombatExtended/CombatExtended/AI/Comps/CompReload.cs
+++ b/Source/CombatExtended/CombatExtended/AI/Comps/CompReload.cs
@@ -24,7 +24,7 @@ namespace CombatExtended.AI
             }
 
             // if out of ammo
-            if (verb.EquipmentSource == CurrentWeapon && !gun.HasAmmo)
+            if (verb.EquipmentSource == CurrentWeapon && gun.UseAmmo && !gun.HasAmmo)
             {
                 CompInventory.SwitchToNextViableWeapon(true, useAOE: !SelPawn.Faction.IsPlayer, stopJob: false);
                 return false;


### PR DESCRIPTION
## Changes

- If the ammo system is disabled, and a pawn tries to fire a weapon that is out of ammo, they will stow their weapon instead of reloading. This patch fixes this behavior.

## References

- Closes #1461

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (A couple hours + 1 micro heavy siege, and no one unequipped their weapon)

## Steps to Reproduce
* Disable the ammo system
* Draft a pawn
* Equip them with a gun (like an assault rifle)
* Give them an attack order so they drain their ammo
* When they run out of ammo, they will automatically attempt to reload
  * Interrupt them by issuing a move order
* Give them another attack command, while they have no ammo
  * They will automatically stow their weapon instead of reloading