### PR TITLE
Fix mid burst bug

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -916,7 +916,9 @@ namespace CombatExtended
         /// <returns>True for successful shot, false otherwise</returns>
         public override bool TryCastShot()
         {
-            Retarget();
+            Log.Message("====================");
+            Log.Message("retarget?" + Retarget().ToString());
+            Log.Message("CurTarget" + currentTarget.ToString());
             repeating = true;
             doRetarget = true;
             storedShotReduction = null;
@@ -958,6 +960,7 @@ namespace CombatExtended
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);
             bool pelletMechanicsOnly = false;
+            Log.Message("FiringWithoutTarget?" + firingWithoutTarget.ToString());
             for (int i = 0; i < projectilePropsCE.pelletCount; i++)
             {
                 if (firingWithoutTarget)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -960,6 +960,20 @@ namespace CombatExtended
             bool pelletMechanicsOnly = false;
             for (int i = 0; i < projectilePropsCE.pelletCount; i++)
             {
+                if (firingWithoutTarget)
+                {
+                    //cease fire if targeting mode is not suppressive and target is null
+                    if (CompFireModes != null && (CompFireModes?.CurrentAimMode == AimMode.AimedShot || CompFireModes?.CurrentAimMode == AimMode.Snapshot))
+                    {
+                        return false;
+                    }
+
+
+                    shotAngle = lastShotAngle;
+                    shotRotation = lastShotRotation;
+                    GetSwayVec(ref shotRotation, ref shotAngle);
+                    GetRecoilVec(ref shotRotation, ref shotAngle);
+                }
 
                 ProjectileCE projectile = (ProjectileCE)ThingMaker.MakeThing(Projectile, null);
                 GenSpawn.Spawn(projectile, shootLine.Source, caster.Map);
@@ -973,19 +987,7 @@ namespace CombatExtended
                 projectile.intendedTarget = currentTarget;
                 projectile.mount = caster.Position.GetThingList(caster.Map).FirstOrDefault(t => t is Pawn && t != caster);
                 projectile.AccuracyFactor = report.accuracyFactor * report.swayDegrees * ((numShotsFired + 1) * 0.75f);
-                if (firingWithoutTarget)
-                {
-                    //cease fire if targeting mode is not suppressive and target is null
-                    if (CompFireModes != null && (CompFireModes?.CurrentAimMode == AimMode.AimedShot || CompFireModes?.CurrentAimMode == AimMode.Snapshot))
-                    {
-                        return false;
-                    }
 
-                    shotAngle = lastShotAngle;
-                    shotRotation = lastShotRotation;
-                    GetSwayVec(ref shotRotation, ref shotAngle);
-                    GetRecoilVec(ref shotRotation, ref shotAngle);
-                }
                 this.lastShotAngle = shotAngle;
                 this.lastShotRotation = shotRotation;
                 this.lastShootLine = shootLine;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -845,7 +845,6 @@ namespace CombatExtended
             {
                 return true;
             }
-            Log.Message("a");
             doRetarget = false;
             if (currentTarget != lastTarget)
             {
@@ -854,12 +853,10 @@ namespace CombatExtended
                 shootingAtDowned = currentTarget.Pawn?.Downed ?? true;
                 return true;
             }
-            Log.Message("b");
             if (shootingAtDowned)
             {
                 return true;
             }
-            Log.Message("c");
             if (currentTarget.Pawn == null || currentTarget.Pawn.Downed || !CanHitFromCellIgnoringRange(Caster.Position, currentTarget, out IntVec3 _))
             {
                 Log.Message("retargeting");
@@ -927,16 +924,17 @@ namespace CombatExtended
             repeating = true;
             doRetarget = true;
             storedShotReduction = null;
-            bool firingSuppresively = false;
             if (!TryFindCEShootLineFromTo(caster.Position, currentTarget, out var shootLine)) // If we are mid burst & suppressive & target is unreachable but alive, keep shooting suppressively.
             {
                 if (numShotsFired == 0 || (CompFireModes != null && CompFireModes.CurrentAimMode != AimMode.SuppressFire) || currentTarget.ThingDestroyed)
                 {
+                    Log.Message("don'tfireSuppresively");
                     return false;
                 }
                 shootLine = lastShootLine;
-                firingSuppresively = true;
                 currentTarget = new LocalTargetInfo(lastTargetPos);
+
+                Log.Message("firingSuppresively");
                 if (!currentTarget.IsValid)
                 {
                     return false;
@@ -961,7 +959,6 @@ namespace CombatExtended
 
             ShiftVecReport report = ShiftVecReportFor(currentTarget);
             bool pelletMechanicsOnly = false;
-            Log.Message("FiringWithoutTarget?" + firingSuppresively.ToString());
             for (int i = 0; i < projectilePropsCE.pelletCount; i++)
             {
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -859,7 +859,6 @@ namespace CombatExtended
             }
             if (currentTarget.Pawn == null || currentTarget.Pawn.Downed || !CanHitFromCellIgnoringRange(Caster.Position, currentTarget, out IntVec3 _))
             {
-                Log.Warning("retargeting");
                 Pawn newTarget = null;
                 Thing caster = Caster;
 
@@ -868,7 +867,6 @@ namespace CombatExtended
                 {
                     if ((possibleTarget.Faction == currentTarget.Pawn?.Faction) && possibleTarget.Faction.HostileTo(caster.Faction) && !possibleTarget.Downed && CanHitFromCellIgnoringRange(Caster.Position, possibleTarget, out IntVec3 dest))
                     {
-                        Log.Message("retarget find pawn");
                         newTarget = possibleTarget;
                         break;
                     }
@@ -918,9 +916,7 @@ namespace CombatExtended
         /// <returns>True for successful shot, false otherwise</returns>
         public override bool TryCastShot()
         {
-            Log.Message("====================");
             Retarget();
-            Log.Message("CurTarget" + currentTarget.ToString());
             repeating = true;
             doRetarget = true;
             storedShotReduction = null;
@@ -928,13 +924,11 @@ namespace CombatExtended
             {
                 if (numShotsFired == 0 || (CompFireModes != null && CompFireModes.CurrentAimMode != AimMode.SuppressFire) || currentTarget.ThingDestroyed)
                 {
-                    Log.Message("don'tfireSuppresively");
                     return false;
                 }
                 shootLine = lastShootLine;
                 currentTarget = new LocalTargetInfo(lastTargetPos);
 
-                Log.Warning("firingSuppresively");
                 if (!currentTarget.IsValid)
                 {
                     return false;

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -841,11 +841,13 @@ namespace CombatExtended
 
         protected bool Retarget()
         {
+            Log.Message("doRetarget?" + doRetarget.ToString());
             if (!doRetarget)
             {
                 return true;
             }
             doRetarget = false;
+            Log.Message("should retarget");
             if (currentTarget != lastTarget)
             {
                 lastTarget = currentTarget;
@@ -859,6 +861,7 @@ namespace CombatExtended
             }
             if (currentTarget.Pawn?.Downed ?? true)
             {
+                Log.Message("retargeting");
                 Pawn newTarget = null;
                 Thing caster = Caster;
 
@@ -867,6 +870,7 @@ namespace CombatExtended
                 {
                     if ((possibleTarget.Faction == currentTarget.Pawn?.Faction) && possibleTarget.Faction.HostileTo(caster.Faction) && !possibleTarget.Downed && CanHitFromCellIgnoringRange(Caster.Position, possibleTarget, out IntVec3 dest))
                     {
+                        Log.Message("retarget find pawn");
                         newTarget = possibleTarget;
                         break;
                     }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -859,7 +859,7 @@ namespace CombatExtended
             }
             if (currentTarget.Pawn == null || currentTarget.Pawn.Downed || !CanHitFromCellIgnoringRange(Caster.Position, currentTarget, out IntVec3 _))
             {
-                Log.Message("retargeting");
+                Log.Warning("retargeting");
                 Pawn newTarget = null;
                 Thing caster = Caster;
 
@@ -934,7 +934,7 @@ namespace CombatExtended
                 shootLine = lastShootLine;
                 currentTarget = new LocalTargetInfo(lastTargetPos);
 
-                Log.Message("firingSuppresively");
+                Log.Warning("firingSuppresively");
                 if (!currentTarget.IsValid)
                 {
                     return false;


### PR DESCRIPTION
## Changes

Put the firingWithoutTarget code in front of projectile makeThing.

## Reasoning

Before this change, the trycastshot code aborts shooting when the target is gone and not in suppress mode *after* the projectile thing was made. Which is normally harmless as the projectile dissolves itself when out of bound. However, under the circumstanse of there're any obstacle between the last target location and (-inf,-inf), a red letter appears as the newly-made-still-in-chamber bullet tries to collide before it dies.
By moving the abortion code in front of projectile make thing, the launch process is aborted before projectile is given birth, fixing this red letter.

## Alternatives

Suffer.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
