### PR TITLE
Biotech charge blaster turret accuracy tweak

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
@@ -7,7 +7,7 @@
     <defName>Gun_ChargeBlasterTurret</defName>
     <statBases>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.2</ShotSpread>
+      <ShotSpread>0.2</ShotSpread> <!-- Manually adjusted from 0.08 due to accuracy concerns. -->
       <SwayFactor>0.56</SwayFactor>
       <Bulk>6.00</Bulk>
     </statBases>

--- a/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Weapons/RangedMechanoid_Turret.xml
@@ -7,7 +7,7 @@
     <defName>Gun_ChargeBlasterTurret</defName>
     <statBases>
       <SightsEfficiency>1</SightsEfficiency>
-      <ShotSpread>0.08</ShotSpread>
+      <ShotSpread>0.2</ShotSpread>
       <SwayFactor>0.56</SwayFactor>
       <Bulk>6.00</Bulk>
     </statBases>


### PR DESCRIPTION
## Changes

- Increased the spread of the mounted charge blaster turret from biotech to 0.2.

## Reasoning

- It's not affected by the accuracy stats of the mech it's mounted on and it's pretty accurate with 0.08 spread, 0.2 degrees of spread should make it less accurate as it seems like it has aimbot or something...

## Alternatives

- Let players mald about the accuracy.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
