### PR TITLE
Fixed .22 Short's mass and bulk values + some spelling corrections

### DIFF
--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -26,8 +26,8 @@
 	<ThingDef Class="CombatExtended.AmmoDef" Name="22ShortBase" ParentName="SmallAmmoBase" Abstract="True">
 		<description>Ultra-light cartridge originally designed for self-defense, but now very obsolete.</description>
 		<statBases>
-			<Mass>0.01</Mass>
-			<Bulk>0.004</Bulk>
+			<Mass>0.004</Mass>
+			<Bulk>0.01</Bulk>
 		</statBases>
 		<tradeTags>
 			<li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -27,7 +27,7 @@
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="280BritishBase" ParentName="SmallAmmoBase" Abstract="True">
-		<description>An experimental rimless bottlenecked intermediate rifle cartrdige.</description>
+		<description>An experimental rimless bottlenecked intermediate rifle cartridge.</description>
 		<statBases>
 			<Mass>0.023</Mass>
 			<Bulk>0.03</Bulk>

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -27,7 +27,7 @@
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="485x49mmBase" ParentName="SmallAmmoBase" Abstract="True">
-		<description>Prototype intermediate rifle cartridge used various small arms.</description>
+		<description>Prototype intermediate rifle cartridge used in various small arms.</description>
 		<statBases>
 			<Mass>0.012</Mass>
 			<Bulk>0.02</Bulk>


### PR DESCRIPTION
## Changes
Fixed .22 Short's mass and bulk values being backwards. Also corrected some small grammar issues.

## References
Projectile sheet: https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning
It's a fix, .22 Short was too heavy and not bulky enough (as if it matters, but still)

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors