### PR TITLE
Update and fix ATR's patch

### DIFF
--- a/Patches/Android Tiers Reforged/Ammo/81mmMortar_SwarmShell.xml
+++ b/Patches/Android Tiers Reforged/Ammo/81mmMortar_SwarmShell.xml
@@ -149,6 +149,10 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/TraderKindDef[defName="ATR_Orbital_Mechanized"]/stockGenerators/li[thingDef="ATR_MicroscytherShell"]</xpath>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Android Tiers Reforged/ThingDef_Misc/Apparel_Packs.xml
+++ b/Patches/Android Tiers Reforged/ThingDef_Misc/Apparel_Packs.xml
@@ -31,15 +31,6 @@
 					</value>
 				</li>
 
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="ATR_OrbitalTargeterMechFall"]</xpath>
-					<value>
-						<statBases>
-							<Bulk>1</Bulk>
-						</statBases> 
-					</value>
-				</li>
-
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers Reforged/ThingDef_Races/AlienRace_Androids.xml
@@ -50,33 +50,11 @@
 					</nomatch>
 				</li>
 
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_Tier5Android"]/comps</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_Tier5Android"]</xpath>
-						<value>
-							<comps/>
-						</value>
-					</nomatch>
-				</li>
-
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_M7Mech"]/comps</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_M7Mech"]</xpath>
-						<value>
-							<comps/>
-						</value>
-					</nomatch>
-				</li>
-
 				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_Tier1Android" or 
 							defName="ATR_Tier2Android" or
 							defName="ATR_Tier3Android" or
-							defName="ATR_Tier4Android" or
-							defName="ATR_Tier5Android" or
-							defName="ATR_M7Mech"
+							defName="ATR_Tier4Android"
 							]</xpath>
 					<value>
 						<li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -89,9 +67,7 @@
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="ATR_Tier1Android" or 
 							defName="ATR_Tier2Android" or
 							defName="ATR_Tier3Android" or
-							defName="ATR_Tier4Android" or
-							defName="ATR_Tier5Android" or
-							defName="ATR_M7Mech"
+							defName="ATR_Tier4Android"
 							]/comps</xpath>
 					<value>
 						<li>

--- a/Patches/Android Tiers Reforged/TraderKindDefs/Android_TraderKinds.xml
+++ b/Patches/Android Tiers Reforged/TraderKindDefs/Android_TraderKinds.xml
@@ -274,6 +274,57 @@
 					</value>
 				</li>
 
+				<!-- Orbital Mechanized Trader -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/TraderKindDef[defName="ATR_Orbital_Mechanized"]/stockGenerators</xpath>
+					<value>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_Ammo</tradeTag>
+							<countRange>
+								<min>400</min>
+								<max>1000</max>
+							</countRange>
+							<price>Cheap</price>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>4</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_MediumAmmo</tradeTag>
+							<countRange>
+								<min>60</min>
+								<max>120</max>
+							</countRange>
+							<price>Cheap</price>
+							<thingDefCountRange>
+								<min>4</min>
+								<max>7</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Tag">
+							<tradeTag>CE_HeavyAmmo</tradeTag>
+							<countRange>
+								<min>15</min>
+								<max>50</max>
+							</countRange>
+							<price>Cheap</price>
+							<thingDefCountRange>
+								<min>2</min>
+								<max>4</max>
+							</thingDefCountRange>
+						</li>
+						<li Class="StockGenerator_Category">
+							<categoryDef>Ammo</categoryDef>
+							<thingDefCountRange>
+								<min>0</min>
+								<max>0</max>
+							</thingDefCountRange>
+						</li>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
## Changes

- What it says on the tin, the orbital trader needed patching and fixing and there were remaining stuff from the migrated races.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony
