### PR TITLE
Add new calibers + some additional multi-caliber compatibility

### DIFF
--- a/Defs/Ammo/Pistols/17HMR.xml
+++ b/Defs/Ammo/Pistols/17HMR.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo17HMR</defName>
+		<label>.17 HMR</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_17HMR</defName>
+		<label>.17 HMR</label>
+		<ammoTypes>
+			<Ammo_17HMR_FMJ>Bullet_17HMR_FMJ</Ammo_17HMR_FMJ>
+			<Ammo_17HMR_AP>Bullet_17HMR_AP</Ammo_17HMR_AP>
+			<Ammo_17HMR_HP>Bullet_17HMR_HP</Ammo_17HMR_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="17HMRBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>A necked down .22 Magnum cartridge using a .17 caliber bullet, known for its high speed.</description>
+		<statBases>
+			<Mass>0.004</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo17HMR</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
+		<defName>Ammo_17HMR_FMJ</defName>
+		<label>.17 HMR cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.03</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_17HMR_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
+		<defName>Ammo_17HMR_AP</defName>
+		<label>.17 HMR cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.03</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_17HMR_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="17HMRBase">
+		<defName>Ammo_17HMR_HP</defName>
+		<label>.17 HMR cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.03</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_17HMR_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base17HMRBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>153</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base17HMRBullet">
+		<defName>Bullet_17HMR_FMJ</defName>
+		<label>.17 HMR bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base17HMRBullet">
+		<defName>Bullet_17HMR_AP</defName>
+		<label>.17 HMR bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>4</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base17HMRBullet">
+		<defName>Bullet_17HMR_HP</defName>
+		<label>.17 HMR bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_17HMR_FMJ</defName>
+		<label>make .17 HMR cartridge x500</label>
+		<description>Craft 500 .17 HMR cartridges.</description>
+		<jobString>Making .17 HMR cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_17HMR_FMJ>500</Ammo_17HMR_FMJ>
+		</products>
+		<workAmount>600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_17HMR_AP</defName>
+		<label>make .17 HMR (AP) cartridge x500</label>
+		<description>Craft 500 .17 HMR (AP) cartridges.</description>
+		<jobString>Making .17 HMR (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_17HMR_AP>500</Ammo_17HMR_AP>
+		</products>
+		<workAmount>720</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_17HMR_HP</defName>
+		<label>make .17 HMR (HP) cartridge x500</label>
+		<description>Craft 500 .17 HMR (HP) cartridges.</description>
+		<jobString>Making .17 HMR (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_17HMR_HP>500</Ammo_17HMR_HP>
+		</products>
+		<workAmount>600</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/22Hornet.xml
+++ b/Defs/Ammo/Pistols/22Hornet.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo22Hornet</defName>
+		<label>.22 Hornet</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_22Hornet</defName>
+		<label>.22 Hornet</label>
+		<ammoTypes>
+			<Ammo_22Hornet_FMJ>Bullet_22Hornet_FMJ</Ammo_22Hornet_FMJ>
+			<Ammo_22Hornet_AP>Bullet_22Hornet_AP</Ammo_22Hornet_AP>
+			<Ammo_22Hornet_HP>Bullet_22Hornet_HP</Ammo_22Hornet_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="22HornetBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>One of the earliest (and fastest) .22 caliber centerfire cartridges.</description>
+		<statBases>
+			<Mass>0.007</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo22Hornet</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
+		<defName>Ammo_22Hornet_FMJ</defName>
+		<label>.22 Hornet cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_22Hornet_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
+		<defName>Ammo_22Hornet_AP</defName>
+		<label>.22 Hornet cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_22Hornet_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22HornetBase">
+		<defName>Ammo_22Hornet_HP</defName>
+		<label>.22 Hornet cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_22Hornet_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base22HornetBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>173</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base22HornetBullet">
+		<defName>Bullet_22Hornet_FMJ</defName>
+		<label>.22 Hornet bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>22.24</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base22HornetBullet">
+		<defName>Bullet_22Hornet_AP</defName>
+		<label>.22 Hornet bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>22.24</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base22HornetBullet">
+		<defName>Bullet_22Hornet_HP</defName>
+		<label>.22 Hornet bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>22.24</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22Hornet_FMJ</defName>
+		<label>make .22 Hornet cartridge x500</label>
+		<description>Craft 500 .22 Hornet cartridges.</description>
+		<jobString>Making .22 Hornet cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22Hornet_FMJ>500</Ammo_22Hornet_FMJ>
+		</products>
+		<workAmount>800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22Hornet_AP</defName>
+		<label>make .22 Hornet (AP) cartridge x500</label>
+		<description>Craft 500 .22 Hornet (AP) cartridges.</description>
+		<jobString>Making .22 Hornet (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22Hornet_AP>500</Ammo_22Hornet_AP>
+		</products>
+		<workAmount>960</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22Hornet_HP</defName>
+		<label>make .22 Hornet (HP) cartridge x500</label>
+		<description>Craft 500 .22 Hornet (HP) cartridges.</description>
+		<jobString>Making .22 Hornet (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22Hornet_HP>500</Ammo_22Hornet_HP>
+		</products>
+		<workAmount>800</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/22WMR.xml
+++ b/Defs/Ammo/Pistols/22WMR.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo22WMR</defName>
+		<label>.22 WMR</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_22WMR</defName>
+		<label>.22 WMR</label>
+		<ammoTypes>
+			<Ammo_22WMR_FMJ>Bullet_22WMR_FMJ</Ammo_22WMR_FMJ>
+			<Ammo_22WMR_AP>Bullet_22WMR_AP</Ammo_22WMR_AP>
+			<Ammo_22WMR_HP>Bullet_22WMR_HP</Ammo_22WMR_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="22WMRBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Common rimfire cartridge with noticebly more power than most other .22 rimfire rounds.</description>
+		<statBases>
+			<Mass>0.006</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo22WMR</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
+		<defName>Ammo_22WMR_FMJ</defName>
+		<label>.22 WMR cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_22WMR_FMJ</cookOffProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
+		<defName>Ammo_22WMR_AP</defName>
+		<label>.22 WMR cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_22WMR_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="22WMRBase">
+		<defName>Ammo_22WMR_HP</defName>
+		<label>.22 WMR cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.04</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_22WMR_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base22WMRBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>114</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base22WMRBullet">
+		<defName>Bullet_22WMR_FMJ</defName>
+		<label>.22 WMR bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>8.32</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="Base22WMRBullet">
+		<defName>Bullet_22WMR_AP</defName>
+		<label>.22 WMR bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>5</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>8.32</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base22WMRBullet">
+		<defName>Bullet_22WMR_HP</defName>
+		<label>.22 WMR bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>8.32</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22WMR_FMJ</defName>
+		<label>make .22 WMR (FMJ) cartridge x500</label>
+		<description>Craft 500 .22 WMR (FMJ) cartridges.</description>
+		<jobString>Making .22 WMR (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22WMR_FMJ>500</Ammo_22WMR_FMJ>
+		</products>
+		<workAmount>800</workAmount>
+	</RecipeDef>
+	
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22WMR_AP</defName>
+		<label>make .22 WMR (AP) cartridge x500</label>
+		<description>Craft 500 .22 WMR (AP) cartridges.</description>
+		<jobString>Making .22 WMR (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22WMR_AP>500</Ammo_22WMR_AP>
+		</products>
+		<workAmount>960</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_22WMR_HP</defName>
+		<label>make .22 WMR (HP) cartridge x500</label>
+		<description>Craft 500 .22 WMR (HP) cartridges.</description>
+		<jobString>Making .22 WMR (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_22WMR_HP>500</Ammo_22WMR_HP>
+		</products>
+		<workAmount>800</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/38-200SW.xml
+++ b/Defs/Ammo/Pistols/38-200SW.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo38200SW</defName>
+		<label>.38/200 S&amp;W</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_38200SW</defName>
+		<label>.38/200 S&amp;W</label>
+		<ammoTypes>
+			<Ammo_38200SW_FMJ>Bullet_38200SW_FMJ</Ammo_38200SW_FMJ>
+			<Ammo_38200SW_AP>Bullet_38200SW_AP</Ammo_38200SW_AP>
+			<Ammo_38200SW_HP>Bullet_38200SW_HP</Ammo_38200SW_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="38200SWBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Low caliber handgun cartridge used mostly in revolvers.</description>
+		<statBases>
+			<Mass>0.015</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo38200SW</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38200SWBase">
+		<defName>Ammo_38200SW_FMJ</defName>
+		<label>.38/200 S&amp;W cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.06</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_38200SW_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38200SWBase">
+		<defName>Ammo_38200SW_AP</defName>
+		<label>.38/200 S&amp;W cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.06</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_38200SW_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38200SWBase">
+		<defName>Ammo_38200SW_HP</defName>
+		<label>.38/200 S&amp;W cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.06</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_38200SW_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base38200SWBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>47</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38200SWBullet">
+		<defName>Bullet_38200SW_FMJ</defName>
+		<label>8mm Nambu bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.48</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38200SWBullet">
+		<defName>Bullet_38200SW_AP</defName>
+		<label>.38/200 S&amp;W bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>5</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.48</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38200SWBullet">
+		<defName>Bullet_38200SW_HP</defName>
+		<label>.38/200 S&amp;W bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>1.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.48</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38200SW_FMJ</defName>
+		<label>make .38/200 S&amp;W (FMJ) cartridge x500</label>
+		<description>Craft 500 .38/200 S&amp;W (FMJ) cartridges.</description>
+		<jobString>Making .38/200 S&amp;W (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38200SW_FMJ>500</Ammo_38200SW_FMJ>
+		</products>
+		<workAmount>1400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38200SW_AP</defName>
+		<label>make .38/200 S&amp;W (AP) cartridge x500</label>
+		<description>Craft 500 .38/200 S&amp;W (AP) cartridges.</description>
+		<jobString>Making .38/200 S&amp;W (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38200SW_AP>500</Ammo_38200SW_AP>
+		</products>
+		<workAmount>1680</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38200SW_HP</defName>
+		<label>make .38/200 S&amp;W (HP) cartridge x500</label>
+		<description>Craft 500 .38/200 S&amp;W (HP) cartridges.</description>
+		<jobString>Making .38/200 S&amp;W (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>14</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38200SW_HP>500</Ammo_38200SW_HP>
+		</products>
+		<workAmount>1400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/38Super.xml
+++ b/Defs/Ammo/Pistols/38Super.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo38Super</defName>
+		<label>.38 Super</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_38Super</defName>
+		<label>.38 Super</label>
+		<ammoTypes>
+			<Ammo_38Super_FMJ>Bullet_38Super_FMJ</Ammo_38Super_FMJ>
+			<Ammo_38Super_AP>Bullet_38Super_AP</Ammo_38Super_AP>
+			<Ammo_38Super_HP>Bullet_38Super_HP</Ammo_38Super_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="38SuperBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Dimensionally identical to the .38 ACP cartridge, but with a much higher pressure powder load for more powerful handguns.</description>
+		<statBases>
+			<Mass>0.014</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo38Super</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
+		<defName>Ammo_38Super_FMJ</defName>
+		<label>.38 Super cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.07</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_38Super_FMJ</cookOffProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
+		<defName>Ammo_38Super_AP</defName>
+		<label>.38 Super cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.07</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_38Super_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="38SuperBase">
+		<defName>Ammo_38Super_HP</defName>
+		<label>.38 Super cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.07</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_38Super_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base38SuperBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>86</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38SuperBullet">
+		<defName>Bullet_38Super_FMJ</defName>
+		<label>.38 Super bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationBlunt>14.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+	
+	<ThingDef ParentName="Base38SuperBullet">
+		<defName>Bullet_38Super_AP</defName>
+		<label>.38 Super bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>14.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base38SuperBullet">
+		<defName>Bullet_38Super_HP</defName>
+		<label>.38 Super bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>14.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38Super_FMJ</defName>
+		<label>make .38 Super (FMJ) cartridge x500</label>
+		<description>Craft 500 .38 Super (FMJ) cartridges.</description>
+		<jobString>Making .38 Super (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38Super_FMJ>500</Ammo_38Super_FMJ>
+		</products>
+		<workAmount>1600</workAmount>
+	</RecipeDef>
+	
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38Super_AP</defName>
+		<label>make .38 Super (AP) cartridge x500</label>
+		<description>Craft 500 .38 Super (AP) cartridges.</description>
+		<jobString>Making .38 Super (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38Super_AP>500</Ammo_38Super_AP>
+		</products>
+		<workAmount>1920</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_38Super_HP</defName>
+		<label>make .38 Super (HP) cartridge x500</label>
+		<description>Craft 500 .38 Super (HP) cartridges.</description>
+		<jobString>Making .38 Super (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>16</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_38Super_HP>500</Ammo_38Super_HP>
+		</products>
+		<workAmount>1600</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/41AE.xml
+++ b/Defs/Ammo/Pistols/41AE.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo41AE</defName>
+		<label>.41 AE</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_41AE</defName>
+		<label>.41 AE</label>
+		<ammoTypes>
+			<Ammo_41AE_FMJ>Bullet_41AE_FMJ</Ammo_41AE_FMJ>
+			<Ammo_41AE_AP>Bullet_41AE_AP</Ammo_41AE_AP>
+			<Ammo_41AE_HP>Bullet_41AE_HP</Ammo_41AE_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="41AEBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Shortened .41 Magnum cartridge designed for semi-auto pistols, similar to the .40 S&amp;W but much less successful.</description>
+		<statBases>
+			<Mass>0.016</Mass>
+			<Bulk>0.01</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo41AE</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41AEBase">
+		<defName>Ammo_41AE_FMJ</defName>
+		<label>.41 AE cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_41AE_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41AEBase">
+		<defName>Ammo_41AE_AP</defName>
+		<label>.41 AE cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_41AE_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41AEBase">
+		<defName>Ammo_41AE_HP</defName>
+		<label>.41 AE cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_41AE_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base41AEBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>58</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41AEBullet">
+		<defName>Bullet_41AE_FMJ</defName>
+		<label>.41 AE bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.26</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41AEBullet">
+		<defName>Bullet_41AE_AP</defName>
+		<label>.41 AE bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>7</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.26</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41AEBullet">
+		<defName>Bullet_41AE_HP</defName>
+		<label>.41 AE bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.26</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41AE_FMJ</defName>
+		<label>make .41 AE cartridge x500</label>
+		<description>Craft 500 .41 AE cartridges.</description>
+		<jobString>Making .41 AE cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41AE_FMJ>500</Ammo_41AE_FMJ>
+		</products>
+		<workAmount>1800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41AE_AP</defName>
+		<label>make .41 AE (AP) cartridge x500</label>
+		<description>Craft 500 .41 AE (AP) cartridges.</description>
+		<jobString>Making .41 AE (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41AE_AP>500</Ammo_41AE_AP>
+		</products>
+		<workAmount>2160</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41AE_HP</defName>
+		<label>make .41 AE (HP) cartridge x500</label>
+		<description>Craft 500 .41 AE (HP) cartridges.</description>
+		<jobString>Making .41 AE (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41AE_HP>500</Ammo_41AE_HP>
+		</products>
+		<workAmount>1800</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/41Magnum.xml
+++ b/Defs/Ammo/Pistols/41Magnum.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo41Magnum</defName>
+		<label>.41 Magnum</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_41Magnum</defName>
+		<label>.41 Magnum</label>
+		<ammoTypes>
+			<Ammo_41Magnum_FMJ>Bullet_41Magnum_FMJ</Ammo_41Magnum_FMJ>
+			<Ammo_41Magnum_AP>Bullet_41Magnum_AP</Ammo_41Magnum_AP>
+			<Ammo_41Magnum_HP>Bullet_41Magnum_HP</Ammo_41Magnum_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="41MagnumBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Rare magnum revolver cartridge designed to sit between the .357 and .44 Magnum rounds in terms of performance, but never as successful as either.</description>
+		<statBases>
+			<Mass>0.023</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo41Magnum</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41MagnumBase">
+		<defName>Ammo_41Magnum_FMJ</defName>
+		<label>.41 Magnum cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_41Magnum_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41MagnumBase">
+		<defName>Ammo_41Magnum_AP</defName>
+		<label>.41 Magnum cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_41Magnum_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="41MagnumBase">
+		<defName>Ammo_41Magnum_HP</defName>
+		<label>.41 Magnum cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_41Magnum_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base41MagnumBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>76</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41MagnumBullet">
+		<defName>Bullet_41Magnum_FMJ</defName>
+		<label>.41 Magnum bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41MagnumBullet">
+		<defName>Bullet_41Magnum_AP</defName>
+		<label>.41 Magnum bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base41MagnumBullet">
+		<defName>Bullet_41Magnum_HP</defName>
+		<label>.41 Magnum bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41Magnum_FMJ</defName>
+		<label>make .41 Magnum cartridge x500</label>
+		<description>Craft 500 .41 Magnum cartridges.</description>
+		<jobString>Making .41 Magnum cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41Magnum_FMJ>500</Ammo_41Magnum_FMJ>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41Magnum_AP</defName>
+		<label>make .41 Magnum (AP) cartridge x500</label>
+		<description>Craft 500 .41 Magnum (AP) cartridges.</description>
+		<jobString>Making .41 Magnum (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41Magnum_AP>500</Ammo_41Magnum_AP>
+		</products>
+		<workAmount>2880</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_41Magnum_HP</defName>
+		<label>make .41 Magnum (HP) cartridge x500</label>
+		<description>Craft 500 .41 Magnum (HP) cartridges.</description>
+		<jobString>Making .41 Magnum (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_41Magnum_HP>500</Ammo_41Magnum_HP>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -31,6 +31,20 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
+  
+  <CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_44Magnum_Revolver</defName>
+		<label>.44 Magnum</label>
+		<ammoTypes>
+			<Ammo_44Magnum_FMJ>Bullet_44Magnum_FMJ</Ammo_44Magnum_FMJ>
+			<Ammo_44Magnum_AP>Bullet_44Magnum_AP</Ammo_44Magnum_AP>
+			<Ammo_44Magnum_HP>Bullet_44Magnum_HP</Ammo_44Magnum_HP>
+      <Ammo_44SWSpecial_FMJ>Bullet_44SWSpecial_FMJ</Ammo_44SWSpecial_FMJ>
+      <Ammo_44SWSpecial_AP>Bullet_44SWSpecial_AP</Ammo_44SWSpecial_AP>
+      <Ammo_44SWSpecial_HP>Bullet_44SWSpecial_HP</Ammo_44SWSpecial_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -1,0 +1,208 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingCategoryDef>
+    <defName>Ammo44SWSpecial</defName>
+    <label>.44 S&amp;W Special</label>
+    <parent>AmmoPistols</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_44SWSpecial</defName>
+    <label>.44 S&amp;W Special</label>
+    <ammoTypes>
+      <Ammo_44SWSpecial_FMJ>Bullet_44SWSpecial_FMJ</Ammo_44SWSpecial_FMJ>
+      <Ammo_44SWSpecial_AP>Bullet_44SWSpecial_AP</Ammo_44SWSpecial_AP>
+      <Ammo_44SWSpecial_HP>Bullet_44SWSpecial_HP</Ammo_44SWSpecial_HP>
+    </ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="44SWSpecialBase" ParentName="SmallAmmoBase" Abstract="True">
+    <description>A centerfire pistol and revolver cartridge that was one of the first to be purposely designed for smokeless powder.</description>
+    <statBases>
+      <Mass>0.019</Mass>
+      <Bulk>0.02</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo44SWSpecial</li>
+    </thingCategories>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
+    <defName>Ammo_44SWSpecial_FMJ</defName>
+    <label>.44 S&amp;W Special cartridge (FMJ)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/FMJ</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.08</MarketValue>
+    </statBases>
+    <ammoClass>FullMetalJacket</ammoClass>
+    <cookOffProjectile>Bullet_44SWSpecial_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
+    <defName>Ammo_44SWSpecial_AP</defName>
+    <label>.44 S&amp;W Special cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.08</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_44SWSpecial_AP</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="44SWSpecialBase">
+    <defName>Ammo_44SWSpecial_HP</defName>
+    <label>.44 S&amp;W Special cartridge (HP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/HP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.08</MarketValue>
+    </statBases>
+    <ammoClass>HollowPoint</ammoClass>
+    <cookOffProjectile>Bullet_44SWSpecial_HP</cookOffProjectile>
+  </ThingDef>
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef Name="Base44SWSpecialBullet" ParentName="BaseBulletCE" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>54</speed>
+      <dropsCasings>true</dropsCasings>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base44SWSpecialBullet">
+    <defName>Bullet_44SWSpecial_FMJ</defName>
+    <label>.44 S&amp;W Special bullet (FMJ)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>11</damageAmountBase>
+      <armorPenetrationSharp>3</armorPenetrationSharp>
+      <armorPenetrationBlunt>9.48</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base44SWSpecialBullet">
+    <defName>Bullet_44SWSpecial_AP</defName>
+    <label>.44 S&amp;W Special bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>7</damageAmountBase>
+      <armorPenetrationSharp>6</armorPenetrationSharp>
+      <armorPenetrationBlunt>9.48</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base44SWSpecialBullet">
+    <defName>Bullet_44SWSpecial_HP</defName>
+    <label>.44 S&amp;W Special bullet (HP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>14</damageAmountBase>
+      <armorPenetrationSharp>1.5</armorPenetrationSharp>
+      <armorPenetrationBlunt>9.48</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <!-- Standard manufacture -->
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_44SWSpecial_FMJ</defName>
+    <label>make .44 S&amp;W Special (FMJ) cartridge x500</label>
+    <description>Craft 500 .44 S&amp;W Special (FMJ) cartridges.</description>
+    <jobString>Making .44 S&amp;W Special (FMJ) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_44SWSpecial_FMJ>500</Ammo_44SWSpecial_FMJ>
+    </products>
+    <workAmount>2000</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_44SWSpecial_AP</defName>
+    <label>make .44 S&amp;W Special (AP) cartridge x500</label>
+    <description>Craft 500 .44 S&amp;W Special (AP) cartridges.</description>
+    <jobString>Making .44 S&amp;W Special (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_44SWSpecial_AP>500</Ammo_44SWSpecial_AP>
+    </products>
+    <workAmount>2400</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_44SWSpecial_HP</defName>
+    <label>make .44 S&amp;W Special (HP) cartridge x500</label>
+    <description>Craft 500 .44 S&amp;W Special (HP) cartridges.</description>
+    <jobString>Making .44 S&amp;W Special (HP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>20</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_44SWSpecial_HP>500</Ammo_44SWSpecial_HP>
+    </products>
+    <workAmount>2000</workAmount>
+  </RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -20,6 +20,9 @@
 			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
 		</ammoTypes>
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -34,6 +37,9 @@
 			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
 			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
 			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -17,6 +17,9 @@
 			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
 		</ammoTypes>
 		<similarTo>AmmoSet_Pistol</similarTo>
 	</CombatExtended.AmmoSetDef>
@@ -54,6 +57,9 @@
 			<Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
 			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
 			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
 			<Ammo_410Bore_Buck>Bullet_410Bore_Buck_SB</Ammo_410Bore_Buck>
 			<Ammo_410Bore_Slug>Bullet_410Bore_Slug_SB</Ammo_410Bore_Slug>
 			<Ammo_410Bore_Beanbag>Bullet_410Bore_Beanbag_SB</Ammo_410Bore_Beanbag>

--- a/Defs/Ammo/Pistols/45Schofield.xml
+++ b/Defs/Ammo/Pistols/45Schofield.xml
@@ -1,0 +1,208 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingCategoryDef>
+    <defName>Ammo45Schofield</defName>
+    <label>.45 Schofield</label>
+    <parent>AmmoPistols</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+  </ThingCategoryDef>
+
+  <!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_45Schofield</defName>
+    <label>.45 Schofield</label>
+    <ammoTypes>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
+    </ammoTypes>
+		<similarTo>AmmoSet_Pistol</similarTo>
+  </CombatExtended.AmmoSetDef>
+
+  <!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="45SchofieldBase" ParentName="SmallAmmoBase" Abstract="True">
+    <description>Old school revolver cartridge designed for the frontier, very similar to the longer .45 Colt.</description>
+    <statBases>
+      <Mass>0.021</Mass>
+      <Bulk>0.02</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo45Schofield</li>
+    </thingCategories>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
+    <defName>Ammo_45Schofield_FMJ</defName>
+    <label>.45 Schofield cartridge (FMJ)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/FMJ</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>FullMetalJacket</ammoClass>
+    <cookOffProjectile>Bullet_45Schofield_FMJ</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
+    <defName>Ammo_45Schofield_AP</defName>
+    <label>.45 Schofield cartridge (AP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/AP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>ArmorPiercing</ammoClass>
+    <cookOffProjectile>Bullet_45Schofield_AP</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="45SchofieldBase">
+    <defName>Ammo_45Schofield_HP</defName>
+    <label>.45 Schofield cartridge (HP)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Pistol/HP</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+    </statBases>
+    <ammoClass>HollowPoint</ammoClass>
+    <cookOffProjectile>Bullet_45Schofield_HP</cookOffProjectile>
+  </ThingDef>
+
+  <!-- ================== Projectiles ================== -->
+
+  <ThingDef Name="Base45SchofieldBullet" ParentName="BaseBulletCE" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Small</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>44</speed>
+      <dropsCasings>true</dropsCasings>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base45SchofieldBullet">
+    <defName>Bullet_45Schofield_FMJ</defName>
+    <label>.45 Schofield bullet (FMJ)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>10</damageAmountBase>
+      <armorPenetrationSharp>2</armorPenetrationSharp>
+      <armorPenetrationBlunt>7.26</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base45SchofieldBullet">
+    <defName>Bullet_45Schofield_AP</defName>
+    <label>.45 Schofield bullet (AP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>7</damageAmountBase>
+      <armorPenetrationSharp>4</armorPenetrationSharp>
+      <armorPenetrationBlunt>7.26</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <ThingDef ParentName="Base45SchofieldBullet">
+    <defName>Bullet_45Schofield_HP</defName>
+    <label>.45 Schofield bullet (HP)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>13</damageAmountBase>
+      <armorPenetrationSharp>1</armorPenetrationSharp>
+      <armorPenetrationBlunt>7.26</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+
+  <!-- ==================== Recipes ========================== -->
+
+  <!-- Standard manufacture -->
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45Schofield_FMJ</defName>
+    <label>make .45 Schofield (FMJ) cartridge x500</label>
+    <description>Craft 500 .45 Schofield (FMJ) cartridges.</description>
+    <jobString>Making .45 Schofield (FMJ) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45Schofield_FMJ>500</Ammo_45Schofield_FMJ>
+    </products>
+    <workAmount>2200</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45Schofield_AP</defName>
+    <label>make .45 Schofield (AP) cartridge x500</label>
+    <description>Craft 500 .45 Schofield (AP) cartridges.</description>
+    <jobString>Making .45 Schofield (AP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45Schofield_AP>500</Ammo_45Schofield_AP>
+    </products>
+    <workAmount>2640</workAmount>
+  </RecipeDef>
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_45Schofield_HP</defName>
+    <label>make .45 Schofield (HP) cartridge x500</label>
+    <description>Craft 500 .45 Schofield (HP) cartridges.</description>
+    <jobString>Making .45 Schofield (HP) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>22</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_45Schofield_HP>500</Ammo_45Schofield_HP>
+    </products>
+    <workAmount>2200</workAmount>
+  </RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/45WinMag.xml
+++ b/Defs/Ammo/Pistols/45WinMag.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo45WinMag</defName>
+		<label>.45 Win Mag</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_45WinMag</defName>
+		<label>.45 Win Mag</label>
+		<ammoTypes>
+			<Ammo_45WinMag_FMJ>Bullet_45WinMag_FMJ</Ammo_45WinMag_FMJ>
+			<Ammo_45WinMag_AP>Bullet_45WinMag_AP</Ammo_45WinMag_AP>
+			<Ammo_45WinMag_HP>Bullet_45WinMag_HP</Ammo_45WinMag_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="45WinMagBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Powerful cartridge designed to bring magnum power to semi-automatic pistols and other handguns.</description>
+		<statBases>
+			<Mass>0.023</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo45WinMag</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45WinMagBase">
+		<defName>Ammo_45WinMag_FMJ</defName>
+		<label>.45 Win Mag cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_45WinMag_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45WinMagBase">
+		<defName>Ammo_45WinMag_AP</defName>
+		<label>.45 Win Mag cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_45WinMag_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45WinMagBase">
+		<defName>Ammo_45WinMag_HP</defName>
+		<label>.45 Win Mag cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.10</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_45WinMag_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base45WinMagBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>76</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base45WinMagBullet">
+		<defName>Bullet_45WinMag_FMJ</defName>
+		<label>.45 Win Mag bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base45WinMagBullet">
+		<defName>Bullet_45WinMag_AP</defName>
+		<label>.45 Win Mag bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base45WinMagBullet">
+		<defName>Bullet_45WinMag_HP</defName>
+		<label>.45 Win Mag bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>23.1</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45WinMag_FMJ</defName>
+		<label>make .45 Win Mag cartridge x500</label>
+		<description>Craft 500 .45 Win Mag cartridges.</description>
+		<jobString>Making .45 Win Mag cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45WinMag_FMJ>500</Ammo_45WinMag_FMJ>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45WinMag_AP</defName>
+		<label>make .45 Win Mag (AP) cartridge x500</label>
+		<description>Craft 500 .45 Win Mag (AP) cartridges.</description>
+		<jobString>Making .45 Win Mag (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45WinMag_AP>500</Ammo_45WinMag_AP>
+		</products>
+		<workAmount>2880</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_45WinMag_HP</defName>
+		<label>make .45 Win Mag (HP) cartridge x500</label>
+		<description>Craft 500 .45 Win Mag (HP) cartridges.</description>
+		<jobString>Making .45 Win Mag (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>24</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_45WinMag_HP>500</Ammo_45WinMag_HP>
+		</products>
+		<workAmount>2400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/460SWMagnum.xml
+++ b/Defs/Ammo/Pistols/460SWMagnum.xml
@@ -20,6 +20,26 @@
 		</ammoTypes>
 		<similarTo>AmmoSet_PistolMagnum</similarTo>
 	</CombatExtended.AmmoSetDef>
+  
+  <CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_460SWMagnum_Revolver</defName>
+		<label>.460 S&amp;W Magnum</label>
+		<ammoTypes>
+			<Ammo_460SWMagnum_FMJ>Bullet_460SWMagnum_FMJ</Ammo_460SWMagnum_FMJ>
+			<Ammo_460SWMagnum_AP>Bullet_460SWMagnum_AP</Ammo_460SWMagnum_AP>			
+			<Ammo_460SWMagnum_HP>Bullet_460SWMagnum_HP</Ammo_460SWMagnum_HP>
+      <Ammo_454Casull_FMJ>Bullet_454Casull_FMJ</Ammo_454Casull_FMJ>
+			<Ammo_454Casull_AP>Bullet_454Casull_AP</Ammo_454Casull_AP>
+			<Ammo_454Casull_HP>Bullet_454Casull_HP</Ammo_454Casull_HP>
+      <Ammo_45Colt_FMJ>Bullet_45Colt_FMJ</Ammo_45Colt_FMJ>
+			<Ammo_45Colt_AP>Bullet_45Colt_AP</Ammo_45Colt_AP>
+			<Ammo_45Colt_HP>Bullet_45Colt_HP</Ammo_45Colt_HP>
+      <Ammo_45Schofield_FMJ>Bullet_45Schofield_FMJ</Ammo_45Schofield_FMJ>
+      <Ammo_45Schofield_AP>Bullet_45Schofield_AP</Ammo_45Schofield_AP>
+      <Ammo_45Schofield_HP>Bullet_45Schofield_HP</Ammo_45Schofield_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
 
 	<!-- ==================== Ammo ========================== -->
 

--- a/Defs/Ammo/Pistols/480Ruger.xml
+++ b/Defs/Ammo/Pistols/480Ruger.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo480Ruger</defName>
+		<label>.480 Ruger</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_480Ruger</defName>
+		<label>.480 Ruger</label>
+		<ammoTypes>
+			<Ammo_480Ruger_FMJ>Bullet_480Ruger_FMJ</Ammo_480Ruger_FMJ>
+			<Ammo_480Ruger_AP>Bullet_480Ruger_AP</Ammo_480Ruger_AP>
+			<Ammo_480Ruger_HP>Bullet_480Ruger_HP</Ammo_480Ruger_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="480RugerBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Uncommon high-power round that was, at one point, the largest (in diameter) mass-produced revolver cartridge.</description>
+		<statBases>
+			<Mass>0.029</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo480Ruger</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="480RugerBase">
+		<defName>Ammo_480Ruger_FMJ</defName>
+		<label>.480 Ruger cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.12</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_480Ruger_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="480RugerBase">
+		<defName>Ammo_480Ruger_AP</defName>
+		<label>.480 Ruger cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.12</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_480Ruger_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="480RugerBase">
+		<defName>Ammo_480Ruger_HP</defName>
+		<label>.480 Ruger cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.12</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_480Ruger_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base480RugerBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>74</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base480RugerBullet">
+		<defName>Bullet_480Ruger_FMJ</defName>
+		<label>.480 Ruger bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>17</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.74</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base480RugerBullet">
+		<defName>Bullet_480Ruger_AP</defName>
+		<label>.480 Ruger bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.74</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base480RugerBullet">
+		<defName>Bullet_480Ruger_HP</defName>
+		<label>.480 Ruger bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>22</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.74</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_480Ruger_FMJ</defName>
+		<label>make .480 Ruger cartridge x500</label>
+		<description>Craft 500 .480 Ruger cartridges.</description>
+		<jobString>Making .480 Ruger cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>30</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_480Ruger_FMJ>500</Ammo_480Ruger_FMJ>
+		</products>
+		<workAmount>3000</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_480Ruger_AP</defName>
+		<label>make .480 Ruger (AP) cartridge x500</label>
+		<description>Craft 500 .480 Ruger (AP) cartridges.</description>
+		<jobString>Making .480 Ruger (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>30</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_480Ruger_AP>500</Ammo_480Ruger_AP>
+		</products>
+		<workAmount>3600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_480Ruger_HP</defName>
+		<label>make .480 Ruger (HP) cartridge x500</label>
+		<description>Craft 500 .480 Ruger (HP) cartridges.</description>
+		<jobString>Making .480 Ruger (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>30</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_480Ruger_HP>500</Ammo_480Ruger_HP>
+		</products>
+		<workAmount>3000</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Pistols/500Bushwhacker.xml
+++ b/Defs/Ammo/Pistols/500Bushwhacker.xml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo500Bushwhacker</defName>
+		<label>.500 Bushwhacker</label>
+		<parent>AmmoPistols</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberPistol</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_500Bushwhacker</defName>
+		<label>.500 Bushwhacker</label>
+		<ammoTypes>
+			<Ammo_500Bushwhacker_FMJ>Bullet_500Bushwhacker_FMJ</Ammo_500Bushwhacker_FMJ>
+			<Ammo_500Bushwhacker_AP>Bullet_500Bushwhacker_AP</Ammo_500Bushwhacker_AP>
+			<Ammo_500Bushwhacker_HP>Bullet_500Bushwhacker_HP</Ammo_500Bushwhacker_HP>			
+		</ammoTypes>
+		<similarTo>AmmoSet_PistolMagnum</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="500BushwhackerBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>A massive handgun cartridge that offers similar ballistic performance to big game rifle cartridges.</description>
+		<statBases>
+			<Mass>0.042</Mass>
+			<Bulk>0.04</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo500Bushwhacker</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500BushwhackerBase">
+		<defName>Ammo_500Bushwhacker_FMJ</defName>
+		<label>.500 Bushwhacker cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.18</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_500Bushwhacker_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500BushwhackerBase">
+		<defName>Ammo_500Bushwhacker_AP</defName>
+		<label>.500 Bushwhacker cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.18</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_500Bushwhacker_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="500BushwhackerBase">
+		<defName>Ammo_500Bushwhacker_HP</defName>
+		<label>.500 Bushwhacker cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Pistol/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.18</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_500Bushwhacker_HP</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base500BushwhackerBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>146</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base500BushwhackerBullet">
+		<defName>Bullet_500Bushwhacker_FMJ</defName>
+		<label>.500 Bushwhacker bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>30</damageAmountBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>143.88</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base500BushwhackerBullet">
+		<defName>Bullet_500Bushwhacker_AP</defName>
+		<label>.500 Bushwhacker bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationBlunt>143.88</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base500BushwhackerBullet">
+		<defName>Bullet_500Bushwhacker_HP</defName>
+		<label>.500 Bushwhacker bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>38</damageAmountBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>143.88</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_500Bushwhacker_FMJ</defName>
+		<label>make .500 Bushwhacker cartridge x500</label>
+		<description>Craft 500 .500 Bushwhacker cartridges.</description>
+		<jobString>Making .500 Bushwhacker cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>44</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_500Bushwhacker_FMJ>500</Ammo_500Bushwhacker_FMJ>
+		</products>
+		<workAmount>4400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_500Bushwhacker_AP</defName>
+		<label>make .500 Bushwhacker (AP) cartridge x500</label>
+		<description>Craft 500 .500 Bushwhacker (AP) cartridges.</description>
+		<jobString>Making .500 Bushwhacker (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>44</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_500Bushwhacker_AP>500</Ammo_500Bushwhacker_AP>
+		</products>
+		<workAmount>5280</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_500Bushwhacker_HP</defName>
+		<label>make .500 Bushwhacker (HP) cartridge x500</label>
+		<description>Craft 500 .500 Bushwhacker (HP) cartridges.</description>
+		<jobString>Making .500 Bushwhacker (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>44</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_500Bushwhacker_HP>500</Ammo_500Bushwhacker_HP>
+		</products>
+		<workAmount>4400</workAmount>
+	</RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo243Winchester</defName>
+		<label>.243 Winchester</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_243Winchester</defName>
+		<label>.243 Winchester</label>
+		<ammoTypes>
+			<Ammo_243Winchester_FMJ>Bullet_243Winchester_FMJ</Ammo_243Winchester_FMJ>
+			<Ammo_243Winchester_AP>Bullet_243Winchester_AP</Ammo_243Winchester_AP>
+			<Ammo_243Winchester_HP>Bullet_243Winchester_HP</Ammo_243Winchester_HP>
+			<Ammo_243Winchester_Incendiary>Bullet_243Winchester_Incendiary</Ammo_243Winchester_Incendiary>
+			<Ammo_243Winchester_HE>Bullet_243Winchester_HE</Ammo_243Winchester_HE>
+			<Ammo_243Winchester_Sabot>Bullet_243Winchester_Sabot</Ammo_243Winchester_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="243WinchesterBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>A versatile centerfire rifle cartridge optimized for hunting medium-sized game.</description>
+		<statBases>
+		<Mass>0.018</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo243Winchester</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+		<defName>Ammo_243Winchester_FMJ</defName>
+		<label>.243 Winchester cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_243Winchester_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+		<defName>Ammo_243Winchester_AP</defName>
+		<label>.243 Winchester cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_243Winchester_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+		<defName>Ammo_243Winchester_HP</defName>
+		<label>.243 Winchester cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.08</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_243Winchester_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+    <defName>Ammo_243Winchester_Incendiary</defName>
+    <label>.243 Winchester cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.10</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_243Winchester_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+    <defName>Ammo_243Winchester_HE</defName>
+    <label>.243 Winchester cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.16</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_243Winchester_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="243WinchesterBase">
+    <defName>Ammo_243Winchester_Sabot</defName>
+    <label>.243 Winchester cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.09</MarketValue>
+	  <Mass>0.016</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_243Winchester_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base243WinchesterBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>198</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_FMJ</defName>
+		<label>.243 Winchester bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>17</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>58.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_AP</defName>
+		<label>.243 Winchester bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>58.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_HP</defName>
+		<label>.243 Winchester bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>22</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>58.8</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_Incendiary</defName>
+		<label>.243 Winchester bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationBlunt>58.8</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>7</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_HE</defName>
+		<label>.243 Winchester bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>17</damageAmountBase>
+		  <armorPenetrationSharp>7</armorPenetrationSharp>
+		  <armorPenetrationBlunt>58.8</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>10</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base243WinchesterBullet">
+		<defName>Bullet_243Winchester_Sabot</defName>
+		<label>.243 Winchester bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>9</damageAmountBase>
+		  <armorPenetrationSharp>24.50</armorPenetrationSharp>
+		  <armorPenetrationBlunt>75.42</armorPenetrationBlunt>
+		  <speed>297</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_243Winchester_FMJ</defName>
+		<label>make .243 Winchester (FMJ) cartridge x500</label>
+		<description>Craft 500 .243 Winchester (FMJ) cartridges.</description>
+		<jobString>Making .243 Winchester (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_243Winchester_FMJ>500</Ammo_243Winchester_FMJ>
+		</products>
+    	<workAmount>1800</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_243Winchester_AP</defName>
+		<label>make .243 Winchester (AP) cartridge x500</label>
+		<description>Craft 500 .243 Winchester (AP) cartridges.</description>
+		<jobString>Making .243 Winchester (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_243Winchester_AP>500</Ammo_243Winchester_AP>
+		</products>
+	<workAmount>2160</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_243Winchester_HP</defName>
+		<label>make .243 Winchester (HP) cartridge x500</label>
+		<description>Craft 500 .243 Winchester (HP) cartridges.</description>
+		<jobString>Making .243 Winchester (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>18</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_243Winchester_HP>500</Ammo_243Winchester_HP>
+		</products>
+	<workAmount>1800</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_243Winchester_Incendiary</defName>
+    <label>make .243 Winchester (AP-I) cartridge x500</label>
+    <description>Craft 500 .243 Winchester (AP-I) cartridges.</description>
+    <jobString>Making .243 Winchester (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_243Winchester_Incendiary>500</Ammo_243Winchester_Incendiary>
+    </products>
+    <workAmount>2600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_243Winchester_HE</defName>
+    <label>make .243 Winchester (AP-HE) cartridge x500</label>
+    <description>Craft 500 .243 Winchester (AP-HE) cartridges.</description>
+    <jobString>Making .243 Winchester (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_243Winchester_HE>500</Ammo_243Winchester_HE>
+    </products>
+    <workAmount>3400</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_243Winchester_Sabot</defName>
+    <label>make .243 Winchester (Sabot) cartridge x500</label>
+    <description>Craft 500 .243 Winchester (Sabot) cartridges.</description>
+    <jobString>Making .243 Winchester (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>12</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_243Winchester_Sabot>500</Ammo_243Winchester_Sabot>
+    </products>
+    <workAmount>2400</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo3030Winchester</defName>
+		<label>.30-30 Winchester</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_3030Winchester</defName>
+		<label>.30-30 Winchester</label>
+		<ammoTypes>
+			<Ammo_3030Winchester_FMJ>Bullet_3030Winchester_FMJ</Ammo_3030Winchester_FMJ>
+			<Ammo_3030Winchester_AP>Bullet_3030Winchester_AP</Ammo_3030Winchester_AP>
+			<Ammo_3030Winchester_HP>Bullet_3030Winchester_HP</Ammo_3030Winchester_HP>
+			<Ammo_3030Winchester_Incendiary>Bullet_3030Winchester_Incendiary</Ammo_3030Winchester_Incendiary>
+			<Ammo_3030Winchester_HE>Bullet_3030Winchester_HE</Ammo_3030Winchester_HE>
+			<Ammo_3030Winchester_Sabot>Bullet_3030Winchester_Sabot</Ammo_3030Winchester_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="3030WinchesterBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Among the most popular centerfire cartridges used in lever-action rifles and large bore rifles, its efficacy as a hunting round has made it widely used even to the present day.</description>
+		<statBases>
+			<Mass>0.025</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo3030Winchester</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_FMJ</defName>
+		<label>.30-30 Winchester cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_AP</defName>
+		<label>.30-30 Winchester cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_HP</defName>
+		<label>.30-30 Winchester cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_HP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_Incendiary</defName>
+		<label>.30-30 Winchester cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_HE</defName>
+		<label>.30-30 Winchester cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.21</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_HE</cookOffProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3030WinchesterBase">
+		<defName>Ammo_3030Winchester_Sabot</defName>
+		<label>.30-30 Winchester cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.12</MarketValue>
+			<Mass>0.021</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_3030Winchester_Sabot</cookOffProjectile>
+	</ThingDef>
+	
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base3030WinchesterBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>142</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_FMJ</defName>
+		<label>.30-30 Winchester cartridge (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>18</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>50.42</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_AP</defName>
+		<label>.30-30 Winchester cartridge (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>50.42</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_HP</defName>
+		<label>.30-30 Winchester cartridge (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>50.42</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_Incendiary</defName>
+		<label>.30-30 bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>10</armorPenetrationSharp>
+		  <armorPenetrationBlunt>50.42</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>7</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_HE</defName>
+		<label>.30-30 bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>18</damageAmountBase>
+		  <armorPenetrationSharp>5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>50.42</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>11</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base3030WinchesterBullet">
+		<defName>Bullet_3030Winchester_Sabot</defName>
+		<label>.30-30 bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>9</damageAmountBase>
+		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>64.66</armorPenetrationBlunt>
+		  <speed>213</speed>
+		</projectile>
+	  </ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3030Winchester_FMJ</defName>
+		<label>make .30-30 Winchester cartridge (FMJ) cartridge x400</label>
+		<description>Craft 500 .30-30 Winchester cartridge (FMJ) cartridges.</description>
+		<jobString>Making .30-30 Winchester cartridge (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3030Winchester_FMJ>500</Ammo_3030Winchester_FMJ>
+		</products>
+	    <workAmount>2600</workAmount>			
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3030Winchester_AP</defName>
+		<label>make .30-30 Winchester cartridge (AP) cartridge x500</label>
+		<description>Craft 500 .30-30 Winchester cartridge (AP) cartridges.</description>
+		<jobString>Making .30-30 Winchester cartridge (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3030Winchester_AP>500</Ammo_3030Winchester_AP>
+		</products>
+	    <workAmount>3120</workAmount>			
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3030Winchester_HP</defName>
+		<label>make .30-30 Winchester cartridge (HP) cartridge x500</label>
+		<description>Craft 500 .30-30 Winchester cartridge (HP) cartridges.</description>
+		<jobString>Making .30-30 Winchester cartridge (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3030Winchester_HP>500</Ammo_3030Winchester_HP>
+		</products>
+	    <workAmount>2600</workAmount>	
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3030Winchester_Incendiary</defName>
+    <label>make .30-30 Winchester (AP-I) cartridge x500</label>
+    <description>Craft 500 .30-30 Winchester (AP-I) cartridges.</description>
+    <jobString>Making .30-30 Winchester (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>26</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3030Winchester_Incendiary>500</Ammo_3030Winchester_Incendiary>
+    </products>
+    <workAmount>3800</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3030Winchester_HE</defName>
+    <label>make .30-30 Winchester (AP-HE) cartridge x500</label>
+    <description>Craft 500 .30-30 Winchester (AP-HE) cartridges.</description>
+    <jobString>Making .30-30 Winchester (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>26</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3030Winchester_HE>500</Ammo_3030Winchester_HE>
+    </products>
+    <workAmount>4600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3030Winchester_Sabot</defName>
+    <label>make .30-30 Winchester (Sabot) cartridge x500</label>
+    <description>Craft 500 .30-30 Winchester (Sabot) cartridges.</description>
+    <jobString>Making .30-30 Winchester (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>16</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3030Winchester_Sabot>500</Ammo_3030Winchester_Sabot>
+    </products>
+    <workAmount>3400</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo3855Winchester</defName>
+		<label>.38-55 Winchester</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_3855Winchester</defName>
+		<label>.38-55 Winchester</label>
+		<ammoTypes>
+			<Ammo_3855Winchester_FMJ>Bullet_3855Winchester_FMJ</Ammo_3855Winchester_FMJ>
+			<Ammo_3855Winchester_AP>Bullet_3855Winchester_AP</Ammo_3855Winchester_AP>
+			<Ammo_3855Winchester_HP>Bullet_3855Winchester_HP</Ammo_3855Winchester_HP>
+			<Ammo_3855Winchester_Incendiary>Bullet_3855Winchester_Incendiary</Ammo_3855Winchester_Incendiary>
+			<Ammo_3855Winchester_HE>Bullet_3855Winchester_HE</Ammo_3855Winchester_HE>
+			<Ammo_3855Winchester_Sabot>Bullet_3855Winchester_Sabot</Ammo_3855Winchester_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_3855WinchesterTrapdoor</defName>
+		<label>.38-55 Winchester</label>
+		<ammoTypes>
+			<Ammo_3855Winchester_FMJ>Bullet_3855WinchesterTrapdoor_FMJ</Ammo_3855Winchester_FMJ>
+			<Ammo_3855Winchester_AP>Bullet_3855WinchesterTrapdoor_AP</Ammo_3855Winchester_AP>
+			<Ammo_3855Winchester_HP>Bullet_3855WinchesterTrapdoor_HP</Ammo_3855Winchester_HP>
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="3855WinchesterBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Old school lever-gun cartridge that offered somewhat similar performance to black powder .45-70 Gov't loads in smaller bore rifles.</description>
+		<statBases>
+			<Mass>0.034</Mass>
+			<Bulk>0.02</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo3855Winchester</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_FMJ</defName>
+		<label>.38-55 Winchester cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_AP</defName>
+		<label>.38-55 Winchester cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_HP</defName>
+		<label>.38-55 Winchester cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_HP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_Incendiary</defName>
+		<label>.38-55 Winchester cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.21</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_HE</defName>
+		<label>.38-55 Winchester cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.35</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_HE</cookOffProjectile>
+	</ThingDef>
+	
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="3855WinchesterBase">
+		<defName>Ammo_3855Winchester_Sabot</defName>
+		<label>.38-55 Winchester cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.16</MarketValue>
+			<Mass>0.026</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_3855Winchester_Sabot</cookOffProjectile>
+	</ThingDef>
+	
+	<!-- ================== Projectiles ================== -->
+
+	<ThingDef Name="Base3855WinchesterBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>118</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_FMJ</defName>
+		<label>.38-55 Winchester cartridge (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>20</damageAmountBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.18</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_AP</defName>
+		<label>.38-55 Winchester cartridge (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.18</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_HP</defName>
+		<label>.38-55 Winchester cartridge (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.18</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_Incendiary</defName>
+		<label>.38-55 bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>13</damageAmountBase>
+		  <armorPenetrationSharp>12</armorPenetrationSharp>
+		  <armorPenetrationBlunt>59.18</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>8</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_HE</defName>
+		<label>.38-55 bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>20</damageAmountBase>
+		  <armorPenetrationSharp>6</armorPenetrationSharp>
+		  <armorPenetrationBlunt>59.18</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>12</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855Winchester_Sabot</defName>
+		<label>.38-55 bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>21</armorPenetrationSharp>
+		  <armorPenetrationBlunt>75.90</armorPenetrationBlunt>
+		  <speed>177</speed>
+		</projectile>
+	  </ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855WinchesterTrapdoor_FMJ</defName>
+		<label>.38-55 Winchester cartridge (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>81</speed>
+			<damageAmountBase>15</damageAmountBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855WinchesterTrapdoor_AP</defName>
+		<label>.38-55 Winchester cartridge (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>81</speed>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base3855WinchesterBullet">
+		<defName>Bullet_3855WinchesterTrapdoor_HP</defName>
+		<label>.38-55 Winchester cartridge (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>81</speed>
+			<damageAmountBase>20</damageAmountBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>27.6</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3855Winchester_FMJ</defName>
+		<label>make .38-55 Winchester cartridge (FMJ) cartridge x400</label>
+		<description>Craft 500 .38-55 Winchester cartridge (FMJ) cartridges.</description>
+		<jobString>Making .38-55 Winchester cartridge (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3855Winchester_FMJ>500</Ammo_3855Winchester_FMJ>
+		</products>
+	    <workAmount>3600</workAmount>			
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3855Winchester_AP</defName>
+		<label>make .38-55 Winchester cartridge (AP) cartridge x500</label>
+		<description>Craft 500 .38-55 Winchester cartridge (AP) cartridges.</description>
+		<jobString>Making .38-55 Winchester cartridge (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3855Winchester_AP>500</Ammo_3855Winchester_AP>
+		</products>
+	    <workAmount>4320</workAmount>			
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_3855Winchester_HP</defName>
+		<label>make .38-55 Winchester cartridge (HP) cartridge x500</label>
+		<description>Craft 500 .38-55 Winchester cartridge (HP) cartridges.</description>
+		<jobString>Making .38-55 Winchester cartridge (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_3855Winchester_HP>500</Ammo_3855Winchester_HP>
+		</products>
+	    <workAmount>3600</workAmount>	
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3855Winchester_Incendiary</defName>
+    <label>make .38-55 Winchester (AP-I) cartridge x500</label>
+    <description>Craft 500 .38-55 Winchester (AP-I) cartridges.</description>
+    <jobString>Making .38-55 Winchester (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>36</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3855Winchester_Incendiary>500</Ammo_3855Winchester_Incendiary>
+    </products>
+    <workAmount>5600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3855Winchester_HE</defName>
+    <label>make .38-55 Winchester (AP-HE) cartridge x500</label>
+    <description>Craft 500 .38-55 Winchester (AP-HE) cartridges.</description>
+    <jobString>Making .38-55 Winchester (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>36</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3855Winchester_HE>500</Ammo_3855Winchester_HE>
+    </products>
+    <workAmount>7600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_3855Winchester_Sabot</defName>
+    <label>make .38-55 Winchester (Sabot) cartridge x500</label>
+    <description>Craft 500 .38-55 Winchester (Sabot) cartridges.</description>
+    <jobString>Making .38-55 Winchester (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>18</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_3855Winchester_Sabot>500</Ammo_3855Winchester_Sabot>
+    </products>
+    <workAmount>4800</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/450Bushmaster.xml
+++ b/Defs/Ammo/Rifle/450Bushmaster.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo450Bushmaster</defName>
+		<label>.450 Bushmaster</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_450Bushmaster</defName>
+		<label>.450 Bushmaster</label>
+		<ammoTypes>
+			<Ammo_450Bushmaster_FMJ>Bullet_450Bushmaster_FMJ</Ammo_450Bushmaster_FMJ>
+			<Ammo_450Bushmaster_AP>Bullet_450Bushmaster_AP</Ammo_450Bushmaster_AP>
+			<Ammo_450Bushmaster_HP>Bullet_450Bushmaster_HP</Ammo_450Bushmaster_HP>
+			<Ammo_450Bushmaster_Incendiary>Bullet_450Bushmaster_Incendiary</Ammo_450Bushmaster_Incendiary>
+			<Ammo_450Bushmaster_HE>Bullet_450Bushmaster_HE</Ammo_450Bushmaster_HE>
+			<Ammo_450Bushmaster_Sabot>Bullet_450Bushmaster_Sabot</Ammo_450Bushmaster_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="450BushmasterBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Rifle cartridge designed to bring the energy of a full power bullet into intermediate-caliber semi-automatic rifles.</description>
+		<statBases>
+		<Mass>0.031</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo450Bushmaster</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+		<defName>Ammo_450Bushmaster_FMJ</defName>
+		<label>.450 Bushmaster cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_450Bushmaster_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+		<defName>Ammo_450Bushmaster_AP</defName>
+		<label>.450 Bushmaster cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_450Bushmaster_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+		<defName>Ammo_450Bushmaster_HP</defName>
+		<label>.450 Bushmaster cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_450Bushmaster_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+    <defName>Ammo_450Bushmaster_Incendiary</defName>
+    <label>.450 Bushmaster cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.20</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_450Bushmaster_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+    <defName>Ammo_450Bushmaster_HE</defName>
+    <label>.450 Bushmaster cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.34</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_450Bushmaster_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="450BushmasterBase">
+    <defName>Ammo_450Bushmaster_Sabot</defName>
+    <label>.450 Bushmaster cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.16</MarketValue>
+	  <Mass>0.023</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_450Bushmaster_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base450BushmasterBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>107</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_FMJ</defName>
+		<label>.450 Bushmaster bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.98</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_AP</defName>
+		<label>.450 Bushmaster bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>13</damageAmountBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.98</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_HP</defName>
+		<label>.450 Bushmaster bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>26</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.98</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_Incendiary</defName>
+		<label>.450 Bushmaster bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>13</damageAmountBase>
+		  <armorPenetrationSharp>15</armorPenetrationSharp>
+		  <armorPenetrationBlunt>53.98</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>8</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_HE</defName>
+		<label>.450 Bushmaster bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>21</damageAmountBase>
+		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>53.98</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>12</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base450BushmasterBullet">
+		<defName>Bullet_450Bushmaster_Sabot</defName>
+		<label>.450 Bushmaster bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>26</armorPenetrationSharp>
+		  <armorPenetrationBlunt>69.32</armorPenetrationBlunt>
+		  <speed>160</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_450Bushmaster_FMJ</defName>
+		<label>make .450 Bushmaster (FMJ) cartridge x500</label>
+		<description>Craft 500 .450 Bushmaster (FMJ) cartridges.</description>
+		<jobString>Making .450 Bushmaster (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_450Bushmaster_FMJ>500</Ammo_450Bushmaster_FMJ>
+		</products>
+    	<workAmount>3200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_450Bushmaster_AP</defName>
+		<label>make .450 Bushmaster (AP) cartridge x500</label>
+		<description>Craft 500 .450 Bushmaster (AP) cartridges.</description>
+		<jobString>Making .450 Bushmaster (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_450Bushmaster_AP>500</Ammo_450Bushmaster_AP>
+		</products>
+	<workAmount>3840</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_450Bushmaster_HP</defName>
+		<label>make .450 Bushmaster (HP) cartridge x500</label>
+		<description>Craft 500 .450 Bushmaster (HP) cartridges.</description>
+		<jobString>Making .450 Bushmaster (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_450Bushmaster_HP>500</Ammo_450Bushmaster_HP>
+		</products>
+	<workAmount>3200</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_450Bushmaster_Incendiary</defName>
+    <label>make .450 Bushmaster (AP-I) cartridge x500</label>
+    <description>Craft 500 .450 Bushmaster (AP-I) cartridges.</description>
+    <jobString>Making .450 Bushmaster (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_450Bushmaster_Incendiary>500</Ammo_450Bushmaster_Incendiary>
+    </products>
+    <workAmount>5200</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_450Bushmaster_HE</defName>
+    <label>make .450 Bushmaster (AP-HE) cartridge x500</label>
+    <description>Craft 500 .450 Bushmaster (AP-HE) cartridges.</description>
+    <jobString>Making .450 Bushmaster (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_450Bushmaster_HE>500</Ammo_450Bushmaster_HE>
+    </products>
+    <workAmount>7200</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_450Bushmaster_Sabot</defName>
+    <label>make .450 Bushmaster (Sabot) cartridge x500</label>
+    <description>Craft 500 .450 Bushmaster (Sabot) cartridges.</description>
+    <jobString>Making .450 Bushmaster (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>12</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_450Bushmaster_Sabot>500</Ammo_450Bushmaster_Sabot>
+    </products>
+    <workAmount>4800</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo458SOCOM</defName>
+		<label>.458 SOCOM</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_458SOCOM</defName>
+		<label>.458 SOCOM</label>
+		<ammoTypes>
+			<Ammo_458SOCOM_FMJ>Bullet_458SOCOM_FMJ</Ammo_458SOCOM_FMJ>
+			<Ammo_458SOCOM_AP>Bullet_458SOCOM_AP</Ammo_458SOCOM_AP>
+			<Ammo_458SOCOM_HP>Bullet_458SOCOM_HP</Ammo_458SOCOM_HP>
+			<Ammo_458SOCOM_Incendiary>Bullet_458SOCOM_Incendiary</Ammo_458SOCOM_Incendiary>
+			<Ammo_458SOCOM_HE>Bullet_458SOCOM_HE</Ammo_458SOCOM_HE>
+			<Ammo_458SOCOM_Sabot>Bullet_458SOCOM_Sabot</Ammo_458SOCOM_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="458SOCOMBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Rifle cartridge designed to bring the energy of a full power bullet into intermediate-caliber semi-automatic rifles.</description>
+		<statBases>
+		<Mass>0.032</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo458SOCOM</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+		<defName>Ammo_458SOCOM_FMJ</defName>
+		<label>.458 SOCOM cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.14</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_458SOCOM_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+		<defName>Ammo_458SOCOM_AP</defName>
+		<label>.458 SOCOM cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.14</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_458SOCOM_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+		<defName>Ammo_458SOCOM_HP</defName>
+		<label>.458 SOCOM cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.14</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_458SOCOM_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+    <defName>Ammo_458SOCOM_Incendiary</defName>
+    <label>.458 SOCOM cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.20</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_458SOCOM_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+    <defName>Ammo_458SOCOM_HE</defName>
+    <label>.458 SOCOM cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.35</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_458SOCOM_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="458SOCOMBase">
+    <defName>Ammo_458SOCOM_Sabot</defName>
+    <label>.458 SOCOM cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.17</MarketValue>
+	  <Mass>0.024</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_458SOCOM_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base458SOCOMBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>112</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_FMJ</defName>
+		<label>.458 SOCOM bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>22</damageAmountBase>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.58</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_AP</defName>
+		<label>.458 SOCOM bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.58</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_HP</defName>
+		<label>.458 SOCOM bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>27</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>59.58</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_Incendiary</defName>
+		<label>.458 SOCOM bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>14</damageAmountBase>
+		  <armorPenetrationSharp>15</armorPenetrationSharp>
+		  <armorPenetrationBlunt>59.58</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>8</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_HE</defName>
+		<label>.458 SOCOM bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>22</damageAmountBase>
+		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>59.58</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>13</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base458SOCOMBullet">
+		<defName>Bullet_458SOCOM_Sabot</defName>
+		<label>.458 SOCOM bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>11</damageAmountBase>
+		  <armorPenetrationSharp>26</armorPenetrationSharp>
+		  <armorPenetrationBlunt>76.42</armorPenetrationBlunt>
+		  <speed>168</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_458SOCOM_FMJ</defName>
+		<label>make .458 SOCOM (FMJ) cartridge x500</label>
+		<description>Craft 500 .458 SOCOM (FMJ) cartridges.</description>
+		<jobString>Making .458 SOCOM (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>34</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_458SOCOM_FMJ>500</Ammo_458SOCOM_FMJ>
+		</products>
+    	<workAmount>3400</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_458SOCOM_AP</defName>
+		<label>make .458 SOCOM (AP) cartridge x500</label>
+		<description>Craft 500 .458 SOCOM (AP) cartridges.</description>
+		<jobString>Making .458 SOCOM (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>34</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_458SOCOM_AP>500</Ammo_458SOCOM_AP>
+		</products>
+	<workAmount>4080</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_458SOCOM_HP</defName>
+		<label>make .458 SOCOM (HP) cartridge x500</label>
+		<description>Craft 500 .458 SOCOM (HP) cartridges.</description>
+		<jobString>Making .458 SOCOM (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>34</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_458SOCOM_HP>500</Ammo_458SOCOM_HP>
+		</products>
+	<workAmount>3400</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_458SOCOM_Incendiary</defName>
+    <label>make .458 SOCOM (AP-I) cartridge x500</label>
+    <description>Craft 500 .458 SOCOM (AP-I) cartridges.</description>
+    <jobString>Making .458 SOCOM (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>34</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_458SOCOM_Incendiary>500</Ammo_458SOCOM_Incendiary>
+    </products>
+    <workAmount>5400</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_458SOCOM_HE</defName>
+    <label>make .458 SOCOM (AP-HE) cartridge x500</label>
+    <description>Craft 500 .458 SOCOM (AP-HE) cartridges.</description>
+    <jobString>Making .458 SOCOM (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>34</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>10</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_458SOCOM_HE>500</Ammo_458SOCOM_HE>
+    </products>
+    <workAmount>7400</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_458SOCOM_Sabot</defName>
+    <label>make .458 SOCOM (Sabot) cartridge x500</label>
+    <description>Craft 500 .458 SOCOM (Sabot) cartridges.</description>
+    <jobString>Making .458 SOCOM (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>14</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_458SOCOM_Sabot>500</Ammo_458SOCOM_Sabot>
+    </products>
+    <workAmount>5000</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo50Beowulf</defName>
+		<label>.50 Beowulf</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_50Beowulf</defName>
+		<label>.50 Beowulf</label>
+		<ammoTypes>
+			<Ammo_50Beowulf_FMJ>Bullet_50Beowulf_FMJ</Ammo_50Beowulf_FMJ>
+			<Ammo_50Beowulf_AP>Bullet_50Beowulf_AP</Ammo_50Beowulf_AP>
+			<Ammo_50Beowulf_HP>Bullet_50Beowulf_HP</Ammo_50Beowulf_HP>
+			<Ammo_50Beowulf_Incendiary>Bullet_50Beowulf_Incendiary</Ammo_50Beowulf_Incendiary>
+			<Ammo_50Beowulf_HE>Bullet_50Beowulf_HE</Ammo_50Beowulf_HE>
+			<Ammo_50Beowulf_Sabot>Bullet_50Beowulf_Sabot</Ammo_50Beowulf_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="50BeowulfBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>A powerful cartridge with heavy bullets designed to bring high stopping power to intermediate semi-automatic rifles.</description>
+		<statBases>
+		<Mass>0.036</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo50Beowulf</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+		<defName>Ammo_50Beowulf_FMJ</defName>
+		<label>.50 Beowulf cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_50Beowulf_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+		<defName>Ammo_50Beowulf_AP</defName>
+		<label>.50 Beowulf cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_50Beowulf_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+		<defName>Ammo_50Beowulf_HP</defName>
+		<label>.50 Beowulf cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.15</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_50Beowulf_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+    <defName>Ammo_50Beowulf_Incendiary</defName>
+    <label>.50 Beowulf cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.22</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_50Beowulf_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+    <defName>Ammo_50Beowulf_HE</defName>
+    <label>.50 Beowulf cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.38</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_50Beowulf_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="50BeowulfBase">
+    <defName>Ammo_50Beowulf_Sabot</defName>
+    <label>.50 Beowulf cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.18</MarketValue>
+	  <Mass>0.027</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_50Beowulf_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base50BeowulfBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>108</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_FMJ</defName>
+		<label>.50 Beowulf bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>23</damageAmountBase>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>64.16</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_AP</defName>
+		<label>.50 Beowulf bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>14</damageAmountBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>64.16</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_HP</defName>
+		<label>.50 Beowulf bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>29</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>64.16</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_Incendiary</defName>
+		<label>.50 Beowulf bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>14</damageAmountBase>
+		  <armorPenetrationSharp>15</armorPenetrationSharp>
+		  <armorPenetrationBlunt>64.16</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>9</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_HE</defName>
+		<label>.50 Beowulf bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>23</damageAmountBase>
+		  <armorPenetrationSharp>7.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>64.16</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>14</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base50BeowulfBullet">
+		<defName>Bullet_50Beowulf_Sabot</defName>
+		<label>.50 Beowulf bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>12</damageAmountBase>
+		  <armorPenetrationSharp>26</armorPenetrationSharp>
+		  <armorPenetrationBlunt>82.28</armorPenetrationBlunt>
+		  <speed>160</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_50Beowulf_FMJ</defName>
+		<label>make .50 Beowulf (FMJ) cartridge x500</label>
+		<description>Craft 500 .50 Beowulf (FMJ) cartridges.</description>
+		<jobString>Making .50 Beowulf (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_50Beowulf_FMJ>500</Ammo_50Beowulf_FMJ>
+		</products>
+    	<workAmount>3600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_50Beowulf_AP</defName>
+		<label>make .50 Beowulf (AP) cartridge x500</label>
+		<description>Craft 500 .50 Beowulf (AP) cartridges.</description>
+		<jobString>Making .50 Beowulf (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_50Beowulf_AP>500</Ammo_50Beowulf_AP>
+		</products>
+	<workAmount>4320</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_50Beowulf_HP</defName>
+		<label>make .50 Beowulf (HP) cartridge x500</label>
+		<description>Craft 500 .50 Beowulf (HP) cartridges.</description>
+		<jobString>Making .50 Beowulf (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_50Beowulf_HP>500</Ammo_50Beowulf_HP>
+		</products>
+	<workAmount>3600</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_50Beowulf_Incendiary</defName>
+    <label>make .50 Beowulf (AP-I) cartridge x500</label>
+    <description>Craft 500 .50 Beowulf (AP-I) cartridges.</description>
+    <jobString>Making .50 Beowulf (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>36</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>6</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50Beowulf_Incendiary>500</Ammo_50Beowulf_Incendiary>
+    </products>
+    <workAmount>6000</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_50Beowulf_HE</defName>
+    <label>make .50 Beowulf (AP-HE) cartridge x500</label>
+    <description>Craft 500 .50 Beowulf (AP-HE) cartridges.</description>
+    <jobString>Making .50 Beowulf (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>36</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>11</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50Beowulf_HE>500</Ammo_50Beowulf_HE>
+    </products>
+    <workAmount>8000</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_50Beowulf_Sabot</defName>
+    <label>make .50 Beowulf (Sabot) cartridge x500</label>
+    <description>Craft 500 .50 Beowulf (Sabot) cartridges.</description>
+    <jobString>Making .50 Beowulf (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>14</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>7</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>7</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_50Beowulf_Sabot>500</Ammo_50Beowulf_Sabot>
+    </products>
+    <workAmount>5600</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/7mm-08Remington.xml
+++ b/Defs/Ammo/Rifle/7mm-08Remington.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo7mm08Remington</defName>
+		<label>7mm-08 Remington</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_7mm08Remington</defName>
+		<label>7mm-08 Remington</label>
+		<ammoTypes>
+			<Ammo_7mm08Remington_FMJ>Bullet_7mm08Remington_FMJ</Ammo_7mm08Remington_FMJ>
+			<Ammo_7mm08Remington_AP>Bullet_7mm08Remington_AP</Ammo_7mm08Remington_AP>
+			<Ammo_7mm08Remington_HP>Bullet_7mm08Remington_HP</Ammo_7mm08Remington_HP>
+			<Ammo_7mm08Remington_Incendiary>Bullet_7mm08Remington_Incendiary</Ammo_7mm08Remington_Incendiary>
+			<Ammo_7mm08Remington_HE>Bullet_7mm08Remington_HE</Ammo_7mm08Remington_HE>
+			<Ammo_7mm08Remington_Sabot>Bullet_7mm08Remington_Sabot</Ammo_7mm08Remington_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="7mm08RemingtonBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Necked down .308 cartridge meant for hunting and sporting use.</description>
+		<statBases>
+		<Mass>0.025</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo7mm08Remington</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+		<defName>Ammo_7mm08Remington_FMJ</defName>
+		<label>7mm-08 Remington cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_7mm08Remington_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+		<defName>Ammo_7mm08Remington_AP</defName>
+		<label>7mm-08 Remington cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_7mm08Remington_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+		<defName>Ammo_7mm08Remington_HP</defName>
+		<label>7mm-08 Remington cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.11</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_7mm08Remington_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+    <defName>Ammo_7mm08Remington_Incendiary</defName>
+    <label>7mm-08 Remington cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.15</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_7mm08Remington_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+    <defName>Ammo_7mm08Remington_HE</defName>
+    <label>7mm-08 Remington cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.21</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_7mm08Remington_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="7mm08RemingtonBase">
+    <defName>Ammo_7mm08Remington_Sabot</defName>
+    <label>7mm-08 Remington cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.12</MarketValue>
+	  <Mass>0.021</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_7mm08Remington_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base7mm08RemingtonBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>162</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_FMJ</defName>
+		<label>7mm-08 Remington bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>63.64</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_AP</defName>
+		<label>7mm-08 Remington bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>14</armorPenetrationSharp>
+			<armorPenetrationBlunt>63.64</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_HP</defName>
+		<label>7mm-08 Remington bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>24</damageAmountBase>
+			<armorPenetrationSharp>3.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>63.64</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_Incendiary</defName>
+		<label>7mm-08 Remington bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>12</damageAmountBase>
+		  <armorPenetrationSharp>14</armorPenetrationSharp>
+		  <armorPenetrationBlunt>63.64</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>7</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_HE</defName>
+		<label>7mm-08 Remington bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>19</damageAmountBase>
+		  <armorPenetrationSharp>7</armorPenetrationSharp>
+		  <armorPenetrationBlunt>63.64</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>11</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base7mm08RemingtonBullet">
+		<defName>Bullet_7mm08Remington_Sabot</defName>
+		<label>7mm-08 Remington bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>10</damageAmountBase>
+		  <armorPenetrationSharp>24.50</armorPenetrationSharp>
+		  <armorPenetrationBlunt>81.64</armorPenetrationBlunt>
+		  <speed>243</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_7mm08Remington_FMJ</defName>
+		<label>make 7mm-08 Remington (FMJ) cartridge x500</label>
+		<description>Craft 500 7mm-08 Remington (FMJ) cartridges.</description>
+		<jobString>Making 7mm-08 Remington (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_7mm08Remington_FMJ>500</Ammo_7mm08Remington_FMJ>
+		</products>
+    	<workAmount>2600</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_7mm08Remington_AP</defName>
+		<label>make 7mm-08 Remington (AP) cartridge x500</label>
+		<description>Craft 500 7mm-08 Remington (AP) cartridges.</description>
+		<jobString>Making 7mm-08 Remington (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_7mm08Remington_AP>500</Ammo_7mm08Remington_AP>
+		</products>
+	<workAmount>3120</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_7mm08Remington_HP</defName>
+		<label>make 7mm-08 Remington (HP) cartridge x500</label>
+		<description>Craft 500 7mm-08 Remington (HP) cartridges.</description>
+		<jobString>Making 7mm-08 Remington (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>26</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_7mm08Remington_HP>500</Ammo_7mm08Remington_HP>
+		</products>
+	<workAmount>2600</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_7mm08Remington_Incendiary</defName>
+    <label>make 7mm-08 Remington (AP-I) cartridge x500</label>
+    <description>Craft 500 7mm-08 Remington (AP-I) cartridges.</description>
+    <jobString>Making 7mm-08 Remington (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>26</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_7mm08Remington_Incendiary>500</Ammo_7mm08Remington_Incendiary>
+    </products>
+    <workAmount>3800</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_7mm08Remington_HE</defName>
+    <label>make 7mm-08 Remington (AP-HE) cartridge x500</label>
+    <description>Craft 500 7mm-08 Remington (AP-HE) cartridges.</description>
+    <jobString>Making 7mm-08 Remington (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>26</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_7mm08Remington_HE>500</Ammo_7mm08Remington_HE>
+    </products>
+    <workAmount>4600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_7mm08Remington_Sabot</defName>
+    <label>make 7mm-08 Remington (Sabot) cartridge x500</label>
+    <description>Craft 500 7mm-08 Remington (Sabot) cartridges.</description>
+    <jobString>Making 7mm-08 Remington (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>16</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>3</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_7mm08Remington_Sabot>500</Ammo_7mm08Remington_Sabot>
+    </products>
+    <workAmount>3400</workAmount>
+  </RecipeDef>
+	
+</Defs>

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -1,0 +1,410 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo8x50mmRMannlicher</defName>
+		<label>8x50mmR Mannlicher</label>
+		<parent>AmmoRifles</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberRifle</iconPath>
+	</ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_8x50mmRMannlicher</defName>
+		<label>8x50mmR Mannlicher</label>
+		<ammoTypes>
+			<Ammo_8x50mmRMannlicher_FMJ>Bullet_8x50mmRMannlicher_FMJ</Ammo_8x50mmRMannlicher_FMJ>
+			<Ammo_8x50mmRMannlicher_AP>Bullet_8x50mmRMannlicher_AP</Ammo_8x50mmRMannlicher_AP>
+			<Ammo_8x50mmRMannlicher_HP>Bullet_8x50mmRMannlicher_HP</Ammo_8x50mmRMannlicher_HP>
+			<Ammo_8x50mmRMannlicher_Incendiary>Bullet_8x50mmRMannlicher_Incendiary</Ammo_8x50mmRMannlicher_Incendiary>
+			<Ammo_8x50mmRMannlicher_HE>Bullet_8x50mmRMannlicher_HE</Ammo_8x50mmRMannlicher_HE>
+			<Ammo_8x50mmRMannlicher_Sabot>Bullet_8x50mmRMannlicher_Sabot</Ammo_8x50mmRMannlicher_Sabot>				
+		</ammoTypes>
+		<similarTo>AmmoSet_Rifle</similarTo>
+	</CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="8x50mmRMannlicherBase" ParentName="SmallAmmoBase" Abstract="True">
+		<description>Rimmed rifle cartridge found mostly in outdated bolt-action firearms.</description>
+		<statBases>
+		<Mass>0.032</Mass>
+		<Bulk>0.03</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo8x50mmRMannlicher</li>
+		</thingCategories>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+		<defName>Ammo_8x50mmRMannlicher_FMJ</defName>
+		<label>8x50mmR Mannlicher cartridge (FMJ)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/FMJ</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>FullMetalJacket</ammoClass>
+		<cookOffProjectile>Bullet_8x50mmRMannlicher_FMJ</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+		<defName>Ammo_8x50mmRMannlicher_AP</defName>
+		<label>8x50mmR Mannlicher cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_8x50mmRMannlicher_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+		<defName>Ammo_8x50mmRMannlicher_HP</defName>
+		<label>8x50mmR Mannlicher cartridge (HP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/Rifle/HP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>0.13</MarketValue>
+		</statBases>
+		<ammoClass>HollowPoint</ammoClass>
+		<cookOffProjectile>Bullet_8x50mmRMannlicher_HP</cookOffProjectile>
+	</ThingDef>
+	
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+    <defName>Ammo_8x50mmRMannlicher_Incendiary</defName>
+    <label>8x50mmR Mannlicher cartridge (AP-I)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Incendiary</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.18</MarketValue>
+    </statBases>
+    <ammoClass>IncendiaryAP</ammoClass>
+    <cookOffProjectile>Bullet_8x50mmRMannlicher_Incendiary</cookOffProjectile>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+    <defName>Ammo_8x50mmRMannlicher_HE</defName>
+    <label>8x50mmR Mannlicher cartridge (AP-HE)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/HE</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.30</MarketValue>
+    </statBases>
+    <ammoClass>ExplosiveAP</ammoClass>
+    <cookOffProjectile>Bullet_8x50mmRMannlicher_HE</cookOffProjectile>
+  </ThingDef>
+ 
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="8x50mmRMannlicherBase">
+    <defName>Ammo_8x50mmRMannlicher_Sabot</defName>
+    <label>8x50mmR Mannlicher cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/Rifle/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.16</MarketValue>
+	  <Mass>0.025</Mass>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+    <cookOffProjectile>Bullet_8x50mmRMannlicher_Sabot</cookOffProjectile>
+  </ThingDef>
+  
+	<!-- ================== Projectiles ================== -->
+	
+	<ThingDef Name="Base8x50mmRMannlicherBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Small</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>119</speed>
+			<dropsCasings>true</dropsCasings>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_FMJ</defName>
+		<label>8x50mmR Mannlicher bullet (FMJ)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>19</damageAmountBase>
+			<armorPenetrationSharp>5.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>56.46</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_AP</defName>
+		<label>8x50mmR Mannlicher bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>12</damageAmountBase>
+			<armorPenetrationSharp>11</armorPenetrationSharp>
+			<armorPenetrationBlunt>56.46</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_HP</defName>
+		<label>8x50mmR Mannlicher bullet (HP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>24</damageAmountBase>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>56.46</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	  <ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_Incendiary</defName>
+		<label>8x50mmR Mannlicher bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>12</damageAmountBase>
+		  <armorPenetrationSharp>11</armorPenetrationSharp>
+		  <armorPenetrationBlunt>56.46</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Flame_Secondary</def>
+			  	<amount>7</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+	  
+	  <ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_HE</defName>
+		<label>8x50mmR Mannlicher bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>19</damageAmountBase>
+		  <armorPenetrationSharp>5.5</armorPenetrationSharp>
+		  <armorPenetrationBlunt>56.46</armorPenetrationBlunt>
+		  <secondaryDamage>
+				<li>
+			  	<def>Bomb_Secondary</def>
+			  	<amount>11</amount>
+				</li>
+		  </secondaryDamage>
+		</projectile>
+	  </ThingDef>
+
+	  <ThingDef ParentName="Base8x50mmRMannlicherBullet">
+		<defName>Bullet_8x50mmRMannlicher_Sabot</defName>
+		<label>8x50mmR Mannlicher bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+		  <damageAmountBase>10</damageAmountBase>
+		  <armorPenetrationSharp>19</armorPenetrationSharp>
+		  <armorPenetrationBlunt>72.40</armorPenetrationBlunt>
+		  <speed>179</speed>
+		</projectile>
+	  </ThingDef>
+	  
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_8x50mmRMannlicher_FMJ</defName>
+		<label>make 8x50mmR Mannlicher (FMJ) cartridge x500</label>
+		<description>Craft 500 8x50mmR Mannlicher (FMJ) cartridges.</description>
+		<jobString>Making 8x50mmR Mannlicher (FMJ) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_8x50mmRMannlicher_FMJ>500</Ammo_8x50mmRMannlicher_FMJ>
+		</products>
+    	<workAmount>3200</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_8x50mmRMannlicher_AP</defName>
+		<label>make 8x50mmR Mannlicher (AP) cartridge x500</label>
+		<description>Craft 500 8x50mmR Mannlicher (AP) cartridges.</description>
+		<jobString>Making 8x50mmR Mannlicher (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_8x50mmRMannlicher_AP>500</Ammo_8x50mmRMannlicher_AP>
+		</products>
+	<workAmount>3840</workAmount>		
+	</RecipeDef>
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_8x50mmRMannlicher_HP</defName>
+		<label>make 8x50mmR Mannlicher (HP) cartridge x500</label>
+		<description>Craft 500 8x50mmR Mannlicher (HP) cartridges.</description>
+		<jobString>Making 8x50mmR Mannlicher (HP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>32</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_8x50mmRMannlicher_HP>500</Ammo_8x50mmRMannlicher_HP>
+		</products>
+	<workAmount>3200</workAmount>		
+	</RecipeDef>
+
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_8x50mmRMannlicher_Incendiary</defName>
+    <label>make 8x50mmR Mannlicher (AP-I) cartridge x500</label>
+    <description>Craft 500 8x50mmR Mannlicher (AP-I) cartridges.</description>
+    <jobString>Making 8x50mmR Mannlicher (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_8x50mmRMannlicher_Incendiary>500</Ammo_8x50mmRMannlicher_Incendiary>
+    </products>
+    <workAmount>4800</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_8x50mmRMannlicher_HE</defName>
+    <label>make 8x50mmR Mannlicher (AP-HE) cartridge x500</label>
+    <description>Craft 500 8x50mmR Mannlicher (AP-HE) cartridges.</description>
+    <jobString>Making 8x50mmR Mannlicher (AP-HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>32</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_8x50mmRMannlicher_HE>500</Ammo_8x50mmRMannlicher_HE>
+    </products>
+    <workAmount>6400</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+    <defName>MakeAmmo_8x50mmRMannlicher_Sabot</defName>
+    <label>make 8x50mmR Mannlicher (Sabot) cartridge x500</label>
+    <description>Craft 500 8x50mmR Mannlicher (Sabot) cartridges.</description>
+    <jobString>Making 8x50mmR Mannlicher (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>16</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_8x50mmRMannlicher_Sabot>500</Ammo_8x50mmRMannlicher_Sabot>
+    </products>
+    <workAmount>4600</workAmount>
+  </RecipeDef>
+	
+</Defs>


### PR DESCRIPTION
## Additions
Adds a bunch of new calibers.

## Changes
- .17 HMR (an extremely fast and mean cartridge despite being so lightweight - very iconic.)
- .22 Hornet (old school powerful .22 cartridge that was used in US military issue survival rifles in the 20th century, but still somewhat popular.)
- .22 WMR (common in hunting and sporting historically, now also pretty widely used in handguns and semi-auto carbines/rifles, like the Kel-Tec PMR-30.) 
- .38 Super (technically just a more powerful .38 ACP, but the rounds tend not to be interchangeable both ways from what I can find online. It's a pretty popular chamber for 1911 variants and sporting pistols.)
- .38/200 S&W (or just .38 S&W Short, but with this designation to separate it a little bit ingame. Was used a lot in turn-of-the-century police revolvers, as well as the later Webleys and Enfield No2.)
- .41 AE (iconic for being a failed attempt to emulate .40 S&W that never took off, but still ended up being used in quite a few different weapons.)
- .41 Magnum (the somewhat obscure middle child between .357 and .44, but still used in a few different guns, even a Desert Eagle variant.)
- .44 S&W Special (fairly common police/civilian revolver cartridge in the early 1900s, and is the equivalent to .38 Special for .44 Magnum in modern weapons.)
- .45 Schofield (common wild west revolver cartridge, also usable in everything that shoots .45 Colt, .454 Casull, & .460 SW)
- .45 Win Mag (one of the more common "other" semi-auto magnum cartridges in pistols like the Wildey and LAR Grizzly, for fans of guns other than the Deagle.)
- .480 Ruger (another big bore revolver cartridge in the vein of .460/.500 S&W that still gets used in Ruger's bigger guns.)
- .500 Bushwhacker (only used in BFR revolvers but it's absurdly powerful.)

- .243 Winchester (a very popular hunting rifle cartridge that shoots extremely fast, and sits between the .223 and .308 in general performance.)
- .30-30 Winchester (it's the most common lever-action rifle cartridge ever, surprised it isn't already implemented.)
- .38-55 Winchester (another popular lever-action rifle cartridge, closer to .45-70 in performance but generally meant for the lighter lever actions.)
- .450 Bushmaster (a pretty common "high power" cartridge for AR15s during the era where everyone was obsessed about .223/5.56 not having enough stopping power.)
- .458 SOCOM (similar to the .450 Bushmaster, it was pretty iconic for a time.)
- .50 Beowulf (same track as the .450 & .458 but using the biggest and heaviest bullet of them all. Had a big internet presence for a long time.)
- 7mm-08 Remington (a reasonably popular hunting rifle and AR-10 cartridge for those that don't wanna be mainstream and use a .308)
- 8x50mmR Mannlicher (added on request, but it was the staple military cartridge of Austro-Hungarian forces during the end of the 19th century through WW1, and also saw some WW2 use.) 

- Also added a .44 Magnum "Revolver" def that chambers .44 Special (separate so that it wouldn't affect the balance by default), as well as a .460 Def that shoots all of the smaller .45 cartridges, and similarly done for .454 Casull and .45 Colt.

## References
https://docs.google.com/spreadsheets/d/1qy4M8YHhX4RLEYH2BDIbSIC89ho5Got_4XvmWXaXrlk/edit?usp=sharing

Added doc notes to provide sources where info is relevant.


## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
