### PR TITLE
Fix Some Revolver Ammosets

### DIFF
--- a/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
+++ b/Patches/Morgante Mafia Weapons Pack/Weapons_Guns.xml
@@ -245,7 +245,7 @@
 			<Properties>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_38ACP_FMJ</defaultProjectile>
+				<defaultProjectile>Bullet_38Special_FMJ</defaultProjectile>
 				<warmupTime>0.6</warmupTime>
 				<range>10</range>
 				<soundCast>Shot_Revolver</soundCast>
@@ -255,7 +255,7 @@
 			<AmmoUser>
 				<magazineSize>6</magazineSize>
 				<reloadTime>4.6</reloadTime>
-				<ammoSet>AmmoSet_38ACP</ammoSet>
+				<ammoSet>AmmoSet_38Special</ammoSet>
 			</AmmoUser>
 			<FireModes>
 				<aiUseBurstMode>FALSE</aiUseBurstMode>
@@ -281,7 +281,7 @@
 			<Properties>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_38ACP_FMJ</defaultProjectile>
+				<defaultProjectile>Bullet_38Special_FMJ</defaultProjectile>
 				<warmupTime>0.6</warmupTime>
 				<range>12</range>
 				<soundCast>Shot_Revolver</soundCast>
@@ -291,7 +291,7 @@
 			<AmmoUser>
 				<magazineSize>6</magazineSize>
 				<reloadTime>4.6</reloadTime>
-				<ammoSet>AmmoSet_38ACP</ammoSet>
+				<ammoSet>AmmoSet_38Special</ammoSet>
 			</AmmoUser>
 			<FireModes>
 				<aiUseBurstMode>FALSE</aiUseBurstMode>

--- a/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
+++ b/Patches/Thog's Guns - More Brukka Pack/Ranged_Industrial.xml
@@ -257,7 +257,7 @@
 	<Properties>
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>True</hasStandardCommand>
-      <defaultProjectile>Bullet_38ACP_FMJ</defaultProjectile>
+      <defaultProjectile>Bullet_38Special_FMJ</defaultProjectile>
       <warmupTime>0.5</warmupTime>
       <range>11</range>
       <soundCast>Shot_Autopistol</soundCast>
@@ -267,7 +267,7 @@
     <AmmoUser>
       <magazineSize>5</magazineSize>
       <reloadTime>4</reloadTime>
-      <ammoSet>AmmoSet_38ACP</ammoSet>
+      <ammoSet>AmmoSet_38Special</ammoSet>
     </AmmoUser>
     <FireModes>
 	  <aiUseBurstMode>False</aiUseBurstMode>


### PR DESCRIPTION
## Changes
- Fix a couple of revolvers that were using .38 ACP (a semi-rimless automatic pistol cartridge) instead of .38 Special (a rimmed revolver cartridge.)

## Reasoning
The .38 ACP ammo would not actually work in the revolvers due to a lack of a rim. Them being given the .38 ACP ammoset was likely a mistake. 

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
