### PR TITLE
.45-70 Trapdoor removed

### DIFF
--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -24,17 +24,6 @@
 		<similarTo>AmmoSet_Rifle</similarTo>
 	</CombatExtended.AmmoSetDef>
 
-	<CombatExtended.AmmoSetDef>
-		<defName>AmmoSet_4570GovTrapdoor</defName>
-		<label>.45-70 Government</label>
-		<ammoTypes>
-			<Ammo_4570Gov_FMJ>Bullet_4570GovTrapdoor_FMJ</Ammo_4570Gov_FMJ>
-			<Ammo_4570Gov_AP>Bullet_4570GovTrapdoor_AP</Ammo_4570Gov_AP>
-			<Ammo_4570Gov_HP>Bullet_4570GovTrapdoor_HP</Ammo_4570Gov_HP>
-		</ammoTypes>
-		<similarTo>AmmoSet_Rifle</similarTo>
-	</CombatExtended.AmmoSetDef>
-
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="4570GovBase" ParentName="SmallAmmoBase" Abstract="True">
@@ -223,39 +212,6 @@
 		  <speed>190</speed>
 		</projectile>
 	  </ThingDef>
-
-	<ThingDef ParentName="Base4570GovBullet">
-		<defName>Bullet_4570GovTrapdoor_FMJ</defName>
-		<label>.45-70 Government cartridge (FMJ)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>98</speed>
-			<damageAmountBase>20</damageAmountBase>
-			<armorPenetrationSharp>5</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.1</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base4570GovBullet">
-		<defName>Bullet_4570GovTrapdoor_AP</defName>
-		<label>.45-70 Government cartridge (AP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>98</speed>
-			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>10</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.1</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
-
-	<ThingDef ParentName="Base4570GovBullet">
-		<defName>Bullet_4570GovTrapdoor_HP</defName>
-		<label>.45-70 Government cartridge (HP)</label>
-		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>98</speed>
-			<damageAmountBase>25</damageAmountBase>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>46.1</armorPenetrationBlunt>
-		</projectile>
-	</ThingDef>
 
 	<!-- ==================== Recipes ========================== -->
 


### PR DESCRIPTION
## Changes

- Removed the .45-70 ammoset as it serves virtually no purpose. The Gatling gun from Armory will use the normal ammoset.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
