### PR TITLE
Fix the MechanoidMinigun weapon tag patch

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -51,7 +51,9 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/PawnKindDef[defName="Mech_CentipedeGunner"]/weaponTags</xpath>
     <value>
-      <weaponTags>MechanoidMinigun</weaponTags>
+      <weaponTags>
+        <li>MechanoidMinigun</li>
+      </weaponTags>
     </value>
   </Operation>
 


### PR DESCRIPTION
## Changes

- Fixed the incorrect syntax for the weapon tag's patch.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
