### PR TITLE
Arrows and Bolts tweaks and fixes

### DIFF
--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -143,7 +143,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
+			<speed>20</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.94</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -27,7 +27,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoCrossbowBoltBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>A crossbow bolt.</description>
     <statBases>
-      <Mass>0.131</Mass>
+      <Mass>0.09</Mass>
       <Bulk>0.24</Bulk>
       <Flammability>1</Flammability>
     </statBases>
@@ -51,7 +51,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.081</Mass>
+      <Mass>0.06</Mass>
       <MarketValue>0.39</MarketValue>
     </statBases>
     <ammoClass>StoneCrossbowBolt</ammoClass>
@@ -81,7 +81,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.99</MarketValue>
+      <Mass>0.07</Mass>
+      <MarketValue>3.06</MarketValue>
     </statBases>
     <ammoClass>PlasteelCrossbowBolt</ammoClass>
 	<generateAllowChance>0.2</generateAllowChance>
@@ -95,11 +96,10 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.131</Mass>	
-      <MarketValue>3.73</MarketValue>
+      <MarketValue>2.71</MarketValue>
     </statBases>
     <ammoClass>VenomCrossbowBolt</ammoClass>
-    <generateAllowChance>0</generateAllowChance>    
+    <generateAllowChance>0.1</generateAllowChance>    
   </ThingDef>
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoCrossbowBoltBase">
@@ -110,7 +110,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.086</Mass>	
+      <Mass>0.07</Mass>	
       <MarketValue>1.29</MarketValue>
     </statBases>
     <ammoClass>FlameCrossbowBolt</ammoClass>
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>24</speed>
+			<speed>22</speed>
 		</projectile>
 	</ThingDef>
 
@@ -144,8 +144,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>18</speed>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>1</armorPenetrationBlunt>
+			<damageAmountBase>10</damageAmountBase>
+			<armorPenetrationBlunt>2.94</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
 			<preExplosionSpawnChance>0.1</preExplosionSpawnChance>	<!-- 11.11 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Stone</preExplosionSpawnThingDef>
@@ -160,7 +160,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
@@ -178,8 +177,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>24</speed>
-			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationBlunt>5.12</armorPenetrationBlunt>
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationBlunt>6.32</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
 			<preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
@@ -194,7 +193,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
@@ -213,10 +211,9 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
 			<explosionRadius>0.2</explosionRadius>
 			<damageDef>ArrowFire</damageDef>
-			<damageAmountBase>3</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.16</preExplosionSpawnChance>	
 		</projectile>
@@ -305,7 +302,7 @@
             <li>Plasteel</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>3</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -317,7 +314,7 @@
     <products>
       <Ammo_CrossbowBolt_Plasteel>10</Ammo_CrossbowBolt_Plasteel>
     </products>
-    <workAmount>1800</workAmount>		
+    <workAmount>1400</workAmount>		
   </RecipeDef>
 
   <RecipeDef ParentName="AmmoRecipeNeolithicBase">
@@ -325,7 +322,7 @@
     <label>make venom crossbow bolts x10</label>
     <description>Craft 10 venom crossbow bolts.</description>
     <jobString>Making venom crossbow bolts.</jobString>
-	<workAmount>1300</workAmount>
+	<workAmount>1000</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -349,7 +346,7 @@
             <li>MedicineHerbal</li>
           </thingDefs>
         </filter>
-        <count>3</count>
+        <count>2</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -41,7 +41,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoArrowBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>Simple arrow design with a cutting head attached to a wooden shaft.</description>
     <statBases>
-      <Mass>0.028</Mass>
+      <Mass>0.022</Mass>
       <Bulk>0.08</Bulk>
       <Flammability>1</Flammability>
     </statBases>
@@ -65,6 +65,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
+      <Mass>0.016</Mass>
       <MarketValue>0.13</MarketValue>
     </statBases>
     <ammoClass>StoneArrow</ammoClass>
@@ -81,7 +82,6 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.034</Mass>	
       <MarketValue>0.53</MarketValue>
     </statBases>
     <ammoClass>SteelArrow</ammoClass>
@@ -95,7 +95,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.022</Mass>	
+      <Mass>0.017</Mass>	
       <MarketValue>1.07</MarketValue>
     </statBases>
     <ammoClass>PlasteelArrow</ammoClass>
@@ -110,11 +110,10 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.034</Mass>	
-      <MarketValue>2.58</MarketValue>
+      <MarketValue>1.55</MarketValue>
     </statBases>
     <ammoClass>VenomArrow</ammoClass>
-    <generateAllowChance>0</generateAllowChance>    
+    <generateAllowChance>0.1</generateAllowChance>    
   </ThingDef>
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="AmmoArrowBase">
@@ -125,7 +124,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.023</Mass>	
+      <Mass>0.017</Mass>	
       <MarketValue>1.16</MarketValue>
     </statBases>
     <ammoClass>FlameArrow</ammoClass>
@@ -141,7 +140,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>16</speed>
+      <speed>20</speed>
     </projectile>
   </ThingDef>
 
@@ -161,7 +160,7 @@
       <speed>18</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
-      <armorPenetrationBlunt>0.88</armorPenetrationBlunt>
+      <armorPenetrationBlunt>1.42</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.333</preExplosionSpawnChance>      <!-- 14.99 arrows per resource -->
       <preExplosionSpawnThingDef>Ammo_Arrow_Stone</preExplosionSpawnThingDef>
     </projectile>
@@ -175,7 +174,6 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.02</armorPenetrationBlunt>
@@ -193,9 +191,9 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>22</speed>
-      <damageAmountBase>6</damageAmountBase>
+      <damageAmountBase>5</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
-      <armorPenetrationBlunt>1.660</armorPenetrationBlunt>
+      <armorPenetrationBlunt>2.82</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.8</preExplosionSpawnChance>      <!-- 50 arrows per resource -->
       <preExplosionSpawnThingDef>Ammo_Arrow_Plasteel</preExplosionSpawnThingDef>
     </projectile>
@@ -209,15 +207,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-    <speed>20</speed>
-		<damageDef>Arrow</damageDef>
-		<damageAmountBase>7</damageAmountBase>
-		<secondaryDamage>
-			<li>
-			<def>ArrowVenom</def>
-			<amount>1</amount>
-			</li>
-		</secondaryDamage>		  
+      <damageDef>ArrowVenom</damageDef>
+      <damageAmountBase>7</damageAmountBase>	  
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.02</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.666</preExplosionSpawnChance>      <!-- 29.94 arrows per resource -->
@@ -234,9 +225,9 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-    <explosionRadius>0.1</explosionRadius>
+	  <explosionRadius>0.1</explosionRadius>
 	  <damageDef>ArrowFire</damageDef>
-	  <damageAmountBase>2</damageAmountBase>
+	  <damageAmountBase>3</damageAmountBase>
 	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
@@ -251,7 +242,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>ArrowHighVelocity</damageDef>
-      <speed>22</speed>
+      <speed>24</speed>
     </projectile>
   </ThingDef>
 
@@ -263,10 +254,10 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
-      <damageAmountBase>7</damageAmountBase>
+      <speed>22</speed>
+      <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
-      <armorPenetrationBlunt>1.740</armorPenetrationBlunt>
+      <armorPenetrationBlunt>2.78</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.2</preExplosionSpawnChance>
       <preExplosionSpawnThingDef>Ammo_Arrow_Stone</preExplosionSpawnThingDef>
     </projectile>
@@ -280,7 +271,6 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>24</speed>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>5.9</armorPenetrationBlunt>
@@ -298,9 +288,9 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <speed>26</speed>
-      <damageAmountBase>8</damageAmountBase>
+      <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
-      <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
+      <armorPenetrationBlunt>5.54</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.75</preExplosionSpawnChance>
       <preExplosionSpawnThingDef>Ammo_Arrow_Plasteel</preExplosionSpawnThingDef>
     </projectile>
@@ -314,15 +304,8 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-    <speed>24</speed>
-	  <damageDef>Arrow</damageDef>
-    <damageAmountBase>9</damageAmountBase>
-		<secondaryDamage>
-			<li>
-			<def>ArrowVenom</def>
-			<amount>2</amount>
-			</li>
-		</secondaryDamage>		  
+	  <damageDef>ArrowVenom</damageDef>
+	  <damageAmountBase>9</damageAmountBase>	  
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>5.9</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.6</preExplosionSpawnChance>
@@ -341,7 +324,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>0.1</explosionRadius>
 	  <damageDef>ArrowFire</damageDef>
-	  <damageAmountBase>2</damageAmountBase>
+	  <damageAmountBase>4</damageAmountBase>
 	  <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 	  <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
     </projectile>
@@ -450,7 +433,7 @@
     <label>make venom arrows x10</label>
     <description>Craft 10 venom arrows.</description>
     <jobString>Making venom arrows.</jobString>
-	  <workAmount>900</workAmount>
+	  <workAmount>600</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -474,7 +457,7 @@
             <li>MedicineHerbal</li>
           </thingDefs>
         </filter>
-        <count>2</count>
+        <count>1</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -27,7 +27,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" Name="AmmoGreatArrowBase" ParentName="NeolithicAmmoBase" Abstract="True">
     <description>Heavy arrow designed to be fired from a great bow.</description>
     <statBases>
-      <Mass>0.105</Mass>
+      <Mass>0.065</Mass>
       <Bulk>0.43</Bulk>
       <Flammability>1</Flammability>
     </statBases>
@@ -51,7 +51,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>0.39</MarketValue>
+      <Mass>0.045</Mass>
+      <MarketValue>0.26</MarketValue>
     </statBases>
     <ammoClass>StoneArrow</ammoClass>
     <tradeTags>
@@ -67,8 +68,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.115</Mass>	
-      <MarketValue>0.66</MarketValue>
+      <MarketValue>0.53</MarketValue>
     </statBases>
     <ammoClass>SteelArrow</ammoClass>
   </ThingDef>
@@ -81,8 +81,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.108</Mass>	
-      <MarketValue>3.06</MarketValue>
+      <Mass>0.05</Mass>
+      <MarketValue>2.0</MarketValue>
     </statBases>
     <ammoClass>PlasteelArrow</ammoClass>
     <generateAllowChance>0.2</generateAllowChance>
@@ -96,8 +96,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.115</Mass>	
-      <MarketValue>4.76</MarketValue>
+      <MarketValue>2.58</MarketValue>
     </statBases>
     <ammoClass>VenomArrow</ammoClass>
     <generateAllowChance>0</generateAllowChance>    
@@ -111,8 +110,8 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <Mass>0.083</Mass>	
-      <MarketValue>1.29</MarketValue>
+      <Mass>0.05</Mass>	
+      <MarketValue>1.16</MarketValue>
     </statBases>
     <ammoClass>FlameArrow</ammoClass>
     <generateAllowChance>0.2</generateAllowChance>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -127,7 +127,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>20</speed>
+			<speed>22</speed>
 		</projectile>
 	</ThingDef>
 	
@@ -161,7 +161,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
@@ -195,7 +194,6 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
 			<damageDef>Arrow</damageDef>
 			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>
@@ -214,18 +212,18 @@
 	<ThingDef ParentName="BaseGreatArrowProjectile">
 		<defName>Projectile_GreatArrow_Flame</defName>
 		<label>great arrow (flame)</label>
-    <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>    
 		<graphicData>
 			<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-    <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <explosionRadius>0.2</explosionRadius>
-      <damageDef>ArrowFire</damageDef>
-      <damageAmountBase>3</damageAmountBase>
-      <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
-      <preExplosionSpawnChance>0.16</preExplosionSpawnChance>
-    </projectile>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<explosionRadius>0.2</explosionRadius>
+			<damageDef>ArrowFire</damageDef>
+			<damageAmountBase>3</damageAmountBase>
+			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+			<preExplosionSpawnChance>0.16</preExplosionSpawnChance>
+		</projectile>
 	</ThingDef>
   
   <!-- ==================== Recipes ========================== -->

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -144,9 +144,9 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
-			<damageAmountBase>8</damageAmountBase>
-			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
+			<speed>20</speed>
+			<damageAmountBase>9</damageAmountBase>
+			<armorPenetrationBlunt>1.46</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.2</preExplosionSpawnChance>	<!-- 12.5 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_GreatArrow_Stone</preExplosionSpawnThingDef>
@@ -162,7 +162,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
-			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.18</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
@@ -178,8 +178,8 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>24</speed>
-			<damageAmountBase>9</damageAmountBase>
-			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
+			<damageAmountBase>8</damageAmountBase>
+			<armorPenetrationBlunt>2.96</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 40 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_GreatArrow_Plasteel</preExplosionSpawnThingDef>
@@ -194,15 +194,9 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Arrow</damageDef>
-			<damageAmountBase>10</damageAmountBase>
-			<secondaryDamage>
-				<li>
-				<def>ArrowVenom</def>
-				<amount>2</amount>
-				</li>
-			</secondaryDamage>			
-			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
+			<damageDef>ArrowVenom</damageDef>
+			<damageAmountBase>10</damageAmountBase>		
+			<armorPenetrationBlunt>3.18</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
@@ -220,7 +214,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>0.2</explosionRadius>
 			<damageDef>ArrowFire</damageDef>
-			<damageAmountBase>3</damageAmountBase>
+			<damageAmountBase>4</damageAmountBase>
 			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 			<preExplosionSpawnChance>0.16</preExplosionSpawnChance>
 		</projectile>


### PR DESCRIPTION
## Changes

- Fixed and tweaked some values for the Arrows and Bolts in the spreadsheet. Some of the mass, velocity and casing mass values needed consistency checks and fixes. The arbitrary Area Factor value for the Stone arrows was changed from 2.0 to 1.5 which allowed for more freedom in accurately changing and fixing the data.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony
