### PR TITLE
Reduce Beanbags' damage to buildings

### DIFF
--- a/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -8,6 +8,8 @@
     <hediff>BruiseBeanbag</hediff>
     <hediffSkin>BruiseBeanbag</hediffSkin>
     <hediffSolid>CrackBeanbag</hediffSolid>
+    <buildingDamageFactor>0.25</buildingDamageFactor>
+    <plantDamageFactor>0.25</plantDamageFactor>
   </DamageDef>
 
 	<DamageDef ParentName="CutBase">
@@ -106,10 +108,10 @@
     <hediff>VenomousArrow</hediff>
   </DamageDef>
 
-<DamageDef ParentName="Arrow">
+  <DamageDef ParentName="Arrow">
 	<defName>ArrowFire</defName>
 	<soundExplosion>BulletImpact_Wood</soundExplosion>
-</DamageDef>
+  </DamageDef>
 
   <DamageDef ParentName="Bullet">
     <defName>Tranquilizer</defName>


### PR DESCRIPTION
## Changes

- What it says on the tin, applied a x0.25 building and plant damage multiplier to the Beanbag damage type so that it does not deal more damage to walls and such than bullets like a shotgun slug.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
