### PR TITLE
New autocannon cartridge

### DIFF
--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+    <ThingCategoryDef>
+        <defName>Ammo23x152mmB</defName>
+        <label>25x152mmB</label>
+        <parent>AmmoHighCaliber</parent>
+        <iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+    </ThingCategoryDef>
+
+    <!-- ==================== AmmoSet ========================== -->
+
+    <CombatExtended.AmmoSetDef>
+        <defName>AmmoSet_23x152mmB</defName>
+        <label>23x152mmB</label>
+        <ammoTypes>
+            <Ammo_23x152mmB_AP>Bullet_23x152mmB_AP</Ammo_23x152mmB_AP>        
+            <Ammo_23x152mmB_Incendiary>Bullet_23x152mmB_Incendiary</Ammo_23x152mmB_Incendiary>
+            <Ammo_23x152mmB_APHE>Bullet_23x152mmB_APHE</Ammo_23x152mmB_APHE>
+            <Ammo_23x152mmB_Sabot>Bullet_23x152mmB_Sabot</Ammo_23x152mmB_Sabot>
+            <Ammo_23x152mmB_HE>Bullet_23x152mmB_HE</Ammo_23x152mmB_HE>
+        </ammoTypes>
+        <similarTo>AmmoSet_Autocannon</similarTo>
+    </CombatExtended.AmmoSetDef>
+
+    <!-- ==================== Ammo ========================== -->
+
+    <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo23x152mmBBase" ParentName="MediumAmmoBase" Abstract="True">
+        <description>Large caliber cartridge used by autocannons.</description>
+        <statBases>
+            <Mass>0.45</Mass>
+            <Bulk>0.62</Bulk>
+        </statBases>
+        <tradeTags>
+            <li>CE_AutoEnableTrade</li>
+            <li>CE_AutoEnableCrafting</li>
+        </tradeTags>
+        <thingCategories>
+            <li>Ammo23x152mmB</li>
+        </thingCategories>
+        <stackLimit>250</stackLimit>
+    </ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+        <defName>Ammo_23x152mmB_AP</defName>
+        <label>23x152mmB cartridge (AP)</label>
+        <graphicData>
+            <texPath>Things/Ammo/HighCaliber/AP</texPath>
+            <graphicClass>Graphic_StackCount</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>1.8</MarketValue>
+        </statBases>
+        <ammoClass>ArmorPiercing</ammoClass>
+        <cookOffProjectile>Bullet_23x152mmB_AP</cookOffProjectile>
+    </ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+        <defName>Ammo_23x152mmB_Incendiary</defName>
+        <label>23x152mmB cartridge (AP-I)</label>
+        <graphicData>
+            <texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+            <graphicClass>Graphic_StackCount</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>2.39</MarketValue>
+        </statBases>
+        <ammoClass>IncendiaryAP</ammoClass>
+        <cookOffProjectile>Bullet_23x152mmB_Incendiary</cookOffProjectile>
+    </ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+        <defName>Ammo_23x152mmB_APHE</defName>
+        <label>23x152mmB cartridge (AP-HE)</label>
+        <graphicData>
+            <texPath>Things/Ammo/HighCaliber/HE</texPath>
+            <graphicClass>Graphic_StackCount</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>3.6</MarketValue>
+        </statBases>
+        <ammoClass>ExplosiveAP</ammoClass>
+        <cookOffProjectile>Bullet_23x152mmB_APHE</cookOffProjectile>
+    </ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+        <defName>Ammo_23x152mmB_Sabot</defName>
+        <label>23x152mmB cartridge (Sabot)</label>
+        <graphicData>
+            <texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+            <graphicClass>Graphic_StackCount</graphicClass>
+        </graphicData>
+        <statBases>
+            <Mass>0.363</Mass>
+            <MarketValue>1.92</MarketValue>
+        </statBases>
+        <ammoClass>Sabot</ammoClass>
+        <cookOffProjectile>Bullet_23x152mmB_Sabot</cookOffProjectile>
+    </ThingDef>
+
+    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+        <defName>Ammo_23x152mmB_HE</defName>
+        <label>23x152mmB (HE)</label>
+        <graphicData>
+            <texPath>Things/Ammo/HighCaliber/HE</texPath>
+            <graphicClass>Graphic_StackCount</graphicClass>
+        </graphicData>
+        <statBases>
+            <MarketValue>2.6</MarketValue>
+        </statBases>
+        <ammoClass>GrenadeHE</ammoClass>
+        <detonateProjectile>Bullet_23x152mmB_HE</detonateProjectile>
+    </ThingDef>
+
+    <!-- ================== Projectiles ================== -->
+
+    <ThingDef Name="Base23x152mmBBullet" ParentName="BaseBulletCE" Abstract="true">
+        <graphicData>
+            <texPath>Things/Projectile/Bullet_Big</texPath>
+            <graphicClass>Graphic_Single</graphicClass>
+        </graphicData>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageDef>Bullet</damageDef>
+            <speed>194</speed>
+            <dropsCasings>true</dropsCasings>
+            <airborneSuppressionFactor>3.17</airborneSuppressionFactor>
+        </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base23x152mmBBullet">
+        <defName>Bullet_23x152mmB_AP</defName>
+        <label>23x152mmB bullet (AP)</label>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageAmountBase>56</damageAmountBase>
+            <armorPenetrationSharp>40</armorPenetrationSharp>
+            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+        </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base23x152mmBBullet">
+        <defName>Bullet_23x152mmB_Incendiary</defName>
+        <label>23x152mmB bullet (AP-I)</label>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageAmountBase>56</damageAmountBase>
+            <armorPenetrationSharp>40</armorPenetrationSharp>
+            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+            <secondaryDamage>
+                <li>
+                    <def>Flame_Secondary</def>
+                    <amount>35</amount>
+                </li>
+            </secondaryDamage>
+        </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base23x152mmBBullet">
+        <defName>Bullet_23x152mmB_APHE</defName>
+        <label>23x152mmB bullet (AP-HE)</label>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageAmountBase>89</damageAmountBase>
+            <armorPenetrationSharp>20</armorPenetrationSharp>
+            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+            <secondaryDamage>
+                <li>
+                    <def>Bomb_Secondary</def>
+                    <amount>53</amount>
+                </li>
+            </secondaryDamage>
+        </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base23x152mmBBullet">
+        <defName>Bullet_23x152mmB_Sabot</defName>
+        <label>23x152mmB bullet (Sabot)</label>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <damageAmountBase>43</damageAmountBase>
+            <armorPenetrationSharp>40</armorPenetrationSharp>
+            <armorPenetrationBlunt>1246.3</armorPenetrationBlunt>
+            <airborneSuppressionFactor>3.57</airborneSuppressionFactor>
+            <speed>220</speed>
+        </projectile>
+    </ThingDef>
+
+    <ThingDef ParentName="Base23x152mmBBullet">
+        <defName>Bullet_23x152mmB_HE</defName>
+        <label>23x152mmB bullet (HE)</label>
+        <projectile Class="CombatExtended.ProjectilePropertiesCE">
+            <explosionRadius>0.5</explosionRadius >
+            <damageDef>Bomb</damageDef>
+            <damageAmountBase>15</damageAmountBase>
+            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+            <suppressionFactor>3.0</suppressionFactor>
+            <dangerFactor>2.0</dangerFactor>
+            <screenShakeFactor>0.5</screenShakeFactor>
+            <speed>196</speed>
+        </projectile>
+        <comps>
+            <li Class="CombatExtended.CompProperties_Fragments">
+                <fragments>
+                    <Fragment_Small>5</Fragment_Small>
+                </fragments>
+            </li>
+        </comps>
+    </ThingDef>
+
+    <!-- ==================== Recipes ========================== -->
+
+    <RecipeDef ParentName="AmmoRecipeBase">
+        <defName>MakeAmmo_23x152mmB_AP</defName>
+        <label>make 23x152mmB (AP) cartridge x200</label>
+        <description>Craft 200 23x152mmB (AP) cartridges.</description>
+        <jobString>Making 23x152mmB (AP) cartridges.</jobString>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Steel</li>
+                    </thingDefs>
+                </filter>
+                <count>180</count>
+            </li>
+        </ingredients>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>Steel</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+            <Ammo_23x152mmB_AP>200</Ammo_23x152mmB_AP>
+        </products>
+        <workAmount>21600</workAmount>
+    </RecipeDef>
+
+    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+        <defName>MakeAmmo_23x152mmB_Incendiary</defName>
+        <label>make 23x152mmB (AP-I) cartridge x200</label>
+        <description>Craft 200 23x152mmB (AP-I) cartridges.</description>
+        <jobString>Making 23x152mmB (AP-I) cartridges.</jobString>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Steel</li>
+                    </thingDefs>
+                </filter>
+                <count>180</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Prometheum</li>
+                    </thingDefs>
+                </filter>
+                <count>19</count>
+            </li>
+        </ingredients>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>Steel</li>
+                <li>Prometheum</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+            <Ammo_23x152mmB_Incendiary>200</Ammo_23x152mmB_Incendiary>
+        </products>
+        <workAmount>25600</workAmount>
+    </RecipeDef>
+
+    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+        <defName>MakeAmmo_23x152mmB_APHE</defName>
+        <label>make 23x152mmB (AP-HE) cartridge x200</label>
+        <description>Craft 200 23x152mmB (AP-HE) cartridges.</description>
+        <jobString>Making 23x152mmB (AP-HE) cartridges.</jobString>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Steel</li>
+                    </thingDefs>
+                </filter>
+                <count>180</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>FSX</li>
+                    </thingDefs>
+                </filter>
+                <count>35</count>
+            </li>
+        </ingredients>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>Steel</li>
+                <li>FSX</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+            <Ammo_23x152mmB_APHE>200</Ammo_23x152mmB_APHE>
+        </products>
+        <workAmount>32000</workAmount>
+    </RecipeDef>
+
+    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+        <defName>MakeAmmo_23x152mmB_Sabot</defName>
+        <label>make 23x152mmB (Sabot) cartridge x200</label>
+        <description>Craft 200 23x152mmB (Sabot) cartridges.</description>
+        <jobString>Making 23x152mmB (Sabot) cartridges.</jobString>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Steel</li>
+                    </thingDefs>
+                </filter>
+                <count>104</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Uranium</li>
+                    </thingDefs>
+                </filter>
+                <count>21</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Chemfuel</li>
+                    </thingDefs>
+                </filter>
+                <count>21</count>
+            </li>
+        </ingredients>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>Steel</li>
+                <li>Uranium</li>
+                <li>Chemfuel</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+            <Ammo_23x152mmB_Sabot>200</Ammo_23x152mmB_Sabot>
+        </products>
+        <workAmount>23000</workAmount>
+    </RecipeDef>
+
+    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
+        <defName>MakeAmmo_23x152mmB_HE</defName>
+        <label>make 23x152mmB (HE) cartridge x200</label>
+        <description>Craft 200 23x152mmB (HE) cartridges.</description>
+        <jobString>Making 23x152mmB (HE) cartridges.</jobString>
+        <ingredients>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>Steel</li>
+                    </thingDefs>
+                </filter>
+                <count>182</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>FSX</li>
+                    </thingDefs>
+                </filter>
+                <count>9</count>
+            </li>
+            <li>
+                <filter>
+                    <thingDefs>
+                        <li>ComponentIndustrial</li>
+                    </thingDefs>
+                </filter>
+                <count>2</count>
+            </li>
+        </ingredients>
+        <fixedIngredientFilter>
+            <thingDefs>
+                <li>Steel</li>
+                <li>FSX</li>
+                <li>ComponentIndustrial</li>
+            </thingDefs>
+        </fixedIngredientFilter>
+        <products>
+            <Ammo_23x152mmB_HE>200</Ammo_23x152mmB_HE>
+        </products>
+        <workAmount>23000</workAmount>
+    </RecipeDef>
+
+</Defs>

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -1,392 +1,310 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-    <ThingCategoryDef>
-        <defName>Ammo23x152mmB</defName>
-        <label>25x152mmB</label>
-        <parent>AmmoHighCaliber</parent>
-        <iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
-    </ThingCategoryDef>
+	<ThingCategoryDef>
+		<defName>Ammo23x152mmB</defName>
+		<label>25x152mmB</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
 
-    <!-- ==================== AmmoSet ========================== -->
+	<!-- ==================== AmmoSet ========================== -->
 
-    <CombatExtended.AmmoSetDef>
-        <defName>AmmoSet_23x152mmB</defName>
-        <label>23x152mmB</label>
-        <ammoTypes>
-            <Ammo_23x152mmB_AP>Bullet_23x152mmB_AP</Ammo_23x152mmB_AP>        
-            <Ammo_23x152mmB_Incendiary>Bullet_23x152mmB_Incendiary</Ammo_23x152mmB_Incendiary>
-            <Ammo_23x152mmB_APHE>Bullet_23x152mmB_APHE</Ammo_23x152mmB_APHE>
-            <Ammo_23x152mmB_Sabot>Bullet_23x152mmB_Sabot</Ammo_23x152mmB_Sabot>
-            <Ammo_23x152mmB_HE>Bullet_23x152mmB_HE</Ammo_23x152mmB_HE>
-        </ammoTypes>
-        <similarTo>AmmoSet_Autocannon</similarTo>
-    </CombatExtended.AmmoSetDef>
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_23x152mmB</defName>
+		<label>23x152mmB</label>
+		<ammoTypes>
+			<Ammo_23x152mmB_AP>Bullet_23x152mmB_AP</Ammo_23x152mmB_AP>
+			<Ammo_23x152mmB_Incendiary>Bullet_23x152mmB_Incendiary</Ammo_23x152mmB_Incendiary>
+			<Ammo_23x152mmB_APHE>Bullet_23x152mmB_APHE</Ammo_23x152mmB_APHE>
+			<Ammo_23x152mmB_Sabot>Bullet_23x152mmB_Sabot</Ammo_23x152mmB_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
 
-    <!-- ==================== Ammo ========================== -->
+	<!-- ==================== Ammo ========================== -->
 
-    <ThingDef Class="CombatExtended.AmmoDef" Name="Ammo23x152mmBBase" ParentName="MediumAmmoBase" Abstract="True">
-        <description>Large caliber cartridge used by autocannons.</description>
-        <statBases>
-            <Mass>0.45</Mass>
-            <Bulk>0.62</Bulk>
-        </statBases>
-        <tradeTags>
-            <li>CE_AutoEnableTrade</li>
-            <li>CE_AutoEnableCrafting</li>
-        </tradeTags>
-        <thingCategories>
-            <li>Ammo23x152mmB</li>
-        </thingCategories>
-        <stackLimit>250</stackLimit>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo23x152mmBBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.45</Mass>
+			<Bulk>0.62</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo23x152mmB</li>
+		</thingCategories>
+		<stackLimit>500</stackLimit>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
-        <defName>Ammo_23x152mmB_AP</defName>
-        <label>23x152mmB cartridge (AP)</label>
-        <graphicData>
-            <texPath>Things/Ammo/HighCaliber/AP</texPath>
-            <graphicClass>Graphic_StackCount</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>1.8</MarketValue>
-        </statBases>
-        <ammoClass>ArmorPiercing</ammoClass>
-        <cookOffProjectile>Bullet_23x152mmB_AP</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+		<defName>Ammo_23x152mmB_AP</defName>
+		<label>23x152mmB cartridge (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.8</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_23x152mmB_AP</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
-        <defName>Ammo_23x152mmB_Incendiary</defName>
-        <label>23x152mmB cartridge (AP-I)</label>
-        <graphicData>
-            <texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
-            <graphicClass>Graphic_StackCount</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>2.39</MarketValue>
-        </statBases>
-        <ammoClass>IncendiaryAP</ammoClass>
-        <cookOffProjectile>Bullet_23x152mmB_Incendiary</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+		<defName>Ammo_23x152mmB_Incendiary</defName>
+		<label>23x152mmB cartridge (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.39</MarketValue>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_23x152mmB_Incendiary</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
-        <defName>Ammo_23x152mmB_APHE</defName>
-        <label>23x152mmB cartridge (AP-HE)</label>
-        <graphicData>
-            <texPath>Things/Ammo/HighCaliber/HE</texPath>
-            <graphicClass>Graphic_StackCount</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>3.6</MarketValue>
-        </statBases>
-        <ammoClass>ExplosiveAP</ammoClass>
-        <cookOffProjectile>Bullet_23x152mmB_APHE</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+		<defName>Ammo_23x152mmB_APHE</defName>
+		<label>23x152mmB cartridge (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>3.6</MarketValue>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_23x152mmB_APHE</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
-        <defName>Ammo_23x152mmB_Sabot</defName>
-        <label>23x152mmB cartridge (Sabot)</label>
-        <graphicData>
-            <texPath>Things/Ammo/HighCaliber/Sabot</texPath>
-            <graphicClass>Graphic_StackCount</graphicClass>
-        </graphicData>
-        <statBases>
-            <Mass>0.363</Mass>
-            <MarketValue>1.92</MarketValue>
-        </statBases>
-        <ammoClass>Sabot</ammoClass>
-        <cookOffProjectile>Bullet_23x152mmB_Sabot</cookOffProjectile>
-    </ThingDef>
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
+		<defName>Ammo_23x152mmB_Sabot</defName>
+		<label>23x152mmB cartridge (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<Mass>0.368</Mass>
+			<MarketValue>2.0</MarketValue>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_23x152mmB_Sabot</cookOffProjectile>
+	</ThingDef>
 
-    <ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo23x152mmBBase">
-        <defName>Ammo_23x152mmB_HE</defName>
-        <label>23x152mmB (HE)</label>
-        <graphicData>
-            <texPath>Things/Ammo/HighCaliber/HE</texPath>
-            <graphicClass>Graphic_StackCount</graphicClass>
-        </graphicData>
-        <statBases>
-            <MarketValue>2.6</MarketValue>
-        </statBases>
-        <ammoClass>GrenadeHE</ammoClass>
-        <detonateProjectile>Bullet_23x152mmB_HE</detonateProjectile>
-    </ThingDef>
+	<!-- ================== Projectiles ================== -->
 
-    <!-- ================== Projectiles ================== -->
+	<ThingDef Name="Base23x152mmBBullet" ParentName="BaseBulletCE" Abstract="true">
+		<graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>194</speed>
+			<dropsCasings>true</dropsCasings>
+			<airborneSuppressionFactor>3.17</airborneSuppressionFactor>
+		</projectile>
+	</ThingDef>
 
-    <ThingDef Name="Base23x152mmBBullet" ParentName="BaseBulletCE" Abstract="true">
-        <graphicData>
-            <texPath>Things/Projectile/Bullet_Big</texPath>
-            <graphicClass>Graphic_Single</graphicClass>
-        </graphicData>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageDef>Bullet</damageDef>
-            <speed>194</speed>
-            <dropsCasings>true</dropsCasings>
-            <airborneSuppressionFactor>3.17</airborneSuppressionFactor>
-        </projectile>
-    </ThingDef>
+	<ThingDef ParentName="Base23x152mmBBullet">
+		<defName>Bullet_23x152mmB_AP</defName>
+		<label>23x152mmB bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>56</damageAmountBase>
+			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
 
-    <ThingDef ParentName="Base23x152mmBBullet">
-        <defName>Bullet_23x152mmB_AP</defName>
-        <label>23x152mmB bullet (AP)</label>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>56</damageAmountBase>
-            <armorPenetrationSharp>40</armorPenetrationSharp>
-            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
-        </projectile>
-    </ThingDef>
+	<ThingDef ParentName="Base23x152mmBBullet">
+		<defName>Bullet_23x152mmB_Incendiary</defName>
+		<label>23x152mmB bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>56</damageAmountBase>
+			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Flame_Secondary</def>
+					<amount>35</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
 
-    <ThingDef ParentName="Base23x152mmBBullet">
-        <defName>Bullet_23x152mmB_Incendiary</defName>
-        <label>23x152mmB bullet (AP-I)</label>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>56</damageAmountBase>
-            <armorPenetrationSharp>40</armorPenetrationSharp>
-            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
-            <secondaryDamage>
-                <li>
-                    <def>Flame_Secondary</def>
-                    <amount>35</amount>
-                </li>
-            </secondaryDamage>
-        </projectile>
-    </ThingDef>
+	<ThingDef ParentName="Base23x152mmBBullet">
+		<defName>Bullet_23x152mmB_APHE</defName>
+		<label>23x152mmB bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>89</damageAmountBase>
+			<armorPenetrationSharp>22.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
+			<secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>53</amount>
+				</li>
+			</secondaryDamage>
+		</projectile>
+	</ThingDef>
 
-    <ThingDef ParentName="Base23x152mmBBullet">
-        <defName>Bullet_23x152mmB_APHE</defName>
-        <label>23x152mmB bullet (AP-HE)</label>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>89</damageAmountBase>
-            <armorPenetrationSharp>20</armorPenetrationSharp>
-            <armorPenetrationBlunt>1787.72</armorPenetrationBlunt>
-            <secondaryDamage>
-                <li>
-                    <def>Bomb_Secondary</def>
-                    <amount>53</amount>
-                </li>
-            </secondaryDamage>
-        </projectile>
-    </ThingDef>
+	<ThingDef ParentName="Base23x152mmBBullet">
+		<defName>Bullet_23x152mmB_Sabot</defName>
+		<label>23x152mmB bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>53</damageAmountBase>
+			<armorPenetrationSharp>78.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>2286.38</armorPenetrationBlunt>
+			<speed>291</speed>
+		</projectile>
+	</ThingDef>
 
-    <ThingDef ParentName="Base23x152mmBBullet">
-        <defName>Bullet_23x152mmB_Sabot</defName>
-        <label>23x152mmB bullet (Sabot)</label>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>43</damageAmountBase>
-            <armorPenetrationSharp>40</armorPenetrationSharp>
-            <armorPenetrationBlunt>1246.3</armorPenetrationBlunt>
-            <airborneSuppressionFactor>3.57</airborneSuppressionFactor>
-            <speed>220</speed>
-        </projectile>
-    </ThingDef>
+	<!-- ==================== Recipes ========================== -->
 
-    <ThingDef ParentName="Base23x152mmBBullet">
-        <defName>Bullet_23x152mmB_HE</defName>
-        <label>23x152mmB bullet (HE)</label>
-        <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <explosionRadius>0.5</explosionRadius >
-            <damageDef>Bomb</damageDef>
-            <damageAmountBase>15</damageAmountBase>
-            <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-            <suppressionFactor>3.0</suppressionFactor>
-            <dangerFactor>2.0</dangerFactor>
-            <screenShakeFactor>0.5</screenShakeFactor>
-            <speed>196</speed>
-        </projectile>
-        <comps>
-            <li Class="CombatExtended.CompProperties_Fragments">
-                <fragments>
-                    <Fragment_Small>5</Fragment_Small>
-                </fragments>
-            </li>
-        </comps>
-    </ThingDef>
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_23x152mmB_AP</defName>
+		<label>make 23x152mmB (AP) cartridge x200</label>
+		<description>Craft 200 23x152mmB (AP) cartridges.</description>
+		<jobString>Making 23x152mmB (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>180</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x152mmB_AP>200</Ammo_23x152mmB_AP>
+		</products>
+		<workAmount>21600</workAmount>
+	</RecipeDef>
 
-    <!-- ==================== Recipes ========================== -->
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x152mmB_Incendiary</defName>
+		<label>make 23x152mmB (AP-I) cartridge x200</label>
+		<description>Craft 200 23x152mmB (AP-I) cartridges.</description>
+		<jobString>Making 23x152mmB (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>180</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>19</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x152mmB_Incendiary>200</Ammo_23x152mmB_Incendiary>
+		</products>
+		<workAmount>25600</workAmount>
+	</RecipeDef>
 
-    <RecipeDef ParentName="AmmoRecipeBase">
-        <defName>MakeAmmo_23x152mmB_AP</defName>
-        <label>make 23x152mmB (AP) cartridge x200</label>
-        <description>Craft 200 23x152mmB (AP) cartridges.</description>
-        <jobString>Making 23x152mmB (AP) cartridges.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>180</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <Ammo_23x152mmB_AP>200</Ammo_23x152mmB_AP>
-        </products>
-        <workAmount>21600</workAmount>
-    </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x152mmB_APHE</defName>
+		<label>make 23x152mmB (AP-HE) cartridge x200</label>
+		<description>Craft 200 23x152mmB (AP-HE) cartridges.</description>
+		<jobString>Making 23x152mmB (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>180</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>35</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x152mmB_APHE>200</Ammo_23x152mmB_APHE>
+		</products>
+		<workAmount>32000</workAmount>
+	</RecipeDef>
 
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-        <defName>MakeAmmo_23x152mmB_Incendiary</defName>
-        <label>make 23x152mmB (AP-I) cartridge x200</label>
-        <description>Craft 200 23x152mmB (AP-I) cartridges.</description>
-        <jobString>Making 23x152mmB (AP-I) cartridges.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>180</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Prometheum</li>
-                    </thingDefs>
-                </filter>
-                <count>19</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-                <li>Prometheum</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <Ammo_23x152mmB_Incendiary>200</Ammo_23x152mmB_Incendiary>
-        </products>
-        <workAmount>25600</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-        <defName>MakeAmmo_23x152mmB_APHE</defName>
-        <label>make 23x152mmB (AP-HE) cartridge x200</label>
-        <description>Craft 200 23x152mmB (AP-HE) cartridges.</description>
-        <jobString>Making 23x152mmB (AP-HE) cartridges.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>180</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>FSX</li>
-                    </thingDefs>
-                </filter>
-                <count>35</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-                <li>FSX</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <Ammo_23x152mmB_APHE>200</Ammo_23x152mmB_APHE>
-        </products>
-        <workAmount>32000</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-        <defName>MakeAmmo_23x152mmB_Sabot</defName>
-        <label>make 23x152mmB (Sabot) cartridge x200</label>
-        <description>Craft 200 23x152mmB (Sabot) cartridges.</description>
-        <jobString>Making 23x152mmB (Sabot) cartridges.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>104</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Uranium</li>
-                    </thingDefs>
-                </filter>
-                <count>21</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Chemfuel</li>
-                    </thingDefs>
-                </filter>
-                <count>21</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-                <li>Uranium</li>
-                <li>Chemfuel</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <Ammo_23x152mmB_Sabot>200</Ammo_23x152mmB_Sabot>
-        </products>
-        <workAmount>23000</workAmount>
-    </RecipeDef>
-
-    <RecipeDef ParentName="AdvancedAmmoRecipeBase">
-        <defName>MakeAmmo_23x152mmB_HE</defName>
-        <label>make 23x152mmB (HE) cartridge x200</label>
-        <description>Craft 200 23x152mmB (HE) cartridges.</description>
-        <jobString>Making 23x152mmB (HE) cartridges.</jobString>
-        <ingredients>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>Steel</li>
-                    </thingDefs>
-                </filter>
-                <count>182</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>FSX</li>
-                    </thingDefs>
-                </filter>
-                <count>9</count>
-            </li>
-            <li>
-                <filter>
-                    <thingDefs>
-                        <li>ComponentIndustrial</li>
-                    </thingDefs>
-                </filter>
-                <count>2</count>
-            </li>
-        </ingredients>
-        <fixedIngredientFilter>
-            <thingDefs>
-                <li>Steel</li>
-                <li>FSX</li>
-                <li>ComponentIndustrial</li>
-            </thingDefs>
-        </fixedIngredientFilter>
-        <products>
-            <Ammo_23x152mmB_HE>200</Ammo_23x152mmB_HE>
-        </products>
-        <workAmount>23000</workAmount>
-    </RecipeDef>
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_23x152mmB_Sabot</defName>
+		<label>make 23x152mmB (Sabot) cartridge x200</label>
+		<description>Craft 200 23x152mmB (Sabot) cartridges.</description>
+		<jobString>Making 23x152mmB (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>104</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_23x152mmB_Sabot>200</Ammo_23x152mmB_Sabot>
+		</products>
+		<workAmount>23600</workAmount>
+	</RecipeDef>
 
 </Defs>


### PR DESCRIPTION
Sources:
https://en.wikipedia.org/wiki/ZU-23-2
https://en.wikipedia.org/wiki/23%C3%97152mmB
http://www.steelbeasts.com/sbwiki/index.php/Ammunition_Data#Autocannon https://arconpartners.net/products/ammunition/medium-caliber/23-x-152-mm-round-with-armour-piercing-incendiary-tracer-projectile-api-t-for-23-mm-anti-aircraft-guns-zu-23-2-2a13-and-zsu-23-4/ https://arconpartners.net/products/ammunition/medium-caliber/23-x-152-mm-round-with-high-explosive-incendiary-projectile-hei-for-23-mm-anti-aircraft-guns-zu-23-2-2a13-and-zsu-23-4/

https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Additions

Adds a new autocannon AmmoSet, 23x152mmB
  - The usual AP, AP-I, AP-HE and Sabot ammo types
  
## Reasoning

  - In case someone decides to add a ZU-23 autocannon. Though the 23mm is gradually being replaced by 30x165mm in the Russian armed forces, their soviet-era weapons like the ZU-23-2 is still seeing a lot of action.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors