### PR TITLE
Patch New Mech: Mini-Miner

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -76,5 +76,6 @@
 		<li>sarg.magicalmenagerie</li>
     	<li>ObsidiaExpansion.Xenos.Mothoids</li>
 		<li>Roo.AntyRaceMod</li>
+		<li>Slashandz.MiniMiner</li>
 	</loadAfter>
 </ModMetaData>

--- a/Patches/New Mech - Mini-Miner/Race_MiniMiner.xml
+++ b/Patches/New Mech - Mini-Miner/Race_MiniMiner.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>New Mech: Mini-Miner</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Pawn inherits needed StatBase stuff from LightMech parent.-->		
+		<li Class="PatchOperationAddModExtension">
+			<xpath>Defs/ThingDef[defName="Mech_MiniMiner"]</xpath>
+			<value>
+				<li Class="CombatExtended.RacePropertiesExtensionCE">
+					<bodyShape>Humanoid</bodyShape>
+				</li>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/ThingDef[defName="Mech_MiniMiner"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>4</power>
+						<cooldownTime>2.0</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
+						<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>right claw</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>2.0</cooldownTime>
+						<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					</li>
+					<li Class="CombatExtended.ToolCE">
+						<label>left claw</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>6</power>
+						<cooldownTime>2.0</cooldownTime>
+						<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -312,6 +312,7 @@ Nakin Race  |
 Nanosuit    |
 Nearmare Race	|
 Neclose Race	|
+New Mech: Mini-Miner    |
 NewRatkinPlus |
 Ni'Hal	|
 Nukes   |


### PR DESCRIPTION
## Additions
- A very small patch for the new Mini-Miner mech. It inherits most of its stats from LightMechanoid, its parent.
- Added it as a 'Load Before' mod because the author has, for some ungodly reason, patched all the new stuff in rather than just making them Defs. This will hopefully go away at some point in the future.

Close #2469 

Also, I removed a bit of trailing whitespace in the ThirdPartyMod file that was there for some reason.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
