### PR TITLE
Fix 90mm recoilless' canister projectile issue

### DIFF
--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -112,7 +112,7 @@
     </comps>
   </ThingDef>
 
-  <ThingDef ParentName="BaseExplosiveBullet">
+  <ThingDef ParentName="Base12GaugeBullet">
     <defName>Bullet_90mmRCR_CAN</defName>
     <label>Flechette</label>
     <graphicData>


### PR DESCRIPTION
## Additions

Makes guns able to use 90mm RCR canister and also display caliber information

## Changes

Changed the base bullet from explosive to Base12GaugeBullet

## Reasoning

Was quick, easy, works, and I wanted to fix something.

## Alternatives

Removing 90mm RCR, or harassing the person who first implemented it for not play testing anything.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony for like 15 minutes. Just made sure a gun wouldn't throw an error when panning over the caliber info.
