### PR TITLE
Rimsenal Assault Armor changes

### DIFF
--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -123,47 +123,27 @@
 							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
+								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
-							<parts>
-								<li>Leg</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
-							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
+								<li>Arm</li>
 								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
+								<li>Arm</li>
 								<li>Hand</li>
 							</parts>
 						  </li>
@@ -229,35 +209,15 @@
 							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-							<parts>
-								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-							<parts>
 								<li>Nose</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-							<parts>
-								<li>Nose</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-							<parts>
 								<li>Jaw</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
 							<parts>
+								<li>Eye</li>
+								<li>Nose</li>
 								<li>Jaw</li>
 							</parts>
 						</li>
@@ -334,23 +294,13 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
+								<li>Arm</li>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -446,23 +396,13 @@
 							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
-							<parts>
-								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
-							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
 							<parts>
+								<li>Eye</li>
 								<li>Nose</li>
 							</parts>
 						</li>
@@ -540,23 +480,13 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
+								<li>Arm</li>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -713,23 +643,13 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
-							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
+								<li>Arm</li>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -815,30 +735,16 @@
 							<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
-							<parts>
-								<li>Nose</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-							<parts>
+								<li>Jaw</li>
 								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
 							<parts>
+								<li>Nose</li>
 								<li>Jaw</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
-							<parts>
-								<li>Jaw</li>
+								<li>Nose</li>
 							</parts>
 						</li>
 					</stats>
@@ -935,35 +841,15 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Neck</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
 								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
+								<li>Neck</li>
+								<li>Arm</li>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -1112,60 +998,30 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
+								<li>Leg</li>
+								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
+								<li>Leg</li>
+								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
+								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
-								<li>Leg</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Leg</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
-							<parts>
 								<li>Hand</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
-							<parts>
-								<li>Hand</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
-								<li>Foot</li>
-							</parts>
-						  </li>
-						  <li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Foot</li>
 							</parts>
 						  </li>
 					  </stats>
@@ -1396,18 +1252,18 @@
 					</value>
 				</nomatch>
 			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
-				<value>
-					<SmokeSensitivity>-1</SmokeSensitivity>
-				</value>
-			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
 					<MoveSpeed>-0.25</MoveSpeed>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
 			
@@ -1594,23 +1450,13 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
+								<li>Eye</li>
 								<li>Nose</li>
 							</parts>
 						</li>
@@ -2275,23 +2121,13 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
-							<parts>
-								<li>Eye</li>
-							</parts>
-						</li>
-						<li>
-							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
-							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
+								<li>Eye</li>
 								<li>Nose</li>
 							</parts>
 						</li>

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -123,27 +123,47 @@
 							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.875</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.875</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.625</ArmorRating_Sharp>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.625</ArmorRating_Blunt>
+							<parts>
 								<li>Hand</li>
 							</parts>
 						  </li>
@@ -209,15 +229,35 @@
 							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-								<li>Nose</li>
-								<li>Jaw</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
 								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
 								<li>Jaw</li>
 							</parts>
 						</li>
@@ -294,13 +334,23 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -396,13 +446,23 @@
 							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.85</ArmorRating_Sharp>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.85</ArmorRating_Blunt>
+							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>
@@ -480,13 +540,23 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -643,13 +713,23 @@
 							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -735,16 +815,30 @@
 							<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
-								<li>Jaw</li>
-								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
 							<parts>
 								<li>Nose</li>
-								<li>Jaw</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
 								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+							<parts>
+								<li>Jaw</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+							<parts>
+								<li>Jaw</li>
 							</parts>
 						</li>
 					</stats>
@@ -841,15 +935,35 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
-								<li>Arm</li>
-								<li>Leg</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
 								<li>Leg</li>
 							</parts>
 						  </li>
@@ -998,30 +1112,60 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Neck</li>
-								<li>Leg</li>
-								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Neck</li>
-								<li>Leg</li>
-								<li>Foot</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
 							<parts>
 								<li>Arm</li>
-								<li>Hand</li>
 							</parts>
 						  </li>
 						  <li>
 							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 							<parts>
 								<li>Arm</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Leg</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+							<parts>
 								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+							<parts>
+								<li>Hand</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Foot</li>
+							</parts>
+						  </li>
+						  <li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
+								<li>Foot</li>
 							</parts>
 						  </li>
 					  </stats>
@@ -1117,8 +1261,9 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>95</CarryWeight>
+					<CarryWeight>115</CarryWeight>
 					<CarryBulk>15</CarryBulk>
+					<MoveSpeed>-0.55</MoveSpeed>
 				</value>
 			</li>
 			
@@ -1256,6 +1401,13 @@
 				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets/MoveSpeed</xpath>
+				<value>
+					<MoveSpeed>-0.25</MoveSpeed>
 				</value>
 			</li>
 			
@@ -1442,13 +1594,23 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>
@@ -2113,13 +2275,23 @@
 							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
 							<parts>
 								<li>Eye</li>
-								<li>Nose</li>
 							</parts>
 						</li>
 						<li>
 							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
 							<parts>
 								<li>Eye</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+							<parts>
+								<li>Nose</li>
+							</parts>
+						</li>
+						<li>
+							<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+							<parts>
 								<li>Nose</li>
 							</parts>
 						</li>


### PR DESCRIPTION
## Changes

Modified the movespeed penalty on the helmet slightly. Increased the provided carry weight for the body armor itself. This should result in an overall simmilar movespeed penalty from the armor from the current configuration, without making the armor exceptionally good when moving capacity is scaled up. Additionally leaves the armor as heavily armored but still somewhat less optimal that cataphract given the price difference in the two.

## Reasoning

Assault Armor is aquired before cataphract, but is supposed to be the heavily armored, slow version of power armor compared to conventional power armor. This leaves the defensive parameters as is as well as movespeed retaining around the same value as previous speed penalty on the armor. Increased mass of the helmet compared to cataphract combined with the movespeed penalty should make it less appealing for other equipment setups as a standalone.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
