### PR TITLE
Patch Dusk Armory

### DIFF
--- a/Patches/Dusk Armory/Apparel_Dusk_Armor.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Armor.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Reactive" or defName="DF_Dusk_Mesh"]/statBases</xpath>
+                    <value>
+                        <Bulk>5</Bulk>
+                        <WornBulk>1</WornBulk>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Reactive" or defName="DF_Dusk_Mesh"]/statBases/MaxHitPoints</xpath>
+                    <value>
+                        <MaxHitPoints>400</MaxHitPoints>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Reactive" or defName="DF_Dusk_Mesh"]/statBases/ArmorRating_Sharp</xpath>
+                    <value>
+                        <ArmorRating_Sharp>18</ArmorRating_Sharp>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Reactive" or defName="DF_Dusk_Mesh"]/statBases/ArmorRating_Blunt</xpath>
+                    <value>
+                        <ArmorRating_Blunt>36</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Apparel_Dusk_Cloak.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Cloak.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Cloak" or defName="DF_Dusk_Cloak_Fur"]/statBases/StuffEffectMultiplierArmor</xpath>
+                    <value>
+                        <StuffEffectMultiplierArmor>3.5</StuffEffectMultiplierArmor>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Cloak" or defName="DF_Dusk_Cloak_Fur"]/statBases</xpath>
+                    <value>
+                        <Bulk>4.5</Bulk>
+                        <WornBulk>1.0</WornBulk>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Apparel_Dusk_Helmet.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Helmet.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/statBases</xpath>
+                    <value>
+                        <Bulk>5</Bulk>
+                        <WornBulk>1</WornBulk>
+						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel> 
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/statBases/Flammability</xpath>
+                    <value>
+                        <Flammability>0</Flammability>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/statBases/MaxHitPoints</xpath>
+                    <value>
+                        <MaxHitPoints>240</MaxHitPoints>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/statBases/ArmorRating_Sharp</xpath>
+                    <value>
+                        <ArmorRating_Sharp>16</ArmorRating_Sharp>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/statBases/ArmorRating_Blunt</xpath>
+                    <value>
+                        <ArmorRating_Blunt>36</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/equippedStatOffsets</xpath>
+                    <value>
+                        <equippedStatOffsets>
+                            <PsychicSensitivity>-0.2</PsychicSensitivity>
+                            <AimingAccuracy>0.15</AimingAccuracy>
+                            <ToxicResistance>0.50</ToxicResistance>
+                            <SmokeSensitivity>-1</SmokeSensitivity>
+                            <SocialImpact>0.10</SocialImpact>
+                        </equippedStatOffsets>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/costList/Plasteel</xpath>
+                    <value>
+                        <Plasteel>45</Plasteel>
+                        <DevilstrandCloth>20</DevilstrandCloth>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet"]/apparel/layers</xpath>
+                    <value>
+                        <li>OnHead</li>
+                        <li>StrappedHead</li>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Apparel_Dusk_Hood.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Hood.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Hood" or defName="DF_Dusk_Hood_Fur"]/statBases/StuffEffectMultiplierArmor</xpath>
+                    <value>
+                        <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Apparel_Dusk_Hood.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Hood.xml
@@ -9,9 +9,10 @@
             <operations>
 
                 <li Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="DF_Dusk_Hood" or defName="DF_Dusk_Hood_Fur"]/statBases/StuffEffectMultiplierArmor</xpath>
+                    <xpath>Defs/ThingDef[@Name="DF_Hood" or @Name="DF_Hood_Fur"]/statBases/StuffEffectMultiplierArmor</xpath>
                     <value>
                         <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+                        <Bulk>1</Bulk>
                     </value>
                 </li>
 

--- a/Patches/Dusk Armory/Apparel_Dusk_Hooded_Helmet.xml
+++ b/Patches/Dusk Armory/Apparel_Dusk_Hooded_Helmet.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/statBases</xpath>
+                    <value>
+                        <Bulk>5.5</Bulk>
+                        <WornBulk>1.5</WornBulk>
+						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel> 
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/statBases/Flammability</xpath>
+                    <value>
+                        <Flammability>0</Flammability>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded" or defName="DF_Dusk_Helmet_Hooded_Fur"]/statBases/MaxHitPoints</xpath>
+                    <value>
+                        <MaxHitPoints>240</MaxHitPoints>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/statBases/ArmorRating_Sharp</xpath>
+                    <value>
+                        <ArmorRating_Sharp>16</ArmorRating_Sharp>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/statBases/ArmorRating_Blunt</xpath>
+                    <value>
+                        <ArmorRating_Blunt>36</ArmorRating_Blunt>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/equippedStatOffsets</xpath>
+                    <value>
+                        <equippedStatOffsets>
+                            <PsychicSensitivity>-0.2</PsychicSensitivity>
+                            <AimingAccuracy>0.15</AimingAccuracy>
+                            <ToxicResistance>0.50</ToxicResistance>
+                            <SmokeSensitivity>-1</SmokeSensitivity>
+                            <SocialImpact>0.15</SocialImpact>
+                        </equippedStatOffsets>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/costList/Plasteel</xpath>
+                    <value>
+                        <Plasteel>45</Plasteel>
+                        <DevilstrandCloth>20</DevilstrandCloth>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded"]/apparel/layers</xpath>
+                    <value>
+                        <li>OnHead</li>
+                        <li>StrappedHead</li>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Helmet_Hooded" or defName="DF_Dusk_Helmet_Hooded_Fur"]/statBases/StuffEffectMultiplierArmor</xpath>
+                    <value>
+                        <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Weapons_Dusk_Melee.xml
+++ b/Patches/Dusk Armory/Weapons_Dusk_Melee.xml
@@ -161,6 +161,7 @@
                     <xpath>/Defs/ThingDef[defName="DF_Dusk_Saw"]/statBases/Mass</xpath>
                     <value>
                         <Bulk>6.5</Bulk>
+                        <Mass>5</Mass>
                         <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
                     </value>
                 </li>

--- a/Patches/Dusk Armory/Weapons_Dusk_Melee.xml
+++ b/Patches/Dusk Armory/Weapons_Dusk_Melee.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!--===== Dusk Kris =====-->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Kris"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Kris handle</label>
+                                <capacities>
+                                    <li>Poke</li>
+                                </capacities>
+                                <power>4</power>
+								<chanceFactor>0.33</chanceFactor>
+                                <cooldownTime>1.34</cooldownTime>
+                                <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Kris point</label>
+                                <capacities>
+                                    <li>Stab</li>
+                                </capacities>
+                                <power>31</power>
+                                <cooldownTime>1.34</cooldownTime>
+                                <armorPenetrationBlunt>0.6</armorPenetrationBlunt>
+                                <armorPenetrationSharp>1.2</armorPenetrationSharp>
+                                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Kris edge</label>
+                                <capacities>
+                                    <li>Cut</li>
+                                </capacities>
+                                <power>23</power>
+                                <cooldownTime>1.24</cooldownTime>
+                                <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+                                <armorPenetrationSharp>0.6</armorPenetrationSharp>
+                                <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Kris"]/statBases</xpath>
+                    <value>
+                        <Bulk>3.4</Bulk>
+                        <MeleeCounterParryBonus>0.45</MeleeCounterParryBonus>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Kris"]</xpath>
+                    <value>
+                        <equippedStatOffsets>
+                            <MeleeCritChance>0.3</MeleeCritChance>
+                            <MeleeParryChance>0.45</MeleeParryChance>
+                            <MeleeDodgeChance>0.3</MeleeDodgeChance>
+                        </equippedStatOffsets>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Kris"]/weaponTags</xpath>
+                    <value>
+                        <li>CE_Sidearm_Melee</li>
+                        <li>CE_OneHandedWeapon</li>
+                    </value>
+                </li>
+
+                <!--===== Dusk Razor =====-->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Razor"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Razor handle</label>
+                                <capacities>
+                                    <li>Poke</li>
+                                </capacities>
+                                <power>5</power>
+                                <cooldownTime>1.59</cooldownTime>
+                                <chanceFactor>0.33</chanceFactor>
+                                <armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Razor point</label>
+                                <capacities>
+                                    <li>Stab</li>
+                                </capacities>
+                                <power>22</power>
+                                <cooldownTime>1.59</cooldownTime>
+                                <armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+                                <armorPenetrationSharp>3.0</armorPenetrationSharp>
+                                <linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Razor edge</label>
+                                <capacities>
+                                    <li>Cut</li>
+                                </capacities>
+                                <power>38</power>
+                                <cooldownTime>1.46</cooldownTime>
+                                <armorPenetrationBlunt>6</armorPenetrationBlunt>
+                                <armorPenetrationSharp>1.5</armorPenetrationSharp>
+                                <linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Razor"]/statBases</xpath>
+                    <value>
+                        <Bulk>7.9</Bulk>
+                        <MeleeCounterParryBonus>1.2</MeleeCounterParryBonus>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Razor"]</xpath>
+                    <value>
+                        <equippedStatOffsets>
+                            <MeleeCritChance>0.73</MeleeCritChance>
+                            <MeleeParryChance>0.85</MeleeParryChance>
+                            <MeleeDodgeChance>0.5</MeleeDodgeChance>
+                        </equippedStatOffsets>
+                    </value>
+                </li>
+
+                <!--===== Dusk Saw =====-->
+                <li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[defName="DF_Dusk_Saw"]/tools</xpath>
+
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>Dusk Saw chain</label>
+                                <capacities>
+                                    <li>Cut</li>
+                                </capacities>
+                                <power>6</power>
+                                <cooldownTime>0.1</cooldownTime>
+                                <armorPenetrationSharp>2</armorPenetrationSharp>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>/Defs/ThingDef[defName="DF_Dusk_Saw"]/statBases/Mass</xpath>
+                    <value>
+                        <Bulk>6.5</Bulk>
+                        <MeleeCounterParryBonus>0.15</MeleeCounterParryBonus>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Saw"]</xpath>
+                    <value>
+                        <equippedStatOffsets>
+                            <MeleeCritChance>0.15</MeleeCritChance>
+                            <MeleeParryChance>0.3</MeleeParryChance>
+                            <MeleeDodgeChance>0.1</MeleeDodgeChance>
+                        </equippedStatOffsets>
+                    </value>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/Patches/Dusk Armory/Weapons_Dusk_Ranged.xml
+++ b/Patches/Dusk Armory/Weapons_Dusk_Ranged.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>Dusk Armory</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+
+                <!--===== TOOLS FOR THE TOOL GOD =====-->
+                <li Class="PatchOperationReplace">
+                    <xpath>Defs/ThingDef[defName="DF_Dusk_Enforcer"]/tools</xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>grip</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>2</power>
+                                <cooldownTime>1.54</cooldownTime>
+                                <chanceFactor>1.5</chanceFactor>
+                                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>muzzle</label>
+                                <capacities>
+                                    <li>Poke</li>
+                                </capacities>
+                                <power>2</power>
+                                <cooldownTime>1.54</cooldownTime>
+                                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <li Class="PatchOperationReplace">
+                    <xpath>
+				    /Defs/ThingDef[
+                    defName = "DF_Dusk_Carbine" or                    
+                    defName = "DF_Dusk_Launcher" or
+                    defName = "DF_Dusk_MAG" or
+                    defName = "DF_Dusk_SMG" or
+                    defName = "DF_Dusk_Striker"]/tools
+                    </xpath>
+                    <value>
+                        <tools>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>stock</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>8</power>
+                                <cooldownTime>1.55</cooldownTime>
+                                <chanceFactor>1.5</chanceFactor>
+                                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>barrel</label>
+                                <capacities>
+                                    <li>Blunt</li>
+                                </capacities>
+                                <power>5</power>
+                                <cooldownTime>2.02</cooldownTime>
+                                <armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+                            </li>
+                            <li Class="CombatExtended.ToolCE">
+                                <label>muzzle</label>
+                                <capacities>
+                                    <li>Poke</li>
+                                </capacities>
+                                <power>8</power>
+                                <cooldownTime>1.55</cooldownTime>
+                                <armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+                                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+                            </li>
+                        </tools>
+                    </value>
+                </li>
+
+                <!--===== Dusk Carbine =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_Carbine</defName>
+                    <statBases>
+                        <Mass>3.16</Mass>
+                        <Bulk>9.93</Bulk>
+                        <SwayFactor>1.33</SwayFactor>
+                        <ShotSpread>0.07</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+                    </statBases>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_9x39mmSoviet_FMJ</defaultProjectile>
+                        <burstShotCount>6</burstShotCount>
+                        <ticksBetweenBurstShots>9</ticksBetweenBurstShots>
+                        <warmupTime>1.1</warmupTime>
+                        <range>55</range>
+                        <soundCast>DF_Shot_Dusk_Carbine</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                        <recoilAmount>1.53</recoilAmount>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>60</magazineSize>
+                        <reloadTime>4</reloadTime>
+                        <ammoSet>AmmoSet_9x39mmSoviet</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aiAimMode>AimedShot</aiAimMode>
+                        <aiUseBurstMode>TRUE</aiUseBurstMode>
+                        <aimedBurstShotCount>3</aimedBurstShotCount>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_AI_Rifle</li>
+                    </weaponTags>
+                </li>
+
+                <!--===== Dusk Enforcer =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_Enforcer</defName>
+                    <statBases>
+                        <Mass>1.29</Mass>
+                        <Bulk>2.31</Bulk>
+                        <SwayFactor>1.27</SwayFactor>
+                        <ShotSpread>0.18</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.42</RangedWeapon_Cooldown>
+                    </statBases>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_500SWMagnum_FMJ</defaultProjectile>
+                        <warmupTime>0.6</warmupTime>
+                        <range>16</range>
+                        <soundCast>DF_Shot_Dusk_Enforcer</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>15</magazineSize>
+                        <reloadTime>4</reloadTime>
+                        <ammoSet>AmmoSet_500SWMagnum</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aiUseBurstMode>FALSE</aiUseBurstMode>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_Sidearm</li>
+                        <li>CE_AI_Pistol</li>
+                        <li>CE_OneHandedWeapon</li>
+                    </weaponTags>
+                </li>
+
+                <!--===== Dusk Launcher =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_Launcher</defName>
+                    <statBases>
+                        <Mass>7.9</Mass>
+                        <Bulk>9.9</Bulk>
+                        <SwayFactor>1.8</SwayFactor>
+                        <ShotSpread>0.15</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.43</RangedWeapon_Cooldown>
+                    </statBases>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+                        <warmupTime>1.1</warmupTime>
+                        <range>45</range>
+                        <soundCast>DF_Shot_Dusk_Launcher</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                        <targetParams>
+                            <canTargetLocations>true</canTargetLocations>
+                        </targetParams>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>20</magazineSize>
+                        <reloadTime>4</reloadTime>
+                        <ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aiUseBurstMode>FALSE</aiUseBurstMode>
+                        <aiAimMode>SuppressFire</aiAimMode>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_AI_Rifle</li>
+                        <li>CE_AI_Launcher</li>
+                        <li>EliteGun</li>
+                    </weaponTags>
+                </li>
+
+                <!--===== Dusk MAG =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_MAG</defName>
+                    <statBases>
+                        <Mass>9.11</Mass>
+                        <Bulk>14.6</Bulk>
+                        <SwayFactor>1.53</SwayFactor>
+                        <ShotSpread>0.05</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+                    </statBases>
+                    <costList>
+                        <Silver>65</Silver>
+                        <Plasteel>65</Plasteel>
+                        <ComponentIndustrial>3</ComponentIndustrial>
+                    </costList>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_127x55mm_FMJ</defaultProjectile>
+                        <burstShotCount>10</burstShotCount>
+                        <ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+                        <warmupTime>1.3</warmupTime>
+                        <range>68</range>
+                        <soundCast>DF_Shot_Dusk_MAG</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                        <recoilAmount>1.32</recoilAmount>
+                        <targetParams>
+                            <canTargetLocations>true</canTargetLocations>
+                        </targetParams>
+                        <recoilPattern>Mounted</recoilPattern>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>250</magazineSize>
+                        <reloadTime>4</reloadTime>
+                        <ammoSet>AmmoSet_127x55mm</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aimedBurstShotCount>5</aimedBurstShotCount>
+                        <aiUseBurstMode>FALSE</aiUseBurstMode>
+                        <aiAimMode>SuppressFire</aiAimMode>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_MachineGun</li>
+                        <li>CE_AI_Suppressive</li>
+                    </weaponTags>
+                </li>
+
+                <!--===== Dusk SMG =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_SMG</defName>
+                    <statBases>
+                        <Mass>2.4</Mass>
+                        <Bulk>4.4</Bulk>
+                        <SwayFactor>0.94</SwayFactor>
+                        <ShotSpread>0.14</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+                    </statBases>
+                    <costList>
+                        <Silver>35</Silver>
+                        <Plasteel>35</Plasteel>
+                        <ComponentIndustrial>2</ComponentIndustrial>
+                    </costList>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_50AE_FMJ</defaultProjectile>
+                        <burstShotCount>6</burstShotCount>
+                        <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+                        <warmupTime>0.6</warmupTime>
+                        <range>25</range>
+                        <soundCast>DF_Shot_Dusk_SMG</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                        <recoilAmount>2.08</recoilAmount>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>80</magazineSize>
+                        <reloadTime>4</reloadTime>
+                        <ammoSet>AmmoSet_50AE</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aimedBurstShotCount>3</aimedBurstShotCount>
+                        <aiUseBurstMode>FALSE</aiUseBurstMode>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_SMG</li>
+                        <li>CE_AI_AssaultWeapon</li>
+                    </weaponTags>
+                </li>
+
+                <!--===== Dusk Striker =====-->
+                <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+                    <defName>DF_Dusk_Striker</defName>
+                    <statBases>
+                        <Mass>3.40</Mass>
+                        <Bulk>6.6</Bulk>
+                        <SwayFactor>1.26</SwayFactor>
+                        <ShotSpread>0.15</ShotSpread>
+                        <SightsEfficiency>1.1</SightsEfficiency>
+                        <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+                    </statBases>
+                    <costList>
+                        <Silver>60</Silver>
+                        <Plasteel>60</Plasteel>
+                        <ComponentIndustrial>3</ComponentIndustrial>
+                    </costList>
+                    <Properties>
+                        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+                        <hasStandardCommand>True</hasStandardCommand>
+                        <defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+                        <warmupTime>0.6</warmupTime>
+                        <range>20</range>
+                        <soundCast>DF_Shot_Dusk_Striker</soundCast>
+                        <soundCastTail>GunTail_Medium</soundCastTail>
+                        <muzzleFlashScale>9</muzzleFlashScale>
+                    </Properties>
+                    <AmmoUser>
+                        <magazineSize>20</magazineSize>
+                        <reloadOneAtATime>true</reloadOneAtATime>
+                        <reloadTime>0.85</reloadTime>
+                        <ammoSet>AmmoSet_12Gauge</ammoSet>
+                    </AmmoUser>
+                    <FireModes>
+                        <aiUseBurstMode>FALSE</aiUseBurstMode>
+                    </FireModes>
+                    <weaponTags>
+                        <li>CE_AI_AssaultWeapon</li>
+                    </weaponTags>
+                </li>
+
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -161,6 +161,7 @@ Dragons Descent    |
 Dragons!	|
 Dubs Rimatomics |
 Dumbs' Dachshunds   |
+Dusk Armory   |
 ED-Shields	|
 Edge of Descension - Monoblades  |
 Eltex Bodysuit  |


### PR DESCRIPTION
## Additions

- What it says on the tin, some apparel and weapons that needed patching.

## Reasoning

- The weapons are based on the Dusk gear unlike the VOID stuff that are loosely based on the X-Dusk set.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
