### PR TITLE
Minor housekeeping

### DIFF
--- a/Patches/Vanilla Weapons Expanded/Ammo/AntiGrainRocket.xml
+++ b/Patches/Vanilla Weapons Expanded/Ammo/AntiGrainRocket.xml
@@ -12,7 +12,7 @@
         <li Class="PatchOperationAdd">
           <xpath>Defs</xpath>
           <value>
-            <ThingDef ParentName="BaseSPG9Grenade">
+            <ThingDef ParentName="BaseSPG9Rocket">
               <defName>Bullet_AntiGrainRocket</defName>
               <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
               <label>anti-grain rocket</label>


### PR DESCRIPTION
## Changes

- Minor housekeeping after tweaking the SPG9 ammo, the old parent def was being used in VWE that needed fixing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
