### PR TITLE
Hard armor health damage reduction

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -14,6 +14,7 @@ namespace CombatExtended
 
         private const float PenetrationRandVariation = 0.05f;    // Armor penetration will be randomized by +- this amount
         private const float SoftArmorMinDamageFactor = 0.2f;    // Soft body armor will always take at least original damage * this number from sharp attacks
+        private const float HardArmorDamageFactor = 0.5f;       // Hard body armor final health damage multiplier
         private const float SpikeTrapAPModifierBlunt = 0.65f;
         private const float BulletImpactForceMultiplier = 0.2f; //Bullet has less mass => less impluse comparing to melee => less Blunt penetration
 
@@ -339,6 +340,7 @@ namespace CombatExtended
                     else
                     {
                         armorDamage = (dmgAmount - newDmgAmount) * Mathf.Min(1.0f, (penAmount * penAmount) / (armorAmount * armorAmount)) + newDmgAmount * Mathf.Clamp01(armorAmount / penAmount);
+                        armorDamage *= HardArmorDamageFactor;
                     }
 
                     TryDamageArmor(def, penAmount, armorAmount, ref armorDamage, armor);


### PR DESCRIPTION
## Changes

1. Hard armor takes half as much damage than before by using a constant factor.

## Reasoning

1. After https://github.com/CombatExtended-Continued/CombatExtended/commit/89577b52c3ba46cacccd8002365e414c99ec6f4a and other armor damage changes, the damage taken by armor changed to blocked damage and how close the penetration value is to the armor value. This caused damage to grow, for example, in the case of a normal steel armor vest against 7.62mm NATO FMJ, from about 8 to about 28, while armor health remained the same.

## Alternatives

1. Update armor health directly:
    1. A lot of busy work required to do that.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony.

## Notes
- This mean that a normal steel armor vest will now be penetrated by 7.62mm NATO FMJ on the 6th bullet instead of the 3rd.
- Testing with the changes:
    - Normal steel armor vest health against 7.62mm NATO FMJ: 125->117->109->101->92->81->71 (partial penetration);
    - Excellent steel armor vest health against 7.62mm NATO FMJ: 125->119->112->106->99->94->87->79->69->58 (partial penetration);
    - Normal cataphract power armor health against 7.62 NATO FMJ: 600->595->590->585->580->575->570->564->559.