### PR TITLE
Fix Rimsenal Security's rocket launcher ammo

### DIFF
--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -301,15 +301,14 @@
 				<graphicClass>Graphic_Single</graphicClass>
 				<shaderType>TransparentPostLight</shaderType>
 			</graphicData>
-			<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>
-			<damageAmountBase>304</damageAmountBase>
-			<soundExplode>MortarBomb_Explode</soundExplode>
-			<armorPenetrationSharp>900</armorPenetrationSharp>
-			<armorPenetrationBlunt>38.687</armorPenetrationBlunt>
-			<speed>64</speed>
-			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>				
+				<damageDef>Bullet</damageDef>
+				<damageAmountBase>304</damageAmountBase>
+				<soundExplode>MortarBomb_Explode</soundExplode>
+				<armorPenetrationSharp>600</armorPenetrationSharp>
+				<armorPenetrationBlunt>38.687</armorPenetrationBlunt>
+				<speed>64</speed>
+				<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 			</projectile>
 			<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">


### PR DESCRIPTION
## Changes

- What it says on the tin, the HEAT rocket incorrectly had the `CombatExtended.ProjectileCE_Explosive` thingClass which needed removing.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
