### PR TITLE
Pikeman mech leg attack tool

### DIFF
--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -385,7 +385,7 @@
           <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
           <armorPenetrationBlunt>12</armorPenetrationBlunt>
           <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-		  <chanceFactor>0.2</chanceFactor>
+          <chanceFactor>0.2</chanceFactor>
         </li>
       </tools>
     </value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -385,6 +385,7 @@
           <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
           <armorPenetrationBlunt>12</armorPenetrationBlunt>
           <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+		  <chanceFactor>0.2</chanceFactor>
         </li>
       </tools>
     </value>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -354,6 +354,28 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
+          <label>front left leg</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>13</power>
+          <cooldownTime>2.67</cooldownTime>
+          <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>5</armorPenetrationBlunt>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+        </li>
+        <li Class="CombatExtended.ToolCE">
+          <label>front right leg</label>
+          <capacities>
+            <li>Blunt</li>
+          </capacities>
+          <power>13</power>
+          <cooldownTime>2.67</cooldownTime>
+          <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+          <armorPenetrationBlunt>5</armorPenetrationBlunt>
+          <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+        </li>
+        <li Class="CombatExtended.ToolCE">
           <label>head</label>
           <capacities>
             <li>Blunt</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -336,6 +336,7 @@
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<chanceFactor>0.2</chanceFactor>
 				</li>
 			</tools>
 		</value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid.xml
@@ -305,6 +305,28 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
+					<label>front left leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>13</power>
+					<cooldownTime>2.67</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>front right leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>13</power>
+					<cooldownTime>2.67</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
@@ -312,7 +334,6 @@
 					<power>15</power>
 					<cooldownTime>3.51</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -351,9 +351,9 @@
                   <power>15</power>
                   <cooldownTime>3.51</cooldownTime>
                   <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-                  <armorPenetrationSharp>0</armorPenetrationSharp>
                   <armorPenetrationBlunt>12</armorPenetrationBlunt>
                   <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				  <chanceFactor>0.2</chanceFactor>
                 </li>
               </tools>
             </value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -321,6 +321,28 @@
             <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman_PlayerControlled"]/tools</xpath>
             <value>
               <tools>
+				<li Class="CombatExtended.ToolCE">
+				  <label>front left leg</label>
+				  <capacities>
+					<li>Blunt</li>
+				  </capacities>
+				  <power>13</power>
+				  <cooldownTime>2.67</cooldownTime>
+				  <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+				  <armorPenetrationBlunt>5</armorPenetrationBlunt>
+				  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+				  <label>front right leg</label>
+				  <capacities>
+					<li>Blunt</li>
+				  </capacities>
+				  <power>13</power>
+				  <cooldownTime>2.67</cooldownTime>
+				  <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+				  <armorPenetrationBlunt>5</armorPenetrationBlunt>
+				  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
                 <li Class="CombatExtended.ToolCE">
                   <label>head</label>
                   <capacities>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_AdvancedMechanoid_PlayerControlled.xml
@@ -321,28 +321,28 @@
             <xpath>Defs/ThingDef[defName="VFE_Mech_AdvancedPikeman_PlayerControlled"]/tools</xpath>
             <value>
               <tools>
-				<li Class="CombatExtended.ToolCE">
-				  <label>front left leg</label>
-				  <capacities>
-					<li>Blunt</li>
-				  </capacities>
-				  <power>13</power>
-				  <cooldownTime>2.67</cooldownTime>
-				  <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
-				  <armorPenetrationBlunt>5</armorPenetrationBlunt>
-				  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-				  <label>front right leg</label>
-				  <capacities>
-					<li>Blunt</li>
-				  </capacities>
-				  <power>13</power>
-				  <cooldownTime>2.67</cooldownTime>
-				  <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
-				  <armorPenetrationBlunt>5</armorPenetrationBlunt>
-				  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				</li>
+                <li Class="CombatExtended.ToolCE">
+                  <label>front left leg</label>
+                  <capacities>
+                  <li>Blunt</li>
+                  </capacities>
+                  <power>13</power>
+                  <cooldownTime>2.67</cooldownTime>
+                  <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+                  <armorPenetrationBlunt>5</armorPenetrationBlunt>
+                  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+                </li>
+                <li Class="CombatExtended.ToolCE">
+                  <label>front right leg</label>
+                  <capacities>
+                  <li>Blunt</li>
+                  </capacities>
+                  <power>13</power>
+                  <cooldownTime>2.67</cooldownTime>
+                  <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+                  <armorPenetrationBlunt>5</armorPenetrationBlunt>
+                  <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+                </li>
                 <li Class="CombatExtended.ToolCE">
                   <label>head</label>
                   <capacities>
@@ -353,7 +353,7 @@
                   <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
                   <armorPenetrationBlunt>12</armorPenetrationBlunt>
                   <alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-				  <chanceFactor>0.2</chanceFactor>
+				          <chanceFactor>0.2</chanceFactor>
                 </li>
               </tools>
             </value>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -298,6 +298,28 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
+					<label>front left leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>13</power>
+					<cooldownTime>2.67</cooldownTime>
+					<linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>front right leg</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>13</power>
+					<cooldownTime>2.67</cooldownTime>
+					<linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
+					<armorPenetrationBlunt>5</armorPenetrationBlunt>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Races/Races_Mechanoid.xml
@@ -327,9 +327,9 @@
 					<power>15</power>
 					<cooldownTime>3.51</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-					<armorPenetrationSharp>0</armorPenetrationSharp>
 					<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					<chanceFactor>0.2</chanceFactor>
 				</li>
 			</tools>
 		</value>


### PR DESCRIPTION
## Changes

- Gave the pikeman mechs their leg melee attack tool back, the poor guys need it.

## References

- https://docs.google.com/spreadsheets/d/11e6FkTQvZiJpq7DpXUk9JSXBSq9enrx0DQhTTJ2xH7c/edit#gid=647442519

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
