### PR TITLE
Fix 10gauge buck's spread multiplier

### DIFF
--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -125,7 +125,7 @@
       <pelletCount>18</pelletCount>
       <armorPenetrationSharp>4</armorPenetrationSharp>
       <armorPenetrationBlunt>3.92</armorPenetrationBlunt>
-      <spreadMult>17.8</spreadMult>
+      <spreadMult>8.9</spreadMult>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Changes

- Fixed the spread multiplier on the 10ga buckshot mamo from 17.8 to 8.9.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
