### PR TITLE
Increase Grapeshot's spread factor

### DIFF
--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -194,7 +194,7 @@
 			<armorPenetrationSharp>8.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>420.68</armorPenetrationBlunt>
 			<pelletCount>27</pelletCount>
-			<spreadMult>17.8</spreadMult>
+			<spreadMult>35.6</spreadMult>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
## Changes

- What it says on the tin.

## Reasoning

- The final spread of the grapeshot ammo was too tight making it a superior single-shot ammo to the round shot instead of it being more of a crown control ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [ ] Playtested a colony (specify how long)
