### PR TITLE
Updated weapon toughness autopatcher

### DIFF
--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -28,7 +28,9 @@ namespace CombatExtended.Compatibility
                         float weaponThickness = Mathf.Sqrt(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f);
 
                         if (weaponThickness == 0f)
+                        {
                             continue;
+                        }
 
                         // Tech level improves toughness
                         switch (def.techLevel)

--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -70,7 +70,7 @@ namespace CombatExtended.Compatibility
                             // Search for a fitting recipe
                             RecipeDef firstRecipeDef = DefDatabase<RecipeDef>.AllDefs
                                 .FirstOrDefault(recipeDef => recipeDef.products?
-                                        .Any(productDef => productDef.thingDef?.defName == def.defName ?? false) ?? false);
+                                        .Any(productDef => productDef.thingDef?.defName == def.defName) ?? false);
 
                             IngredientCount biggestIngredientCount = firstRecipeDef?.ingredients?
                                 .MaxBy(ingredientCount => ingredientCount.count);

--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -27,6 +27,9 @@ namespace CombatExtended.Compatibility
                         // Approximate weapon thickness via the bulk of the weapon. Longswords get about 2.83mm, knives get 1mm, spears get about 3.162mm
                         float weaponThickness = Mathf.Sqrt(def.statBases?.Find(statMod => statMod.stat.defName == CE_StatDefOf.Bulk.defName)?.value ?? 0f);
 
+                        if (weaponThickness == 0f)
+                            continue;
+
                         // Tech level improves toughness
                         switch (def.techLevel)
                         {
@@ -43,7 +46,13 @@ namespace CombatExtended.Compatibility
                         }
 
                         // Blunt weapons get double thickness because edges are easier to damage. Note that ranged weapons are excluded
-                        if (!def.IsRangedWeapon && (!def.tools?.Any(tool => tool.capacities?.Any(capacityDef => DefDatabase<DamageDef>.defsList.Any(damageDef => damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp && capacityDef.defName == damageDef.defName)) ?? false) ?? false))
+                        if (!def.IsRangedWeapon
+                                && (!def.tools?
+                                    .Any(tool => tool.capacities?
+                                        .Any(capacityDef => DefDatabase<DamageDef>.defsList
+                                            .Any(damageDef => damageDef.armorCategory == DamageArmorCategoryDefOf.Sharp && capacityDef.defName == damageDef.defName))
+                                        ?? false)
+                                    ?? false))
                         {
                             weaponThickness *= 2f;
                         }
@@ -56,26 +65,37 @@ namespace CombatExtended.Compatibility
                         // Non-stuffable weapons get the rating value
                         else
                         {
-                            // C# magic
-                            var largestIngredientCount = DefDatabase<RecipeDef>.AllDefs.ToList().Find(recipeDef => (bool)recipeDef.products?.Any(product => product.thingDef.defName == def.defName))?.ingredients?.MaxBy(ingredientCount => ingredientCount.count);
-                            var largestIngredient = (largestIngredientCount?.IsFixedIngredient ?? false) ? largestIngredientCount.FixedIngredient : largestIngredientCount?.filter?.thingDefs?.MaxBy(thingDef => thingDef.statBases?.Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?.value);
-                            float? largestIngredientSharpArmor = largestIngredient?.statBases?.Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?.value * (largestIngredient?.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f);
+                            // Search for a fitting recipe
+                            RecipeDef firstRecipeDef = DefDatabase<RecipeDef>.AllDefs
+                                .FirstOrDefault(recipeDef => recipeDef.products?
+                                        .Any(productDef => productDef.thingDef.defName == def.defName) ?? false);
 
-                            // For weapons that do not have a recipe
-                            if (largestIngredientSharpArmor == null)
+                            IngredientCount biggestIngredientCount = firstRecipeDef?.ingredients?
+                                .MaxBy(ingredientCount => ingredientCount.count);
+
+                            float strongestIngredientSharpArmor = 0f;
+
+                            // Recipe does exist and has a fixed ingredient
+                            if (biggestIngredientCount?.IsFixedIngredient ?? false)
                             {
-                                // Anything above spacer tech is assumed to be made out of plasteel at least
-                                if (def.techLevel > TechLevel.Industrial)
-                                {
-                                    largestIngredientSharpArmor = 2f;
-                                }
-                                else
-                                {
-                                    largestIngredientSharpArmor = 1f;
-                                }
+                                strongestIngredientSharpArmor = biggestIngredientCount.FixedIngredient.statBases?
+                                    .Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?
+                                    .value * (biggestIngredientCount.FixedIngredient.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f) ?? 0f;
+                            }
+                            // Recipe may or may not exist
+                            else
+                            {
+                                // Becomes null if the recipe doesn't exist or doesn't have any ingredients
+                                float? nullableSharpArmor = biggestIngredientCount?.filter?.thingDefs?
+                                    .Max(thingDef => thingDef.statBases?
+                                            .Find(statMod => statMod.stat.defName == StatDefOf.ArmorRating_Sharp.GetStatPart<StatPart_Stuff>().stuffPowerStat.defName)?
+                                            .value * (thingDef.GetModExtension<StuffToughnessMultiplierExtensionCE>()?.toughnessMultiplier ?? 1f) ?? 0f);
+
+                                // Fallback to tech level; above industrial is assumed to have items made out of plasteel (hardcoded)
+                                strongestIngredientSharpArmor = nullableSharpArmor ?? (def.techLevel > TechLevel.Industrial ? 2f : 1f);
                             }
 
-                            def.statBases.Add(new StatModifier { stat = CE_StatDefOf.ToughnessRating, value = weaponThickness * (float)largestIngredientSharpArmor });
+                            def.statBases.Add(new StatModifier { stat = CE_StatDefOf.ToughnessRating, value = weaponThickness * strongestIngredientSharpArmor });
                         }
                     }
                 }

--- a/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
+++ b/Source/CombatExtended/Compatibility/WeaponToughnessAutoPatcher.cs
@@ -70,7 +70,7 @@ namespace CombatExtended.Compatibility
                             // Search for a fitting recipe
                             RecipeDef firstRecipeDef = DefDatabase<RecipeDef>.AllDefs
                                 .FirstOrDefault(recipeDef => recipeDef.products?
-                                        .Any(productDef => productDef.thingDef.defName == def.defName) ?? false);
+                                        .Any(productDef => productDef.thingDef?.defName == def.defName ?? false) ?? false);
 
                             IngredientCount biggestIngredientCount = firstRecipeDef?.ingredients?
                                 .MaxBy(ingredientCount => ingredientCount.count);


### PR DESCRIPTION
## Changes

- Attempted to improve the weapon toughness autopatcher's resilience to breaking.

## References

- Toughness autopatcher was mentioned in https://gist.github.com/HugsLibRecordKeeper/fc0a532e4a6ddf4548ee55acbf50b795
- Other mentions of the autopatcher breaking.

## Reasoning

- Less red errors. One of the main reasons for the autopatcher breaking was a recipe definition with unexpected properties.

## Testing

- [x] Compiles without warnings;
- [x] Game runs without errors;
- [ ] Playtested a colony;
- [ ] Tested with a variety of mods.
