### PR TITLE
RPG-7 ammo bulk tweaks and housekeeping

### DIFF
--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -48,8 +48,8 @@
     </graphicData>
     <statBases>
       <MarketValue>57.78</MarketValue>
-      <Mass>2.6</Mass>
-      <Bulk>9.37</Bulk>
+      <Mass>2.8</Mass>
+      <Bulk>7.14</Bulk>
     </statBases>
     <ammoClass>RocketHEAT</ammoClass>
 	<detonateProjectile>Bullet_RPG7Grenade_HEAT</detonateProjectile>
@@ -64,8 +64,8 @@
     </graphicData>
     <statBases>
       <MarketValue>123.58</MarketValue>
-      <Mass>4.5</Mass>
-      <Bulk>12.99</Bulk>
+      <Mass>4.7</Mass>
+      <Bulk>8.61</Bulk>
     </statBases>
     <ammoClass>RocketThermobaric</ammoClass>
 	<detonateProjectile>Bullet_RPG7Grenade_Thermobaric</detonateProjectile>
@@ -79,9 +79,9 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>38.96</MarketValue>
-      <Mass>2.0</Mass>
-      <Bulk>1.89</Bulk>
+      <MarketValue>38.86</MarketValue>
+      <Mass>2.2</Mass>
+      <Bulk>3.4</Bulk>
     </statBases>
     <stackLimit>100</stackLimit>    
     <ammoClass>RocketFrag</ammoClass>


### PR DESCRIPTION
## Changes

- Changed the dimensions of RPG-7 grenades based on a new calculation in the projectile spreadsheet resulting in smaller bulk values.
- Fixed some inconsistencies.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- The majority of the bulk taken up by RPG-7 grenades are the rocket motor and the booster that sit in the carrier's backpack and the warhead usually sticks out of the backpack's top. The spreadsheet counted the warhead diameter and length for bulk calculations which is not representative of how much space the grenades take. As a result, to take the motor and booster length into account and reduce the unrealistic bulk value of the ammo, the spreadsheet data is changed in a way that the overall length of the ammo is actually the total length of the grenades and for the diameter of the ammo, a weighted sum is used. x2 weight for the motor and booster being 40mm wide and x1 weight for the warhead being 94mm for HEAT and 105mm for Thermobaric grenades which results in more reasonable bulk values for RPG-7 ammo.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors