### PR TITLE
BombSuper damageDef consistency check

### DIFF
--- a/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -73,7 +73,21 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/DamageDef[defName="Bomb"]/defaultArmorPenetration</xpath>
 		<value>
-			<defaultArmorPenetration>209.55</defaultArmorPenetration>
+			<defaultArmorPenetration>210</defaultArmorPenetration>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="BombSuper"]/defaultDamage</xpath>
+		<value>
+			<defaultDamage>800</defaultDamage>
+		</value>
+	</Operation>
+  
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/DamageDef[defName="BombSuper"]/defaultArmorPenetration</xpath>
+		<value>
+			<defaultArmorPenetration>264</defaultArmorPenetration>
 		</value>
 	</Operation>
 
@@ -141,11 +155,11 @@
 		</value>
 	</Operation>
 	
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/DamageDef[defName="RangedStab"]</xpath>
-    <value>
-      <harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
-    </value>
-  </Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/DamageDef[defName="RangedStab"]</xpath>
+		<value>
+			<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+		</value>
+	</Operation>
   
 </Patch>


### PR DESCRIPTION
## Changes

- Patched the default damage and armor penetration of BombSuper damageDef.

## Reasoning

- The damage type is used in various places without a damageAmount node which means it deals the default 550 damage contrary to the 81mm anti-grain shells dealing 800 damage. Patching the default damage and AP to 800 and 264 repectively makes its performance consistent with said shells everywhere it's used.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
