### PR TITLE
Launcher grenade consistency checks

### DIFF
--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -114,7 +114,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>1.85</MarketValue>
+      <MarketValue>1.95</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_20x42mmGrenade_HE</detonateProjectile>
@@ -128,7 +128,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.28</MarketValue>
+      <MarketValue>3.6</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -223,7 +223,7 @@
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<explosionRadius>1.0</explosionRadius>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
@@ -242,7 +242,7 @@
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<explosionRadius>1.5</explosionRadius>
 		</projectile>
 	</ThingDef>
@@ -285,7 +285,7 @@
     <products>
       <Ammo_20x42mm_AP>100</Ammo_20x42mm_AP>
     </products>
-    <workAmount>4896</workAmount>
+    <workAmount>4080</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -378,7 +378,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>5</count>
+        <count>6</count>
       </li>
       <li>
         <filter>
@@ -399,7 +399,7 @@
     <products>
       <Ammo_20x42mmGrenade_HE>100</Ammo_20x42mmGrenade_HE>
     </products>
-    <workAmount>6600</workAmount>    
+    <workAmount>7000</workAmount>    
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -426,7 +426,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>8</count>
+        <count>9</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -438,7 +438,7 @@
     <products>
       <Ammo_20x42mmGrenade_EMP>100</Ammo_20x42mmGrenade_EMP>
     </products>
-    <workAmount>8200</workAmount>        
+    <workAmount>8800</workAmount>        
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -134,7 +134,7 @@
 		<thingClass>CombatExtended.BulletCE</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>56</damageAmountBase>
+			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>      
 			<armorPenetrationBlunt>4.818</armorPenetrationBlunt>
 		</projectile>

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -147,7 +147,7 @@
 		  </li>
 		  <li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-			  <Fragment_Small>10</Fragment_Small>
+			  <Fragment_Small>12</Fragment_Small>
 			</fragments>
 		  </li>
 		</comps>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -78,7 +78,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.68</MarketValue>
+      <MarketValue>2.37</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
     <detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
@@ -189,13 +189,13 @@
     <label>40x46mm grenade (HEDP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>19</damageAmountBase>
+      <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>63</armorPenetrationSharp>
-      <armorPenetrationBlunt>7.302</armorPenetrationBlunt>
+      <armorPenetrationBlunt>5.942</armorPenetrationBlunt>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <damageAmountBase>24</damageAmountBase>
+        <damageAmountBase>20</damageAmountBase>
         <explosiveDamageType>Bomb</explosiveDamageType>
         <explosiveRadius>0.5</explosiveRadius>
         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -353,7 +353,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>10</count>
+        <count>7</count>
       </li>
       <li>
         <filter>
@@ -374,7 +374,7 @@
     <products>
       <Ammo_40x46mmGrenade_HEDP>100</Ammo_40x46mmGrenade_HEDP>
     </products>
-    <workAmount>10200</workAmount>
+    <workAmount>9000</workAmount>
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -202,7 +202,7 @@
       </li>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Small>15</Fragment_Small>
+          <Fragment_Small>9</Fragment_Small>
         </fragments>
       </li>
     </comps>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -187,7 +187,7 @@
       </li>
       <li Class="CombatExtended.CompProperties_Fragments">
         <fragments>
-          <Fragment_Small>20</Fragment_Small>
+          <Fragment_Small>17</Fragment_Small>
         </fragments>
       </li>
     </comps>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -50,7 +50,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.75</MarketValue>
+      <MarketValue>2.89</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.37</MarketValue>
+      <MarketValue>2.89</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -78,7 +78,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>3.4</MarketValue>
+      <MarketValue>2.89</MarketValue>
     </statBases>
     <ammoClass>GrenadeHEDP</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>
@@ -174,13 +174,13 @@
     <label>40x53mm grenade (HEDP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <damageAmountBase>22</damageAmountBase>
+      <damageAmountBase>25</damageAmountBase>
       <armorPenetrationSharp>76</armorPenetrationSharp>
-      <armorPenetrationBlunt>8.348</armorPenetrationBlunt>
+      <armorPenetrationBlunt>5.942</armorPenetrationBlunt>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
-        <damageAmountBase>28</damageAmountBase>
+        <damageAmountBase>20</damageAmountBase>
         <explosiveDamageType>Bomb</explosiveDamageType>
         <explosiveRadius>0.5</explosiveRadius>
         <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -64,7 +64,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.89</MarketValue>
+      <MarketValue>3.75</MarketValue>
     </statBases>
     <ammoClass>GrenadeHETF</ammoClass>
     <detonateProjectile>Bullet_40x53mmGrenade_HE</detonateProjectile>

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -49,7 +49,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>2.78</MarketValue>
+      <MarketValue>2.68</MarketValue>
     </statBases>
     <ammoClass>GrenadeHE</ammoClass>
 	<detonateProjectile>Bullet_40x53mmVOG25Grenade_HE</detonateProjectile>
@@ -77,7 +77,7 @@
       <graphicClass>Graphic_StackCount</graphicClass>
     </graphicData>
     <statBases>
-      <MarketValue>5.55</MarketValue>
+      <MarketValue>5.22</MarketValue>
     </statBases>
     <ammoClass>GrenadeEMP</ammoClass>
     <generateAllowChance>0.5</generateAllowChance>
@@ -119,7 +119,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>1.0</explosionRadius >
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>26</damageAmountBase>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
     </projectile>
     <comps>
@@ -138,7 +138,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>1.0</explosionRadius >
       <damageDef>Bomb</damageDef>
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>26</damageAmountBase>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
       <aimHeightOffset>1.4</aimHeightOffset>
       <armingDelay>2</armingDelay>
@@ -159,7 +159,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>2</explosionRadius>
       <damageDef>EMP</damageDef>
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>26</damageAmountBase>
     </projectile>
   </ThingDef>
 
@@ -198,7 +198,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>11</count>
+        <count>10</count>
       </li>
       <li>
         <filter>
@@ -219,7 +219,7 @@
     <products>
       <Ammo_40x53mmVOG25Grenade_HE>100</Ammo_40x53mmVOG25Grenade_HE>
     </products>
-    <workAmount>10600</workAmount>       
+    <workAmount>10200</workAmount>       
   </RecipeDef>
   
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -243,7 +243,7 @@
             <li>FSX</li>
           </thingDefs>
         </filter>
-        <count>11</count>
+        <count>10</count>
       </li>
       <li>
         <filter>
@@ -264,7 +264,7 @@
     <products>
       <Ammo_40x53mmVOG25Grenade_HE_TFuzed>100</Ammo_40x53mmVOG25Grenade_HE_TFuzed>
     </products>
-    <workAmount>11000</workAmount>
+    <workAmount>10400</workAmount>
   </RecipeDef>  
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">
@@ -291,7 +291,7 @@
             <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>14</count>
+        <count>13</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -303,7 +303,7 @@
     <products>
       <Ammo_40x53mmVOG25Grenade_EMP>100</Ammo_40x53mmVOG25Grenade_EMP>
     </products>
-    <workAmount>13400</workAmount>       
+    <workAmount>12800</workAmount>       
   </RecipeDef>
 
   <RecipeDef ParentName="LauncherAmmoRecipeBase">


### PR DESCRIPTION
## Changes

- Updated and fixed some values according to the spreadsheet and new sources.
- Introduced a 50% bullet damage multiplier for HEDP nades as not all of the projectile's mass does the damage transfer. It also alleviates the need for arbitrary bullet damage values that are currently used.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
