### PR TITLE
30mm Fuel Cell housekeeping

### DIFF
--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -87,7 +87,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>40</speed>
+      <speed>54</speed>
       <flyOverhead>false</flyOverhead>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -136,11 +136,12 @@
 
   <!-- ==================== Recipes ========================== -->
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_30x64mmFuel_Incendiary</defName>
     <label>make 30x64mm fuel cell (Incendiary) x50</label>
     <description>Craft 50 30x64mm incendiary fuel cells.</description>
     <jobString>Making incendiary fuel cells.</jobString>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
     <ingredients>
       <li>
         <filter>
@@ -180,11 +181,12 @@
     <workAmount>7600</workAmount>		
   </RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_30x64mmFuel_Thermobaric</defName>
     <label>make 30x64mm fuel cell (Thermobaric) x50</label>
     <description>Craft 50 30x64mm thermobaric fuel cells.</description>
     <jobString>Making thermobaric fuel cells.</jobString>
+    <researchPrerequisite>CE_AdvancedLaunchers</researchPrerequisite>
     <ingredients>
       <li>
         <filter>
@@ -223,12 +225,16 @@
     <workAmount>10400</workAmount>		
   </RecipeDef>
 
-  <RecipeDef ParentName="AmmoRecipeBase">
+  <RecipeDef ParentName="LauncherAmmoRecipeBase">
     <defName>MakeAmmo_30x64mmFuel_Foam</defName>
     <label>make 30x64mm fuel cell (Foam) x50</label>
     <description>Craft 50 30x64mm foam fuel cells.</description>
     <jobString>Making foam fuel cells.</jobString>
-    <researchPrerequisite>Firefoam</researchPrerequisite>
+    <researchPrerequisite Inherit="False"/>
+    <researchPrerequisites>
+      <li>Firefoam</li>
+      <li>CE_AdvancedLaunchers</li>
+    </researchPrerequisites>
     <ingredients>
       <li>
         <filter>

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -87,7 +87,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>54</speed>
+      <speed>40</speed>
       <flyOverhead>false</flyOverhead>
     </projectile>
   </ThingDef>


### PR DESCRIPTION
## Changes

- Made 30mm fuel cells craftable in the machining bench similar to other launcher ammo and fixed its research prerequisites.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
