### PR TITLE
Projectile velocity overhaul and housekeeping

### DIFF
--- a/Defs/Ammo/Advanced/10x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/10x18mmCharged.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>95</speed>
+      <speed>102</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -88,7 +88,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>120</speed>
+      <speed>122</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/12mmRailgun.xml
+++ b/Defs/Ammo/Advanced/12mmRailgun.xml
@@ -60,7 +60,7 @@
 			<damageAmountBase>73</damageAmountBase>
 			<armorPenetrationSharp>130</armorPenetrationSharp>
 			<armorPenetrationBlunt>7250</armorPenetrationBlunt>
-			<speed>500</speed>
+			<speed>354</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -64,7 +64,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <damageAmountBase>39</damageAmountBase>
-      <speed>180</speed>
+      <speed>165</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>

--- a/Defs/Ammo/Advanced/12x72mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x72mmCharged.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>180</speed>
+      <speed>165</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -54,7 +54,7 @@
 	<ThingDef Name="Base15x65mmDiffusingChargedBullet" ParentName="BaseBulletCE" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>116</speed>
+			<speed>119</speed>
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Advanced/164x284mmDemoShell.xml
+++ b/Defs/Ammo/Advanced/164x284mmDemoShell.xml
@@ -78,7 +78,7 @@
       <damageAmountBase>20</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
       <armorPenetrationBlunt>0</armorPenetrationBlunt>
-      <speed>48</speed>
+      <speed>61</speed>
       <flyOverhead>false</flyOverhead>
       <explosionRadius>2</explosionRadius>
       <soundExplode>ThumpCannon_Impact</soundExplode>
@@ -89,8 +89,8 @@
 	<comps>
 		<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-				<Bullet_164x284mmDemo_ASA>2</Bullet_164x284mmDemo_ASA>
-				<Bullet_164x284mmDemo_ASB>2</Bullet_164x284mmDemo_ASB>
+				<Bullet_164x284mmDemo_ASA>1</Bullet_164x284mmDemo_ASA>
+				<Bullet_164x284mmDemo_ASB>1</Bullet_164x284mmDemo_ASB>
 			</fragments>
 			<fragXZAngleRange>-5~5</fragXZAngleRange>
 			<fragAngleRange>0~5</fragAngleRange>

--- a/Defs/Ammo/Advanced/20x105mmCharged.xml
+++ b/Defs/Ammo/Advanced/20x105mmCharged.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>220</speed>
+      <speed>192</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -87,7 +87,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>40</speed>
+      <speed>54</speed>
       <flyOverhead>false</flyOverhead>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Advanced/5x16mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x16mmCharged.xml
@@ -59,7 +59,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>120</speed>
+      <speed>122</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -63,7 +63,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <damageAmountBase>11</damageAmountBase>
-      <speed>200</speed>
+      <speed>178</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -63,7 +63,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Burn</damageDef>
       <damageAmountBase>33</damageAmountBase>
-      <speed>60</speed>
+      <speed>73</speed>
       <flyOverhead>false</flyOverhead>
       <explosionRadius>7.5</explosionRadius>
       <soundExplode>MortarIncendiary_Explode</soundExplode>

--- a/Defs/Ammo/Advanced/6mmRailgun.xml
+++ b/Defs/Ammo/Advanced/6mmRailgun.xml
@@ -59,7 +59,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>59</armorPenetrationSharp>
 			<armorPenetrationBlunt>290.80</armorPenetrationBlunt>
-			<speed>400</speed>
+			<speed>300</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -88,7 +88,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>120</speed>
+      <speed>122</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/6x22mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x22mmCharged.xml
@@ -62,7 +62,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <damageAmountBase>13</damageAmountBase>
-      <speed>160</speed>
+      <speed>151</speed>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -88,7 +88,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>160</speed>
+      <speed>151</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -86,7 +86,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>32</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -76,7 +76,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>PrometheumFlame</damageDef>
       <damageAmountBase>9</damageAmountBase>
-      <speed>60</speed>
+      <speed>73</speed>
       <flyOverhead>false</flyOverhead>
       <explosionRadius>5.9</explosionRadius>
       <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>

--- a/Defs/Ammo/Advanced/8mmRailgun.xml
+++ b/Defs/Ammo/Advanced/8mmRailgun.xml
@@ -59,7 +59,7 @@
 			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationSharp>55</armorPenetrationSharp>
 			<armorPenetrationBlunt>252.720</armorPenetrationBlunt>
-			<speed>360</speed>
+			<speed>277</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>160</speed>
+      <speed>151</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/8x40mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x40mmCharged.xml
@@ -60,7 +60,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>200</speed>
+      <speed>178</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/8x50mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x50mmCharged.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>200</speed>
+      <speed>178</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellHeavy.xml
@@ -70,7 +70,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>180</speed>
+			<speed>165</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>18</damageAmountBase>
 			<explosionRadius>1</explosionRadius>

--- a/Defs/Ammo/Advanced/PlasmaCellPistol.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellPistol.xml
@@ -69,7 +69,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>140</speed>
+			<speed>137</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>2</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Advanced/PlasmaCellRifle.xml
+++ b/Defs/Ammo/Advanced/PlasmaCellRifle.xml
@@ -69,7 +69,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>200</speed>
+			<speed>178</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>2</damageAmountBase>
 			<explosionRadius>0.5</explosionRadius>

--- a/Defs/Ammo/Grenade/20x42mmGrenade.xml
+++ b/Defs/Ammo/Grenade/20x42mmGrenade.xml
@@ -159,7 +159,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>62</speed>
+			<speed>74</speed>
 		</projectile>
 	</ThingDef>
 
@@ -170,7 +170,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>62</speed>
+			<speed>74</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -109,7 +109,7 @@
       <drawSize>(0.35,0.35)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>42</speed>
+      <speed>56</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/25x59mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x59mmGrenade.xml
@@ -124,7 +124,7 @@
 			<drawSize>(0.35,0.35)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>85</speed>
+			<speed>94</speed>
 		</projectile>
 	</ThingDef>
 		

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -109,7 +109,7 @@
       <drawSize>(0.4,0.4)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>37</speed>
+      <speed>52</speed>
       <flyOverhead>false</flyOverhead>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
+++ b/Defs/Ammo/Grenade/35x32mmSRGrenade.xml
@@ -108,7 +108,7 @@
 			<drawSize>(0.45,0.45)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>38</speed>
+			<speed>52</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -139,7 +139,7 @@
       <drawSize>(0.5,0.5)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
+      <speed>27</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/40x47mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x47mmGrenade.xml
@@ -94,7 +94,7 @@
 			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>26</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/40x53mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmGrenade.xml
@@ -124,7 +124,7 @@
 			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>49</speed>
+			<speed>62</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
+++ b/Defs/Ammo/Grenade/40x53mmVOG25Grenade.xml
@@ -109,7 +109,7 @@
       <drawSize>(0.5,0.5)</drawSize>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>20</speed>
+      <speed>26</speed>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Grenade/50mmGS50Grenade.xml
+++ b/Defs/Ammo/Grenade/50mmGS50Grenade.xml
@@ -94,7 +94,7 @@
 			<drawSize>(0.5,0.5)</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
+			<speed>30</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/83mmPIATGrenade.xml
+++ b/Defs/Ammo/Grenade/83mmPIATGrenade.xml
@@ -92,7 +92,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>26</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -121,7 +121,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>172</speed>
+      <speed>159</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -182,10 +182,10 @@
     <defName>Bullet_127x108mm_Sabot</defName>
     <label>12.7x108mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>234</speed>
-	    <damageAmountBase>21</damageAmountBase>
+	    <speed>216</speed>
+	    <damageAmountBase>22</damageAmountBase>
 	    <armorPenetrationSharp>49</armorPenetrationSharp>
-	    <armorPenetrationBlunt>377.82</armorPenetrationBlunt>
+	    <armorPenetrationBlunt>459.3</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -120,7 +120,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>157</speed>
+			<speed>149</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -181,7 +181,7 @@
 		<defName>Bullet_132x92mmSRTuF_Sabot</defName>
 		<label>13.2x92mmSR TuF bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>236</speed>
+			<speed>202</speed>
 			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationSharp>45.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>406.94</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -121,7 +121,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>200</speed>
+      <speed>178</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -182,7 +182,7 @@
     <defName>Bullet_145x114mm_Sabot</defName>
     <label>14.5x114mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	  <speed>300</speed>
+	  <speed>242</speed>
       <damageAmountBase>27</damageAmountBase>
       <armorPenetrationSharp>63</armorPenetrationSharp>
       <armorPenetrationBlunt>820.360</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -68,7 +68,7 @@
       <defName>Bullet_152x169mm_Sabot</defName>
       <label>15.2x169mm bullet (Sabot)</label>
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
-        <speed>435</speed>
+        <speed>235</speed>
 	    <damageAmountBase>26</damageAmountBase>
 	    <armorPenetrationSharp>60</armorPenetrationSharp>
 	    <armorPenetrationBlunt>420.5</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -121,7 +121,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>78</speed>
+			<speed>88</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -182,7 +182,7 @@
     <defName>Bullet_2Bore_Sabot</defName>
     <label>2-Bore bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>117</speed>
+	    <speed>119</speed>
 	    <damageAmountBase>30</damageAmountBase>
 	    <armorPenetrationSharp>44</armorPenetrationSharp>
 	    <armorPenetrationBlunt>734.84</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/20x102mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/20x102mmNATO.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>206</speed>
+			<speed>182</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>37</damageAmountBase>
 			<armorPenetrationSharp>53</armorPenetrationSharp>
 			<armorPenetrationBlunt>1320.02</armorPenetrationBlunt>
-			<speed>309</speed>
+			<speed>247</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/20x110mmHispano.xml
+++ b/Defs/Ammo/HighCaliber/20x110mmHispano.xml
@@ -106,7 +106,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>169</speed>
+      <speed>157</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -157,7 +157,7 @@
     <defName>Bullet_20x110mmHispano_Sabot</defName>
     <label>14.5x114mm bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>254</speed>
+	    <speed>213</speed>
 	    <damageAmountBase>35</damageAmountBase>
 	    <armorPenetrationSharp>49</armorPenetrationSharp>
 	    <armorPenetrationBlunt>1113.92</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
+++ b/Defs/Ammo/HighCaliber/20x128mmOerlikon.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>207</speed>
+			<speed>183</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -157,7 +157,7 @@
     <defName>Bullet_20x128mmOerlikon_Sabot</defName>
     <label>20x128mm Oerlikon bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>311</speed>
+	    <speed>248</speed>
 	    <damageAmountBase>20</damageAmountBase>
 	    <armorPenetrationSharp>63</armorPenetrationSharp>
 	    <armorPenetrationBlunt>1642.44</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/20x138mmB.xml
+++ b/Defs/Ammo/HighCaliber/20x138mmB.xml
@@ -106,7 +106,7 @@
 		  <damageAmountBase>43</damageAmountBase>
 		  <armorPenetrationSharp>34</armorPenetrationSharp>
 		  <armorPenetrationBlunt>972</armorPenetrationBlunt>
-		  <speed>180</speed>
+		  <speed>165</speed>
 		</projectile>
 	</ThingDef>
 
@@ -148,7 +148,7 @@
     <defName>Bullet_20x138mmB_Sabot</defName>
     <label>20x138mmB bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>270</speed>
+	    <speed>223</speed>
 	    <damageAmountBase>36</damageAmountBase>
 	    <armorPenetrationSharp>60</armorPenetrationSharp>
 	    <armorPenetrationBlunt>1257.52</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/20x139mm.xml
+++ b/Defs/Ammo/HighCaliber/20x139mm.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>210</speed>
+			<speed>185</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -157,7 +157,7 @@
 		<defName>Bullet_20x139mm_Sabot</defName>
 		<label>20x139mm bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>315</speed>
+			<speed>251</speed>
 			<damageAmountBase>41</damageAmountBase>
 			<armorPenetrationSharp>66.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>1736.44</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/20x82mmMauser.xml
+++ b/Defs/Ammo/HighCaliber/20x82mmMauser.xml
@@ -106,7 +106,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>144</speed>
+      <speed>139</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -116,7 +116,7 @@
     <label>20mm Mauser bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>24</armorPenetrationSharp>
+      <armorPenetrationSharp>26</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -126,7 +126,7 @@
     <label>20mm Mauser bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>36</damageAmountBase>
-      <armorPenetrationSharp>24</armorPenetrationSharp>
+      <armorPenetrationSharp>26</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -142,7 +142,7 @@
     <label>20mm Mauser bullet (AP-HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>57</damageAmountBase>
-      <armorPenetrationSharp>12</armorPenetrationSharp>
+      <armorPenetrationSharp>13</armorPenetrationSharp>
       <armorPenetrationBlunt>570.24</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
@@ -157,9 +157,9 @@
     <defName>Bullet_20x82mmMauser_Sabot</defName>
     <label>20mm Mauser bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>216</speed>
+	    <speed>189</speed>
 	    <damageAmountBase>30</damageAmountBase>
-	    <armorPenetrationSharp>42</armorPenetrationSharp>
+	    <armorPenetrationSharp>45.5</armorPenetrationSharp>
 	    <armorPenetrationBlunt>734.84</armorPenetrationBlunt>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
+++ b/Defs/Ammo/HighCaliber/20x99mmShVAK.xml
@@ -106,7 +106,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>150</speed>
+      <speed>144</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -157,7 +157,7 @@
     <defName>Bullet_20x99mmRShVAK_Sabot</defName>
     <label>20mmR ShVAK bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	    <speed>225</speed>
+	    <speed>195</speed>
 	    <damageAmountBase>30</damageAmountBase>
 	    <armorPenetrationSharp>47</armorPenetrationSharp>
 	    <armorPenetrationBlunt>696.1</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/23x152mmB.xml
+++ b/Defs/Ammo/HighCaliber/23x152mmB.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>194</speed>
+			<speed>174</speed>
 			<dropsCasings>true</dropsCasings>
 			<airborneSuppressionFactor>3.17</airborneSuppressionFactor>
 		</projectile>
@@ -161,7 +161,7 @@
 			<damageAmountBase>53</damageAmountBase>
 			<armorPenetrationSharp>78.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>2286.38</armorPenetrationBlunt>
-			<speed>291</speed>
+			<speed>236</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/25x137mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/25x137mmNATO.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>220</speed>
+			<speed>192</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>52</damageAmountBase>
 			<armorPenetrationSharp>98</armorPenetrationSharp>
 			<armorPenetrationBlunt>2870.88</armorPenetrationBlunt>
-			<speed>330</speed>
+			<speed>259</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>200</speed>
+      <speed>178</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -181,7 +181,7 @@
     <defName>Bullet_300WinchesterMagnum_Sabot</defName>
     <label>.300 Winchester Magnum bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>300</speed>
+      <speed>242</speed>
       <damageAmountBase>12</damageAmountBase>
       <armorPenetrationSharp>35</armorPenetrationSharp>
       <armorPenetrationBlunt>137.26</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/30x113mmB.xml
+++ b/Defs/Ammo/HighCaliber/30x113mmB.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>155</speed>
+			<speed>147</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>57</damageAmountBase>
 			<armorPenetrationSharp>70</armorPenetrationSharp>
 			<armorPenetrationBlunt>2125.56</armorPenetrationBlunt>
-			<speed>233</speed>
+			<speed>200</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x165mm.xml
+++ b/Defs/Ammo/HighCaliber/30x165mm.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>180</speed>
+			<speed>165</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>63</damageAmountBase>
 			<armorPenetrationSharp>100</armorPenetrationSharp>
 			<armorPenetrationBlunt>4051.42</armorPenetrationBlunt>
-			<speed>270</speed>
+			<speed>223</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/30x173mmNATO.xml
+++ b/Defs/Ammo/HighCaliber/30x173mmNATO.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>204</speed>
+			<speed>181</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>58</damageAmountBase>
 			<armorPenetrationSharp>123</armorPenetrationSharp>
 			<armorPenetrationBlunt>4936.96</armorPenetrationBlunt>
-			<speed>306</speed>
+			<speed>245</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>182</speed>
+      <speed>166</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -184,7 +184,7 @@
       <damageAmountBase>14</damageAmountBase>
       <armorPenetrationSharp>39</armorPenetrationSharp>
       <armorPenetrationBlunt>173.980</armorPenetrationBlunt>
-      <speed>273</speed>	  
+      <speed>225</speed>	  
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>162</speed>
+      <speed>152</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -184,7 +184,7 @@
       <damageAmountBase>13</damageAmountBase>
       <armorPenetrationSharp>39</armorPenetrationSharp>
       <armorPenetrationBlunt>162.46</armorPenetrationBlunt>
-      <speed>243</speed>	  
+      <speed>206</speed>	  
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>220</speed>
+      <speed>192</speed>
 	  <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -181,7 +181,7 @@
     <defName>Bullet_408CheyenneTactical_Sabot</defName>
     <label>.408 Cheyenne Tactical bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>330</speed>
+      <speed>259</speed>
       <damageAmountBase>18</damageAmountBase>
       <armorPenetrationSharp>42</armorPenetrationSharp>
       <armorPenetrationBlunt>310.36</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/40x311mmR.xml
+++ b/Defs/Ammo/HighCaliber/40x311mmR.xml
@@ -106,7 +106,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>170</speed>
+			<speed>158</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -160,7 +160,7 @@
 			<damageAmountBase>89</damageAmountBase>
 			<armorPenetrationSharp>175</armorPenetrationSharp>
 			<armorPenetrationBlunt>8339.46</armorPenetrationBlunt>
-			<speed>255</speed>
+			<speed>214</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/470NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/470NitroExpress.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>132</speed>
+      <speed>131</speed>
 	  <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -184,7 +184,7 @@
 		  <damageAmountBase>16</damageAmountBase>
 		  <armorPenetrationSharp>38.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>178.78</armorPenetrationBlunt>
-		  <speed>198</speed>
+		  <speed>177</speed>
 		</projectile>
 	  </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -121,7 +121,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>178</speed>
+      <speed>163</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -182,10 +182,10 @@
     <defName>Bullet_50BMG_Sabot</defName>
     <label>.50 BMG bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>21</damageAmountBase>	
+      <damageAmountBase>22</damageAmountBase>	
       <armorPenetrationSharp>49</armorPenetrationSharp>
-      <armorPenetrationBlunt>388.88</armorPenetrationBlunt>
-      <speed>244</speed>
+      <armorPenetrationBlunt>462.92</armorPenetrationBlunt>
+      <speed>221</speed>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -120,7 +120,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>177</speed>
+			<speed>163</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -181,7 +181,7 @@
 		<defName>Bullet_55Boys_Sabot</defName>
 		<label>.55 Boys bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>266</speed>
+			<speed>220</speed>
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>42</armorPenetrationSharp>
 			<armorPenetrationBlunt>611.36</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -120,7 +120,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>124</speed>
+      <speed>125</speed>
 	  <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -181,7 +181,7 @@
     <defName>Bullet_600NitroExpress_Sabot</defName>
     <label>.600 Nitro Express bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>186</speed>
+      <speed>169</speed>
       <damageAmountBase>19</damageAmountBase>
       <armorPenetrationSharp>38.5</armorPenetrationSharp>
       <armorPenetrationBlunt>246.5</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
+++ b/Defs/Ammo/HighCaliber/7.92x94mm Patronen.xml
@@ -121,7 +121,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>242</speed>
+      <speed>206</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
@@ -182,7 +182,7 @@
     <defName>Bullet_792x94mmPatronen_Sabot</defName>
     <label>7.92x94mm Patronen bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	  <speed>363</speed>
+	  <speed>279</speed>
       <damageAmountBase>16</damageAmountBase>
       <armorPenetrationSharp>52.5</armorPenetrationSharp>
       <armorPenetrationBlunt>276.06</armorPenetrationBlunt>

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -120,7 +120,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>134</speed>
+			<speed>132</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -181,7 +181,7 @@
 		<defName>Bullet_50JDJ_Sabot</defName>
 		<label>.950 JDJ bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>201</speed>
+			<speed>179</speed>
 			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationSharp>63</armorPenetrationSharp>
 			<armorPenetrationBlunt>1341.42</armorPenetrationBlunt>

--- a/Defs/Ammo/Medieval/BlunderbussShot.xml
+++ b/Defs/Ammo/Medieval/BlunderbussShot.xml
@@ -69,7 +69,7 @@
 		<defName>Bullet_BlunderbussShot</defName>
 		<label>blunderbuss pellet</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>60</speed>
+			<speed>73</speed>
 			<damageAmountBase>7</damageAmountBase>
 			<pelletCount>20</pelletCount>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>

--- a/Defs/Ammo/Medieval/CannonBall.xml
+++ b/Defs/Ammo/Medieval/CannonBall.xml
@@ -121,7 +121,7 @@
 		<drawSize>2,2</drawSize>
 	</graphicData>	
 	<projectile Class="CombatExtended.ProjectilePropertiesCE">
-		<speed>91</speed>
+		<speed>99</speed>
 		<soundExplode>MortarBomb_Explode</soundExplode>
 		<flyOverhead>false</flyOverhead>
 		<dropsCasings>false</dropsCasings>
@@ -146,7 +146,7 @@
 		<label>bursting shell</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>91</speed>
+			<speed>99</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>142</damageAmountBase>
 			<armorPenetrationSharp>0</armorPenetrationSharp>
@@ -170,7 +170,7 @@
 		<label>flaming shell</label>
 		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>91</speed>
+			<speed>99</speed>
 			<damageDef>PrometheumFlame</damageDef>
 			<damageAmountBase>6</damageAmountBase>
 			<explosionRadius>4.5</explosionRadius>

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>22</speed>
+			<speed>28</speed>
 		</projectile>
 	</ThingDef>
 
@@ -143,7 +143,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>25</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.94</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.5</armorPenetrationSharp>			
@@ -176,7 +176,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>24</speed>
+			<speed>31</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>6.32</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>

--- a/Defs/Ammo/Medieval/MiniCannonBall.xml
+++ b/Defs/Ammo/Medieval/MiniCannonBall.xml
@@ -79,7 +79,7 @@
 			<drawSize>1.5,1.5</drawSize>
 		</graphicData>	
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>60</speed>
+			<speed>73</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>false</dropsCasings>

--- a/Defs/Ammo/Medieval/MortarGrenade.xml
+++ b/Defs/Ammo/Medieval/MortarGrenade.xml
@@ -66,16 +66,16 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.2</explosionRadius>
+			<explosionRadius>1.0</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>40</damageAmountBase>
-			<speed>17</speed>
+			<damageAmountBase>30</damageAmountBase>
+			<speed>21</speed>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 			<fragments>
-				<Fragment_Large>8</Fragment_Large>
+				<Fragment_Small>12</Fragment_Small>
 			</fragments>
 			</li>
 		</comps>

--- a/Defs/Ammo/Medieval/MusketBall.xml
+++ b/Defs/Ammo/Medieval/MusketBall.xml
@@ -80,7 +80,7 @@
 		<defName>Bullet_FastMusketBall</defName>
 		<label>musket ball</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>90</speed>
+			<speed>98</speed>
 			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>64.8</armorPenetrationBlunt>
@@ -93,7 +93,7 @@
 		<defName>Bullet_SlowMusketBall</defName>
 		<label>musket ball</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>50</speed>
+			<speed>63</speed>
 			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>20</armorPenetrationBlunt>

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -140,7 +140,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Arrow</damageDef>
-      <speed>20</speed>
+      <speed>36</speed>
     </projectile>
   </ThingDef>
 
@@ -157,7 +157,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>31</speed>
       <damageAmountBase>6</damageAmountBase>
       <armorPenetrationSharp>0.2</armorPenetrationSharp>
       <armorPenetrationBlunt>1.42</armorPenetrationBlunt>
@@ -190,7 +190,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>39</speed>
       <damageAmountBase>5</damageAmountBase>
       <armorPenetrationSharp>1</armorPenetrationSharp>
       <armorPenetrationBlunt>2.82</armorPenetrationBlunt>
@@ -242,7 +242,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>ArrowHighVelocity</damageDef>
-      <speed>24</speed>
+      <speed>46</speed>
     </projectile>
   </ThingDef>
 
@@ -254,7 +254,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>40</speed>
       <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>2.78</armorPenetrationBlunt>
@@ -287,7 +287,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>26</speed>
+      <speed>50</speed>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>5.54</armorPenetrationBlunt>

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -126,7 +126,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
-			<speed>22</speed>
+			<speed>25</speed>
 		</projectile>
 	</ThingDef>
 	
@@ -143,7 +143,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>20</speed>
+			<speed>21</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>1.46</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -176,7 +176,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>24</speed>
+			<speed>26</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>2.96</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>

--- a/Defs/Ammo/Neolithic/Javelins.xml
+++ b/Defs/Ammo/Neolithic/Javelins.xml
@@ -36,7 +36,7 @@
 		<label>pilum (thrown)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
-			<speed>16</speed>
+			<speed>14</speed>
 			<armorPenetrationBlunt>6.54</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.75</preExplosionSpawnChance>	<!-- 4 javelins per resource -->
@@ -49,7 +49,7 @@
 		<label>pilum (fired)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>28</damageAmountBase>
-			<speed>41</speed>
+			<speed>30</speed>
 			<armorPenetrationBlunt>48.6</armorPenetrationBlunt>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.4</preExplosionSpawnChance> <!-- 1.67 javelins per resource -->

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/13mmGyrojet.xml
+++ b/Defs/Ammo/Pistols/13mmGyrojet.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>55</speed>
+			<speed>68</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>88</speed>
+			<speed>97</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>50</speed>
+			<speed>63</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>79</speed>
+			<speed>60</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -87,7 +87,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>64</speed>
+			<speed>76</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -103,7 +103,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>86</speed>
+			<speed>94</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>82</speed>
+			<speed>92</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/380ACP.xml
+++ b/Defs/Ammo/Pistols/380ACP.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>60</speed>
+			<speed>73</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38ACP.xml
+++ b/Defs/Ammo/Pistols/38ACP.xml
@@ -88,7 +88,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>70</speed>
+			<speed>81</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38SW.xml
+++ b/Defs/Ammo/Pistols/38SW.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>47</speed>
+			<speed>60</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -89,7 +89,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>54</speed>
+      <speed>67</speed>
       <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Pistols/38Super.xml
+++ b/Defs/Ammo/Pistols/38Super.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>86</speed>
+			<speed>95</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>68</speed>
+			<speed>80</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/41Rimfire.xml
+++ b/Defs/Ammo/Pistols/41Rimfire.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>26</speed>
+			<speed>39</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -114,7 +114,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>78</speed>
+			<speed>88</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -158,7 +158,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
-			<speed>110</speed>
+			<speed>114</speed>
 		</projectile>
 	</ThingDef>
 
@@ -169,7 +169,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
-			<speed>110</speed>
+			<speed>114</speed>
 		</projectile>
 	</ThingDef>
 
@@ -180,7 +180,7 @@
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.04</armorPenetrationBlunt>
-			<speed>110</speed>
+			<speed>114</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/44SWSpecial.xml
+++ b/Defs/Ammo/Pistols/44SWSpecial.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>54</speed>
+			<speed>67</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -116,7 +116,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>92</speed>
+			<speed>100</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/455Webley.xml
+++ b/Defs/Ammo/Pistols/455Webley.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>36</speed>
+			<speed>50</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -104,7 +104,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>54</speed>
+			<speed>67</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -136,7 +136,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>56</speed>
+			<speed>69</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -180,7 +180,7 @@
 			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
-			<speed>86</speed>
+			<speed>94</speed>
 		</projectile>
 	</ThingDef>
 
@@ -191,7 +191,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
-			<speed>86</speed>
+			<speed>94</speed>
 		</projectile>
 	</ThingDef>
 
@@ -202,7 +202,7 @@
 			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>26.58</armorPenetrationBlunt>
-			<speed>86</speed>
+			<speed>94</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/45Schofield.xml
+++ b/Defs/Ammo/Pistols/45Schofield.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>44</speed>
+			<speed>58</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/460SWMagnum.xml
+++ b/Defs/Ammo/Pistols/460SWMagnum.xml
@@ -109,7 +109,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>101</speed>
+			<speed>107</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>120</speed>
+			<speed>122</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>98</speed>
+			<speed>117</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/50AE.xml
+++ b/Defs/Ammo/Pistols/50AE.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>90</speed>
+			<speed>98</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/58x21mmDAP92.xml
+++ b/Defs/Ammo/Pistols/58x21mmDAP92.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>106</speed>
+			<speed>111</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/7.5FK.xml
+++ b/Defs/Ammo/Pistols/7.5FK.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>122</speed>
+			<speed>123</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>100</speed>
+			<speed>106</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>66</speed>
+			<speed>77</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>89</speed>
+			<speed>97</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/765x20mmLongue.xml
+++ b/Defs/Ammo/Pistols/765x20mmLongue.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>69</speed>
+			<speed>81</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>58</speed>
+			<speed>71</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>64</speed>
+			<speed>76</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -100,7 +100,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>72</speed>
+			<speed>83</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -112,7 +112,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>60</speed>
+			<speed>72</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/9x21mmGyurza.xml
+++ b/Defs/Ammo/Pistols/9x21mmGyurza.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>82</speed>
+			<speed>92</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/FN57x28mm.xml
+++ b/Defs/Ammo/Pistols/FN57x28mm.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>130</speed>
+			<speed>129</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/127x55mm.xml
+++ b/Defs/Ammo/Rifle/127x55mm.xml
@@ -136,7 +136,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>59</speed>
+			<speed>72</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -210,7 +210,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>24.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>65.84</armorPenetrationBlunt>
-			<speed>89</speed>			
+			<speed>97</speed>			
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/17HMR.xml
+++ b/Defs/Ammo/Rifle/17HMR.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>153</speed>
+			<speed>146</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/22Hornet.xml
+++ b/Defs/Ammo/Rifle/22Hornet.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>170</speed>
+			<speed>158</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/22WMR.xml
+++ b/Defs/Ammo/Rifle/22WMR.xml
@@ -89,7 +89,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>115</speed>
+			<speed>117</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/243Winchester.xml
+++ b/Defs/Ammo/Rifle/243Winchester.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>182</speed>
+			<speed>199</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>23</armorPenetrationSharp>
 			<armorPenetrationBlunt>65.12</armorPenetrationBlunt>
-			<speed>273</speed>
+			<speed>225</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/277Fury.xml
+++ b/Defs/Ammo/Rifle/277Fury.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>182</speed>
+			<speed>166</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>26.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>93.16</armorPenetrationBlunt>
-		  <speed>273</speed>
+		  <speed>225</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/280British.xml
+++ b/Defs/Ammo/Rifle/280British.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>156</speed>
+			<speed>148</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>21</armorPenetrationSharp>
 			<armorPenetrationBlunt>70.3</armorPenetrationBlunt>
-			<speed>233</speed>
+			<speed>200</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/30-30Winchester.xml
+++ b/Defs/Ammo/Rifle/30-30Winchester.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>142</speed>
+			<speed>138</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>17.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>67.04</armorPenetrationBlunt>
-			<speed>213</speed>
+			<speed>187</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>178</speed>
+			<speed>163</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>28</armorPenetrationSharp>
 		  <armorPenetrationBlunt>101.58</armorPenetrationBlunt>
-		  <speed>267</speed>
+		  <speed>221</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>135</speed>
+			<speed>133</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>8</damageAmountBase>
 		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>46.74</armorPenetrationBlunt>
-		  <speed>203</speed>
+		  <speed>180</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>154</speed>
+			<speed>147</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>23</armorPenetrationSharp>
 		  <armorPenetrationBlunt>86.72</armorPenetrationBlunt>
-		  <speed>224</speed>
+		  <speed>199</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>122</speed>
+			<speed>123</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>33.02</armorPenetrationBlunt>
-		  <speed>182</speed>
+		  <speed>166</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/38-55Winchester.xml
+++ b/Defs/Ammo/Rifle/38-55Winchester.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>118</speed>
+			<speed>120</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>19</armorPenetrationSharp>
 			<armorPenetrationBlunt>73.86</armorPenetrationBlunt>
-			<speed>177</speed>
+			<speed>163</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -136,7 +136,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>76</speed>
+			<speed>86</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -211,7 +211,7 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>23.94</armorPenetrationBlunt>
-		  <speed>114</speed>
+		  <speed>117</speed>
 		</projectile>
 	  </ThingDef>
   

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>127</speed>
+			<speed>126</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>99.54</armorPenetrationBlunt>
-		  <speed>190</speed>
+		  <speed>171</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/458SOCOM.xml
+++ b/Defs/Ammo/Rifle/458SOCOM.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>116</speed>
+			<speed>119</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>22.75</armorPenetrationSharp>
 			<armorPenetrationBlunt>83.86</armorPenetrationBlunt>
-			<speed>174</speed>
+			<speed>161</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>185</speed>
+			<speed>168</speed>
 		</projectile>
 	</ThingDef>
 
@@ -208,7 +208,7 @@
 		  <damageAmountBase>6</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.58</armorPenetrationBlunt>
-		  <speed>278</speed>
+		  <speed>228</speed>
 		</projectile>
 	  </ThingDef>
  

--- a/Defs/Ammo/Rifle/485x49mm.xml
+++ b/Defs/Ammo/Rifle/485x49mm.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>190</speed>
+			<speed>171</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>21</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.16</armorPenetrationBlunt>
-			<speed>285</speed>
+			<speed>232</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/50Beowulf.xml
+++ b/Defs/Ammo/Rifle/50Beowulf.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>108</speed>
+			<speed>113</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>22.75</armorPenetrationSharp>
 			<armorPenetrationBlunt>81.36</armorPenetrationBlunt>
-			<speed>162</speed>
+			<speed>152</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>176</speed>
+			<speed>162</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -223,7 +223,7 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.6</armorPenetrationBlunt>
-		  <speed>264</speed>
+		  <speed>219</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -236,7 +236,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
-			<speed>147</speed>
+			<speed>142</speed>
 		</projectile>
 	</ThingDef>
 
@@ -247,7 +247,7 @@
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
-			<speed>147</speed>
+			<speed>142</speed>
 		</projectile>
 	</ThingDef>
 
@@ -258,7 +258,7 @@
 			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>19.56</armorPenetrationBlunt>
-			<speed>147</speed>
+			<speed>142</speed>
 		</projectile>
 	</ThingDef>
 
@@ -275,7 +275,7 @@
 			  <amount>4</amount>
 			</li>
 		  </secondaryDamage>
-		  <speed>147</speed>
+		  <speed>142</speed>
 		</projectile>
 	  </ThingDef>
 	  
@@ -292,7 +292,7 @@
 			  	<amount>7</amount>
 				</li>
 		  </secondaryDamage>
-		  <speed>147</speed>
+		  <speed>142</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -303,7 +303,7 @@
 		  <damageAmountBase>6</damageAmountBase>
 		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>25.5</armorPenetrationBlunt>
-		  <speed>221</speed>
+		  <speed>192</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -149,7 +149,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>185</speed>
+			<speed>168</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -223,7 +223,7 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>44.18</armorPenetrationBlunt>
-		  <speed>277</speed>
+		  <speed>227</speed>
 		</projectile>
 	  </ThingDef>
 	  
@@ -236,7 +236,7 @@
 				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationSharp>5</armorPenetrationSharp>
 				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
-				<speed>148</speed>
+				<speed>142</speed>
 			</projectile>
 		</ThingDef>
 
@@ -247,7 +247,7 @@
 				<damageAmountBase>8</damageAmountBase>
 				<armorPenetrationSharp>10</armorPenetrationSharp>
 				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
-				<speed>148</speed>
+				<speed>142</speed>
 			</projectile>
 		</ThingDef>
 
@@ -258,7 +258,7 @@
 				<damageAmountBase>15</damageAmountBase>
 				<armorPenetrationSharp>3</armorPenetrationSharp>
 				<armorPenetrationBlunt>21.96</armorPenetrationBlunt>
-				<speed>148</speed>
+				<speed>142</speed>
 			</projectile>
 		</ThingDef>
 
@@ -275,7 +275,7 @@
 						<amount>5</amount>
 					</li>
 				</secondaryDamage>
-				<speed>148</speed>
+				<speed>142</speed>
 			</projectile>
 		</ThingDef>
 		
@@ -292,7 +292,7 @@
 						<amount>7</amount>
 					</li>
 				</secondaryDamage>
-				<speed>148</speed>
+				<speed>142</speed>
 			</projectile>
 		</ThingDef>
 
@@ -303,7 +303,7 @@
 				<damageAmountBase>6</damageAmountBase>
 				<armorPenetrationSharp>17.5</armorPenetrationSharp>
 				<armorPenetrationBlunt>28.42</armorPenetrationBlunt>
-				<speed>222</speed>
+				<speed>193</speed>
 			</projectile>
 		</ThingDef>
 

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>74</speed>
+			<speed>84</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>38.94</armorPenetrationBlunt>
-		  <speed>110</speed>
+		  <speed>114</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>186</speed>
+			<speed>169</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>8</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>46.12</armorPenetrationBlunt>
-		  <speed>279</speed>
+		  <speed>229</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/5x100mmCaseless.xml
+++ b/Defs/Ammo/Rifle/5x100mmCaseless.xml
@@ -76,7 +76,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>18</armorPenetrationSharp>
 		  <armorPenetrationBlunt>75</armorPenetrationBlunt>
-		  <speed>200</speed>
+		  <speed>178</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -92,7 +92,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>20</armorPenetrationSharp>
 		  <armorPenetrationBlunt>108</armorPenetrationBlunt>
-		  <speed>240</speed>
+		  <speed>204</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Defs/Ammo/Rifle/6.5Creedmoor.xml
+++ b/Defs/Ammo/Rifle/6.5Creedmoor.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>166</speed>
+			<speed>155</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>23</armorPenetrationSharp>
 		  <armorPenetrationBlunt>87.28</armorPenetrationBlunt>
-		  <speed>203</speed>
+		  <speed>210</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
+++ b/Defs/Ammo/Rifle/6.5x52mm Carcano.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>154</speed>
+			<speed>137</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -146,7 +146,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
-			<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
+			<armorPenetrationBlunt>51.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -156,7 +156,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
-			<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
+			<armorPenetrationBlunt>51.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -166,7 +166,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>22</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
-			<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
+			<armorPenetrationBlunt>51.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -176,7 +176,7 @@
 	<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<damageAmountBase>11</damageAmountBase>
 		<armorPenetrationSharp>12</armorPenetrationSharp>
-		<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
+		<armorPenetrationBlunt>51.46</armorPenetrationBlunt>
 		<secondaryDamage>
 			<li>
 			<def>Flame_Secondary</def>
@@ -192,7 +192,7 @@
 	<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<damageAmountBase>17</damageAmountBase>
 		<armorPenetrationSharp>6</armorPenetrationSharp>
-		<armorPenetrationBlunt>53.96</armorPenetrationBlunt>
+		<armorPenetrationBlunt>51.46</armorPenetrationBlunt>
 		<secondaryDamage>
 			<li>
 			<def>Bomb_Secondary</def>
@@ -208,8 +208,8 @@
 	<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<damageAmountBase>9</damageAmountBase>
 		<armorPenetrationSharp>21</armorPenetrationSharp>
-		<armorPenetrationBlunt>69.24</armorPenetrationBlunt>
-		<speed>231</speed>
+		<armorPenetrationBlunt>66.04</armorPenetrationBlunt>
+		<speed>185</speed>
 	</projectile>
 	</ThingDef>
 
@@ -227,7 +227,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>24</count>
+				<count>26</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -238,7 +238,7 @@
 		<products>
 			<Ammo_65x52mmCarcano_FMJ>500</Ammo_65x52mmCarcano_FMJ>
 		</products>
-    	<workAmount>2800</workAmount>		
+    	<workAmount>2600</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -253,7 +253,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>30</count>
+				<count>26</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 		<products>
 			<Ammo_65x52mmCarcano_AP>500</Ammo_65x52mmCarcano_AP>
 		</products>
-    	<workAmount>3000</workAmount>		
+    	<workAmount>3120</workAmount>		
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeBase">
@@ -279,7 +279,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>30</count>
+				<count>26</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -290,7 +290,7 @@
 		<products>
 			<Ammo_65x52mmCarcano_HP>500</Ammo_65x52mmCarcano_HP>
 		</products>
-    	<workAmount>3000</workAmount>		
+    	<workAmount>2600</workAmount>		
 	</RecipeDef>
 
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -305,7 +305,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>30</count>
+        <count>26</count>
       </li>
       <li>
         <filter>
@@ -325,7 +325,7 @@
     <products>
       <Ammo_65x52mmCarcano_Incendiary>500</Ammo_65x52mmCarcano_Incendiary>
     </products>
-    <workAmount>4200</workAmount>
+    <workAmount>3800</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -340,7 +340,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>30</count>
+        <count>26</count>
       </li>
       <li>
         <filter>
@@ -360,7 +360,7 @@
     <products>
       <Ammo_65x52mmCarcano_HE>500</Ammo_65x52mmCarcano_HE>
     </products>
-    <workAmount>5800</workAmount>
+    <workAmount>5400</workAmount>
   </RecipeDef>
   
   <RecipeDef ParentName="AdvancedAmmoRecipeBase">
@@ -375,7 +375,7 @@
             <li>Steel</li>
           </thingDefs>
         </filter>
-        <count>18</count>
+        <count>14</count>
       </li>
       <li>
         <filter>
@@ -383,7 +383,7 @@
             <li>Uranium</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>3</count>
       </li>
       <li>
         <filter>
@@ -391,7 +391,7 @@
             <li>Chemfuel</li>
           </thingDefs>
         </filter>
-        <count>4</count>
+        <count>3</count>
       </li>		  
     </ingredients>
     <fixedIngredientFilter>
@@ -404,7 +404,7 @@
     <products>
       <Ammo_65x52mmCarcano_Sabot>500</Ammo_65x52mmCarcano_Sabot>
     </products>
-    <workAmount>4200</workAmount>
+    <workAmount>3200</workAmount>
   </RecipeDef>
 
 </Defs>

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>154</speed>
+			<speed>147</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>9</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>69.24</armorPenetrationBlunt>
-		  <speed>231</speed>
+		  <speed>199</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>164</speed>
+			<speed>154</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>100.92</armorPenetrationBlunt>
-		  <speed>246</speed>
+		  <speed>208</speed>
 		</projectile>
 	  </ThingDef>
   

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>164</speed>
+			<speed>154</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>77.62</armorPenetrationBlunt>
-		  <speed>246</speed>
+		  <speed>208</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>144</speed>
+			<speed>139</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>8</damageAmountBase>
 		  <armorPenetrationSharp>19.25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>53.36</armorPenetrationBlunt>
-		  <speed>216</speed>
+		  <speed>189</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>168</speed>
+			<speed>156</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>25</armorPenetrationSharp>
 		  <armorPenetrationBlunt>86.28</armorPenetrationBlunt>
-		  <speed>252</speed>
+		  <speed>212</speed>
 		</projectile>
 	  </ThingDef>
   

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>166</speed>
+			<speed>155</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
       <damageAmountBase>10</damageAmountBase>
       <armorPenetrationSharp>25</armorPenetrationSharp>
       <armorPenetrationBlunt>87.280</armorPenetrationBlunt>
-      <speed>249</speed>
+      <speed>210</speed>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>148</speed>
+			<speed>142</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -210,7 +210,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>77.26</armorPenetrationBlunt>
-		  <speed>222</speed>
+		  <speed>193</speed>
 		</projectile>
 	  </ThingDef>
     

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>137</speed>
+			<speed>134</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>9</damageAmountBase>
 		  <armorPenetrationSharp>17.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>48.36</armorPenetrationBlunt>
-		  <speed>206</speed>
+		  <speed>182</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/8.6mmBlackout.xml
+++ b/Defs/Ammo/Rifle/8.6mmBlackout.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>122</speed>
+			<speed>123</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>101.58</armorPenetrationBlunt>
-		  <speed>203</speed>
+		  <speed>167</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>146</speed>
+			<speed>141</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>87.52</armorPenetrationBlunt>
-		  <speed>219</speed>
+		  <speed>191</speed>
 		</projectile>
 	  </ThingDef>
 	  

--- a/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
+++ b/Defs/Ammo/Rifle/8x50mmRMannlicher.xml
@@ -135,7 +135,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>119</speed>
+			<speed>121</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationSharp>19</armorPenetrationSharp>
 			<armorPenetrationBlunt>71.6</armorPenetrationBlunt>
-			<speed>179</speed>
+			<speed>164</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -134,7 +134,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>64</speed>
+			<speed>76</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -208,9 +208,10 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>14</armorPenetrationSharp>
 		  <armorPenetrationBlunt>21.16</armorPenetrationBlunt>
-		  <speed>96</speed>
+		  <speed>103</speed>
 		</projectile>
 	  </ThingDef>	
+
 	<!-- ==================== Recipes ========================== -->
 
 	<RecipeDef ParentName="AmmoRecipeBase">

--- a/Defs/Ammo/Rocket/127mmJavelinMissile.xml
+++ b/Defs/Ammo/Rocket/127mmJavelinMissile.xml
@@ -16,7 +16,7 @@
 			<damageAmountBase>363</damageAmountBase>
 			<armorPenetrationSharp>750</armorPenetrationSharp>
 			<armorPenetrationBlunt>175.402</armorPenetrationBlunt>
-			<speed>44</speed>
+			<speed>57</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Rocket/130mmType63.xml
+++ b/Defs/Ammo/Rocket/130mmType63.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>88</speed>
+			<speed>96</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Rocket/132mmM13.xml
+++ b/Defs/Ammo/Rocket/132mmM13.xml
@@ -65,7 +65,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>70</speed>
+			<speed>81</speed>
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>337</damageAmountBase>
 			<explosionRadius>4</explosionRadius>

--- a/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
+++ b/Defs/Ammo/Rocket/150mmMBTLAWMissile.xml
@@ -16,7 +16,7 @@
 			<damageAmountBase>281</damageAmountBase>
 			<armorPenetrationSharp>600</armorPenetrationSharp>
 			<armorPenetrationBlunt>137.525</armorPenetrationBlunt>
-			<speed>40</speed>
+			<speed>54</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Rocket/20mmFliegerfaust.xml
+++ b/Defs/Ammo/Rocket/20mmFliegerfaust.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>70</speed>
+			<speed>81</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/70mmAPKWS.xml
+++ b/Defs/Ammo/Rocket/70mmAPKWS.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>200</speed>
+			<speed>173</speed>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Rocket/83mmSMAW.xml
+++ b/Defs/Ammo/Rocket/83mmSMAW.xml
@@ -94,7 +94,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>44</speed>
+			<speed>58</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/84mmAT4.xml
+++ b/Defs/Ammo/Rocket/84mmAT4.xml
@@ -16,7 +16,7 @@
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>420</armorPenetrationSharp>
 			<armorPenetrationBlunt>31.995</armorPenetrationBlunt>
-			<speed>50</speed>
+			<speed>63</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -79,7 +79,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>51</speed>
+			<speed>64</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	
@@ -116,6 +116,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bomb</damageDef>
       <damageAmountBase>151</damageAmountBase>
+      <speed>61</speed>
       <explosionRadius>2.5</explosionRadius>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Defs/Ammo/Rocket/88mmRPzB.xml
+++ b/Defs/Ammo/Rocket/88mmRPzB.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>22</speed>
+			<speed>34</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/90mmMATADOR.xml
+++ b/Defs/Ammo/Rocket/90mmMATADOR.xml
@@ -16,7 +16,7 @@
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
 			<armorPenetrationBlunt>33.233</armorPenetrationBlunt>
-			<speed>50</speed>
+			<speed>63</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Rocket/90mmRecoilless.xml
+++ b/Defs/Ammo/Rocket/90mmRecoilless.xml
@@ -77,7 +77,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>43</speed>
+      <speed>56</speed>
       <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
     </projectile>
   </ThingDef>
@@ -120,7 +120,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>77</speed>
+      <speed>87</speed>
       <damageAmountBase>27</damageAmountBase>
       <pelletCount>120</pelletCount>       <!-- Originally 2400 flechettes are present, changed to 120 buffed projectile -->
       <armorPenetrationSharp>5</armorPenetrationSharp>

--- a/Defs/Ammo/Rocket/M6.xml
+++ b/Defs/Ammo/Rocket/M6.xml
@@ -63,7 +63,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>17</speed>
+			<speed>27</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/M6A1.xml
+++ b/Defs/Ammo/Rocket/M6A1.xml
@@ -52,7 +52,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>17</speed>
+			<speed>27</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/M6A3.xml
+++ b/Defs/Ammo/Rocket/M6A3.xml
@@ -76,7 +76,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>17</speed>
+			<speed>27</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/M72LAW.xml
+++ b/Defs/Ammo/Rocket/M72LAW.xml
@@ -12,7 +12,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>29</speed>
+			<speed>42</speed>
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>248</damageAmountBase>
 			<armorPenetrationSharp>300</armorPenetrationSharp>

--- a/Defs/Ammo/Rocket/M74.xml
+++ b/Defs/Ammo/Rocket/M74.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>23</speed>
+			<speed>35</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/RPG28.xml
+++ b/Defs/Ammo/Rocket/RPG28.xml
@@ -16,7 +16,7 @@
 			<damageAmountBase>279</damageAmountBase>
 			<armorPenetrationSharp>1000</armorPenetrationSharp>
 			<armorPenetrationBlunt>46.227</armorPenetrationBlunt>
-      		<speed>52</speed>
+      		<speed>65</speed>
       		<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 		<comps>

--- a/Defs/Ammo/Rocket/RPG32.xml
+++ b/Defs/Ammo/Rocket/RPG32.xml
@@ -77,7 +77,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>28</speed>
+			<speed>41</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -95,7 +95,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>60</speed>
+      <speed>73</speed>
       <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
     </projectile>
   </ThingDef>

--- a/Defs/Ammo/Rocket/RPO.xml
+++ b/Defs/Ammo/Rocket/RPO.xml
@@ -16,7 +16,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>25</speed>
+			<speed>38</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 		</projectile>
 	</ThingDef>	

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -111,7 +111,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>64</speed>
+      <speed>75</speed>
       <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
     </projectile>
   </ThingDef>
@@ -124,7 +124,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>87</speed>
+      <speed>96</speed>
       <damageDef>Bullet</damageDef>
       <damageAmountBase>248</damageAmountBase>
       <armorPenetrationSharp>400</armorPenetrationSharp>

--- a/Defs/Ammo/Rocket/TomahawkLAM.xml
+++ b/Defs/Ammo/Rocket/TomahawkLAM.xml
@@ -57,7 +57,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>50</speed>
+			<speed>63</speed>
 			<soundHitThickRoof>Explosion_GiantBomb</soundHitThickRoof>
 			<soundExplode>Explosion_GiantBomb</soundExplode>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -76,7 +76,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>180</speed>
+			<speed>165</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/105mmHowitzer.xml
+++ b/Defs/Ammo/Shell/105mmHowitzer.xml
@@ -249,7 +249,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>154</speed>
+			<speed>147</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
@@ -266,7 +266,7 @@
 		  <graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>200</speed>
+			<speed>178</speed>
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>352</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>

--- a/Defs/Ammo/Shell/105x607mmR.xml
+++ b/Defs/Ammo/Shell/105x607mmR.xml
@@ -75,7 +75,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>101</speed>
+			<speed>107</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -75,7 +75,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>280</speed>
+			<speed>229</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -227,7 +227,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		  </graphicData>
 		  <projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>166</speed>
+			<speed>155</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -60,7 +60,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>178</speed>
+			<speed>163</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>

--- a/Defs/Ammo/Shell/37x223mmR.xml
+++ b/Defs/Ammo/Shell/37x223mmR.xml
@@ -75,7 +75,7 @@
 		<defName>Bullet_37x223mmR_HE</defName>
 		<label>37x223mmR shell (APHE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>159</speed>
+			<speed>150</speed>
 			<damageAmountBase>136</damageAmountBase>
 			<armorPenetrationSharp>54</armorPenetrationSharp>
 			<armorPenetrationBlunt>3826.32</armorPenetrationBlunt>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -74,7 +74,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>205</speed>
+			<speed>181</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -60,7 +60,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>207</speed>
+			<speed>193</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/762x385mmRCannon.xml
+++ b/Defs/Ammo/Shell/762x385mmRCannon.xml
@@ -101,7 +101,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>136</speed>
+			<speed>134</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -153,7 +153,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>160</speed>
+      <speed>151</speed>
       <soundExplode>MortarBomb_Explode</soundExplode>
       <flyOverhead>false</flyOverhead>
       <dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Shotgun/10Gauge.xml
+++ b/Defs/Ammo/Shotgun/10Gauge.xml
@@ -106,7 +106,7 @@
   <ThingDef Name="Base10GaugeBullet" ParentName="BaseBulletCE" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>67</speed>
+      <speed>79</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -137,7 +137,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>102</speed>
+      <speed>108</speed>
       <damageAmountBase>33</damageAmountBase>
       <armorPenetrationSharp>6</armorPenetrationSharp>
       <armorPenetrationBlunt>129</armorPenetrationBlunt>
@@ -152,7 +152,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>30</speed>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>12</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -169,7 +169,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>30</speed>
+      <speed>43</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>19</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -106,7 +106,7 @@
   <ThingDef Name="Base12GaugeBullet" ParentName="BaseBulletCE" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>72</speed>
+      <speed>83</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -137,7 +137,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>110</speed>
+      <speed>114</speed>
       <damageAmountBase>28</damageAmountBase>
       <armorPenetrationSharp>6</armorPenetrationSharp>
       <armorPenetrationBlunt>85.2</armorPenetrationBlunt>
@@ -152,7 +152,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>22</speed>
+      <speed>30</speed>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -169,7 +169,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>30</speed>
+      <speed>43</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>12</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Defs/Ammo/Shotgun/16Gauge.xml
+++ b/Defs/Ammo/Shotgun/16Gauge.xml
@@ -106,7 +106,7 @@
   <ThingDef Name="Base16GaugeBullet" ParentName="BaseBulletCE" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>75</speed>
+      <speed>85</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -137,7 +137,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>98</speed>
+      <speed>104</speed>
       <damageAmountBase>23</damageAmountBase>
       <armorPenetrationSharp>5</armorPenetrationSharp>
       <armorPenetrationBlunt>54.02</armorPenetrationBlunt>
@@ -152,7 +152,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>30</speed>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>8</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -169,7 +169,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>30</speed>
+      <speed>43</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>11</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -106,7 +106,7 @@
 	<ThingDef Name="Base20GaugeBullet" ParentName="BaseBulletCE" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>74</speed>
+			<speed>84</speed>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -137,7 +137,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>97</speed>
+			<speed>103</speed>
 			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.14</armorPenetrationBlunt>
@@ -156,7 +156,7 @@
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>2.18</armorPenetrationBlunt>
 			<spreadMult>2</spreadMult>
-			<speed>18</speed>
+			<speed>30</speed>
 		</projectile>
 	</ThingDef>
 
@@ -173,7 +173,7 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<empShieldBreakChance>0.18</empShieldBreakChance>
-			<speed>30</speed>
+			<speed>43</speed>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -106,7 +106,7 @@
 	<ThingDef Name="Base23x75mmRBullet" ParentName="BaseBulletCE" Abstract="true">
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>78</speed>
+			<speed>88</speed>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 			<casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -137,7 +137,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>100</speed>
+			<speed>106</speed>
 			<damageAmountBase>38</damageAmountBase>
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>162.5</armorPenetrationBlunt>
@@ -152,7 +152,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>18</speed>
+			<speed>30</speed>
 			<damageDef>Beanbag</damageDef>
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBlunt>7.38</armorPenetrationBlunt>
@@ -173,7 +173,7 @@
 			<armorPenetrationSharp>0</armorPenetrationSharp>
 			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<empShieldBreakChance>0.5</empShieldBreakChance>
-			<speed>46</speed>
+			<speed>60</speed>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -118,7 +118,7 @@
   <ThingDef Name="Base410BoreBullet" ParentName="BaseBulletCE" Abstract="true">
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>70</speed>
+      <speed>81</speed>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
       <casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -149,7 +149,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>110</speed>
+      <speed>114</speed>
       <damageAmountBase>15</damageAmountBase>
       <armorPenetrationSharp>4.5</armorPenetrationSharp>
       <armorPenetrationBlunt>21.36</armorPenetrationBlunt>
@@ -164,7 +164,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>30</speed>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>5</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -181,7 +181,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>30</speed>
+      <speed>43</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -198,7 +198,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>49</speed>
+      <speed>62</speed>
       <damageAmountBase>7</damageAmountBase> 
       <pelletCount>5</pelletCount>
       <armorPenetrationSharp>2.1</armorPenetrationSharp>
@@ -215,7 +215,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>78</speed>
+      <speed>88</speed>
       <damageAmountBase>11</damageAmountBase>
       <armorPenetrationSharp>3.2</armorPenetrationSharp>
       <armorPenetrationBlunt>10.72</armorPenetrationBlunt>
@@ -230,7 +230,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>18</speed>
+      <speed>23</speed>
       <damageDef>Beanbag</damageDef>
       <damageAmountBase>4</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>
@@ -247,7 +247,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>21</speed>
+      <speed>33</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>7</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
+++ b/Patches/Alpha Mechs/Mods/Biotech/ThingDef_Misc/Weapons.xml
@@ -170,7 +170,7 @@
 								<projectile Class="CombatExtended.ProjectilePropertiesCE">
 									<damageDef>Bullet</damageDef>
 									<damageAmountBase>52</damageAmountBase>
-									<speed>200</speed>
+									<speed>178</speed>
 									<secondaryDamage>
 										<li>
 											<def>Bomb_Secondary</def>
@@ -274,7 +274,7 @@
 										<amount>15</amount>
 									</li>
 								</secondaryDamage>
-								<speed>240</speed>
+								<speed>204</speed>
 							</projectile>
 						  </ThingDef>
 
@@ -704,7 +704,7 @@
 									<damageAmountBase>8</damageAmountBase>
 									<armorPenetrationSharp>12</armorPenetrationSharp>
 									<armorPenetrationBlunt>48</armorPenetrationBlunt>
-									<speed>160</speed>
+									<speed>150</speed>
 								</projectile>
 							</ThingDef>
 

--- a/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
+++ b/Patches/Android Tiers/Ammo/MastiffShotgunShell.xml
@@ -66,7 +66,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>107</speed>
+								<speed>111</speed>
 								<damageAmountBase>16</damageAmountBase>
 								<damageDef>Fragment</damageDef>
 								<pelletCount>150</pelletCount>

--- a/Patches/Apex - Rimworld Legends/ApexRimworldLegends_AmmoPatch.xml
+++ b/Patches/Apex - Rimworld Legends/ApexRimworldLegends_AmmoPatch.xml
@@ -65,7 +65,7 @@
             <damageDef>ARL_Bomb_ChargeMinigun</damageDef>
             <damageAmountBase>10</damageAmountBase>
             <explosionRadius>1.4</explosionRadius>
-            <speed>70</speed>
+            <speed>81</speed>
             <flyOverhead>false</flyOverhead>
             <dropsCasings>true</dropsCasings>
           </projectile>
@@ -126,7 +126,7 @@
             <damageAmountBase>40</damageAmountBase>
             <explosionRadius>1.6</explosionRadius>
             <explosionDelay>30</explosionDelay>
-            <speed>40</speed>
+            <speed>54</speed>
             <ai_IsIncendiary>false</ai_IsIncendiary>
             <flyOverhead>false</flyOverhead>
             <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Patches/Arasaka Corporation [1.3]/7mmMiniRailgun.xml
+++ b/Patches/Arasaka Corporation [1.3]/7mmMiniRailgun.xml
@@ -69,7 +69,7 @@
 			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationSharp>20</armorPenetrationSharp>
 			<armorPenetrationBlunt>76.720</armorPenetrationBlunt>
-			<speed>236</speed>
+			<speed>202</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Arasaka Corporation [1.3]/BigBrainGyrojet.xml
+++ b/Patches/Arasaka Corporation [1.3]/BigBrainGyrojet.xml
@@ -99,7 +99,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>74</speed>
+			<speed>85</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
+++ b/Patches/CP DOOM & DOOM Kit Classic/CP_DOOM_CE_Patch_Ammo_12Gauge_Dual.xml
@@ -39,7 +39,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>83</speed>
+								<speed>92</speed>
 								<damageAmountBase>46</damageAmountBase>
 								<pelletCount>2</pelletCount> <!-- Double slugs -->
 								<armorPenetrationSharp>6</armorPenetrationSharp>
@@ -55,7 +55,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>18</speed>
+								<speed>30</speed>
 								<damageDef>Beanbag</damageDef>
 								<damageAmountBase>18</damageAmountBase>
 								<pelletCount>2</pelletCount> <!-- Double beanbags -->
@@ -73,7 +73,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>30</speed>
+								<speed>43</speed>
 								<damageDef>EMP</damageDef>
 								<damageAmountBase>24</damageAmountBase>
 								<pelletCount>2</pelletCount> <!-- Double EMP slugs -->

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Blunders/Blundergat.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Blunders/Blundergat.xml
@@ -66,7 +66,7 @@
 						<!-- ==================== Projectiles ========================== -->
 						<ThingDef Name="CODZP_BlunderBulletBase" ParentName="Base12GaugeBullet" Abstract="true">
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>83</speed>
+								<speed>92</speed>
 								<dropsCasings>true</dropsCasings>
 								<damageDef>Bullet</damageDef>
 								<pelletCount>4</pelletCount>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Blunders/Blundergat_Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Blunders/Blundergat_Punched.xml
@@ -66,7 +66,7 @@
 						<!-- ==================== Projectiles ========================== -->
 						<ThingDef Name="CODZP_BlunderBulletPunched" ParentName="CODZP_BlunderBulletBase" Abstract="true">
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>95</speed>
+								<speed>102</speed>
 							</projectile>
 						</ThingDef>
 						<ThingDef ParentName="CODZP_BlunderBulletPunched">

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Hells/Hells Retriever.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Hells/Hells Retriever.xml
@@ -31,7 +31,7 @@
 			<texPath>Things/Projectile/CODZP_Hell_Retriever</texPath>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>150</speed>
+			<speed>144</speed>
 			<damageAmountBase>60</damageAmountBase>
 			<armorPenetrationSharp>20</armorPenetrationSharp>
 			<armorPenetrationBlunt>20</armorPenetrationBlunt>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Hells/Hells Retriever_Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Hells/Hells Retriever_Punched.xml
@@ -19,7 +19,7 @@
 			<texPath>Things/Projectile/CODZP_Hell_Redeemer</texPath>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>180</speed>
+			<speed>165</speed>
 			<damageAmountBase>80</damageAmountBase>
 			<armorPenetrationSharp>40</armorPenetrationSharp>
 			<armorPenetrationBlunt>40</armorPenetrationBlunt>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun.xml
@@ -62,7 +62,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>54</speed>
+								<speed>67</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2.xml
@@ -61,7 +61,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>300</speed>
+								<speed>242</speed>
 								<dropsCasings>false</dropsCasings>
 							</projectile>
 						</ThingDef>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2_Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun2_Punched.xml
@@ -54,7 +54,7 @@
 						<!-- ==================== Projectiles ========================== -->
 						<ThingDef Name="Raygun2BulletPunched" ParentName="Raygun2Bullet" Abstract="true">
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>345</speed>
+								<speed>268</speed>
 							</projectile>
 						</ThingDef>
 						<ThingDef ParentName="Raygun2BulletPunched">

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun_Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Rayguns/Raygun_Punched.xml
@@ -55,7 +55,7 @@
 						<!-- ==================== Projectiles ========================== -->
 						<ThingDef Name="RaygunBulletPunched" ParentName="BaseRaygunBullet" Abstract="true">
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>66</speed>
+								<speed>78</speed>
 							</projectile>
 						</ThingDef>
 						<ThingDef ParentName="RaygunBulletPunched">

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/12Gauge-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/12Gauge-Punched.xml
@@ -90,7 +90,7 @@
             <ThingDef Name="Punched12GaugeBullet" ParentName="BaseBulletCE" Abstract="true">
               <projectile Class="CombatExtended.ProjectilePropertiesCE">
                 <damageDef>Bullet</damageDef>
-                <speed>83</speed>
+                <speed>92</speed>
                 <dropsCasings>true</dropsCasings>
                 <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
                 </projectile>
@@ -135,7 +135,7 @@
 								<shaderType>TransparentPostLight</shaderType>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>30</speed>
+								<speed>43</speed>
 								<damageDef>EMP</damageDef>
 								<damageAmountBase>12</damageAmountBase>
 								<armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/303British-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/303British-Punched.xml
@@ -138,7 +138,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>171</speed>
+								<speed>159</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>
@@ -206,7 +206,7 @@
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>42</armorPenetrationSharp>
 								<armorPenetrationBlunt>80.960</armorPenetrationBlunt>
-								<speed>257</speed>
+								<speed>215</speed>
 							</projectile>
 						</ThingDef>
 						<!-- ==================== Recipes ==================== -->

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/30x64mmFuelCell-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/30x64mmFuelCell-Punched.xml
@@ -90,7 +90,7 @@
 								<shaderType>TransparentPostLight</shaderType>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>46</speed>
+								<speed>60</speed>
 								<flyOverhead>false</flyOverhead>
 							</projectile>
 						</ThingDef>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/44Magnum-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/44Magnum-Punched.xml
@@ -92,7 +92,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>90</speed>
+								<speed>98</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/45ACP-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/45ACP-Punched.xml
@@ -92,7 +92,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>62</speed>
+								<speed>74</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/556x45mmNATO-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/556x45mmNATO-Punched.xml
@@ -138,7 +138,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>212</speed>
+								<speed>186</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>
@@ -206,7 +206,7 @@
 								<damageAmountBase>14</damageAmountBase>
 								<armorPenetrationSharp>42</armorPenetrationSharp>
 								<armorPenetrationBlunt>44.18</armorPenetrationBlunt>
-								<speed>318</speed>
+								<speed>252</speed>
 							</projectile>
 						</ThingDef>
 						<!-- ==================== Recipes ==================== -->

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/6x24mmCharged-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/6x24mmCharged-Punched.xml
@@ -83,7 +83,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>184</speed>
+								<speed>168</speed>
 							</projectile>
 						</ThingDef>
 						<ThingDef ParentName="Punched6x24mmChargedBullet">

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/762x51mmNATO-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/762x51mmNATO-Punched.xml
@@ -138,7 +138,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>193</speed>
+								<speed>174</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>
@@ -206,7 +206,7 @@
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>50</armorPenetrationSharp>
 								<armorPenetrationBlunt>86.28</armorPenetrationBlunt>
-								<speed>289</speed>
+								<speed>235</speed>
 							</projectile>
 						</ThingDef>
 						<!-- ==================== Recipes ==================== -->

--- a/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/762x54mmR-Punched.xml
+++ b/Patches/Call of Duty - Zombies Pack/Ammo/Recipe/762x54mmR-Punched.xml
@@ -138,7 +138,7 @@
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>190</speed>
+								<speed>172</speed>
 								<dropsCasings>true</dropsCasings>
 							</projectile>
 						</ThingDef>
@@ -206,7 +206,7 @@
 								<damageAmountBase>20</damageAmountBase>
 								<armorPenetrationSharp>50</armorPenetrationSharp>
 								<armorPenetrationBlunt>87.280</armorPenetrationBlunt>
-								<speed>286</speed>
+								<speed>233</speed>
 							</projectile>
 						</ThingDef>
 						<!-- ==================== Recipes ==================== -->

--- a/Patches/Censored Armory/30mm Rifle Grenade.xml
+++ b/Patches/Censored Armory/30mm Rifle Grenade.xml
@@ -122,7 +122,7 @@
             <graphicClass>Graphic_Single</graphicClass>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>15</speed>
+            <speed>26</speed>
             <flyOverhead>false</flyOverhead>
           </projectile>
         </ThingDef>

--- a/Patches/Censored Armory/37x249mmR.xml
+++ b/Patches/Censored Armory/37x249mmR.xml
@@ -82,7 +82,7 @@
 					<defName>Bullet_37x249mmR_HE</defName>
 					<label>37x249mmR shell (APHE)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>153</speed>
+						<speed>146</speed>
 						<damageAmountBase>155</damageAmountBase>
 						<armorPenetrationSharp>54</armorPenetrationSharp>
 						<armorPenetrationBlunt>5574.18</armorPenetrationBlunt>
@@ -99,7 +99,7 @@
 					<defName>Bullet_37x249mmR_AP</defName>
 					<label>37x249mmR shell (AP)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>153</speed>
+						<speed>146</speed>
 						<damageAmountBase>97</damageAmountBase>
 						<armorPenetrationSharp>77</armorPenetrationSharp>
 						<armorPenetrationBlunt>5574.18</armorPenetrationBlunt>

--- a/Patches/Censored Armory/75cm leIG18.xml
+++ b/Patches/Censored Armory/75cm leIG18.xml
@@ -95,7 +95,7 @@
 						<shaderType>TransparentPostLight</shaderType>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>42</speed>
+						<speed>56</speed>
 						<soundExplode>MortarBomb_Explode</soundExplode>
 						<flyOverhead>false</flyOverhead>
 						<dropsCasings>true</dropsCasings>

--- a/Patches/Censored Armory/75x714mmR.xml
+++ b/Patches/Censored Armory/75x714mmR.xml
@@ -103,7 +103,7 @@
             <graphicClass>Graphic_Single</graphicClass>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>90</speed>
+            <speed>98</speed>
             <dropsCasings>true</dropsCasings>
             <damageDef>Bullet</damageDef>
             <damageAmountBase>248</damageAmountBase>
@@ -136,7 +136,7 @@
             <graphicClass>Graphic_Single</graphicClass>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>90</speed>
+            <speed>98</speed>
             <dropsCasings>true</dropsCasings>
             <damageDef>Bomb</damageDef>
             <damageAmountBase>111</damageAmountBase>

--- a/Patches/Censored Armory/80mm Panzerfaust.xml
+++ b/Patches/Censored Armory/80mm Panzerfaust.xml
@@ -19,7 +19,7 @@
 						<graphicClass>Graphic_Single</graphicClass>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>22</speed>
+						<speed>34</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>208</damageAmountBase>
 						<armorPenetrationSharp>200</armorPenetrationSharp>

--- a/Patches/Censored Armory/Weapons_Guns.xml
+++ b/Patches/Censored Armory/Weapons_Guns.xml
@@ -1334,7 +1334,7 @@
 							<explosionDelay>60</explosionDelay>
 							<dropsCasings>false</dropsCasings>
 							<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-							<speed>10</speed>
+							<speed>19</speed>
 						</projectile>
 					</value>
 				</li>

--- a/Patches/Cursed Guns/CursedAmmo.xml
+++ b/Patches/Cursed Guns/CursedAmmo.xml
@@ -48,7 +48,7 @@
 					<graphicClass>Graphic_Single</graphicClass>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<speed>16</speed>
+					<speed>27</speed>
 					<damageDef>Beanbag</damageDef>
 					<damageAmountBase>20</damageAmountBase>
 					<armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Expanded Materials - Metals/Ammo/Arrows_ExpandedMetals.xml
+++ b/Patches/Expanded Materials - Metals/Ammo/Arrows_ExpandedMetals.xml
@@ -72,7 +72,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>24</speed>
+			<speed>37</speed>
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationSharp>0.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.02</armorPenetrationBlunt>
@@ -91,7 +91,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>33</speed>
+			<speed>47</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>1.0</armorPenetrationSharp>
 			<armorPenetrationBlunt>5.9</armorPenetrationBlunt>

--- a/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
+++ b/Patches/Forsakens/Forsakens_CE_Patch_Ammo_ForsakensArrows.xml
@@ -62,7 +62,7 @@
 								<armorPenetrationBlunt>4.5</armorPenetrationBlunt>
 								<armorPenetrationSharp>5</armorPenetrationSharp>
 								<preExplosionSpawnChance>0.5</preExplosionSpawnChance>
-								<speed>26</speed>
+								<speed>39</speed>
 								<!-- 25 arrows per resource -->
 								<preExplosionSpawnThingDef>Ammo_ForsakensArrows</preExplosionSpawnThingDef>
 							</projectile>
@@ -76,7 +76,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>15</speed>
+			<speed>26</speed>
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.660</armorPenetrationBlunt>
 			<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -93,7 +93,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>19</speed>
+			<speed>31</speed>
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>2.340</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
@@ -110,7 +110,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>23</speed>
+			<speed>36</speed>
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBlunt>2.140</armorPenetrationBlunt>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
@@ -127,7 +127,7 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>19</speed>
+			<speed>31</speed>
 			<damageDef>Arrow</damageDef>
 			<damageAmountBase>10</damageAmountBase>
 			<secondaryDamage>

--- a/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/105mmShapedCharge.xml
+++ b/Patches/Halo - Rimworld Auxiliary Combat Armory/Ammo/105mmShapedCharge.xml
@@ -67,7 +67,7 @@
             <shaderType>TransparentPostLight</shaderType>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>60</speed>
+            <speed>73</speed>
             <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
           </projectile>
         </ThingDef>

--- a/Patches/Halo - UNSC Armoury/Ammo_UNSC.xml
+++ b/Patches/Halo - UNSC Armoury/Ammo_UNSC.xml
@@ -140,7 +140,7 @@
 					<defName>Bullet_95x40mm_FMJ</defName>
 					<label>7.62mm  bullet (FMJ)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>194</speed>
+						<speed>174</speed>
 						<damageAmountBase>23</damageAmountBase>
 						<armorPenetrationSharp>8</armorPenetrationSharp>
 						<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
@@ -151,7 +151,7 @@
 					<defName>Bullet_95x40mm_AP</defName>
 					<label>7.62mm  bullet (AP)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>194</speed>
+						<speed>174</speed>
 						<damageAmountBase>14</damageAmountBase>
 						<armorPenetrationSharp>16</armorPenetrationSharp>
 						<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
@@ -162,7 +162,7 @@
 					<defName>Bullet_95x40mm_HP</defName>
 					<label>7.62mm  bullet (HP)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>194</speed>
+						<speed>174</speed>
 						<damageAmountBase>29</damageAmountBase>
 						<armorPenetrationSharp>4</armorPenetrationSharp>
 						<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
@@ -173,7 +173,7 @@
 					<defName>Bullet_95x40mm_Incendiary</defName>
 					<label>7.62mm  bullet (AP-I)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>194</speed>
+						<speed>174</speed>
 						<damageAmountBase>14</damageAmountBase>
 						<armorPenetrationSharp>16</armorPenetrationSharp>
 						<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
@@ -190,7 +190,7 @@
 					<defName>Bullet_95x40mm_HE</defName>
 					<label>7.62mm  bullet (HE)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>194</speed>
+						<speed>174</speed>
 						<damageAmountBase>23</damageAmountBase>
 						<armorPenetrationSharp>8</armorPenetrationSharp>
 						<armorPenetrationBlunt>82.8</armorPenetrationBlunt>
@@ -210,7 +210,7 @@
 						<damageAmountBase>11</damageAmountBase>
 						<armorPenetrationSharp>25</armorPenetrationSharp>
 						<armorPenetrationBlunt>86.28</armorPenetrationBlunt>
-						<speed>291</speed>
+						<speed>236</speed>
 					</projectile>
 				</ThingDef>
 

--- a/Patches/Halo Ammo/102mmM41Rockets.xml
+++ b/Patches/Halo Ammo/102mmM41Rockets.xml
@@ -96,7 +96,7 @@
 			<damageAmountBase>264</damageAmountBase>
 			<armorPenetrationSharp>650</armorPenetrationSharp>
 			<armorPenetrationBlunt>41.818</armorPenetrationBlunt>
-			<speed>37</speed>
+			<speed>51</speed>
 		</projectile>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -128,7 +128,7 @@
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>240</damageAmountBase>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<speed>37</speed>
+			<speed>51</speed>
 		</projectile>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_Fragments">

--- a/Patches/Halo Ammo/12.7x40mm.xml
+++ b/Patches/Halo Ammo/12.7x40mm.xml
@@ -108,7 +108,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>38.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -119,7 +119,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>38.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -130,7 +130,7 @@
 			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>38.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -141,7 +141,7 @@
 			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationSharp>8</armorPenetrationSharp>
 			<armorPenetrationBlunt>32.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -152,7 +152,7 @@
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>16</armorPenetrationSharp>
 			<armorPenetrationBlunt>32.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 
@@ -163,7 +163,7 @@
 			<damageAmountBase>22</damageAmountBase>
 			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>32.480</armorPenetrationBlunt>
-			<speed>99</speed>
+			<speed>105</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Halo Ammo/12.7x99mm.xml
+++ b/Patches/Halo Ammo/12.7x99mm.xml
@@ -158,7 +158,7 @@
       <damageAmountBase>19</damageAmountBase>	
       <armorPenetrationSharp>55</armorPenetrationSharp>
       <armorPenetrationBlunt>384.780</armorPenetrationBlunt>
-      <speed>244</speed>
+      <speed>207</speed>
     </projectile>
   </ThingDef>
   

--- a/Patches/Halo Ammo/14.5x114mmUNSC.xml
+++ b/Patches/Halo Ammo/14.5x114mmUNSC.xml
@@ -158,7 +158,7 @@
     <defName>Bullet_145x114mmUNSC_Sabot</defName>
     <label>14.5x114mmUNSC bullet (Sabot)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-	  <speed>300</speed>
+	  <speed>242</speed>
       <damageAmountBase>27</damageAmountBase>
       <armorPenetrationSharp>74</armorPenetrationSharp>
       <armorPenetrationBlunt>860.360</armorPenetrationBlunt>

--- a/Patches/Halo Ammo/16x65mm.xml
+++ b/Patches/Halo Ammo/16x65mm.xml
@@ -71,7 +71,7 @@
       </graphicData>      
       <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <damageDef>Bullet</damageDef>
-        <speed>400</speed>      
+        <speed>406</speed>      
       <damageAmountBase>72</damageAmountBase>
       <armorPenetrationSharp>300</armorPenetrationSharp>
       <armorPenetrationBlunt>920.88</armorPenetrationBlunt>

--- a/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
+++ b/Patches/Halo Ammo/40x46mmGrenadesUNSC.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>48</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
 			<armorPenetrationBlunt>31.584</armorPenetrationBlunt>
-      <speed>21</speed>
+      <speed>33</speed>
 		 	 <secondaryDamage>
 				<li>
 			  	<def>EMP</def>
@@ -98,7 +98,7 @@
       <damageDef>Bomb</damageDef>
       <damageAmountBase>25</damageAmountBase>
       <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-      <speed>21</speed>
+      <speed>33</speed>
     </projectile>
     <comps>
       <li Class="CombatExtended.CompProperties_Fragments">
@@ -116,7 +116,7 @@
       <explosionRadius>1.5</explosionRadius>
       <damageDef>EMP</damageDef>
       <damageAmountBase>25</damageAmountBase>
-      <speed>21</speed>
+      <speed>33</speed>
     </projectile>
   </ThingDef>
 
@@ -130,7 +130,7 @@
 <dangerFactor>0.0</dangerFactor>
       <postExplosionGasType>BlindSmoke</postExplosionGasType>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
-      <speed>21</speed>
+      <speed>33</speed>
     </projectile>
   </ThingDef>
 

--- a/Patches/Halo Ammo/5x23mmCaseless.xml
+++ b/Patches/Halo Ammo/5x23mmCaseless.xml
@@ -165,7 +165,7 @@
 		  <damageAmountBase>6</damageAmountBase>
 		  <armorPenetrationSharp>21</armorPenetrationSharp>
 		  <armorPenetrationBlunt>36.58</armorPenetrationBlunt>
-		  <speed>246</speed>
+		  <speed>205</speed>
 		  <dropsCasings>false</dropsCasings>
 		</projectile>
 	  </ThingDef>

--- a/Patches/Halo Ammo/7.62x51mmUNSC.xml
+++ b/Patches/Halo Ammo/7.62x51mmUNSC.xml
@@ -199,7 +199,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-			<speed>188</speed>
+			<speed>170</speed>
 		</projectile>
 	</ThingDef>
 
@@ -210,7 +210,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>20</armorPenetrationSharp>
 			<armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-			<speed>188</speed>
+			<speed>170</speed>
 		</projectile>
 	</ThingDef>
 
@@ -221,7 +221,7 @@
 			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-			<speed>188</speed>
+			<speed>170</speed>
 		</projectile>
 	</ThingDef>
 
@@ -233,7 +233,7 @@
 			<damageDef>Fragment</damageDef>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-			<speed>188</speed>
+			<speed>170</speed>
 		</projectile>
 	</ThingDef>
 
@@ -244,7 +244,7 @@
 		  <damageAmountBase>12</damageAmountBase>
 		  <armorPenetrationSharp>20</armorPenetrationSharp>
 		  <armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-		  <speed>188</speed>
+		  <speed>170</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
@@ -261,7 +261,7 @@
 		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationSharp>10</armorPenetrationSharp>
 		  <armorPenetrationBlunt>69.72</armorPenetrationBlunt>
-		  <speed>188</speed>
+		  <speed>170</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -278,7 +278,7 @@
 		  <damageAmountBase>10</damageAmountBase>
 		  <armorPenetrationSharp>30</armorPenetrationSharp>
 		  <armorPenetrationBlunt>92.28</armorPenetrationBlunt>
-		  <speed>278</speed>
+		  <speed>228</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -289,7 +289,7 @@
 			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationSharp>11</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-			<speed>208</speed>
+			<speed>184</speed>
 		</projectile>
 	</ThingDef>
 
@@ -300,7 +300,7 @@
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-			<speed>208</speed>
+			<speed>184</speed>
 		</projectile>
 	</ThingDef>
 
@@ -311,7 +311,7 @@
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationSharp>5.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-			<speed>208</speed>
+			<speed>184</speed>
 		</projectile>
 	</ThingDef>
 
@@ -323,7 +323,7 @@
 			<damageDef>Fragment</damageDef>
 			<armorPenetrationSharp>5.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-			<speed>208</speed>
+			<speed>184</speed>
 		</projectile>
 	</ThingDef>
 
@@ -334,7 +334,7 @@
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationSharp>22</armorPenetrationSharp>
 		  <armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-		  <speed>208</speed>
+		  <speed>184</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
@@ -351,7 +351,7 @@
 		  <damageAmountBase>21</damageAmountBase>
 		  <armorPenetrationSharp>11</armorPenetrationSharp>
 		  <armorPenetrationBlunt>74.72</armorPenetrationBlunt>
-		  <speed>208</speed>
+		  <speed>184</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -368,7 +368,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>33</armorPenetrationSharp>
 		  <armorPenetrationBlunt>100.28</armorPenetrationBlunt>
-		  <speed>278</speed>
+		  <speed>228</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Patches/Halo Ammo/8 Gauge.xml
+++ b/Patches/Halo Ammo/8 Gauge.xml
@@ -149,7 +149,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>110</speed>
+      <speed>114</speed>
       <damageAmountBase>39</damageAmountBase>
       <armorPenetrationSharp>8</armorPenetrationSharp>
       <armorPenetrationBlunt>98.2</armorPenetrationBlunt>
@@ -164,7 +164,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>40</speed>
+      <speed>54</speed>
       <damageDef>EMP</damageDef>
       <damageAmountBase>22</damageAmountBase>
       <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Halo Ammo/9.5x40mm.xml
+++ b/Patches/Halo Ammo/9.5x40mm.xml
@@ -150,7 +150,7 @@
 			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
-			<speed>196</speed>
+			<speed>176</speed>
 		</projectile>
 	</ThingDef>
 
@@ -161,7 +161,7 @@
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>24</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
-			<speed>196</speed>
+			<speed>176</speed>
 		</projectile>
 	</ThingDef>
 
@@ -172,7 +172,7 @@
 			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>80.72</armorPenetrationBlunt>
-			<speed>196</speed>
+			<speed>176</speed>
 		</projectile>
 	</ThingDef>
 
@@ -183,7 +183,7 @@
 		  <damageAmountBase>15</damageAmountBase>
 		  <armorPenetrationSharp>24</armorPenetrationSharp>
 		  <armorPenetrationBlunt>80.72</armorPenetrationBlunt>
-		  <speed>196</speed>
+		  <speed>176</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Flame_Secondary</def>
@@ -200,7 +200,7 @@
 		  <damageAmountBase>23</damageAmountBase>
 		  <armorPenetrationSharp>12</armorPenetrationSharp>
 		  <armorPenetrationBlunt>80.72</armorPenetrationBlunt>
-		  <speed>196</speed>
+		  <speed>176</speed>
 		  <secondaryDamage>
 				<li>
 			  	<def>Bomb_Secondary</def>
@@ -217,7 +217,7 @@
 		  <damageAmountBase>11</damageAmountBase>
 		  <armorPenetrationSharp>35</armorPenetrationSharp>
 		  <armorPenetrationBlunt>101.28</armorPenetrationBlunt>
-		  <speed>278</speed>
+		  <speed>228</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Patches/Impact Weaponry/ImpactAmmo.xml
+++ b/Patches/Impact Weaponry/ImpactAmmo.xml
@@ -192,7 +192,7 @@
 					</graphicData>
 					<label>Impact Shells (Small)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>80</speed>
+						<speed>90</speed>
 						<damageAmountBase>18</damageAmountBase>
 						<armorPenetrationSharp>6</armorPenetrationSharp>
 						<armorPenetrationBlunt>2.131</armorPenetrationBlunt>
@@ -221,7 +221,7 @@
 						<damageAmountBase>37</damageAmountBase>
 						<armorPenetrationSharp>14</armorPenetrationSharp>
 						<armorPenetrationBlunt>2.931</armorPenetrationBlunt>
-						<speed>75</speed>
+						<speed>86</speed>
 						<casingMoteDefname>Mote_BolterCasing</casingMoteDefname>
 					</projectile>
 					<comps>
@@ -246,7 +246,7 @@
 						<damageAmountBase>64</damageAmountBase>
 						<armorPenetrationSharp>20</armorPenetrationSharp>
 						<armorPenetrationBlunt>5.101</armorPenetrationBlunt>
-						<speed>70</speed>
+						<speed>81</speed>
 						<damageDef>Bullet</damageDef>
 					</projectile>
 					<comps>
@@ -268,7 +268,7 @@
 					</graphicData>
 					<label>Impact Shells (Sniper)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>78</speed>
+						<speed>88</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>56</damageAmountBase>
 						<armorPenetrationSharp>18</armorPenetrationSharp>
@@ -293,7 +293,7 @@
 					</graphicData>
 					<label>Impact Shells (Bolter)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>78</speed>
+						<speed>88</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>24</damageAmountBase>
 						<armorPenetrationSharp>8</armorPenetrationSharp>
@@ -319,7 +319,7 @@
 					</graphicData>
 					<label>Impact Shells (Slugger)</label>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>75</speed>
+						<speed>86</speed>
 						<pelletCount>3</pelletCount>
 						<explosionRadius>0.4</explosionRadius>
 						<damageDef>Bomb</damageDef>

--- a/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
+++ b/Patches/K4G Rimworld War 2/AmmoDefs/WW2_RocketAmmo.xml
@@ -76,7 +76,7 @@
                   <graphicClass>Graphic_Single</graphicClass>
                </graphicData>
                <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                  <speed>22</speed>
+                  <speed>34</speed>
                   <damageDef>Bullet</damageDef>
                   <damageAmountBase>208</damageAmountBase>
                   <armorPenetrationSharp>200</armorPenetrationSharp>
@@ -108,7 +108,7 @@
                   <graphicClass>Graphic_Single</graphicClass>
                </graphicData>
                <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                  <speed>22</speed>
+                  <speed>34</speed>
                   <damageDef>Bullet</damageDef>
                   <damageAmountBase>208</damageAmountBase>
                   <armorPenetrationSharp>150</armorPenetrationSharp>
@@ -140,7 +140,7 @@
                   <graphicClass>Graphic_Single</graphicClass>
                </graphicData>
                <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                  <speed>19</speed>
+                  <speed>31</speed>
                   <damageDef>Bullet</damageDef>
                   <damageAmountBase>208</damageAmountBase>
                   <armorPenetrationSharp>172</armorPenetrationSharp>

--- a/Patches/Kaiser Armory/77x230mmR.xml
+++ b/Patches/Kaiser Armory/77x230mmR.xml
@@ -97,7 +97,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>93</speed>
+			<speed>101</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
+++ b/Patches/Kit's Gunpowder Weapons/Ammo_KitsGunpowder.xml
@@ -88,7 +88,7 @@
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>12</armorPenetrationBlunt>
 			<spreadMult>22.5</spreadMult>
-			<speed>64</speed>
+			<speed>76</speed>
 		</projectile>
 	</ThingDef>
 	

--- a/Patches/Kit's Roman Weapons/Roman_Weapons.xml
+++ b/Patches/Kit's Roman Weapons/Roman_Weapons.xml
@@ -368,7 +368,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
-			<speed>9</speed>
+			<speed>18</speed>
 			<armorPenetrationBlunt>2.36</armorPenetrationBlunt>
 			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.65</preExplosionSpawnChance>	<!-- 4 javelins per resource -->

--- a/Patches/Kurin Deluxe Patch/Ammo/Ammo_Kurin.xml
+++ b/Patches/Kurin Deluxe Patch/Ammo/Ammo_Kurin.xml
@@ -37,7 +37,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 	
       <damageDef>Bullet</damageDef>
-      <speed>150</speed>
+      <speed>144</speed>
       <damageAmountBase>18</damageAmountBase>
       <secondaryDamage>
         <li>
@@ -60,7 +60,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>150</speed>
+      <speed>144</speed>
       <damageAmountBase>14</damageAmountBase>
       <secondaryDamage>
         <li>
@@ -83,7 +83,7 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
-      <speed>150</speed>
+      <speed>144</speed>
       <damageAmountBase>14</damageAmountBase>
       <secondaryDamage>
         <li>
@@ -130,7 +130,7 @@
 			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationSharp>70</armorPenetrationSharp>
 			<armorPenetrationBlunt>500</armorPenetrationBlunt>
-			<speed>150</speed>
+			<speed>144</speed>
 		</projectile>
 	</ThingDef>
 		
@@ -153,7 +153,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
         <damageDef>RangedStab</damageDef>
 		<damageAmountBase>15</damageAmountBase>
-		<speed>20</speed>
+		<speed>32</speed>
 		<armorPenetrationBlunt>2.22</armorPenetrationBlunt>
 		<armorPenetrationSharp>1</armorPenetrationSharp>
     </projectile>
@@ -185,7 +185,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<damageDef>Kurin_Damage_Unmaker</damageDef>
 		<damageAmountBase>175</damageAmountBase>
-		<speed>90</speed>
+		<speed>98</speed>
 		<flyOverhead>false</flyOverhead>
 		<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 		<explosionRadius>3.9</explosionRadius>

--- a/Patches/LF Red Dawn/135mm9M113Konkur.xml
+++ b/Patches/LF Red Dawn/135mm9M113Konkur.xml
@@ -73,7 +73,7 @@
       						<shaderType>TransparentPostLight</shaderType>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>42</speed>
+						<speed>56</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>300</damageAmountBase>
 						<armorPenetrationSharp>800</armorPenetrationSharp>

--- a/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
+++ b/Patches/LF Red Dawn/RPG123456789_Projectiles.xml
@@ -20,7 +20,7 @@
 					<shaderType>TransparentPostLight</shaderType>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<speed>29</speed>
+					<speed>42</speed>
 					<damageDef>Bullet</damageDef>
 					<damageAmountBase>248</damageAmountBase>
 					<armorPenetrationSharp>300</armorPenetrationSharp>
@@ -53,7 +53,7 @@
 					<shaderType>TransparentPostLight</shaderType>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<speed>29</speed>
+					<speed>42</speed>
 					<damageDef>Bullet</damageDef>
 					<damageAmountBase>268</damageAmountBase>
 					<armorPenetrationSharp>400</armorPenetrationSharp>
@@ -86,7 +86,7 @@
 					<shaderType>TransparentPostLight</shaderType>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<speed>29</speed>
+					<speed>42</speed>
 					<damageDef>Bullet</damageDef>
 					<damageAmountBase>268</damageAmountBase>
 					<armorPenetrationSharp>440</armorPenetrationSharp>
@@ -119,7 +119,7 @@
 					<shaderType>TransparentPostLight</shaderType>
 				</graphicData>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
-					<speed>36</speed>
+					<speed>50</speed>
 					<damageDef>Bullet</damageDef>
 					<damageAmountBase>375</damageAmountBase>
 					<armorPenetrationSharp>750</armorPenetrationSharp>

--- a/Patches/LF Red Dawn/RPG16.xml
+++ b/Patches/LF Red Dawn/RPG16.xml
@@ -86,7 +86,7 @@
       <shaderType>TransparentPostLight</shaderType>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>72</speed>
+      <speed>83</speed>
       <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
     </projectile>
   </ThingDef>

--- a/Patches/LF Red Dawn/RPG29.xml
+++ b/Patches/LF Red Dawn/RPG29.xml
@@ -89,7 +89,7 @@
       						<shaderType>TransparentPostLight</shaderType>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>64</speed>
+						<speed>76</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>380</damageAmountBase>
 						<armorPenetrationSharp>750</armorPenetrationSharp>

--- a/Patches/MH Military Tiers/Ammo/RotaryShrapnelcannonShell.xml
+++ b/Patches/MH Military Tiers/Ammo/RotaryShrapnelcannonShell.xml
@@ -72,7 +72,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>114</speed>
+								<speed>117</speed>
 								<damageAmountBase>57</damageAmountBase>
 								<damageDef>Fragment</damageDef>
 								<pelletCount>6</pelletCount>

--- a/Patches/Mantodean Insectoid Race/Ammo/Projectiles.xml
+++ b/Patches/Mantodean Insectoid Race/Ammo/Projectiles.xml
@@ -22,7 +22,7 @@
 						</graphicData>
 						<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>35</speed>
+							<speed>49</speed>
 							<damageDef>MantoPoison</damageDef>
 							<damageAmountBase>7</damageAmountBase>
 							<armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Orassans/Ammo/10mmRailgunOE.xml
+++ b/Patches/Orassans/Ammo/10mmRailgunOE.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>38</damageAmountBase>
 			<armorPenetrationSharp>38</armorPenetrationSharp>
 			<armorPenetrationBlunt>165.320</armorPenetrationBlunt>
-			<speed>390</speed>
+			<speed>294</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Orassans/Ammo/12mm-autoRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-autoRailgunOE.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>110.80</armorPenetrationBlunt>
-			<speed>320</speed>
+			<speed>253</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Orassans/Ammo/12mm-longRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-longRailgunOE.xml
@@ -68,7 +68,7 @@
 			<damageAmountBase>60</damageAmountBase>
 			<armorPenetrationSharp>52</armorPenetrationSharp>
 			<armorPenetrationBlunt>290.890</armorPenetrationBlunt>
-			<speed>450</speed>
+			<speed>327</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Orassans/Ammo/12mm-subsonicRailgunOE.xml
+++ b/Patches/Orassans/Ammo/12mm-subsonicRailgunOE.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationSharp>50</armorPenetrationSharp>
 			<armorPenetrationBlunt>210.80</armorPenetrationBlunt>
-			<speed>280</speed>
+			<speed>229</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
+++ b/Patches/Orassans/Ammo/40x90mmGrenadeOE.xml
@@ -114,7 +114,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>26</speed>
+      <speed>39</speed>
     </projectile>
   </ThingDef>
 
@@ -141,7 +141,7 @@
     <defName>Bullet_40x90mmGrenadeOE_HEAT</defName>
     <label>40x90mm grenade OE (HEAT)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <speed>42</speed>
+      <speed>56</speed>
       <damageDef>Bullet</damageDef>
       <damageAmountBase>65</damageAmountBase>
       <armorPenetrationSharp>75</armorPenetrationSharp>
@@ -178,7 +178,7 @@
     <defName>Bullet_40x90mmGrenadeOE_Cryo</defName>
     <label>40x90mm grenade OE (Cryo)</label>
          <projectile Class="CombatExtended.ProjectilePropertiesCE">
-           <speed>34</speed>
+           <speed>48</speed>
            <damageDef>OFrostbite</damageDef>
            <damageAmountBase>20</damageAmountBase>
            <armorPenetrationSharp>0</armorPenetrationSharp>

--- a/Patches/Orassans/Ammo/6mmRailgunOE.xml
+++ b/Patches/Orassans/Ammo/6mmRailgunOE.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
 			<armorPenetrationBlunt>130.80</armorPenetrationBlunt>
-			<speed>300</speed>
+			<speed>242</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/Orassans/Ammo/8mmRailgunOE.xml
+++ b/Patches/Orassans/Ammo/8mmRailgunOE.xml
@@ -67,7 +67,7 @@
 			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationSharp>32</armorPenetrationSharp>
 			<armorPenetrationBlunt>95.720</armorPenetrationBlunt>
-			<speed>350</speed>
+			<speed>271</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Patches/RH2 Rimmu-Nation² - Security/152mmBGM71.xml
+++ b/Patches/RH2 Rimmu-Nation² - Security/152mmBGM71.xml
@@ -73,7 +73,7 @@
       						<shaderType>TransparentPostLight</shaderType>
 					</graphicData>
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
-						<speed>56</speed>
+						<speed>69</speed>
 						<damageDef>Bullet</damageDef>
 						<damageAmountBase>400</damageAmountBase>
 						<armorPenetrationSharp>900</armorPenetrationSharp>

--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
@@ -204,7 +204,7 @@
                      <projectile Class="CombatExtended.ProjectilePropertiesCE" Inherit="False">
                         <damageDef>Bullet</damageDef>
                         <damageAmountBase>9</damageAmountBase>
-                        <speed>160</speed>
+                        <speed>151</speed>
                         <secondaryDamage>
                            <li>
                               <def>Bomb_Secondary</def>
@@ -229,7 +229,7 @@
                      <projectile Class="CombatExtended.ProjectilePropertiesCE" Inherit="False">
                         <damageDef>Bullet</damageDef>
                         <damageAmountBase>13</damageAmountBase>
-                        <speed>240</speed>
+                        <speed>204</speed>
                         <secondaryDamage>
                            <li>
                               <def>Bomb_Secondary</def>
@@ -252,7 +252,7 @@
                      </graphicData>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
                         <damageDef>RM_Damage_ShardShot</damageDef>
-                        <speed>72</speed>
+                        <speed>83</speed>
                         <dropsCasings>false</dropsCasings>
                         <pelletCount>2</pelletCount>
                         <spreadMult>2</spreadMult>
@@ -272,7 +272,7 @@
                      </graphicData>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
                         <damageDef>RM_Damage_ShardShot</damageDef>
-                        <speed>72</speed>
+                        <speed>83</speed>
                         <dropsCasings>false</dropsCasings>
                         <pelletCount>3</pelletCount>
                         <spreadMult>2</spreadMult>
@@ -292,7 +292,7 @@
                      </graphicData>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
                         <damageDef>RM_Damage_ShardShot</damageDef>
-                        <speed>72</speed>
+                        <speed>83</speed>
                         <dropsCasings>false</dropsCasings>
                         <pelletCount>4</pelletCount>
                         <spreadMult>2</spreadMult>
@@ -356,7 +356,7 @@
                      <thingClass>CombatExtended.BulletCE</thingClass>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
                         <damageDef>Burn</damageDef>
-                        <speed>150</speed>
+                        <speed>144</speed>
                      </projectile>
                   </ThingDef>
 
@@ -368,7 +368,7 @@
                         <graphicClass>Graphic_Single</graphicClass>
                      </graphicData>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                        <speed>150</speed>
+                        <speed>114450</speed>
                         <damageDef>Burn</damageDef>
                         <damageAmountBase>14</damageAmountBase>
                         <armorPenetrationSharp>8</armorPenetrationSharp>
@@ -442,7 +442,7 @@
 							<drawSize>4</drawSize>
 						</graphicData>
 						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<speed>300</speed>
+							<speed>242</speed>
 							<flyOverhead>false</flyOverhead>
 							<dropsCasings>false</dropsCasings>
 							<casingMoteDefname>Mote_BigShell</casingMoteDefname>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/RangedContractors.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/RangedContractors.xml
@@ -807,7 +807,7 @@
 					<damageAmountBase>350</damageAmountBase>
 					<armorPenetrationSharp>600</armorPenetrationSharp>
 					<armorPenetrationBlunt>50</armorPenetrationBlunt>
-					<speed>65</speed>
+					<speed>77</speed>
 				</projectile>
 				</value>
 			</li>

--- a/Patches/RimSec-Security/Ammo/SRS Ammo.xml
+++ b/Patches/RimSec-Security/Ammo/SRS Ammo.xml
@@ -36,7 +36,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <damageAmountBase>13</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -62,7 +62,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <damageAmountBase>10</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -88,7 +88,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <damageAmountBase>10</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -132,7 +132,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>120</speed>
+                                <speed>122</speed>
                                 <damageAmountBase>10</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -158,7 +158,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>120</speed>
+                                <speed>122</speed>
                                 <damageAmountBase>8</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -184,7 +184,7 @@
                                 <graphicClass>Graphic_Single</graphicClass>
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                                <speed>120</speed>
+                                <speed>122</speed>
                                 <damageAmountBase>8</damageAmountBase>
                                 <secondaryDamage>
                                     <li>
@@ -229,7 +229,7 @@
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
                                 <damageAmountBase>19</damageAmountBase>
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <secondaryDamage>
                                     <li>
                                         <def>Bomb_Secondary</def>
@@ -255,7 +255,7 @@
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
                                 <damageAmountBase>15</damageAmountBase>
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <secondaryDamage>
                                     <li>
                                         <def>Bomb_Secondary</def>
@@ -281,7 +281,7 @@
                             </graphicData>
                             <projectile Class="CombatExtended.ProjectilePropertiesCE">
                                 <damageAmountBase>15</damageAmountBase>
-                                <speed>160</speed>
+                                <speed>151</speed>
                                 <secondaryDamage>
                                     <li>
                                         <def>EMP</def>

--- a/Patches/Rimsenal Collection/Core/Ammo_GD.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_GD.xml
@@ -36,7 +36,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
 
@@ -47,7 +47,7 @@
 			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
 
@@ -58,7 +58,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>14.06</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
  
@@ -75,7 +75,7 @@
 			  	<amount>4</amount>
 				</li>
 		  </secondaryDamage>
-		  <speed>130</speed>
+		  <speed>129</speed>
 		</projectile>
 	  </ThingDef>
 	  
@@ -92,7 +92,7 @@
 			  	<amount>6</amount>
 				</li>
 		  </secondaryDamage>
-		  <speed>130</speed>
+		  <speed>129</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -103,7 +103,7 @@
 		  <damageAmountBase>5</damageAmountBase>
 		  <armorPenetrationSharp>18</armorPenetrationSharp>
 		  <armorPenetrationBlunt>18.06</armorPenetrationBlunt>
-		  <speed>195</speed>
+		  <speed>175</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -131,7 +131,7 @@
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
 
@@ -142,7 +142,7 @@
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationSharp>16</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
 
@@ -153,7 +153,7 @@
 			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>47.96</armorPenetrationBlunt>
-			<speed>130</speed>
+			<speed>129</speed>
 		</projectile>
 	</ThingDef>
  
@@ -170,7 +170,7 @@
 			  	<amount>6</amount>
 				</li>
 		  </secondaryDamage>
-		  <speed>130</speed>
+		  <speed>129</speed>
 		</projectile>
 	  </ThingDef>
 	  
@@ -187,7 +187,7 @@
 			  	<amount>9</amount>
 				</li>
 		  </secondaryDamage>
-		  <speed>130</speed>
+		  <speed>129</speed>
 		</projectile>
 	  </ThingDef>
 
@@ -198,7 +198,7 @@
 		  <damageAmountBase>7</damageAmountBase>
 		  <armorPenetrationSharp>31.5</armorPenetrationSharp>
 		  <armorPenetrationBlunt>52.68</armorPenetrationBlunt>
-		  <speed>195</speed>
+		  <speed>175</speed>
 		</projectile>
 	  </ThingDef>
 

--- a/Patches/Rimsenal Collection/Core/Ammo_JI.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_JI.xml
@@ -107,7 +107,7 @@
 			<shaderType>TransparentPostLight</shaderType>			
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>80</speed>
+			<speed>90</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>		
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>210</damageAmountBase>
@@ -197,7 +197,7 @@
 			<shaderType>TransparentPostLight</shaderType>			
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>80</speed>
+			<speed>90</speed>
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>80</damageAmountBase>
 			<armorPenetrationBlunt>51200</armorPenetrationBlunt>
@@ -238,7 +238,7 @@
 	  <soundExplode>MortarBomb_Explode</soundExplode>
 	  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 	  <ai_IsIncendiary>false</ai_IsIncendiary>
-	  <speed>35</speed>
+	  <speed>49</speed>
 	  <gravityFactor>10</gravityFactor>
 	</projectile>
 	<comps>
@@ -311,7 +311,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>120</speed>
+			<speed>122</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>10</damageAmountBase>			
 			<armorPenetrationBlunt>60</armorPenetrationBlunt>
@@ -400,7 +400,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>140</speed>
+			<speed>137</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>28</damageAmountBase>			
 			<armorPenetrationBlunt>490</armorPenetrationBlunt>
@@ -429,7 +429,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>200</speed>
+			<speed>178</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>128</damageAmountBase>		
 			<armorPenetrationBlunt>20000</armorPenetrationBlunt>
@@ -469,7 +469,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>140</speed>
+			<speed>137</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>22</damageAmountBase>		
 			<armorPenetrationBlunt>245</armorPenetrationBlunt>

--- a/Patches/Rimsenal Collection/Core/Ammo_TE.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_TE.xml
@@ -206,7 +206,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>KineticImpact</damageDef>
-			<speed>48</speed>
+			<speed>61</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>30</damageAmountBase>
 			<armorPenetrationBlunt>24</armorPenetrationBlunt>
@@ -244,7 +244,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>KineticImpact</damageDef>
-			<speed>40</speed>
+			<speed>54</speed>
 		</projectile>
 		<comps>
 		  <li Class="CombatExtended.CompProperties_ExplosiveCE">
@@ -285,7 +285,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>KineticImpact</damageDef>
-			<speed>72</speed>
+			<speed>83</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationBlunt>54</armorPenetrationBlunt>

--- a/Patches/Rimsenal Collection/Core/Ammo_YP.xml
+++ b/Patches/Rimsenal Collection/Core/Ammo_YP.xml
@@ -35,7 +35,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Shredder</damageDef>
-			<speed>72</speed>
+			<speed>83</speed>
 			<dropsCasings>false</dropsCasings>
 			<pelletCount>2</pelletCount>
 			<spreadMult>2</spreadMult>		
@@ -114,7 +114,7 @@
 			</graphicData>			
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Shredder</damageDef>
-				<speed>170</speed>
+				<speed>158</speed>
 				<dropsCasings>false</dropsCasings>			
 				<damageAmountBase>5</damageAmountBase>
 				<armorPenetrationBlunt>10</armorPenetrationBlunt>
@@ -131,7 +131,7 @@
 			</graphicData>			
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Shredder</damageDef>
-				<speed>55</speed>
+				<speed>68</speed>
 				<dropsCasings>false</dropsCasings>			
 				<damageAmountBase>6</damageAmountBase>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
@@ -259,7 +259,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Shredder</damageDef>
-			<speed>240</speed>
+			<speed>204</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>36</armorPenetrationBlunt>
@@ -276,7 +276,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Shredder</damageDef>
-			<speed>180</speed>
+			<speed>165</speed>
 			<soundHitThickRoof>RS_ShotShard</soundHitThickRoof>
 			<flyOverhead>true</flyOverhead>
 			<gravityFactor>450</gravityFactor>

--- a/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
+++ b/Patches/Rimsenal Collection/Enhanced Vanilla/Ammo_EnhancedVanilla.xml
@@ -57,7 +57,7 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Blunt</damageDef>			
 				<damageAmountBase>15</damageAmountBase>
-				<speed>12</speed>
+				<speed>22</speed>
 				<armorPenetrationBlunt>0.18</armorPenetrationBlunt>
 				<preExplosionSpawnChance>0.50</preExplosionSpawnChance>
 				<preExplosionSpawnThingDef>Gun_ThrowingClubs</preExplosionSpawnThingDef>				
@@ -81,7 +81,7 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Cut</damageDef>			
 				<damageAmountBase>16</damageAmountBase>
-				<speed>12</speed>
+				<speed>22</speed>
 				<armorPenetrationSharp>1.4</armorPenetrationSharp>
 				<armorPenetrationBlunt>27</armorPenetrationBlunt>
 				<preExplosionSpawnChance>0.80</preExplosionSpawnChance>
@@ -158,7 +158,7 @@
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageDef>Arrow</damageDef>
-				<speed>36</speed>			
+				<speed>50</speed>			
 				<damageAmountBase>12</damageAmountBase>
 				<armorPenetrationBlunt>2.34</armorPenetrationBlunt>
 				<armorPenetrationSharp>2.5</armorPenetrationSharp>

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Ammo_Fed.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Ammo_Fed.xml
@@ -25,7 +25,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>100</speed>
+			<speed>106</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBlunt>5</armorPenetrationBlunt>
@@ -70,7 +70,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>90</speed>
+			<speed>98</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationBlunt>5</armorPenetrationBlunt>
@@ -92,7 +92,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>50</speed>
+			<speed>63</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>50</damageAmountBase>
 			<armorPenetrationBlunt>5</armorPenetrationBlunt>
@@ -113,7 +113,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>40</speed>
+			<speed>54</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBlunt>5</armorPenetrationBlunt>
@@ -134,7 +134,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
-			<speed>30</speed>
+			<speed>43</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>100</damageAmountBase>
 			<armorPenetrationBase>0.5</armorPenetrationBase>
@@ -154,7 +154,7 @@
 		</graphicData>			
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
@@ -173,7 +173,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
@@ -192,7 +192,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBlunt>3</armorPenetrationBlunt>
@@ -211,7 +211,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
@@ -232,7 +232,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Flame</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
@@ -252,7 +252,7 @@
 		</graphicData>				
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
@@ -273,7 +273,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>20</speed>
+			<speed>32</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBlunt>30</armorPenetrationBlunt>
@@ -295,7 +295,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Plasma</damageDef>
-			<speed>30</speed>
+			<speed>43</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>100</damageAmountBase>
 			<armorPenetrationBase>0.5</armorPenetrationBase>
@@ -315,7 +315,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Optic</damageDef>
-			<speed>80</speed>
+			<speed>90</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>3.5</armorPenetrationBlunt>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Ammo_Feral.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Ammo_Feral.xml
@@ -80,7 +80,7 @@
 		<pelletCount>20</pelletCount> 
 		<spreadMult>17.8</spreadMult>
 		<damageDef>Bullet</damageDef> 
-		<speed>50</speed> 
+		<speed>63</speed> 
 		<dropsCasings>false</dropsCasings> 		 
 	</projectile> 
 	</ThingDef>
@@ -152,7 +152,7 @@
 		</graphicData>		
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>60</speed>
+			<speed>73</speed>
 			<dropsCasings>false</dropsCasings>		
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBlunt>10</armorPenetrationBlunt>

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_MutantWeapons.xml
@@ -176,7 +176,7 @@
 				<damageDef>Spore</damageDef>
 				<damageAmountBase>5</damageAmountBase>
 				<explosionRadius>3.2</explosionRadius>			
-				<speed>30</speed>
+				<speed>54</speed>
 				<postExplosionGasType>BlindSmoke</postExplosionGasType>				
 			  </projectile>
 			</value>

--- a/Patches/Rimsenal Collection/Security/Ammo_Security.xml
+++ b/Patches/Rimsenal Collection/Security/Ammo_Security.xml
@@ -94,7 +94,7 @@
 					<shaderType>TransparentPostLight</shaderType>					
 				</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>160</speed>
+			<speed>151</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>false</flyOverhead>
 			<dropsCasings>false</dropsCasings>			
@@ -280,7 +280,7 @@
 			<explosionRadius>3.5</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<speed>64</speed>
+			<speed>76</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>			
 			</projectile>
 			<comps>
@@ -307,7 +307,7 @@
 				<soundExplode>MortarBomb_Explode</soundExplode>
 				<armorPenetrationSharp>600</armorPenetrationSharp>
 				<armorPenetrationBlunt>38.687</armorPenetrationBlunt>
-				<speed>64</speed>
+				<speed>76</speed>
 				<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
 			</projectile>
 			<comps>
@@ -453,7 +453,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>Bomb</damageDef>
 			  <damageAmountBase>156</damageAmountBase>
@@ -481,7 +481,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>PrometheumFlame</damageDef>
 			  <damageAmountBase>6</damageAmountBase>
@@ -501,7 +501,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>EMP</damageDef>
 			  <damageAmountBase>156</damageAmountBase>
@@ -518,7 +518,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>Extinguish</damageDef>
 			  <suppressionFactor>0.0</suppressionFactor>
@@ -545,7 +545,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>Smoke</damageDef>
 			  <suppressionFactor>0.0</suppressionFactor>
@@ -571,7 +571,7 @@
 			  <graphicClass>Graphic_Single</graphicClass>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			  <speed>32</speed>
+			  <speed>45</speed>
 			  <gravityFactor>2</gravityFactor>
 			  <damageDef>Bomb</damageDef>
 			  <damageAmountBase>800</damageAmountBase>

--- a/Patches/Rimsenal Xenotype Pack - Askbarn/Ammo_Askbarn.xml
+++ b/Patches/Rimsenal Xenotype Pack - Askbarn/Ammo_Askbarn.xml
@@ -35,7 +35,7 @@
 					</graphicData>		
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 						<damageDef>Bullet</damageDef>
-						<speed>100</speed>
+						<speed>106</speed>
 						<dropsCasings>false</dropsCasings>		
 						<damageAmountBase>14</damageAmountBase>			
 						<armorPenetrationBlunt>125</armorPenetrationBlunt>
@@ -68,7 +68,7 @@
 					<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<damageDef>EMP</damageDef>
 					<damageAmountBase>75</damageAmountBase>
-					<speed>60</speed>
+					<speed>73</speed>
 					<flyOverhead>false</flyOverhead>
 					<explosionRadius>2</explosionRadius>
 					<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Arrows.xml
@@ -259,7 +259,7 @@
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                             <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                         <comps>
                             <li Class="CombatExtended.CompProperties_Fragments">
@@ -283,7 +283,7 @@
                             <damageAmountBase>10</damageAmountBase>
                             <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
                             <preExplosionSpawnChance>1</preExplosionSpawnChance>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                     </ThingDef>
 
@@ -302,7 +302,7 @@
                             <dropsCasings>true</dropsCasings>
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                     </ThingDef>
 
@@ -317,7 +317,7 @@
                             <explosionRadius>1.1</explosionRadius>
                             <damageDef>Bomb</damageDef>
                             <damageAmountBase>200</damageAmountBase>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                     </ThingDef>
                 
@@ -345,7 +345,7 @@
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                             <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-                            <speed>20</speed>
+                            <speed>32</speed>
                         </projectile>
                         <comps>
                             <li Class="CombatExtended.CompProperties_Fragments">
@@ -369,7 +369,7 @@
                             <damageAmountBase>10</damageAmountBase>
                             <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
                             <preExplosionSpawnChance>1</preExplosionSpawnChance>
-                            <speed>20</speed>
+                            <speed>32</speed>
                         </projectile>
                     </ThingDef>
 
@@ -388,7 +388,7 @@
                             <dropsCasings>true</dropsCasings>
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-                            <speed>20</speed>
+                            <speed>32</speed>
                         </projectile>
                     </ThingDef>
 
@@ -403,7 +403,7 @@
                             <explosionRadius>1.1</explosionRadius>
                             <damageDef>Bomb</damageDef>
                             <damageAmountBase>200</damageAmountBase>
-                            <speed>20</speed>
+                            <speed>32</speed>
                         </projectile>
                     </ThingDef>
                 
@@ -431,7 +431,7 @@
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
                             <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                         <comps>
                             <li Class="CombatExtended.CompProperties_Fragments">
@@ -455,7 +455,7 @@
                             <damageAmountBase>10</damageAmountBase>
                             <preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
                             <preExplosionSpawnChance>1</preExplosionSpawnChance>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                     </ThingDef>
 
@@ -474,7 +474,7 @@
                             <dropsCasings>true</dropsCasings>
                             <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
                             <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-                            <speed>20</speed>
+                            <speed>32</speed>
                         </projectile>
                     </ThingDef>
 
@@ -489,7 +489,7 @@
                             <explosionRadius>1.1</explosionRadius>
                             <damageDef>Bomb</damageDef>
                             <damageAmountBase>200</damageAmountBase>
-                            <speed>18</speed>
+                            <speed>30</speed>
                         </projectile>
                     </ThingDef>
                 

--- a/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
+++ b/Patches/Rimworld-Style Pilas And Bows Strapped With Grenades and Shells Extended/Javelin.xml
@@ -277,7 +277,7 @@
                         <label>pilum with HE shell on the tip</label>
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageAmountBase>14</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
                             <armorPenetrationSharp>4</armorPenetrationSharp>
                         </projectile>
@@ -290,7 +290,7 @@
                             </li>
                             <li Class="CombatExtended.CompProperties_Fragments">
                                 <fragments>
-                                    <Fragment_Large>16</Fragment_Large>
+                                    <Fragment_Large>27</Fragment_Large>
                                     <Fragment_Small>100</Fragment_Small>
                                 </fragments>
                             </li>
@@ -302,7 +302,7 @@
                         <label>pilum with incendiary shell on the tip</label>
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageAmountBase>14</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
                             <armorPenetrationSharp>4</armorPenetrationSharp>
                         </projectile>
@@ -323,7 +323,7 @@
                         <label>pilum with EMP shell on the tip</label>
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageAmountBase>14</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
                             <armorPenetrationSharp>4</armorPenetrationSharp>
                         </projectile>
@@ -341,7 +341,7 @@
                         <label>pilum with smoke shell on the tip</label>
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageAmountBase>14</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
                             <armorPenetrationSharp>4</armorPenetrationSharp>
                         </projectile>
@@ -362,7 +362,7 @@
                         <label>pilum with smoke shell on the tip</label>
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageAmountBase>14</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <armorPenetrationBlunt>5.44</armorPenetrationBlunt>
                             <armorPenetrationSharp>4</armorPenetrationSharp>
                         </projectile>
@@ -385,7 +385,7 @@
                         <projectile Class="CombatExtended.ProjectilePropertiesCE">
                             <damageDef>Bomb</damageDef>
                             <damageAmountBase>800</damageAmountBase>
-                            <speed>16</speed>
+                            <speed>27</speed>
                             <explosionRadius>50</explosionRadius>
                             <explosionChanceToStartFire>0.22</explosionChanceToStartFire>
                             <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Patches/Urbworld Weaponry - Caseless/6.5x21mmCaseless.xml
+++ b/Patches/Urbworld Weaponry - Caseless/6.5x21mmCaseless.xml
@@ -113,7 +113,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>146</speed>
+			<speed>141</speed>
 			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Patches/Urbworld Weaponry - Caseless/7.7mmPC.xml
+++ b/Patches/Urbworld Weaponry - Caseless/7.7mmPC.xml
@@ -145,7 +145,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>164</speed>
+			<speed>154</speed>
 			<dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>
@@ -219,7 +219,7 @@
       <damageAmountBase>10</damageAmountBase>
       <armorPenetrationSharp>26</armorPenetrationSharp>
       <armorPenetrationBlunt>114.98</armorPenetrationBlunt>
-      <speed>246</speed>
+      <speed>208</speed>
     </projectile>
   </ThingDef>
   

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Javelin.xml
@@ -35,7 +35,7 @@
 			<label>javelin</label>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 				<damageAmountBase>14</damageAmountBase>
-				<speed>16</speed>
+				<speed>14</speed>
 				<armorPenetrationBlunt>5.44</armorPenetrationBlunt>
 				<armorPenetrationSharp>5.5</armorPenetrationSharp>
 				<secondaryDamage>
@@ -54,7 +54,7 @@
 				<label>pilum (fired)</label>
 				<projectile Class="CombatExtended.ProjectilePropertiesCE">
 					<damageAmountBase>29</damageAmountBase>
-					<speed>44</speed>
+					<speed>30</speed>
 					<armorPenetrationBlunt>141.12</armorPenetrationBlunt>
 					<armorPenetrationSharp>14</armorPenetrationSharp>
 					<secondaryDamage>

--- a/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
+++ b/Patches/Vanilla Factions Expanded - Classical/Ammo_Scorpion.xml
@@ -53,7 +53,7 @@
               <damageAmountBase>14</damageAmountBase>
               <armorPenetrationBlunt>6.85</armorPenetrationBlunt>
               <armorPenetrationSharp>3.45</armorPenetrationSharp>
-              <speed>22</speed>			
+              <speed>34</speed>			
               <preExplosionSpawnChance>0.233</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -70,7 +70,7 @@
               <damageAmountBase>12</damageAmountBase>
               <armorPenetrationBlunt>8.82</armorPenetrationBlunt>
               <armorPenetrationSharp>4.75</armorPenetrationSharp>
-              <speed>24</speed>				
+              <speed>37</speed>				
               <preExplosionSpawnChance>0.5</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
             </projectile>
@@ -88,7 +88,7 @@
               <damageAmountBase>14</damageAmountBase>
               <armorPenetrationBlunt>6.85</armorPenetrationBlunt>
               <armorPenetrationSharp>3.25</armorPenetrationSharp>
-              <speed>22</speed>	
+              <speed>34</speed>	
               <preExplosionSpawnChance>0.4</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -106,7 +106,7 @@
               <damageAmountBase>7</damageAmountBase>
               <armorPenetrationBlunt>3.68</armorPenetrationBlunt>
               <armorPenetrationSharp>2.25</armorPenetrationSharp>
-              <speed>22</speed>	
+              <speed>34</speed>	
             </projectile>
           </ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/ChargeThumperRound.xml
@@ -57,7 +57,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Thump</damageDef>
             <damageAmountBase>8</damageAmountBase>
-            <speed>60</speed>
+            <speed>73</speed>
             <armorPenetrationSharp>0</armorPenetrationSharp>
             <armorPenetrationBlunt>0</armorPenetrationBlunt>
             <explosionRadius>1.5</explosionRadius>

--- a/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Ammo/FletcherRifleRound.xml
@@ -55,7 +55,7 @@
           </graphicData>  
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageAmountBase>6</damageAmountBase>
-            <speed>150</speed>
+            <speed>144</speed>
             <damageDef>VFEE_Fletcher</damageDef>
             <armorPenetrationSharp>16</armorPenetrationSharp>
             <armorPenetrationBlunt>36</armorPenetrationBlunt>

--- a/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Empire/Buildings_Security_Turrets.xml
@@ -153,7 +153,7 @@
             <projectile>
               <damageDef>Bullet</damageDef>
               <damageAmountBase>15</damageAmountBase>
-              <speed>170</speed>
+              <speed>158</speed>
               <armorPenetrationBase>25</armorPenetrationBase>
             </projectile>
           </ThingDef>

--- a/Patches/Vanilla Factions Expanded - Insectoids/Ammo/PlasmaCells.xml
+++ b/Patches/Vanilla Factions Expanded - Insectoids/Ammo/PlasmaCells.xml
@@ -124,7 +124,7 @@
           <thingClass>CombatExtended.BulletCE</thingClass>          <!-- If i don't add this the ammo won't work -->
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Burn</damageDef>
-            <speed>160</speed>
+            <speed>151</speed>
           </projectile>
         </ThingDef>
 
@@ -157,7 +157,7 @@
             <graphicClass>Graphic_Single</graphicClass>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>130</speed>
+            <speed>129</speed>
             <damageAmountBase>10</damageAmountBase>
             <armorPenetrationSharp>8</armorPenetrationSharp>
             <armorPenetrationBlunt>8</armorPenetrationBlunt>

--- a/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
+++ b/Patches/Vanilla Factions Expanded - Mechanoids/ThingDefs_Misc/Ammo_Mechanoid.xml
@@ -29,7 +29,7 @@
 			<projectile Class="CombatExtended.ProjectilePropertiesCE" Inherit="False">
 				<damageDef>Bullet</damageDef>
 				<damageAmountBase>14</damageAmountBase>
-				<speed>280</speed>
+				<speed>229</speed>
 				<secondaryDamage>
 					<li>
 						<def>Bomb_Secondary</def>
@@ -51,7 +51,7 @@
 				<drawSize>4</drawSize>
 			</graphicData>
 			<projectile Class="CombatExtended.ProjectilePropertiesCE">
-				<speed>300</speed>
+				<speed>242</speed>
 				<flyOverhead>false</flyOverhead>
 				<dropsCasings>false</dropsCasings>
 				<casingMoteDefname>Mote_BigShell</casingMoteDefname>
@@ -88,7 +88,7 @@
 				<damageAmountBase>21</damageAmountBase>
 				<explosionRadius>2.5</explosionRadius>
 				<soundExplode>MortarBomb_Explode</soundExplode>
-				<speed>300</speed>
+				<speed>242</speed>
 				<flyOverhead>false</flyOverhead>
 				<dropsCasings>false</dropsCasings>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
+++ b/Patches/Vanilla Factions Expanded - Medieval/ThingDef_Misc/VanillaMedieval_Ranged.xml
@@ -53,7 +53,7 @@
               <damageAmountBase>12</damageAmountBase>
               <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
               <armorPenetrationSharp>2.85</armorPenetrationSharp>
-              <speed>18</speed>			
+              <speed>30</speed>			
               <preExplosionSpawnChance>0.333</preExplosionSpawnChance>	<!-- 14.99 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -70,7 +70,7 @@
               <damageAmountBase>10</damageAmountBase>
               <armorPenetrationBlunt>8.12</armorPenetrationBlunt>
               <armorPenetrationSharp>4</armorPenetrationSharp>
-              <speed>20</speed>				
+              <speed>32</speed>				
               <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 bolts per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Plasteel</preExplosionSpawnThingDef>
             </projectile>
@@ -88,7 +88,7 @@
               <damageAmountBase>12</damageAmountBase>
               <armorPenetrationBlunt>6.5</armorPenetrationBlunt>
               <armorPenetrationSharp>2.5</armorPenetrationSharp>
-              <speed>18</speed>	
+              <speed>30</speed>	
               <preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
               <preExplosionSpawnThingDef>Ammo_CrossbowBolt_Steel</preExplosionSpawnThingDef>
             </projectile>
@@ -106,7 +106,7 @@
               <damageAmountBase>5</damageAmountBase>
               <armorPenetrationBlunt>3.28</armorPenetrationBlunt>
               <armorPenetrationSharp>1.5</armorPenetrationSharp>
-              <speed>18</speed>	
+              <speed>30</speed>	
             </projectile>
           </ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/Ammo/SlughthrowerShell.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/Ammo/SlughthrowerShell.xml
@@ -118,7 +118,7 @@
 						<ThingDef Name="BaseSlugthrowerBullet" ParentName="BaseBulletCE" Abstract="true">
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
 								<damageDef>Bullet</damageDef>
-								<speed>100</speed>
+								<speed>106</speed>
 								<dropsCasings>true</dropsCasings>
 								<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 								<casingFilthDefname>Filth_ShotgunAmmoCasings</casingFilthDefname>
@@ -149,7 +149,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>153</speed>
+								<speed>146</speed>
 								<damageAmountBase>74</damageAmountBase>
 								<armorPenetrationSharp>10</armorPenetrationSharp>
 								<armorPenetrationBlunt>638.7</armorPenetrationBlunt>
@@ -164,7 +164,7 @@
 								<graphicClass>Graphic_Single</graphicClass>
 							</graphicData>
 							<projectile Class="CombatExtended.ProjectilePropertiesCE">
-								<speed>18</speed>
+								<speed>30</speed>
 								<damageDef>Beanbag</damageDef>
 								<damageAmountBase>19</damageAmountBase>
 								<armorPenetrationBlunt>12.56</armorPenetrationBlunt>
@@ -185,7 +185,7 @@
 								<armorPenetrationSharp>0</armorPenetrationSharp>
 								<armorPenetrationBlunt>0</armorPenetrationBlunt>
 								<empShieldBreakChance>0.75</empShieldBreakChance>
-								<speed>46</speed>
+								<speed>60</speed>
 							</projectile>
 						</ThingDef>
 

--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/ThingDefs_Turrets.xml
@@ -201,7 +201,7 @@
       <li Class="PatchOperationReplace">
         <xpath>Defs/ThingDef[defName = "VFEP_Bullet_GauntletChargeCanon"]/projectile/speed</xpath>
         <value>
-          <speed>150</speed>
+          <speed>144</speed>
         </value>
       </li>
 

--- a/Patches/Vanilla Factions Expanded - Vikings/Ammo_Vikings.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Ammo_Vikings.xml
@@ -176,7 +176,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>CE_Crypto</damageDef>
 			<damageAmountBase>11</damageAmountBase>
-			<speed>120</speed>		
+			<speed>122</speed>		
 			<armorPenetrationSharp>22.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>26</armorPenetrationBlunt>
 		</projectile>
@@ -189,7 +189,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>CE_Crypto</damageDef>		
 			<damageAmountBase>9</damageAmountBase>
-			<speed>120</speed>	
+			<speed>122</speed>	
 			<armorPenetrationSharp>16</armorPenetrationSharp>
 			<armorPenetrationBlunt>18</armorPenetrationBlunt>
 		</projectile>
@@ -208,7 +208,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>CE_Crypto</damageDef>		
 			<damageAmountBase>24</damageAmountBase>
-			<speed>120</speed>	
+			<speed>122</speed>	
 			<armorPenetrationSharp>14</armorPenetrationSharp>
 			<armorPenetrationBlunt>26</armorPenetrationBlunt>
 		</projectile>
@@ -227,7 +227,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>CE_Crypto</damageDef>		
 			<damageAmountBase>52</damageAmountBase>
-			<speed>120</speed>	
+			<speed>122</speed>	
 			<armorPenetrationSharp>24</armorPenetrationSharp>
 			<armorPenetrationBlunt>64</armorPenetrationBlunt>
 		</projectile>

--- a/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
+++ b/Patches/Vanilla Factions Expanded - Vikings/Weapons_Medieval.xml
@@ -393,7 +393,7 @@
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageDef>Cut</damageDef>			
             <damageAmountBase>16</damageAmountBase>
-            <speed>14</speed>
+            <speed>25</speed>
             <armorPenetrationSharp>1.5</armorPenetrationSharp>
             <armorPenetrationBlunt>3</armorPenetrationBlunt>
             <preExplosionSpawnChance>0.60</preExplosionSpawnChance>
@@ -406,7 +406,7 @@
           <label>thrown harpoon</label>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
             <damageAmountBase>13</damageAmountBase>
-            <speed>16</speed>
+            <speed>27</speed>
             <armorPenetrationBlunt>4.54</armorPenetrationBlunt>
             <armorPenetrationSharp>1.8</armorPenetrationSharp>
             <secondaryDamage>

--- a/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/Ammo_Security.xml
@@ -26,7 +26,7 @@
 				  <damageAmountBase>42</damageAmountBase>
 				  <explosionRadius>4</explosionRadius>
 				  <soundExplode>MortarBomb_Explode</soundExplode>				
-				  <speed>130</speed>
+				  <speed>129</speed>
 				  <flyOverhead>false</flyOverhead>
 				  <dropsCasings>false</dropsCasings>
 				  <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
+++ b/Patches/Vanilla Weapons Expanded - Heavy Weapons/Ammo/M73.xml
@@ -66,7 +66,7 @@
             <shaderType>TransparentPostLight</shaderType>
           </graphicData>
           <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <speed>29</speed>
+            <speed>42</speed>
             <damageDef>Bomb</damageDef>
             <damageAmountBase>124</damageAmountBase>
             <explosionRadius>4</explosionRadius>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/RubberBullet.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/RubberBullet.xml
@@ -61,7 +61,7 @@
 				</li>
 			</secondaryDamage>        
 			<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
-      <speed>20</speed>
+      <speed>32</speed>
       <dropsCasings>false</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/TaserCartridge.xml
@@ -57,7 +57,7 @@
       		<damageDef>Taser</damageDef>               
 			<armorPenetrationSharp>0.65</armorPenetrationSharp>
 			<armorPenetrationBlunt>3</armorPenetrationBlunt>
-			<speed>18</speed>
+			<speed>30</speed>
 			<dropsCasings>false</dropsCasings>      
 		</projectile>
 	</ThingDef>

--- a/Patches/Vanilla Weapons Expanded - Non-Lethal/TranquilizerDart.xml
+++ b/Patches/Vanilla Weapons Expanded - Non-Lethal/TranquilizerDart.xml
@@ -48,7 +48,7 @@
 				<damageAmountBase>2</damageAmountBase>
 				<armorPenetrationSharp>1.85</armorPenetrationSharp>
 				<armorPenetrationBlunt>12.85</armorPenetrationBlunt>
-				<speed>30</speed>
+				<speed>43</speed>
 			</projectile>
 		</ThingDef>
 

--- a/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
+++ b/Patches/Vanilla Weapons Expanded - Tribal/Ranged_Neolithic.xml
@@ -70,7 +70,7 @@
             <damageDef>RangedStab</damageDef>
             <damageAmountBase>7</damageAmountBase>
             <flyOverhead>false</flyOverhead>
-            <speed>14</speed>
+            <speed>25</speed>
             <armorPenetrationBlunt>0.45</armorPenetrationBlunt>
             <armorPenetrationSharp>0.26</armorPenetrationSharp>
             <preExplosionSpawnChance>0.60</preExplosionSpawnChance>


### PR DESCRIPTION
## Changes

- What it says on the tin, changed the speed conversion formula in the spreadsheet to be velocity^(0.75) instead of velocity*0.2 for better normalized in-game speed values.
- some minor housekeeping and consistency checks for a couple cartridges.

## References

- https://docs.google.com/spreadsheets/d/1P9U8EtYoRBh-jPMPmXcqam1O3qvKZPMml2ktAMPssOk/edit#gid=1393347070

## Reasoning

- Linear functions don't really translate very high and very low values into usable in-game stats, the new non-linear function allows for more sensible speed values for RW purposes.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
- [ ] Playtested a colony (specify how long)
