### PR TITLE
Parka thickness adjusted

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechChild.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechChild.xml
@@ -26,7 +26,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_KidParka"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
-			<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 

--- a/Patches/AOC The Cleanup Devil/Apparel/Apparel - Flex.xml
+++ b/Patches/AOC The Cleanup Devil/Apparel/Apparel - Flex.xml
@@ -75,7 +75,7 @@
         <li Class="PatchOperationAdd">
           <xpath>Defs/ThingDef[defName="AOC_FLEX_Coat"]/statBases/StuffEffectMultiplierArmor</xpath>
           <value>
-            <StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+            <StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
           </value>
         </li>
 

--- a/Patches/Apparello/ThingDefs/StuffPowers.xml
+++ b/Patches/Apparello/ThingDefs/StuffPowers.xml
@@ -60,7 +60,7 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName = "Apparello_Sheet" or defName="Apparello_Furhat"]/statBases</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Patches/CP British Military Kit/CP_BMK_CE_Patch_Apparel_Shell.xml
+++ b/Patches/CP British Military Kit/CP_BMK_CE_Patch_Apparel_Shell.xml
@@ -20,7 +20,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RHApparel_PcsParka_MTP"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 
@@ -44,7 +44,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="RHApparel_PcsParka_MTP_PLCE"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -46,7 +46,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Parka"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
-			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
@@ -78,13 +78,6 @@
 		<value>
 			<Bulk>5</Bulk>
 			<WornBulk>1</WornBulk>
-		</value>
-	</Operation>
-	
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Parka"]/costStuffCount</xpath>
-		<value>
-			<costStuffCount>110</costStuffCount>
 		</value>
 	</Operation>
 	

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -51,7 +51,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Moyo_Parka"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>7.5</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			

--- a/Patches/Nearmare Race/ThingDefs_Misc/Nearmare_Apparel.xml
+++ b/Patches/Nearmare Race/ThingDefs_Misc/Nearmare_Apparel.xml
@@ -148,7 +148,7 @@
 				defName="HAR_NM_Sh_SKo"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -187,7 +187,7 @@
 				defName="HAR_NC_Shell_c"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>

--- a/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
+++ b/Patches/NewRatkinPlus/ThingDef_Misc/Ratkin_Apparel.xml
@@ -68,7 +68,7 @@
 				<value>
 					<Bulk>6</Bulk>
 					<WornBulk>4</WornBulk>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>			
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>			
 				</value>
 			</li>			
 

--- a/Patches/O21 Outer Rim/Patch_OuterRim_Apparel.xml
+++ b/Patches/O21 Outer Rim/Patch_OuterRim_Apparel.xml
@@ -21,7 +21,7 @@
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="O21_OuterRim_JawaRobe" or defName="O21_OuterRim_TuskenRaiderRobeA" or defName="O21_OuterRim_TuskenRaiderRobeB"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
-				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 			</value>
 		</li>
 		

--- a/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Shell.xml
+++ b/Patches/Rimmu-Nation - Clothing/RNC_CE_Patch_Apparel_Shell.xml
@@ -26,7 +26,7 @@
 					defName="RNApparel_Parka_M65Blank"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -61,7 +61,7 @@
 					defName="RNApparel_TrenchCoat_PUBG"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 
@@ -132,7 +132,7 @@
 					defName="RNApparel_Jacket_LeatherBlank"
 					]/statBases/StuffEffectMultiplierArmor</xpath>
 					<value>
-						<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+						<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					</value>
 				</li>
 

--- a/Patches/SCP/Apparel_SCP.xml
+++ b/Patches/SCP/Apparel_SCP.xml
@@ -72,7 +72,7 @@
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="Apparel_SCPParka" or defName="Apparel_GOCParka" or defName="Apparel_CIInsurgentParka"]/statBases/StuffEffectMultiplierArmor</xpath>
 			<value>
-				<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+				<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 				<Bulk>10</Bulk>
 				<WornBulk>5</WornBulk>
 			</value>

--- a/Patches/Saclean Race/ThingDefs_Misc/Saclean_Apparel.xml
+++ b/Patches/Saclean Race/ThingDefs_Misc/Saclean_Apparel.xml
@@ -41,7 +41,7 @@
 				defName="HAR_SL_Shell_c"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>

--- a/Patches/Silkiera Race/ThingDefs_Misc/Silkiera_Apparel.xml
+++ b/Patches/Silkiera Race/ThingDefs_Misc/Silkiera_Apparel.xml
@@ -49,7 +49,7 @@
 				defName="HAR_SK_AS_c"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>
@@ -60,7 +60,7 @@
 				defName="HAR_SK_AS_b"
 				]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>

--- a/Patches/Solark Race/ThingDefs_Misc/Solark_Apparel.xml
+++ b/Patches/Solark Race/ThingDefs_Misc/Solark_Apparel.xml
@@ -91,7 +91,7 @@
 				defName="HAR_SA_Shell_b"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -172,7 +172,7 @@
 				defName="HAR_XO_AS_b"
 				]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>
 					<Bulk>10</Bulk>
 					<WornBulk>5</WornBulk>
 				</value>


### PR DESCRIPTION
## Changes

- Made parkas 4mm thick (<StuffEffectMultiplierArmor>4</StuffEffectMultiplierArmor>).

## Reasoning

- Parkas are fluffy and when compressed, they are actually less than 5mm thick so it makes sense for them to reflect that thickness when it comes to armor multipliers.
- The vanilla parka has a x0.2 armor factor vs duster's x0.3 and CE dusters are 5mm thick, the change would help with the huge gap
- Parkas are useless outside of cold insulation in vanilla, it requires no tech to be made and with that high of a thickness. Flak jackets should and do outperform parkas in regards to raw armor value in vanilla but that's the opposite in CE by a large margin, the competition in vanilla is flak jacket vs duster and parkas are nowhere near them in terms of armor.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
