### PR TITLE
Tweak warcasket melee weapons

### DIFF
--- a/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
+++ b/Patches/Vanilla Factions Expanded - Pirates/ThingDefs_Misc/Melee_Warcaskets.xml
@@ -18,10 +18,10 @@
 							<capacities>
 								<li>Stab</li>
 							</capacities>
-							<power>33</power>
-							<cooldownTime>2.24</cooldownTime>
+							<power>30</power>
+							<cooldownTime>2.0</cooldownTime>
 							<armorPenetrationBlunt>14</armorPenetrationBlunt>
-							<armorPenetrationSharp>8</armorPenetrationSharp>
+							<armorPenetrationSharp>9</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -29,10 +29,10 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>44</power>
-							<cooldownTime>3.17</cooldownTime>
+							<power>40</power>
+							<cooldownTime>2.9</cooldownTime>
 							<armorPenetrationBlunt>10</armorPenetrationBlunt>
-							<armorPenetrationSharp>2.15</armorPenetrationSharp>
+							<armorPenetrationSharp>3</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>
@@ -71,8 +71,8 @@
 							</capacities>
 							<power>56</power>
 							<cooldownTime>2.4</cooldownTime>
-							<armorPenetrationBlunt>9</armorPenetrationBlunt>
-							<armorPenetrationSharp>6</armorPenetrationSharp>
+							<armorPenetrationBlunt>18</armorPenetrationBlunt>
+							<armorPenetrationSharp>12</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -83,7 +83,7 @@
 							<power>68</power>
 							<cooldownTime>3.35</cooldownTime>
 							<armorPenetrationBlunt>17</armorPenetrationBlunt>
-							<armorPenetrationSharp>4.8</armorPenetrationSharp>
+							<armorPenetrationSharp>7.2</armorPenetrationSharp>
 							<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 						</li>
 					</tools>


### PR DESCRIPTION
## Changes

- Increased the armor penetration of the warcasket knife and broadsword, both were severely lacking in the AP department for weighing 10 and 35kgs each.
- Made the warcasket knife attack faster in return for a bit less damage.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
