### PR TITLE
Mechanitor command range increase

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -45,6 +45,7 @@
 		<li>Rah.RVTE</li>
 		<li>miho.fortifiedoutremer</li>		
 		<li>co.uk.epicguru.whatsthatmod</li>
+		<li>sarg.alphagenes</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using UnityEngine;
+using Verse;
+
+namespace CombatExtended.HarmonyCE.Compatibility
+{
+
+    public static class Harmony_AlphaGenes
+    {
+        private static Type TypeOfCanCommandTo_Patch_HarmonyPatches
+        {
+            get
+            {
+                return AccessTools.TypeByName("AlphaGenes.AlphaGenes_Pawn_MechanitorTracker_CanCommandTo_Patch");
+            }
+        }
+        private static Type TypeOfDrawCommandRadius_Patch_HarmonyPatches
+        {
+            get
+            {
+                return AccessTools.TypeByName("AlphaGenes.AlphaGenes_Pawn_MechanitorTracker_DrawCommandRadius_Patch");
+            }
+        }
+        [HarmonyPatch]
+        public static class Harmony_CanCommandTo_Patch
+        {
+            public static bool Prepare()
+            {
+                return TypeOfCanCommandTo_Patch_HarmonyPatches != null;
+            }
+
+            public static MethodBase TargetMethod()
+            {
+                return AccessTools.Method("AlphaGenes.AlphaGenes_Pawn_MechanitorTracker_CanCommandTo_Patch:ModifyRange");
+            }
+
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                foreach (var instruction in instructions)
+                {
+                    if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 1225f)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 55f * 55f); //Your value here
+                    }
+                    else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 225f)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 22f * 22f); //Your value here
+                    }
+                    else
+                    {
+                        yield return instruction;
+                    }
+                }
+            }
+        }
+
+        [HarmonyPatch]
+        public static class Harmony_DrawCommandRadius_Patch
+        {
+            public static bool Prepare()
+            {
+                return TypeOfDrawCommandRadius_Patch_HarmonyPatches != null;
+            }
+
+            public static MethodBase TargetMethod()
+            {
+                return AccessTools.Method("AlphaGenes.AlphaGenes_Pawn_MechanitorTracker_DrawCommandRadius_Patch:DrawExtraCommandRadius");
+            }
+
+            public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                foreach (var instruction in instructions)
+                {
+                    if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 35f)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 55f); //Your value here
+                    }
+                    else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 15f)
+                    {
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 22f); //Your value here
+                    }
+                    else
+                    {
+                        yield return instruction;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
@@ -45,11 +45,11 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 1225f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 59f * 59f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 3469.21f); //Your value here
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 225f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 29f * 29f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 835.21f); //Your value here
                     }
                     else
                     {
@@ -78,11 +78,11 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 35f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 59f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 58.9f); //Your value here
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 15f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 29f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 28.9f); //Your value here
                     }
                     else
                     {

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony_AlphaGenes.cs
@@ -45,11 +45,11 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 1225f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 55f * 55f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 59f * 59f); //Your value here
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 225f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 22f * 22f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 29f * 29f); //Your value here
                     }
                     else
                     {
@@ -78,11 +78,11 @@ namespace CombatExtended.HarmonyCE.Compatibility
                 {
                     if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 35f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 55f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 59f); //Your value here
                     }
                     else if (instruction.opcode == OpCodes.Ldc_R4 && ((float)instruction.operand) == 15f)
                     {
-                        yield return new CodeInstruction(OpCodes.Ldc_R4, 22f); //Your value here
+                        yield return new CodeInstruction(OpCodes.Ldc_R4, 29f); //Your value here
                     }
                     else
                     {

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_CanCommandTo.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_CanCommandTo.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(Pawn_MechanitorTracker), nameof(Pawn_MechanitorTracker.CanCommandTo))]
+    public static class Harmony_MechanitorTracker_CanCommandTo
+    {
+        static void Postfix(Pawn_MechanitorTracker __instance, ref bool __result, LocalTargetInfo target, Pawn ___pawn)
+        {
+            if (___pawn != null)
+            {
+                __result = (float)___pawn.Position.DistanceToSquared(target.Cell) < 1927.21;
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_CanCommandTo.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_CanCommandTo.cs
@@ -11,7 +11,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (___pawn != null)
             {
-                __result = (float)___pawn.Position.DistanceToSquared(target.Cell) < 1936;
+                __result = (float)___pawn.Position.DistanceToSquared(target.Cell) < 1927.21;
             }
         }
     }

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace CombatExtended.HarmonyCE
+{
+    [HarmonyPatch(typeof(Pawn_MechanitorTracker), nameof(Pawn_MechanitorTracker.DrawCommandRadius))]
+    public static class Harmony_MechanitorTracker_DrawCommandRadius
+    {
+        public static bool Prefix(Pawn_MechanitorTracker __instance, Pawn ___pawn)
+        {
+            if (___pawn != null && ___pawn.Spawned && __instance.AnySelectedDraftedMechs)
+            {
+                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, (IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c));
+            }
+            return false;
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
@@ -12,7 +12,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (___pawn != null && ___pawn.Spawned && __instance.AnySelectedDraftedMechs)
             {
-                GenDraw.DrawRadiusRing(___pawn.Position, 44f, Color.white, (IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c));
+                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, /*(IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c)*/null); //Radii ending in .9 line up with the radial pattern used, predicate check isn't needed
             }
             return false;
         }

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
@@ -12,7 +12,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (___pawn != null && ___pawn.Spawned && __instance.AnySelectedDraftedMechs)
             {
-                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, (IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c));
+                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, /*(IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c)*/null); //radii ending in .9 match up with the radial pattern, predicates aren't needed
             }
             return false;
         }

--- a/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
+++ b/Source/CombatExtended/Harmony/Harmony_MechanitorTracker_DrawCommandRadius.cs
@@ -12,7 +12,7 @@ namespace CombatExtended.HarmonyCE
         {
             if (___pawn != null && ___pawn.Spawned && __instance.AnySelectedDraftedMechs)
             {
-                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, /*(IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c)*/null); //radii ending in .9 match up with the radial pattern, predicates aren't needed
+                GenDraw.DrawRadiusRing(___pawn.Position, 43.9f, Color.white, (IntVec3 c) => ___pawn.mechanitor.CanCommandTo(c));
             }
             return false;
         }


### PR DESCRIPTION
## Additions

Increased the Mechanitor control range to 43.9 cells.

The draw radius patch destructively prefixes the original to stop it from drawing, but should still play nice with other postfixes on it.

## Additional notes

**This will likely conflict with other mods that modify the range and will have to be resolved manually.**

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
