### PR TITLE
Finish Warhammer 40k - Genes and Psycasts

### DIFF
--- a/Patches/Warhammer 40k - Genes and Psycasts/Abilities_SpaceMarine.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/Abilities_SpaceMarine.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+      		<li>Warhammer 40k - Genes and Psycasts</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ============== Betcher's Spit ================ -->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/AbilityDef[defName="BEWH_BetchersSpit"]/verbProperties/range</xpath>
+				<value>
+					<range>32</range>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="BEWH_SpitProjectile"]/projectile</xpath>
+				<value>
+					<projectile Class="CombatExtended.ProjectilePropertiesCE">
+						<damageDef>AcidBurn</damageDef>
+						<speed>48</speed>      
+						<damageAmountBase>18</damageAmountBase>
+						<armorPenetrationBlunt>8</armorPenetrationBlunt>
+						<shadowSize>0</shadowSize>
+						<filth>Filth_SpentAcid</filth>
+						<filthCount>1</filthCount>
+						<arcHeightFactor>0.4</arcHeightFactor>					
+					</projectile>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/GeneDefs.xml
@@ -1,11 +1,43 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
+
   <Operation Class="PatchOperationFindMod">
     <mods>
       <li>Warhammer 40k - Genes and Psycasts</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
+
+        <!-- Progenoid Glands -->
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/GeneDef[defName="BEWH_ProgenoidGlands"]</xpath>
+          <value>
+            <statOffsets>
+              <SmokeSensitivity>-1</SmokeSensitivity>
+            </statOffsets>
+          </value>
+        </li>
+
+        <!-- Multi-Lung -->
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/GeneDef[defName="BEWH_MultiLung"]/statOffsets</xpath>
+          <value>
+            <SmokeSensitivity>-1</SmokeSensitivity>
+          </value>
+        </li>
+
+        <!-- Occulobe -->
+
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/GeneDef[defName="BEWH_Occulobe"]</xpath>
+          <value>
+            <statOffsets>
+              <NightVisionEfficiency>0.8</NightVisionEfficiency>
+            </statOffsets>  
+          </value>
+        </li>
 
         <!-- Ossmodula -->
 
@@ -15,6 +47,7 @@
             <ArmorRating_Blunt>6</ArmorRating_Blunt>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_Ossmodula"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>
@@ -48,14 +81,18 @@
           <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>24.5</ArmorRating_Blunt>
+            <NightVisionEfficiency>0.8</NightVisionEfficiency>
+            <SmokeSensitivity>-1</SmokeSensitivity>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+            <ArmorRating_Sharp>8</ArmorRating_Sharp>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_Custodes"]/statOffsets/CarryingCapacity</xpath>
           <value>
@@ -69,14 +106,18 @@
           <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/ArmorRating_Blunt</xpath>
           <value>
             <ArmorRating_Blunt>33.75</ArmorRating_Blunt>
+            <NightVisionEfficiency>0.8</NightVisionEfficiency>
+            <SmokeSensitivity>-1</SmokeSensitivity>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>9</ArmorRating_Sharp>
+            <ArmorRating_Sharp>11</ArmorRating_Sharp>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_Primarch"]/statOffsets/CarryingCapacity</xpath>
           <value>
@@ -89,13 +130,14 @@
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_NurgleMark"]/statOffsets/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>12</ArmorRating_Blunt>
+            <ArmorRating_Blunt>4</ArmorRating_Blunt>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_NurgleMark"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>3.25</ArmorRating_Sharp>
+            <ArmorRating_Sharp>2</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -104,13 +146,14 @@
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_UndividedMark"]/statOffsets/ArmorRating_Blunt</xpath>
           <value>
-            <ArmorRating_Blunt>3</ArmorRating_Blunt>
+            <ArmorRating_Blunt>2</ArmorRating_Blunt>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_UndividedMark"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>
-            <ArmorRating_Sharp>1</ArmorRating_Sharp>
+            <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
           </value>
         </li>
 
@@ -122,6 +165,7 @@
             <ArmorRating_Blunt>17</ArmorRating_Blunt>
           </value>
         </li>
+
         <li Class="PatchOperationReplace">
           <xpath>Defs/GeneDef[defName="BEWH_DaemonHide"]/statOffsets/ArmorRating_Sharp</xpath>
           <value>

--- a/Patches/Warhammer 40k - Genes and Psycasts/Hediffs_Attacks.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/Hediffs_Attacks.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+      		<li>Warhammer 40k - Genes and Psycasts</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- Daemonic Melee Attacks -->
+
+		  <li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="BEWH_DaemonicHornAttack"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+                        <label>daemonic horns</label>
+						<capacities>
+							<li>Stab</li>
+						</capacities>
+						<power>18</power>
+						<cooldownTime>0.82</cooldownTime>
+						<armorPenetrationSharp>8</armorPenetrationSharp>
+						<armorPenetrationBlunt>12</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		  </li>
+
+		  <li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="BEWH_DaemonicTailAttack"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+				   <li Class="CombatExtended.ToolCE">
+                    <label>daemonic tail</label>
+					  <capacities>
+						 <li>Blunt</li>
+					  </capacities>
+					  <power>4</power>
+					  <armorPenetrationBlunt>0.4</armorPenetrationBlunt>
+					  <cooldownTime>0.76</cooldownTime>
+				   </li>
+				</tools>
+			</value>
+		  </li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Patches/Warhammer 40k - Genes and Psycasts/PawnKinds.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/PawnKinds.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Warhammer 40k - Genes and Psycasts</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <!-- Chaos Cultist & Imperial Trader -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/PawnKindDef[@Name="ChaosCultistBasePawn" or defName="BEWH_ImperiumTrader"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>4</min>
+                <max>6</max>
+              </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+        <!-- Chaos Cultist -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/PawnKindDef[@Name="ChaosCultistBasePawn"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>4</min>
+                <max>6</max>
+              </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+        <!-- Daemon Prince -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/PawnKindDef[@Name="DaemonPrincePawnBase"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>6</min>
+                <max>12</max>
+              </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+        <!-- Space Marines -->
+        <li Class="PatchOperationAddModExtension">
+          <xpath>Defs/PawnKindDef[@Name="ChaosMarineBasePawn" or @Name="SpaceMarineBasePawn"]</xpath>
+          <value>
+            <li Class="CombatExtended.LoadoutPropertiesExtension">
+              <primaryMagazineCount>
+                <min>6</min>
+                <max>10</max>
+              </primaryMagazineCount>
+            </li>
+          </value>
+        </li>
+
+      </operations>
+    </match>
+
+  </Operation>
+
+</Patch>

--- a/Patches/Warhammer 40k - Genes and Psycasts/TraderKinds.xml
+++ b/Patches/Warhammer 40k - Genes and Psycasts/TraderKinds.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+      		<li>Warhammer 40k - Genes and Psycasts</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+			<!-- ========== Imperial Base ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="BEWH_ImperiumTraderBase"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>FSX</thingDef>
+						<countRange>
+							<min>25</min>
+							<max>100</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_SingleDef">
+						<thingDef>Prometheum</thingDef>
+						<countRange>
+							<min>25</min>
+							<max>100</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Ammo</tradeTag>
+						<countRange>
+							<min>500</min>
+							<max>2000</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>5</min>
+							<max>9</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>30</min>
+							<max>100</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>5</min>
+							<max>8</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>10</min>
+							<max>50</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>4</min>
+							<max>6</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>Ammo</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Turret</tradeTag>
+						<thingDefCountRange>
+							<min>-2</min>
+							<max>4</max>
+						</thingDefCountRange>
+						<countRange>
+							<min>1</min>
+							<max>2</max>
+						</countRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>WeaponsTurrets</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Animals">
+						<tradeTagsSell>
+							<li>CE_AnimalBoom</li>
+						</tradeTagsSell>
+						<tradeTagsBuy>
+							<li>CE_AnimalBoom</li>
+						</tradeTagsBuy>
+						<kindCountRange>
+							<min>1</min>
+							<max>2</max>
+						</kindCountRange>
+						<countRange>
+							<min>-2</min>
+							<max>4</max>
+						</countRange>
+					</li>
+				</value>
+			</li>
+
+			<!-- ========== Imperial Caravan ========== -->
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraderKindDef[defName="BEWH_ImperiumTraderCaravan"]/stockGenerators</xpath>
+				<value>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_Ammo</tradeTag>
+						<countRange>
+							<min>200</min>
+							<max>400</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>1</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_MediumAmmo</tradeTag>
+						<countRange>
+							<min>20</min>
+							<max>40</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>6</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Tag">
+						<tradeTag>CE_HeavyAmmo</tradeTag>
+						<countRange>
+							<min>5</min>
+							<max>10</max>
+						</countRange>
+						<thingDefCountRange>
+							<min>2</min>
+							<max>4</max>
+						</thingDefCountRange>
+					</li>
+					<li Class="StockGenerator_Category">
+						<categoryDef>Ammo</categoryDef>
+						<thingDefCountRange>
+							<min>0</min>
+							<max>0</max>
+						</thingDefCountRange>
+					</li>
+				</value>
+			</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions
Finish up the patch originally added as a draft PR. #2185 
- Patch pawnkinds and traders.
- Add ancillary stats to the various genes (smoke sensitivity, night vision, etc.)
- Balance pass for a few of the gene stats.
- Patch the acid spitting attack.

## Reasoning
Armor levels and carrying capacity are fairly strong. In vanilla, this should make the xenotypes quite strong in combat--though, this will be lessened by power creep from other mods.

## Alternatives
Could reduce carry weight and natural armor to lower levels, which might make them mesh somewhat more with vanilla. However, this would probably undermine the status of the space marine xenotypes as super-human killing machines.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
