### PR TITLE
Add base abstract for medieval weapons made at the smithy to inherit …

### DIFF
--- a/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Defs/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -29,6 +29,28 @@
 			</li>
 		</comps>
 	</ThingDef>
+	
+	  <!-- ==================== Base Medieval ==================== -->
+
+	<ThingDef Name="BaseWeaponRangedMedieval" Abstract="True" ParentName="BaseWeaponNeolithic">
+		<weaponClasses>
+			<li>Ranged</li>
+		</weaponClasses>
+		<inspectorTabs>
+			<li>ITab_Art</li>
+		</inspectorTabs>
+		<statBases>
+			<Flammability>0.75</Flammability>
+		</statBases>
+		<comps>
+			<li Class="CompProperties_Art">
+				<nameMaker>NamerArtWeaponGun</nameMaker>
+				<descriptionMaker>ArtDescription_WeaponGun</descriptionMaker>
+				<minQualityForArtistic>Excellent</minQualityForArtistic>
+			</li>
+		</comps>
+	</ThingDef>
+  
 
 	<!-- ========================== SPECIFICS ============================== -->
 


### PR DESCRIPTION
…from.

## Additions

- Abstract def for medieval type weapons made at the smithy to inherit from

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

- Flintlocks and crossbows from Combat Extended - Guns could not be sold due to the abstract they inherited from.  Abstract was better placed here in the parent mod

## Alternatives

- Keep abstract in CE - Guns submod.

## Testing

Check tests you have performed:
- [ x ] Compiles without warnings
- [ x ] Game runs without errors
- [ x ] Playtested a colony (5 minutes)
