### PR TITLE
No shell casings for 81mm shells

### DIFF
--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -257,9 +257,7 @@
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
-      <dropsCasings>true</dropsCasings>
-      <casingMoteDefname>Mote_BigShell</casingMoteDefname>
-      <casingFilthDefname>Filth_CannonAmmoCasings</casingFilthDefname>
+      <dropsCasings>false</dropsCasings>
       <gravityFactor>5</gravityFactor>
     </projectile>
   </ThingDef>


### PR DESCRIPTION
## Changes

- What it says on the tin, 81 mortar shells don't have casings like howitzer shells.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [ ] Game runs without errors
