### PR TITLE
RM2 projectile velocity typo fix

### DIFF
--- a/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
+++ b/Patches/Reinforced Mechanoid 2/ThingDefs_Misc/RM_Ammo_Spacer.xml
@@ -368,7 +368,7 @@
                         <graphicClass>Graphic_Single</graphicClass>
                      </graphicData>
                      <projectile Class="CombatExtended.ProjectilePropertiesCE">
-                        <speed>114450</speed>
+                        <speed>144</speed>
                         <damageDef>Burn</damageDef>
                         <damageAmountBase>14</damageAmountBase>
                         <armorPenetrationSharp>8</armorPenetrationSharp>


### PR DESCRIPTION
## Changes

- What it says on the tin, should have changed from 150 to 144.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
