### PR TITLE
Tweak and fix the explosive belt from VAE Accessories

### DIFF
--- a/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
+++ b/Patches/Vanilla Apparel Expanded - Accessories/Apparel_Utility.xml
@@ -112,6 +112,24 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/costList</xpath>
+				<value>
+					<costList>
+						<Steel>5</Steel>
+						<FSX>2</FSX>
+						<ComponentIndustrial>1</ComponentIndustrial>
+					</costList>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAEA_Apparel_ExplosiveBelt"]/comps/li[@Class="VAE_Accessories.CompProperties_ExplodeOnDeath"]</xpath>
+				<value>
+					<damageAmountBase>200</damageAmountBase>
+				</value>
+			</li>
+
 			<!-- == Ranged Shield Pack == -->
 
 			<li Class="PatchOperationAdd">


### PR DESCRIPTION
## Changes

- Adjusted the cost of the belt to reflect an explosive belt.
- Adjusted the bomb damage dealt by the belt exploding to 200 as it was using the default Bomb damageDef's damage value of 634.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
