### PR TITLE
Fix Multiplayer desyncs caused by Projectile_FireTrail

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/Projectile_FireTrail.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/Projectile_FireTrail.cs
@@ -22,12 +22,14 @@ namespace CombatExtended
             {
                 return;
             }
+            Rand.PushState();
             MoteThrown moteThrown = (MoteThrown)ThingMaker.MakeThing(ThingDef.Named("Mote_Firetrail"), null);
             moteThrown.Scale = Rand.Range(1.5f, 2.5f) * size;
             moteThrown.exactRotation = Rand.Range(-0.5f, 0.5f);
             moteThrown.exactPosition = loc;
             moteThrown.SetVelocity((float)Rand.Range(30, 40), Rand.Range(0.008f, 0.012f));
             GenSpawn.Spawn(moteThrown, loc.ToIntVec3(), map);
+            Rand.PopState();
         }
     }
 }


### PR DESCRIPTION
## Changes

- Code creating the motes for `Projectile_FireTrail` is now surrounded with `Rand.PushState()` and `Rand.PopState()`

## Reasoning

- Calls to `Verse.Rand` (specifically `Rand.Range`) happen after `GenView.ShouldSpawnMotesAt`, which would mean that those calls may trigger based on the current map.
- Unseeded calls to `Verse.Rand` cause desync if they happen at a different time or only for some players, as the state of the RNG seed would progress for only some of the players.
- General state of RNG must remain the same for all players, as Multiplayer uses deterministic lockstep to keep everyone synchronized - so calls to RNG would have different result where they were expected to be the same.

## Testing

Check tests you have performed:
- [x] Compiles without warnings (there were some errors and warnings from Rider, however they didn't affect/appear during compilation)
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (tested only for a couple of minutes with dev quickstart - didn't seem like it was important to test more)