### PR TITLE
Greatbow research redemption

### DIFF
--- a/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
+++ b/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
+	<!-- Greatbow adjustments -->
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ResearchProjectDef[defName="Greatbow"]/techLevel</xpath>
+        <value>
+          <techLevel>Neolithic</techLevel>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ResearchProjectDef[defName="Greatbow"]/baseCost</xpath>
+        <value>
+          <baseCost>400</baseCost>
+        </value>
+    </Operation>
+
+	<!-- Gunsmithing adjustments -->
+
     <Operation Class="PatchOperationAdd">
         <xpath>Defs/ResearchProjectDef[defName="Gunsmithing"]</xpath>
         <value>
@@ -17,6 +35,8 @@
         </value>
     </Operation>
 
+	<!-- Turret tech adjustments -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/researchViewX</xpath>
 		<value>
@@ -31,7 +51,6 @@
 		</value>
 	</Operation>
 
-	<!-- Make Uranium Slug & Auto Turret require 'CE_HeavyTurret' -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/prerequisites</xpath>
 		<value>
@@ -47,6 +66,7 @@
 	</Operation>
 
 	<!-- Add CE's Simple Launchers to the Rocketswarm turret' research project -->
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ResearchProjectDef[defName="RocketswarmLauncher"]/hiddenPrerequisites</xpath>
 		<value>
@@ -55,6 +75,7 @@
 	</Operation>
 
 	<!-- Reduce Uranium Slug & Auto Turret cost, since they have a new prerequisite -->
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ResearchProjectDef[defName="HeavyTurrets"]/baseCost</xpath>
 		<value>


### PR DESCRIPTION
## Changes

- Changed the Greatbow's research project techLevel to Neolithic.
- Reduced the Greatbow research project cost from 600 down to 400.

## Reasoning

- Greatbows/Longbows date back to thousands or years ago and the weapon itself is considered a neolithic thing in xml.
- The research project already requires 400 points of prior research in non-tribal starts and 600 is too much for something that does not provide that much of an improvement over a recurve bow.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
